### PR TITLE
Feature/custombeirmodel

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,16 +132,16 @@ evaluation = MTEB(tasks=["Banking77Classification"])
 evaluation.run(model)
 ```
 
-If you'd like to use different encoding functions for query and corpus when evaluating on BeIR, you can make your model BeIR compatible. If compatible like the below example, it will be used for BeIR upon evaluation.
+If you'd like to use different encoding functions for query and corpus when evaluating a Dense Retrieval Exact Search (DRES) model on retrieval tasks from BeIR, you can make your model DRES compatible. If compatible like the below example, it will be used for BeIR upon evaluation.
 
 ```python
-from mteb import AbsTaskRetrieval, BeIRModel
+from mteb import AbsTaskRetrieval, DRESModel
 
-class MyModel(BeIRModel):
-    # Refer to the code of BeIRModel for the methods to overwrite
+class MyModel(DRESModel):
+    # Refer to the code of DRESModel for the methods to overwrite
     pass
 
-assert AbsTaskRetrieval.is_beir_compatible(MyModel)
+assert AbsTaskRetrieval.is_dres_compatible(MyModel)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,19 @@ evaluation = MTEB(tasks=["Banking77Classification"])
 evaluation.run(model)
 ```
 
+If you'd like to use different encoding functions for query and corpus when evaluating on BeIR, you can make your model BeIR compatible. If compatible like the below example, it will be used for BeIR upon evaluation.
+
+```python
+from mteb import AbsTaskRetrieval, BeIRModel
+
+class MyModel(BeIRModel):
+    # Refer to the code of BeIRModel for the methods to overwrite
+    pass
+
+assert AbsTaskRetrieval.is_beir_compatible(MyModel)
+```
+
+
 ### Evaluating on a custom task
 
 To add a new task, you need to implement a new class that inherits from the `AbsTask` associated with the task type (e.g. `AbsTaskReranking` for reranking tasks). You can find the supported task types in [here](https://github.com/embeddings-benchmark/mteb-draft/tree/main/mteb/abstasks).

--- a/mteb/abstasks/AbsTaskRetrieval.py
+++ b/mteb/abstasks/AbsTaskRetrieval.py
@@ -28,17 +28,17 @@ class AbsTaskRetrieval(AbsTask):
         super().__init__(**kwargs)
 
     @staticmethod
-    def is_beir_compatible(beir_model, is_parallel=True):
+    def is_beir_compatible(model, is_parallel=True):
         methods = BEIR_METHODS_PARALLEL if is_parallel else BEIR_METHODS
         for method in methods:
-            op = getattr(beir_model, method, None)
+            op = getattr(model, method, None)
             if not(callable(op)):
                 return False
         return True
 
     def evaluate(
         self,
-        beir_model,
+        model,
         split="test",
         batch_size=128,
         corpus_chunk_size=None,
@@ -56,16 +56,13 @@ class AbsTaskRetrieval(AbsTask):
 
         corpus, queries, relevant_docs = self.corpus[split], self.queries[split], self.relevant_docs[split]
 
-        # Check if the provided model already is BeIR compatible
-        
-
         try:
             from beir.retrieval.search.dense import DenseRetrievalParallelExactSearch as DRPES
 
-            beir_model = beir_model if self.is_beir_compatible(beir_model, is_parallel=True) else BeIRModel(model)
+            model = model if self.is_beir_compatible(model, is_parallel=True) else BeIRModel(model)
 
             model = DRPES(
-                beir_model,
+                model,
                 batch_size=batch_size,
                 target_devices=target_devices,
                 corpus_chunk_size=corpus_chunk_size,
@@ -80,7 +77,7 @@ class AbsTaskRetrieval(AbsTask):
 
             from beir.retrieval.search.dense import DenseRetrievalExactSearch as DRES
             
-            beir_model = beir_model if self.is_beir_compatible(beir_model, is_parallel=False) else BeIRModel(model)
+            model = model if self.is_beir_compatible(model, is_parallel=False) else BeIRModel(model)
 
             model = DRES(
                 BeIRModel(model),

--- a/mteb/abstasks/AbsTaskRetrieval.py
+++ b/mteb/abstasks/AbsTaskRetrieval.py
@@ -11,8 +11,8 @@ from .AbsTask import AbsTask
 
 logger = logging.getLogger(__name__)
 
-BEIR_METHODS = ["encode_queries", "encode_corpus"]
-BEIR_METHODS_PARALLEL = ["start_multi_process_pool", "stop_multi_process_pool", "encode_queries", "encode_corpus", "encode_corpus_parallel"]
+DRES_METHODS = ["encode_queries", "encode_corpus"]
+DRPES_METHODS = ["start_multi_process_pool", "stop_multi_process_pool", "encode_queries", "encode_corpus", "encode_corpus_parallel"]
 
 
 class AbsTaskRetrieval(AbsTask):
@@ -28,8 +28,8 @@ class AbsTaskRetrieval(AbsTask):
         super().__init__(**kwargs)
 
     @staticmethod
-    def is_beir_compatible(model, is_parallel=True):
-        methods = BEIR_METHODS_PARALLEL if is_parallel else BEIR_METHODS
+    def is_dres_compatible(model, is_parallel=True):
+        methods = DRPES_METHODS if is_parallel else DRES_METHODS
         for method in methods:
             op = getattr(model, method, None)
             if not(callable(op)):
@@ -59,7 +59,7 @@ class AbsTaskRetrieval(AbsTask):
         try:
             from beir.retrieval.search.dense import DenseRetrievalParallelExactSearch as DRPES
 
-            model = model if self.is_beir_compatible(model, is_parallel=True) else BeIRModel(model)
+            model = model if self.is_dres_compatible(model, is_parallel=True) else DRESModel(model)
 
             model = DRPES(
                 model,
@@ -77,7 +77,7 @@ class AbsTaskRetrieval(AbsTask):
 
             from beir.retrieval.search.dense import DenseRetrievalExactSearch as DRES
             
-            model = model if self.is_beir_compatible(model, is_parallel=False) else BeIRModel(model)
+            model = model if self.is_dres_compatible(model, is_parallel=False) else DRESModel(model)
 
             model = DRES(
                 model,
@@ -106,11 +106,10 @@ class AbsTaskRetrieval(AbsTask):
         return scores
 
 
-class BeIRModel:
+class DRESModel:
     """
-    BeIR requires to have an encode_queries and encode_corpus method.
-    This class converts a MTEB model (with just an .encode method) into
-    BeIR format model
+    Dense Retrieval Exact Search (DRES) in BeIR requires an encode_queries & encode_corpus method.
+    This class converts a MTEB model (with just an .encode method) into BeIR DRES format.
     """
 
     def __init__(self, model, sep=" ", **kwargs):

--- a/mteb/abstasks/AbsTaskRetrieval.py
+++ b/mteb/abstasks/AbsTaskRetrieval.py
@@ -28,7 +28,7 @@ class AbsTaskRetrieval(AbsTask):
         super().__init__(**kwargs)
 
     @staticmethod
-    def is_beir_compatible(beir_model, is_parallel):
+    def is_beir_compatible(beir_model, is_parallel=True):
         methods = BEIR_METHODS_PARALLEL if is_parallel else BEIR_METHODS
         for method in methods:
             op = getattr(beir_model, method, None)

--- a/mteb/abstasks/AbsTaskRetrieval.py
+++ b/mteb/abstasks/AbsTaskRetrieval.py
@@ -80,7 +80,7 @@ class AbsTaskRetrieval(AbsTask):
             model = model if self.is_beir_compatible(model, is_parallel=False) else BeIRModel(model)
 
             model = DRES(
-                BeIRModel(model),
+                model,
                 batch_size=batch_size,
                 corpus_chunk_size=corpus_chunk_size if corpus_chunk_size is not None else 50000,
                 **kwargs,


### PR DESCRIPTION
Some models like OpenAI's API endpoint or SGPT use separate encoding functions for Query & Corpus, so this is useful imo.

A notebook example:

```python
!pip install -q git+https://github.com/muennighoff/mteb.git@feature/custombeirmodel
!pip install -q git+https://github.com/beir-cellar/beir.git
!pip install -q evaluate
!pip install --upgrade git+https://github.com/Muennighoff/sentence-transformers.git@sgpt_poolings_specb
```
```python
%%writefile xxx.py

from mteb import BeIRModel
from typing import Dict, List, Union, Tuple

import numpy as np
from sentence_transformers import SentenceTransformer, models
from torch import Tensor


class SentenceBERTBOSEOS(BeIRModel):
    def __init__(self, model_path: Union[str, Tuple] = None, sep: str = " ", **kwargs):
        self.sep = sep
        self.model = SentenceTransformer(model_path, **kwargs)

        word_embedding_model = self.model._first_module()
        assert isinstance(word_embedding_model, models.Transformer)

        tokens = ["[SOS]", "{SOS}"]
        word_embedding_model.tokenizer.add_tokens(tokens, special_tokens=True)
        word_embedding_model.auto_model.resize_token_embeddings(len(word_embedding_model.tokenizer))

        # Will be replaced with the rep ones
        word_embedding_model.bos_spec_token_q = word_embedding_model.tokenizer.encode("[SOS]", add_special_tokens=False)[0]
        word_embedding_model.bos_spec_token_d = word_embedding_model.tokenizer.encode("{SOS}", add_special_tokens=False)[0]

        word_embedding_model.bos_spec_token_q_rep = word_embedding_model.tokenizer.encode("[", add_special_tokens=False)[0]
        word_embedding_model.eos_spec_token_q = word_embedding_model.tokenizer.encode("]", add_special_tokens=False)[0]
        
        word_embedding_model.bos_spec_token_d_rep = word_embedding_model.tokenizer.encode("{", add_special_tokens=False)[0]
        word_embedding_model.eos_spec_token_d = word_embedding_model.tokenizer.encode("}", add_special_tokens=False)[0]

        word_embedding_model.replace_bos = True

    def encode_queries(self, queries: List[str], batch_size: int = 16, **kwargs) -> Union[List[Tensor], np.ndarray, Tensor]:
        # Will be replaced with [ in the models tokenization
        # If we would put [ here, there is a risk of it getting chained with a different token when encoding
        queries = ["[SOS]" + q for q in queries]
        return self.model.encode(queries, batch_size=batch_size, **kwargs)
    
    def encode_corpus(self, corpus: List[Dict[str, str]], batch_size: int = 8, **kwargs) -> Union[List[Tensor], np.ndarray, Tensor]:
        # Will be replaced with { in the models tokenization
        # If we would put { here, there is a risk of it getting chained with a different token when encoding
        sentences = [("{SOS}" + doc["title"] + self.sep + doc["text"]).strip() if "title" in doc else "{SOS}" + doc["text"].strip() for doc in corpus]
        return self.model.encode(sentences, batch_size=batch_size, **kwargs)

    def encode_corpus_parallel(
        self, corpus: List[Dict[str, str]], pool: Dict[str, object], batch_size: int, chunk_id: int, **kwargs
    ):
        if type(corpus) is dict:
            sentences = [
                ("{SOS}" + corpus["title"][i] + self.sep + corpus["text"][i]).strip()
                if "title" in corpus
                else "{SOS}" + corpus["text"][i].strip()
                for i in range(len(corpus["text"]))
            ]
        else:
            sentences = [
                ("{SOS}" + doc["title"] + self.sep + doc["text"]).strip() if "title" in doc else "{SOS}" + doc["text"].strip()
                for doc in corpus
            ]

        if chunk_id is not None and chunk_id >= len(pool["processes"]):
            output_queue = pool["output"]
            output_queue.get()

        input_queue = pool["input"]
        input_queue.put([chunk_id, batch_size, sentences])


from mteb.abstasks import AbsTaskRetrieval

assert AbsTaskRetrieval.is_beir_compatible(SentenceBERTBOSEOS, is_parallel=True)


from mteb import MTEB

model_name = "Muennighoff/SGPT-125M-weightedmean-msmarco-specb-bitfit"
model = SentenceBERTBOSEOS(model_name)
evaluation = MTEB(tasks=["SciFact"])
results = evaluation.run(model, output_folder=f"results/{model_name}")
```
```
!python xxx.py
```
