### PR TITLE
Added spanish passage retrieval

### DIFF
--- a/mteb/tasks/Retrieval/SpanishPassageRetrievalS2P.py
+++ b/mteb/tasks/Retrieval/SpanishPassageRetrievalS2P.py
@@ -1,0 +1,35 @@
+from ...abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+
+import datasets
+
+
+class SpanishPassageRetrievalS2P(AbsTaskRetrieval):
+    @property
+    def description(self):
+        return {
+            "name": "SpanishPassageRetrievalS2P",
+            "hf_hub_name": "jinaai/spanish_passage_retrieval",
+            "description": "Test collection for passage retrieval from health-related Web resources in Spanish.",
+            "reference": "https://mklab.iti.gr/results/spanish-passage-retrieval-dataset/",
+            "type": "Retrieval",
+            "category": "s2p",
+            "eval_splits": ["test"],
+            "eval_langs": ["es"],
+            "main_score": "ndcg_at_10",
+        }
+
+    def load_data(self, **kwargs):
+        if self.data_loaded:
+            return
+
+        query_rows = datasets.load_dataset(self.description["hf_hub_name"], "queries", split='test', trust_remote_code=True)
+        corpus_rows = datasets.load_dataset(self.description["hf_hub_name"], "corpus.documents", split='test', trust_remote_code=True)
+        qrels_rows = datasets.load_dataset(self.description["hf_hub_name"], "qrels.s2p", split='test', trust_remote_code=True)
+
+        self.queries = {'test': {row["_id"]: row["text"] for row in query_rows}}
+        self.corpus = {'test': {row["_id"]: row for row in corpus_rows}}
+        self.relevant_docs = {
+            'test': {row["_id"]: {v: 1 for v in row["text"].split(" ")} for row in qrels_rows}
+        }
+
+        self.data_loaded = True

--- a/mteb/tasks/Retrieval/SpanishPassageRetrievalS2S.py
+++ b/mteb/tasks/Retrieval/SpanishPassageRetrievalS2S.py
@@ -1,0 +1,35 @@
+from ...abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+
+import datasets
+
+
+class SpanishPassageRetrievalS2S(AbsTaskRetrieval):
+    @property
+    def description(self):
+        return {
+            "name": "SpanishPassageRetrievalS2S",
+            "hf_hub_name": "jinaai/spanish_passage_retrieval",
+            "description": "Test collection for passage retrieval from health-related Web resources in Spanish.",
+            "reference": "https://mklab.iti.gr/results/spanish-passage-retrieval-dataset/",
+            "type": "Retrieval",
+            "category": "s2s",
+            "eval_splits": ["test"],
+            "eval_langs": ["es"],
+            "main_score": "ndcg_at_10",
+        }
+
+    def load_data(self, **kwargs):
+        if self.data_loaded:
+            return
+
+        query_rows = datasets.load_dataset(self.description["hf_hub_name"], "queries", split='test', trust_remote_code=True)
+        corpus_rows = datasets.load_dataset(self.description["hf_hub_name"], "corpus.sentences", split='test', trust_remote_code=True)
+        qrels_rows = datasets.load_dataset(self.description["hf_hub_name"], "qrels.s2s", split='test', trust_remote_code=True)
+
+        self.queries = {'test': {row["_id"]: row["text"] for row in query_rows}}
+        self.corpus = {'test': {row["_id"]: row for row in corpus_rows}}
+        self.relevant_docs = {
+            'test': {row["_id"]: {v: 1 for v in row["text"].split(" ")} for row in qrels_rows}
+        }
+
+        self.data_loaded = True

--- a/mteb/tasks/Retrieval/__init__.py
+++ b/mteb/tasks/Retrieval/__init__.py
@@ -38,3 +38,5 @@ from .SCIDOCSPLRetrieval import *
 from .SciFactPLRetrieval import *
 from .TRECCOVIDPLRetrieval import *
 from .NarrativeQARetrieval import *
+from .SpanishPassageRetrievalS2S import *
+from .SpanishPassageRetrievalS2P import *

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ setup(
         "torch",
         "tqdm",
         "rich",
+        "patool",
     ],
     extras_require=extras,
     classifiers=[


### PR DESCRIPTION
This adds this dataset here: https://mklab.iti.gr/results/spanish-passage-retrieval-dataset/
We add both an S2S variant and an S2P variant.

Multilingual E5 Base performance (NDCG@10):
- S2S: 0.62613
- S2P: 0.39404