### PR TITLE
Update Custom Model `encode` type signature in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ class MyModel():
             batch_size (`int`): Batch size for the encoding
 
         Returns:
-            `List[np.ndarray]` or `List[tensor]`: List of embeddings for the given sentences
+            `np.array` or `tensor`: An array/tensor of embeddings for the given sentences.
+            Should have shape `(len(sentences), embedding_size)`
         """
         pass
 


### PR DESCRIPTION
Ran into a matrix math error when returning `List[np.array]` from my custom Model. Updating here so that others don't run into the same error and have to debug.

Let me know if this should instead be filed as a bug for `List[np.array]` return types not being supported