### PR TITLE
feat: add code search net eval

### DIFF
--- a/mteb/tasks/Clustering/BigPatentClustering.py
+++ b/mteb/tasks/Clustering/BigPatentClustering.py
@@ -1,0 +1,21 @@
+from ...abstasks.AbsTaskClustering import AbsTaskClustering
+
+
+class BigPatentClustering(AbsTaskClustering):
+    @property
+    def description(self):
+        return {
+            "name": "BigPatentClustering",
+            "hf_hub_name": "jinaai/big-patent-clustering",
+            "description": (
+                "Clustering of documents from the Big Patent dataset. Test set only includes documents"
+                "belonging to a single category, with a total of 9 categories."
+            ),
+            "reference": "https://huggingface.co/datasets/big_patent",
+            "type": "Clustering",
+            "category": "p2p",
+            "eval_splits": ["test"],
+            "eval_langs": ["en"],
+            "main_score": "v_measure",
+            "revision": "62d5330920bca426ce9d3c76ea914f15fc83e891",
+        }

--- a/mteb/tasks/Clustering/WikiCitiesClustering.py
+++ b/mteb/tasks/Clustering/WikiCitiesClustering.py
@@ -9,7 +9,7 @@ class WikiCitiesClustering(AbsTaskClustering):
             "hf_hub_name": "jinaai/cities_wiki_clustering",
             "description": (
                 "Clustering of Wikipedia articles of cities by country from https://huggingface.co/datasets/wikipedia."
-                "Test set includes cities from 133 countries."
+                "Test set includes 126 countries, and a total of 3531 cities."
             ),
             "reference": "https://huggingface.co/datasets/wikipedia",
             "type": "Clustering",
@@ -17,5 +17,5 @@ class WikiCitiesClustering(AbsTaskClustering):
             "eval_splits": ["test"],
             "eval_langs": ["en"],
             "main_score": "v_measure",
-            "revision": "2af05f538fd902351ce5ec7ac84f23f71d52bae1",
+            "revision": "ddc9ee9242fa65332597f70e967ecc38b9d734fa",
         }

--- a/mteb/tasks/Clustering/WikiCitiesClustering.py
+++ b/mteb/tasks/Clustering/WikiCitiesClustering.py
@@ -1,0 +1,21 @@
+from ...abstasks.AbsTaskClustering import AbsTaskClustering
+
+
+class WikiCitiesClustering(AbsTaskClustering):
+    @property
+    def description(self):
+        return {
+            "name": "WikiCitiesClustering",
+            "hf_hub_name": "jinaai/cities_wiki_clustering",
+            "description": (
+                "Clustering of Wikipedia articles of cities by country from https://huggingface.co/datasets/wikipedia."
+                "Test set includes cities from 133 countries."
+            ),
+            "reference": "https://huggingface.co/datasets/wikipedia",
+            "type": "Clustering",
+            "category": "p2p",
+            "eval_splits": ["test"],
+            "eval_langs": ["en"],
+            "main_score": "v_measure",
+            "revision": "2af05f538fd902351ce5ec7ac84f23f71d52bae1",
+        }

--- a/mteb/tasks/Clustering/__init__.py
+++ b/mteb/tasks/Clustering/__init__.py
@@ -15,3 +15,5 @@ from .TenKGnadClusteringS2S import *
 from .TwentyNewsgroupsClustering import *
 from .CMTEBClustering import *
 from .PolishClustering import *
+from .BigPatentClustering import *
+from .WikiCitiesClustering import *

--- a/mteb/tasks/Retrieval/CodeSearchNetRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetRetrieval.py
@@ -1,0 +1,45 @@
+import datasets
+from ...abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+
+
+class NarrativeQARetrieval(AbsTaskRetrieval):
+    _EVAL_SPLIT = 'test'
+
+    @property
+    def description(self):
+        return {
+            'name': 'CodeSearchNetRetrieval',
+            'hf_hub_name': 'code_search_net',
+            'reference': 'https://github.com/github/CodeSearchNet',
+            "description": (
+                "CodeSearchNet is a collection of datasets and benchmarks that explore the problem of code retrieval using natural language."
+            ),
+            "type": "Retrieval",
+            "category": "s2p",
+            "eval_splits": ["test"],
+            "eval_langs": ["en"],
+            "main_score": "mrr",
+        }
+
+    def load_data(self, **kwargs):
+        if self.data_loaded:
+            return
+
+        data = datasets.load_dataset(self.description['hf_hub_name'], split=self._EVAL_SPLIT)
+        self.queries = {self._EVAL_SPLIT: {}}
+        self.corpus = {self._EVAL_SPLIT: {}}
+        self.relevant_docs = {self._EVAL_SPLIT: {}}
+        q = set()
+        d = set()
+        for idx, row in enumerate(data):
+            if row['func_documentation_string'] in q:
+                continue
+            if row['func_code_string'] in d:
+                continue
+            q.add(row['func_documentation_string'])
+            d.add(row['func_code_string'])
+            self.queries[self._EVAL_SPLIT][f'q{idx}'] = row['func_documentation_string']
+            self.corpus[self._EVAL_SPLIT][f'd{idx}'] = row['func_code_string']
+            self.relevant_docs[self._EVAL_SPLIT][f'q{idx}'] = {f'd{idx}': 1}
+
+        self.data_loaded = True

--- a/mteb/tasks/Retrieval/NarrativeQARetrieval.py
+++ b/mteb/tasks/Retrieval/NarrativeQARetrieval.py
@@ -1,0 +1,35 @@
+import datasets
+from ...abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+
+
+class NarrativeQARetrieval(AbsTaskRetrieval):
+
+    _EVAL_SPLIT = 'test'
+
+    @property
+    def description(self):
+        return {
+            'name': 'NarrativeQARetrieval',
+            'hf_hub_name': 'narrativeqa',
+            'reference': 'https://metatext.io/datasets/narrativeqa',
+            "description": (
+                "NarrativeQA is a dataset for the task of question answering on long narratives. It consists of "
+                "realistic QA instances collected from literature (fiction and non-fiction) and movie scripts. "
+            ),
+            "type": "Retrieval",
+            "category": "s2p",
+            "eval_splits": ["test"],
+            "eval_langs": ["en"],
+            "main_score": "ndcg_at_10",
+        }
+
+    def load_data(self, **kwargs):
+        if self.data_loaded:
+            return
+
+        data = datasets.load_dataset(self.description['hf_hub_name'], split=self._EVAL_SPLIT)
+        self.queries = {self._EVAL_SPLIT: {str(i): row['question']['text'] for i, row in enumerate(data)}}
+        self.corpus = {self._EVAL_SPLIT: {str(row['document']['id']): {'text': row['document']['text']} for row in data}}
+        self.relevant_docs = {self._EVAL_SPLIT: {str(i): {row['document']['id']: 1} for i, row in enumerate(data)}}
+
+        self.data_loaded = True

--- a/mteb/tasks/Retrieval/__init__.py
+++ b/mteb/tasks/Retrieval/__init__.py
@@ -37,3 +37,4 @@ from .QuoraPLRetrieval import *
 from .SCIDOCSPLRetrieval import *
 from .SciFactPLRetrieval import *
 from .TRECCOVIDPLRetrieval import *
+from .NarrativeQARetrieval import *


### PR DESCRIPTION
script is not identical as original code search net, now i'm using:

function docstring to search function code, also very short function docstring (length < 3) has been filtered.

The result is evaluated based on mean reciprocal rank (mrr) since each docstring has 1 matched code.