### PR TITLE
Fixed missing revision error on Norwegian Bitext Mining

### DIFF
--- a/mteb/tasks/BitextMining/NorwegianCourtsBitextMining.py
+++ b/mteb/tasks/BitextMining/NorwegianCourtsBitextMining.py
@@ -19,7 +19,7 @@ class NorwegianCourtsBitextMining(AbsTaskBitextMining):
             "eval_splits": ["test"],
             "eval_langs": ["nb", "nn"],
             "main_score": "f1",
-            "revision": "3bc5cfb4ec514264fe2db5615fac9016f7251552",
+            "revision": None,
         }
 
     def load_data(self, **kwargs):

--- a/mteb/tasks/BitextMining/NorwegianCourtsBitextMining.py
+++ b/mteb/tasks/BitextMining/NorwegianCourtsBitextMining.py
@@ -19,7 +19,7 @@ class NorwegianCourtsBitextMining(AbsTaskBitextMining):
             "eval_splits": ["test"],
             "eval_langs": ["nb", "nn"],
             "main_score": "f1",
-            "revision": None,
+            "revision": "d79af07e969a6678fcbbe819956840425816468f",
         }
 
     def load_data(self, **kwargs):


### PR DESCRIPTION
I created the task originally by copying code over from another task, and accidentally left its specific git revision in there.
The issue has already been addressed in [SEB](https://kennethenevoldsen.github.io/scandinavian-embedding-benchmark/).