### PR TITLE
Removing bitext mining tasks from fr evaluation script

### DIFF
--- a/scripts/run_mteb_french.py
+++ b/scripts/run_mteb_french.py
@@ -48,14 +48,6 @@ TASK_LIST_RETRIEVAL = [
 
 TASK_LIST_STS = ["SummEvalFr", "STSBenchmarkMultilingualSTS", "STS22", "SICKFr"]
 
-TASK_LIST_BITEXTMINING = [
-    "DiaBLaBitextMining",
-    "FloresBitextMining",
-    "TatoebaBitextMining",
-    "BUCCBitextMining",
-]
-
-
 TASK_LIST = (
     TASK_LIST_CLASSIFICATION
     + TASK_LIST_CLUSTERING
@@ -63,7 +55,6 @@ TASK_LIST = (
     + TASK_LIST_RERANKING
     + TASK_LIST_RETRIEVAL
     + TASK_LIST_STS
-    + TASK_LIST_BITEXTMINING
 )
 
 model_name = "dangvantuan/sentence-camembert-base"


### PR DESCRIPTION
Related to this issue #334
 
This PR removes bitext mining tasks from the French evaluation script, since these tasks need two input languages to run (which was making Flores run forever btw). They should be run separately. 
The scores are also not included in the French leaderboard since it concerns 2 languages and not one.