### PR TITLE
Fix Mind Reference

### DIFF
--- a/mteb/tasks/Reranking/MindSmallReranking.py
+++ b/mteb/tasks/Reranking/MindSmallReranking.py
@@ -8,7 +8,7 @@ class MindSmallReranking(AbsTaskReranking):
             "name": "MindSmallReranking",
             "hf_hub_name": "mteb/mind_small",
             "description": "Microsoft News Dataset: A Large-Scale English Dataset for News Recommendation Research",
-            "reference": "https://www.microsoft.com/en-us/research/uploads/prod/2019/03/nl4se18LinkSO.pdf",
+            "reference": "https://msnews.github.io/assets/doc/ACL2020_MIND.pdf",
             "type": "Reranking",
             "category": "s2s",
             "eval_splits": ["test"],


### PR DESCRIPTION
Two other notes:
- The renaming can create confusion as there exists a test set just that I assume we don't have the labels - I clarified it [here](https://huggingface.co/datasets/mteb/mind_small/discussions/2)
- MIND uses AUC & MRR & NDCG scores, not MAP, see https://msnews.github.io/