### PR TITLE
Add @property annotation to description method of AbsTask

### DIFF
--- a/mteb/abstasks/AbsTask.py
+++ b/mteb/abstasks/AbsTask.py
@@ -33,6 +33,7 @@ class AbsTask(ABC):
         )
         self.data_loaded = True
 
+    @property
     @abstractmethod
     def description(self):
         """


### PR DESCRIPTION
Add the missing @property annotation to AbsTask.description, which prevents typing errors (when checked with mypy) in subclasses.