### PR TITLE
Fallback to old dataloader for cqadupstack

### DIFF
--- a/mteb/abstasks/AbsTaskRetrieval.py
+++ b/mteb/abstasks/AbsTaskRetrieval.py
@@ -57,6 +57,8 @@ class AbsTaskRetrieval(AbsTask):
         corpus, queries, relevant_docs = self.corpus[split], self.queries[split], self.relevant_docs[split]
 
         try:
+            if self.description["beir_name"].startswith("cqadupstack"):
+                raise ImportError("CQADupstack is incompatible with latest BEIR")
             from beir.retrieval.search.dense import DenseRetrievalParallelExactSearch as DRPES
 
             model = model if self.is_dres_compatible(model, is_parallel=True) else DRESModel(model)

--- a/mteb/abstasks/BeIRTask.py
+++ b/mteb/abstasks/BeIRTask.py
@@ -19,6 +19,8 @@ class BeIRTask(AbsTask):
 
         USE_BEIR_DEVELOPMENT = False
         try:
+            if self.description["beir_name"].startswith("cqadupstack"):
+                raise ImportError("CQADupstack is incompatible with latest BEIR")
             from beir.datasets.data_loader_hf import HFDataLoader as BeirDataLoader
 
             USE_BEIR_DEVELOPMENT = True


### PR DESCRIPTION
Somewhat fixes https://github.com/embeddings-benchmark/mteb/issues/66 by falling back to the old data loader, i.e. we do not support DPRES + CQADupstack.

This is a BEIR limitation, so I opened an issue here: https://github.com/beir-cellar/beir/issues/114 Once it's fixed we can remove this hopefully.
