### PR TITLE
Improve logging when the revision is None

### DIFF
--- a/mteb/abstasks/TaskMetadata.py
+++ b/mteb/abstasks/TaskMetadata.py
@@ -176,7 +176,8 @@ class TaskMetadata(BaseModel):
                 "You must explicitly specify a revision for the dataset (either a SHA or None)."
             )
         if dataset["revision"] is None:
-            logging.warning(
-                "It is encourage to specify a dataset revision for reproducability"
+            logger.warning(
+                "Revision missing for the dataset %s. It is encourage to specify a dataset revision for reproducability.",
+                dataset["path"],
             )
         return dataset

--- a/tests/test_TaskMetadata.py
+++ b/tests/test_TaskMetadata.py
@@ -118,7 +118,12 @@ def test_given_none_revision_path_then_it_logs_warning(caplog):
         )
 
         assert my_task.dataset["revision"] is None
+
+        warning_logs = [record for record in caplog.records if record.levelname == "WARNING"]
+        assert len(warning_logs) == 1
         assert (
-            len([record for record in caplog.records if record.levelname == "WARNING"])
-            == 1
+            warning_logs[0].message ==
+            "Revision missing for the dataset test/dataset. "
+            "It is encourage to specify a dataset revision for reproducability."
         )
+


### PR DESCRIPTION
This small PR fixes the logging for the missing dataset revision:

- Use the current logger instead of the root logger
- Adds the path of the dataset to the log. Previously, let's say you have in your code base many datasets with missing revision, it would simply log the message a few times at import time without telling you which datasets are problematic.