### PR TITLE
[#215] Optionally specify language when encoding texts 

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ You can evaluate only on `test` splits of all tasks by doing the following:
 evaluation.run(model, eval_splits=["test"])
 ```
 
-Note that the public leaderboard uses the test splits for all datasets except MSMARCO, where the "dev" split is used.
+Note that the public leaderboard for English uses the test splits for all datasets except MSMARCO, where the "dev" split is used.
 
 ### Using a custom model
 
@@ -137,6 +137,13 @@ model = MyModel()
 evaluation = MTEB(tasks=["Banking77Classification"])
 evaluation.run(model)
 ```
+Please note that some evaluators pass additional arguments to `encode` (such as `show_progress_bar` or `convert_to_tensor`), 
+expecting the [SentenceTransformer.method](https://github.com/UKPLab/sentence-transformers/blob/master/sentence_transformers/SentenceTransformer.py#L220) 
+or a compatible one. A custom `encode` method with `**kwargs` will ignore all such extra arguments.
+
+If your model needs the language tag to embed the texts, you can add the `language` argument to its `encode` method.
+If you are running it on multilingual tasks, please make sure that diverse language codes 
+(such as `es`, `ber`, `zh-TW`, `da-bornholm`) are processed correctly.
 
 If you'd like to use different encoding functions for query and corpus when evaluating on Retrieval or Reranking tasks, you can add separate methods for `encode_queries` and `encode_corpus`. If these methods exist, they will be automatically used for those tasks. You can refer to the `DRESModel` at `mteb/mteb/abstasks/AbsTaskRetrieval.py` for an example of these functions.
 
@@ -199,6 +206,11 @@ evaluation.run(model)
 ```
 
 > **Note:** for multilingual tasks, make sure your class also inherits from the `MultilingualTask` class like in [this](https://github.com/embeddings-benchmark/mteb-draft/blob/main/mteb/tasks/Classification/MTOPIntentClassification.py) example.
+
+### Task-specific notes
+* To run the `DKHateClassification` task (Danish language) you need first to manually ask for access to the gated 
+dataset: https://huggingface.co/datasets/DDSC/dkhate.
+
 
 ## Leaderboard
 

--- a/mteb/abstasks/AbsTask.py
+++ b/mteb/abstasks/AbsTask.py
@@ -56,3 +56,11 @@ class AbsTask(ABC):
         :param split: Which datasplit to be used.
         """
         raise NotImplementedError
+
+    def get_language(self):
+        """ Return the first language of the task.
+        This is not meaningful for multilingual or cross-lingual tasks.
+        Also, a few Nordic tasks although not marked as multilingual, contain multiple languages.
+        For them, the first language will be returned.
+        """
+        return self.description['eval_langs'][0]

--- a/mteb/abstasks/AbsTask.py
+++ b/mteb/abstasks/AbsTask.py
@@ -1,9 +1,13 @@
+import logging
 import random
 from abc import ABC, abstractmethod
 
 import datasets
 import numpy as np
 import torch
+
+
+logger = logging.getLogger(__name__)
 
 
 class AbsTask(ABC):
@@ -63,4 +67,8 @@ class AbsTask(ABC):
         Also, a few Nordic tasks although not marked as multilingual, contain multiple languages.
         For them, the first language will be returned.
         """
-        return self.description['eval_langs'][0]
+        langs = self.description['eval_langs']
+        if len(langs) != 1:
+            name = self.description['name']
+            logger.warning(f"For task {name}, the number of languages is not 1: {langs}. Is it multi- or cross-lingual?")
+        return langs[0]

--- a/mteb/abstasks/AbsTaskBitextMining.py
+++ b/mteb/abstasks/AbsTaskBitextMining.py
@@ -19,15 +19,15 @@ class AbsTaskBitextMining(AbsTask):
             for lang in self.dataset:
                 logger.info(f"\nTask: {self.description['name']}, split: {split}, language: {lang}. Running...")
                 data_split = self.dataset[lang][split]
-                scores[lang] = self._evaluate_split(model, data_split, **kwargs)
+                scores[lang] = self._evaluate_split(model, data_split, split_langs=lang, **kwargs)
         else:
             logger.info(f"\nTask: {self.description['name']}, split: {split}. Running...")
             data_split = self.dataset[split]
-            scores = self._evaluate_split(model, data_split, **kwargs)
+            scores = self._evaluate_split(model, data_split, split_langs=self.get_language(), **kwargs)
 
         return scores
 
-    def _evaluate_split(self, model, data_split, **kwargs):
+    def _evaluate_split(self, model, data_split, split_langs, **kwargs):
         if len(data_split["sentence1"]) == 1:
             sentence1 = data_split["sentence1"][0]
         else:
@@ -52,7 +52,7 @@ class AbsTaskBitextMining(AbsTask):
                 [(i > 0) and (j > 0) for i, j in gold]
             ), "Found negative gold indices. This may be caused by MTEB expecting 1-indexed gold labels."
 
-        evaluator = BitextMiningEvaluator(sentence1, sentence2, gold, **kwargs)
+        evaluator = BitextMiningEvaluator(sentence1, sentence2, gold, language=split_langs, **kwargs)
         metrics = evaluator(model)
         self._add_main_score(metrics)
         return metrics

--- a/mteb/abstasks/AbsTaskClassification.py
+++ b/mteb/abstasks/AbsTaskClassification.py
@@ -48,16 +48,16 @@ class AbsTaskClassification(AbsTask):
             scores = {}
             for lang in self.dataset:
                 logger.info(f"\nTask: {self.description['name']}, split: {eval_split}, language: {lang}. Running...")
-                scores[lang] = self._evaluate_monolingual(model, self.dataset[lang], eval_split, train_split, **kwargs)
+                scores[lang] = self._evaluate_monolingual(model, self.dataset[lang], eval_split, train_split, language=lang, **kwargs)
                 self._add_main_score(scores[lang])
         else:
             logger.info(f"\nTask: {self.description['name']}, split: {eval_split}. Running...")
-            scores = self._evaluate_monolingual(model, self.dataset, eval_split, train_split, **kwargs)
+            scores = self._evaluate_monolingual(model, self.dataset, eval_split, train_split, language=self.get_language(), **kwargs)
             self._add_main_score(scores)
 
         return scores
 
-    def _evaluate_monolingual(self, model, dataset, eval_split="test", train_split="train", **kwargs):
+    def _evaluate_monolingual(self, model, dataset, eval_split="test", train_split="train", language=None, **kwargs):
         train_split = dataset[train_split]
         eval_split = dataset[eval_split]
         params = {"k": self.k, "batch_size": self.batch_size}
@@ -74,15 +74,15 @@ class AbsTaskClassification(AbsTask):
 
             if self.method == "kNN":
                 evaluator = kNNClassificationEvaluator(
-                    X_sampled, y_sampled, eval_split["text"], eval_split["label"], **params
+                    X_sampled, y_sampled, eval_split["text"], eval_split["label"], language=language, **params
                 )
             elif self.method == "kNN-pytorch":
                 evaluator = kNNClassificationEvaluatorPytorch(
-                    X_sampled, y_sampled, eval_split["text"], eval_split["label"], **params
+                    X_sampled, y_sampled, eval_split["text"], eval_split["label"], language=language, **params
                 )
             elif self.method == "logReg":
                 evaluator = logRegClassificationEvaluator(
-                    X_sampled, y_sampled, eval_split["text"], eval_split["label"], **params
+                    X_sampled, y_sampled, eval_split["text"], eval_split["label"], language=language, **params
                 )
             else:
                 raise ValueError(f"Method {self.method} not supported")

--- a/mteb/abstasks/AbsTaskClustering.py
+++ b/mteb/abstasks/AbsTaskClustering.py
@@ -15,7 +15,7 @@ class AbsTaskClustering(AbsTask):
 
         v_measures = []
         for cluster_set in tqdm.tqdm(self.dataset[split], desc="Clustering"):
-            evaluator = ClusteringEvaluator(cluster_set["sentences"], cluster_set["labels"], **kwargs)
+            evaluator = ClusteringEvaluator(cluster_set["sentences"], cluster_set["labels"], language=self.get_language(), **kwargs)
             metrics = evaluator(model)
             v_measures.append(metrics["v_measure"])
 

--- a/mteb/abstasks/AbsTaskPairClassification.py
+++ b/mteb/abstasks/AbsTaskPairClassification.py
@@ -23,7 +23,9 @@ class AbsTaskPairClassification(AbsTask):
 
         logging.getLogger("sentence_transformers.evaluation.PairClassificationEvaluator").setLevel(logging.WARN)
         evaluator = PairClassificationEvaluator(
-            data_split["sent1"], data_split["sent2"], data_split["labels"], **kwargs
+            data_split["sent1"], data_split["sent2"], data_split["labels"], 
+            language=self.get_language(),
+            **kwargs
         )
         scores = evaluator.compute_metrics(model)
 

--- a/mteb/abstasks/AbsTaskReranking.py
+++ b/mteb/abstasks/AbsTaskReranking.py
@@ -20,7 +20,7 @@ class AbsTaskReranking(AbsTask):
 
         data_split = self.dataset[split]
 
-        evaluator = RerankingEvaluator(data_split, **kwargs)
+        evaluator = RerankingEvaluator(data_split, language=self.get_language(), **kwargs)
         scores = evaluator(model)
 
         return dict(scores)

--- a/mteb/abstasks/AbsTaskRetrieval.py
+++ b/mteb/abstasks/AbsTaskRetrieval.py
@@ -77,7 +77,7 @@ class AbsTaskRetrieval(AbsTask):
             )
 
 
-
+        # TODO: find a way to pass the language to the retriever model
         retriever = EvaluateRetrieval(model, score_function=score_function)  # or "cos_sim" or "dot"
         start_time = time()
         results = retriever.retrieve(corpus, queries)

--- a/mteb/abstasks/AbsTaskSTS.py
+++ b/mteb/abstasks/AbsTaskSTS.py
@@ -34,19 +34,19 @@ class AbsTaskSTS(AbsTask):
             for lang in self.dataset:
                 logger.info(f"Task: {self.description['name']}, split: {split}, language: {lang}. Running...")
                 data_split = self.dataset[lang][split]
-                scores[lang] = self._evaluate_split(model, data_split, **kwargs)
+                scores[lang] = self._evaluate_split(model, data_split, language=lang, **kwargs)
         else:
             logger.info(f"\nTask: {self.description['name']}, split: {split}. Running...")
             data_split = self.dataset[split]
-            scores = self._evaluate_split(model, data_split, **kwargs)
+            scores = self._evaluate_split(model, data_split, language=self.get_language(), **kwargs)
 
         return scores
 
-    def _evaluate_split(self, model, data_split, **kwargs):
+    def _evaluate_split(self, model, data_split, language, **kwargs):
         def normalize(x):
             return (x - self.min_score) / (self.max_score - self.min_score)
 
         normalized_scores = list(map(normalize, data_split["score"]))
-        evaluator = STSEvaluator(data_split["sentence1"], data_split["sentence2"], normalized_scores, **kwargs)
+        evaluator = STSEvaluator(data_split["sentence1"], data_split["sentence2"], normalized_scores, language=language, **kwargs)
         metrics = evaluator(model)
         return metrics

--- a/mteb/abstasks/AbsTaskSummarization.py
+++ b/mteb/abstasks/AbsTaskSummarization.py
@@ -37,15 +37,15 @@ class AbsTaskSummarization(AbsTask):
             for lang in self.dataset:
                 logger.info(f"\nTask: {self.description['name']}, split: {split}, language: {lang}. Running...")
                 data_split = self.dataset[lang][split]
-                scores[lang] = self._evaluate_split(model, data_split, **kwargs)
+                scores[lang] = self._evaluate_split(model, data_split, language=lang, **kwargs)
         else:
             logger.info(f"\nTask: {self.description['name']}, split: {split}. Running...")
             data_split = self.dataset[split]
-            scores = self._evaluate_split(model, data_split, **kwargs)
+            scores = self._evaluate_split(model, data_split, language=self.get_language(), **kwargs)
 
         return scores
 
-    def _evaluate_split(self, model, data_split, **kwargs):
+    def _evaluate_split(self, model, data_split, language, **kwargs):
         normalized_scores = list(
             map(lambda x: (np.array(x) - self.min_score) / (self.max_score - self.min_score), data_split["relevance"])
         )
@@ -54,6 +54,7 @@ class AbsTaskSummarization(AbsTask):
             human_summaries=data_split["human_summaries"],
             texts=data_split["text"],
             gold_scores=normalized_scores,
+            language=language,
             **kwargs,
         )
         metrics = evaluator(model)

--- a/mteb/evaluation/evaluators/ClassificationEvaluator.py
+++ b/mteb/evaluation/evaluators/ClassificationEvaluator.py
@@ -1,4 +1,5 @@
 import logging
+from mteb.utils import get_embed_with_lang_func
 
 import numpy as np
 import torch
@@ -13,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 class kNNClassificationEvaluator(Evaluator):
-    def __init__(self, sentences_train, y_train, sentences_test, y_test, k=1, batch_size=32, limit=None, **kwargs):
+    def __init__(self, sentences_train, y_train, sentences_test, y_test, language, k=1, batch_size=32, limit=None, **kwargs):
         super().__init__(**kwargs)
         if limit is not None:
             sentences_train = sentences_train[:limit]
@@ -29,14 +30,18 @@ class kNNClassificationEvaluator(Evaluator):
 
         self.k = k
 
+        self.langauge = language
+
     def __call__(self, model, test_cache=None):
         scores = {}
         max_accuracy = 0
         max_f1 = 0
         max_ap = 0
-        X_train = np.asarray(model.encode(self.sentences_train, batch_size=self.batch_size))
+        embed_fn = get_embed_with_lang_func(model)
+
+        X_train = np.asarray(embed_fn(self.sentences_train, batch_size=self.batch_size, language=self.language))
         if test_cache is None:
-            X_test = np.asarray(model.encode(self.sentences_test, batch_size=self.batch_size))
+            X_test = np.asarray(embed_fn(self.sentences_test, batch_size=self.batch_size, language=self.language))
             test_cache = X_test
         else:
             X_test = test_cache
@@ -63,7 +68,7 @@ class kNNClassificationEvaluator(Evaluator):
 
 
 class kNNClassificationEvaluatorPytorch(Evaluator):
-    def __init__(self, sentences_train, y_train, sentences_test, y_test, k=1, batch_size=32, limit=None, **kwargs):
+    def __init__(self, sentences_train, y_train, sentences_test, y_test, language, k=1, batch_size=32, limit=None, **kwargs):
         super().__init__(**kwargs)
         if limit is not None:
             sentences_train = sentences_train[:limit]
@@ -80,14 +85,19 @@ class kNNClassificationEvaluatorPytorch(Evaluator):
 
         self.k = k
 
+        self.language = language
+
     def __call__(self, model, test_cache=None):
         scores = {}
         max_accuracy = 0
         max_f1 = 0
         max_ap = 0
-        X_train = np.asarray(model.encode(self.sentences_train, batch_size=self.batch_size))
+
+        embed_fn = get_embed_with_lang_func(model)
+
+        X_train = np.asarray(embed_fn(self.sentences_train, batch_size=self.batch_size, language=self.language))
         if test_cache is None:
-            X_test = np.asarray(model.encode(self.sentences_test, batch_size=self.batch_size))
+            X_test = np.asarray(embed_fn(self.sentences_test, batch_size=self.batch_size, language=self.language))
             test_cache = X_test
         else:
             X_test = test_cache
@@ -183,7 +193,7 @@ class kNNClassificationEvaluatorPytorch(Evaluator):
 
 class logRegClassificationEvaluator(Evaluator):
     def __init__(
-        self, sentences_train, y_train, sentences_test, y_test, max_iter=100, batch_size=32, limit=None, **kwargs
+        self, sentences_train, y_train, sentences_test, y_test, language, max_iter=100, batch_size=32, limit=None, **kwargs
     ):
         super().__init__(**kwargs)
         if limit is not None:
@@ -198,6 +208,7 @@ class logRegClassificationEvaluator(Evaluator):
 
         self.max_iter = max_iter
         self.batch_size = batch_size
+        self.language = language
 
     def __call__(self, model, test_cache=None):
         scores = {}
@@ -208,10 +219,11 @@ class logRegClassificationEvaluator(Evaluator):
             verbose=1 if logger.isEnabledFor(logging.DEBUG) else 0,
         )
         logger.info(f"Encoding {len(self.sentences_train)} training sentences...")
-        X_train = np.asarray(model.encode(self.sentences_train, batch_size=self.batch_size))
+        embed_fn = get_embed_with_lang_func(model)
+        X_train = np.asarray(embed_fn(self.sentences_train, batch_size=self.batch_size, language=self.language))
         logger.info(f"Encoding {len(self.sentences_test)} test sentences...")
         if test_cache is None:
-            X_test = np.asarray(model.encode(self.sentences_test, batch_size=self.batch_size))
+            X_test = np.asarray(embed_fn(self.sentences_test, batch_size=self.batch_size, language=self.language))
             test_cache = X_test
         else:
             X_test = test_cache

--- a/mteb/evaluation/evaluators/ClusteringEvaluator.py
+++ b/mteb/evaluation/evaluators/ClusteringEvaluator.py
@@ -1,4 +1,5 @@
 import logging
+from mteb.utils import get_embed_with_lang_func
 
 import numpy as np
 import sklearn
@@ -10,7 +11,7 @@ from .Evaluator import Evaluator
 
 
 class ClusteringEvaluator(Evaluator):
-    def __init__(self, sentences, labels, clustering_batch_size=500, batch_size=32, limit=None, **kwargs):
+    def __init__(self, sentences, labels, language, clustering_batch_size=500, batch_size=32, limit=None, **kwargs):
         super().__init__(**kwargs)
         if limit is not None:
             sentences = sentences[:limit]
@@ -19,10 +20,12 @@ class ClusteringEvaluator(Evaluator):
         self.labels = labels
         self.clustering_batch_size = clustering_batch_size
         self.batch_size = batch_size
+        self.language = language
 
     def __call__(self, model):
         logger.info(f"Encoding {len(self.sentences)} sentences...")
-        corpus_embeddings = np.asarray(model.encode(self.sentences, batch_size=self.batch_size))
+        embed_fn = get_embed_with_lang_func(model)
+        corpus_embeddings = np.asarray(embed_fn(self.sentences, batch_size=self.batch_size, language=self.language))
 
         logger.info("Fitting Mini-Batch K-Means model...")
         clustering_model = sklearn.cluster.MiniBatchKMeans(

--- a/mteb/evaluation/evaluators/PairClassificationEvaluator.py
+++ b/mteb/evaluation/evaluators/PairClassificationEvaluator.py
@@ -57,7 +57,6 @@ class PairClassificationEvaluator(Evaluator):
 
     def compute_metrics(self, model):
         embed_fn = get_embed_with_lang_func(model)
-         # TODO: split the language in two, if this task is cross-lingual
         lang1, lang2 = maybe_split_language_pair(self.language)
         logger.info(f"Encoding {len(self.sentences1)} LHS sentences...")
         embeddings1 = embed_fn(self.sentences1, language=lang1)

--- a/mteb/evaluation/evaluators/RerankingEvaluator.py
+++ b/mteb/evaluation/evaluators/RerankingEvaluator.py
@@ -1,4 +1,5 @@
 import logging
+from mteb.utils import get_embed_with_lang_func
 
 import numpy as np
 import torch
@@ -32,6 +33,7 @@ class RerankingEvaluator(Evaluator):
         batch_size: int = 512,
         use_batched_encoding: bool = True,
         limit: int = None,
+        language: str = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -43,6 +45,7 @@ class RerankingEvaluator(Evaluator):
         self.similarity_fct = similarity_fct
         self.batch_size = batch_size
         self.use_batched_encoding = use_batched_encoding
+        self.language = language
 
         if isinstance(self.samples, dict):
             self.samples = list(self.samples.values())
@@ -73,8 +76,8 @@ class RerankingEvaluator(Evaluator):
 
         # using encode_queries and encode_corpus functions if they exists,
         # which can be defined by users to add different instructions for query and passage conveniently
-        encode_queries_func = model.encode_queries if hasattr(model, 'encode_queries') else model.encode
-        encode_corpus_func = model.encode_corpus if hasattr(model, 'encode_corpus') else model.encode
+        encode_queries_func = get_embed_with_lang_func(model, language=self.language, query_specific=True)
+        encode_corpus_func = get_embed_with_lang_func(model, language=self.language, corpus_specific=True)
 
         logger.info("Encoding queries...")
         if isinstance(self.samples[0]["query"], str):
@@ -136,8 +139,8 @@ class RerankingEvaluator(Evaluator):
 
         # using encode_queries and encode_corpus functions if they exists,
         # which can be defined by users to add different instructions for query and passage conveniently
-        encode_queries_func = model.encode_queries if hasattr(model, 'encode_queries') else model.encode
-        encode_corpus_func = model.encode_corpus if hasattr(model, 'encode_corpus') else model.encode
+        encode_queries_func = get_embed_with_lang_func(model, language=self.language, query_specific=True)
+        encode_corpus_func = get_embed_with_lang_func(model, language=self.language, corpus_specific=True)
         
         for instance in tqdm.tqdm(self.samples, desc="Samples"):
             query = instance["query"]

--- a/mteb/evaluation/evaluators/SummarizationEvaluator.py
+++ b/mteb/evaluation/evaluators/SummarizationEvaluator.py
@@ -1,4 +1,5 @@
 import logging
+from mteb.utils import get_embed_with_lang_func
 
 import numpy as np
 import torch
@@ -18,6 +19,7 @@ class SummarizationEvaluator(Evaluator):
         human_summaries=None,
         machine_summaries=None,
         texts=None,
+        language=None,
         gold_scores=None,
         limit=None,
         batch_size=32,
@@ -38,6 +40,7 @@ class SummarizationEvaluator(Evaluator):
         self.texts = texts
         self.gold_scores = gold_scores
         self.batch_size = batch_size
+        self.language = language
 
     def __call__(self, model):
         cosine_spearman_scores = []
@@ -50,14 +53,17 @@ class SummarizationEvaluator(Evaluator):
         machine_lens = [len(machine_summaries) for machine_summaries in self.machine_summaries]
 
         logger.info(f"Encoding {sum(human_lens)} human summaries...")
-        embs_human_summaries_all = model.encode(
+        embed_fn = get_embed_with_lang_func(model)
+        embs_human_summaries_all = embed_fn(
             [summary for human_summaries in self.human_summaries for summary in human_summaries],
             batch_size=self.batch_size,
+            language=self.language,
         )
         logger.info(f"Encoding {sum(machine_lens)} machine summaries...")
-        embs_machine_summaries_all = model.encode(
+        embs_machine_summaries_all = embed_fn(
             [summary for machine_summaries in self.machine_summaries for summary in machine_summaries],
             batch_size=self.batch_size,
+            language=self.language,
         )
 
         # Split the embeddings into the original human & machine summaries

--- a/mteb/tasks/BitextMining/NorwegianCourtsBitextMining.py
+++ b/mteb/tasks/BitextMining/NorwegianCourtsBitextMining.py
@@ -19,7 +19,7 @@ class NorwegianCourtsBitextMining(AbsTaskBitextMining):
             "eval_splits": ["test"],
             "eval_langs": ["nb", "nn"],
             "main_score": "f1",
-            "revision": "3bc5cfb4ec514264fe2db5615fac9016f7251552",
+            "revision": None,
         }
 
     def load_data(self, **kwargs):

--- a/mteb/tasks/Classification/ScalaClassification.py
+++ b/mteb/tasks/Classification/ScalaClassification.py
@@ -52,7 +52,7 @@ class ScalaNbClassification(AbsTaskClassification):
             "type": "Classification",
             "category": "s2s",
             "eval_splits": ["test"],
-            "eval_langs": ["no", "nb"],
+            "eval_langs": ["nb"],
             "main_score": "accuracy",
             "n_experiments": 10,
             "samples_per_label": 16,
@@ -83,14 +83,14 @@ class ScalaNnClassification(AbsTaskClassification):
     @property
     def description(self):
         return {
-            "name": "ScalaNbClassification",
+            "name": "ScalaNnClassification",
             "hf_hub_name": "ScandEval/scala-nn",
             "description": "A Norwegian dataset for linguistic acceptability classification for Nynorsk",
             "reference": "https://aclanthology.org/2023.nodalida-1.20/",
             "type": "Classification",
             "category": "s2s",
             "eval_splits": ["test"],
-            "eval_langs": ["no", "nn"],
+            "eval_langs": ["nn"],
             "main_score": "accuracy",
             "n_experiments": 10,
             "samples_per_label": 16,

--- a/mteb/utils.py
+++ b/mteb/utils.py
@@ -1,0 +1,47 @@
+import inspect
+
+
+def get_embed_with_lang_func(model, query_specific=False, corpus_specific=False):
+    """
+    If model.encode supports the `language` argument, return this function.
+    Otherwise, return a wrapper of model.encode with this extra argument.
+    This is needed, because some of the models migh embed in a language-specific way.
+    """
+    func = model.encode
+
+    # for reranking tasks, a model (like E5) may have special methods for encoding queries and passages.
+    if query_specific and hasattr(model, 'encode_queries'):
+        func = model.encode_queries
+    if corpus_specific and hasattr(model, 'encode_corpus'):
+        func = model.encode_corpus
+
+    signature = inspect.signature(func)
+    if "language" in signature.parameters:
+        return func
+
+    # TODO: describe the signature of this function with more details
+    # text, batch_size, maybe progress_bar
+    def func_without_language(sentences, *args, language=None, **kwargs):
+        return func(sentences, *args, **kwargs)
+
+    return func_without_language
+
+
+# language codes that contain a dash and should not be split 
+LANGS_WITH_DASH = {
+    "zh-CN", 
+    "zh-TW",
+    "da-bornholm",
+    "en-ext",  # ???
+}
+
+
+def maybe_split_language_pair(lang: str):
+    """
+    If the language code is actually a pair (like "en-fr"), return the two individual language codes.
+    Otherwise, return the input language code twice.
+    """
+    if isinstance(lang, str) and lang.count('-') == 1 and lang not in LANGS_WITH_DASH:
+        lang1, lang2 = lang.split('-')
+        return lang1, lang2
+    return lang, lang

--- a/tests/test_ClusteringEvaluator.py
+++ b/tests/test_ClusteringEvaluator.py
@@ -13,7 +13,7 @@ class TestClusteringEvaluator:
 
         model = Model()
         sentences = ["dog walked home", "cat walked home", "robot walked to the park"]
-        clusterer = ClusteringEvaluator(sentences=sentences, labels=[1, 2, 3])
+        clusterer = ClusteringEvaluator(sentences=sentences, labels=[1, 2, 3], language="en")
         result = clusterer(model)
 
         assert result == {"v_measure": 1.0}

--- a/tests/test_RetrievalEvaluator.py
+++ b/tests/test_RetrievalEvaluator.py
@@ -23,6 +23,7 @@ class TestRetrievalEvaluator:
             accuracy_at_k=[],
             precision_recall_at_k=[],
             map_at_k=[],
+            language="en",
         )
 
     def test_accuracy_at_k(self):


### PR DESCRIPTION
**Motivation**: see #215 

**Implementation**: 
- Add the language argument to each abstract task and each evaluator, and pass to the model, if its encode method has the `language` argument.
- For cross-lingual tasks, split the language code in two.
- Include https://github.com/embeddings-benchmark/mteb/pull/221.
- Fix task name `ScalaNnClassification` (it used to be `ScalaNbClassification`, copy-pasted from the previous task).
- For `ScalaNbClassification` and `ScalaNnClassification`, remove redundant language codes, because they are monolingual: `nn` and `nb` are just special cases of `no`.
- Update the readme with a few nits about non-English task.

**Some issues spotted**
- A few tasks are not marked as multilingual or crosslingual, but do contain multiple languages (BornholmBitextMining, NordicLangClassification, ScalaNbClassification, ScalaNnClassification). The last two seem to be monolingual, but are marked with two codes. BornholmBitextMining contains Danish and its Bornholm dialect; both will be interpreted as Danish by the model. 
For NordicLangClassification; the first language code (da) will be passed to the model for the texts in all languages. Using the same code for all languages makes sense (because we want to classify the languages without leaking the answer), but the choice of the code is arbitrary.
- Polish retrieval tasks still don't work: https://github.com/embeddings-benchmark/mteb/issues/219

**Testing**
Relying on the automatic tests. 
Also, succesfully ran the evaluation with SONAR in https://github.com/embeddings-benchmark/mteb/issues/139.