### PR TITLE
Fix task splits

### DIFF
--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -208,15 +208,15 @@ class MTEB:
                     continue
 
             try:
-                eval_splits = eval_splits if eval_splits is not None else task.description.get("eval_splits", [])
+                task_eval_splits = eval_splits if eval_splits is not None else task.description.get("eval_splits", [])
 
                 # load data
                 logger.info(f"Loading dataset for {task.description['name']}")
-                task.load_data(eval_splits=eval_splits)
+                task.load_data(eval_splits=task_eval_splits)
 
                 # run evaluation
                 task_results = {}
-                for split in eval_splits:
+                for split in task_eval_splits:
                     tick = time()
                     results = task.evaluate(model, split, **kwargs)
                     tock = time()


### PR DESCRIPTION
If you run multiple tasks it will reuse previous splits which may not exist 