### PR TITLE
fix: add missing task-langs attribute

### DIFF
--- a/mteb/cmd.py
+++ b/mteb/cmd.py
@@ -52,6 +52,14 @@ def main():
         default=None,
         help="List of tasks to be evaluated. If specified, the other arguments are ignored.",
     )
+    parser.add_argument(
+        "-l",
+        "--task-langs",
+        nargs="*",
+        type=str,
+        default=None,
+        help="List of languages to be evaluated. if not set, all languages will be evaluated.",
+    )
     parser.add_argument("--device", type=int, default=None, help="Device to use for computation")
     parser.add_argument("--batch_size", type=int, default=32, help="Batch size for computation")
     parser.add_argument("--seed", type=int, default=42, help="Random seed for computation")


### PR DESCRIPTION
Currently the command line tool is not working because of a change made by #131. This might be fixed if the refactoring of the command line tool propose in #7 will be ever merged. However, since this PR is work in progress for over one year and not finished. I made this small fix.

At the moment you get the following error message when you try to run the mteb comment (version on main branch) because `args.task_langs` does not exsists:

```python
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/michael/workspace/mteb-long-documents/mteb/cmd.py", line 124, in <module>
    main()
  File "/home/michael/workspace/mteb-long-documents/mteb/cmd.py", line 117, in main
    task_categories=args.task_categories, task_types=args.task_types, task_langs=args.task_langs, tasks=args.tasks
AttributeError: 'Namespace' object has no attribute 'task_langs'
```