### PR TITLE
fix: msmarco-v2 uses dev.tsv, not dev1.tsv

### DIFF
--- a/mteb/tasks/Retrieval/MSMARCOv2Retrieval.py
+++ b/mteb/tasks/Retrieval/MSMARCOv2Retrieval.py
@@ -12,7 +12,7 @@ class MSMARCOv2(AbsTaskRetrieval, BeIRTask):
             "reference": "https://microsoft.github.io/msmarco/TREC-Deep-Learning.html",
             "type": "Retrieval",
             "category": "s2p",
-            "eval_splits": ["dev1", "dev2"],
+            "eval_splits": ["dev", "dev2"],
             "eval_langs": ["en"],
             "main_score": "ndcg_at_10",
         }


### PR DESCRIPTION
The `MSMARCOV2` class lists the `eval_splits` as `["dev1", "dev2"]`, but the actual names of the `.tsv` files are instead `["dev", "dev2"]`. As is, a `ValueError` is raised:

```python
ValueError: File /your_path_to_hf_cache/BeIR/msmarco-v2/qrels/dev1.tsv not present! Please provide accurate file.
```

The correct `dev.tsv` file name can be checked against [the url](https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/) used to [download the dataset](https://github.com/garrett361/mteb/blob/a1dbe2dc8ab468ced4e8e82cf283abb4ba31e16b/mteb/abstasks/BeIRTask.py#L50-L50).