### PR TITLE
tests: do not run tests on collection

### DIFF
--- a/tests/test_all_abstasks.py
+++ b/tests/test_all_abstasks.py
@@ -7,17 +7,19 @@ from mteb.tasks.BitextMining import BUCCBitextMining
 
 logging.basicConfig(level=logging.INFO)
 
-model = SentenceTransformer("average_word_embeddings_komninos")
-eval = MTEB(
-    tasks=[
-        BUCCBitextMining(),
-        "Banking77Classification",
-        "TwentyNewsgroupsClustering",
-        "SciDocsRR",
-        "SprintDuplicateQuestions",
-        "NFCorpus",
-        "STS12",
-        "SummEval",
-    ]
-)
-eval.run(model)
+
+def test_mteb_tasks():
+    model = SentenceTransformer("average_word_embeddings_komninos")
+    eval = MTEB(
+        tasks=[
+            BUCCBitextMining(),
+            "Banking77Classification",
+            "TwentyNewsgroupsClustering",
+            "SciDocsRR",
+            "SprintDuplicateQuestions",
+            "NFCorpus",
+            "STS12",
+            "SummEval",
+        ]
+    )
+    eval.run(model)


### PR DESCRIPTION
I noticed test collection was quite slow. Turns out one of the tests was run on import, i.e. as soon as pytest collects the tests.

Instead, I have wrapped it as its own test, and collection is now much faster!