### PR TITLE
Fix the extending of language pairs in `MTEB`

### DIFF
--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -55,9 +55,7 @@ class MTEB:
         self._task_langs = task_langs if task_langs is not None else []
         if type(self._task_langs) is str:
             self._task_langs = [self._task_langs]
-        self._task_langs.extend(
-            [f"{x}-{y}" for x in self._task_langs for y in self._task_langs]
-        )  # add all possible pairs
+        self._extend_lang_paris()  # add all possible pairs
 
         self._tasks = tasks
 
@@ -76,6 +74,18 @@ class MTEB:
     @property
     def available_task_categories(self):
         return set([x.description["category"] for x in self.tasks_cls])
+
+    def _extend_lang_paris(self):
+        # add all possible language pairs
+        langs = set(self._task_langs)
+        for x in langs:
+            if '-' not in x:
+                for y in langs:
+                    if '-' not in y:
+                        pair = f"{x}-{y}"
+                        if pair not in langs:
+                            self._task_langs.append(pair)
+        return
 
     def _display_tasks(self, task_list, name=None):
         console = Console()

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -55,7 +55,7 @@ class MTEB:
         self._task_langs = task_langs if task_langs is not None else []
         if type(self._task_langs) is str:
             self._task_langs = [self._task_langs]
-        self._extend_lang_paris()  # add all possible pairs
+        self._extend_lang_pairs()  # add all possible pairs
 
         self._tasks = tasks
 
@@ -75,7 +75,7 @@ class MTEB:
     def available_task_categories(self):
         return set([x.description["category"] for x in self.tasks_cls])
 
-    def _extend_lang_paris(self):
+    def _extend_lang_pairs(self):
         # add all possible language pairs
         langs = set(self._task_langs)
         for x in langs:


### PR DESCRIPTION
## Changes
- fix the logic of adding all possible language pairs, add a `_extend_lang_paris` for `MTEB` in `mteb/evaluation/MTEB.py`.


## Reproducible Example

When I was runinng a script like
```python
TASK_LIST = [.........]
langs = ['en']
for task in TASK_LIST:
    logger.info(f"Running task: {task}")
    eval_splits = ["dev"] if task == "MSMARCO" else ["test"]
    evaluation = MTEB(tasks=[task], task_langs=langs)
    evaluation.run(model, output_folder=output_folder, eval_splits=eval_splits)
```

After running multiple tasks, the memory will quickly increase and then the program crash.
Since I repeatedly pass in the same list `langs`, it is constantly being extended in `MTEB`.
The `self._task_langs ` will be `['en', 'en-en', 'en-en', 'en-en-en', 'en-en-en', 'en-en-en-en', ...... ]`

Although I could pass a new `list` every time, I think fixing this extension logic would be better.