### PR TITLE
Add AbsTaskInstructionRetrieval from the FollowIR paper

### DIFF
--- a/mteb/__init__.py
+++ b/mteb/__init__.py
@@ -77,6 +77,12 @@ MTEB_MAIN_EN = [
     "TwitterURLCorpus",
 ]
 
+MTEB_RETRIEVAL_WITH_INSTRUCTIONS = [
+    "RobustInstructionRetrieval",
+    "NewsInstructionRetrieval",
+    "CoreInstructionRetrieval",
+]
+
 MTEB_RETRIEVAL_LAW = [
     "LegalSummarization",
     "LegalBenchConsumerContractsQA",

--- a/mteb/abstasks/AbstractTaskInstructionRetrieval.py
+++ b/mteb/abstasks/AbstractTaskInstructionRetrieval.py
@@ -1,0 +1,609 @@
+import json
+import logging
+import os
+from collections import defaultdict
+from time import time
+from typing import Dict, List, Tuple
+
+import tqdm
+from datasets import Features, Value, load_dataset
+
+from ..evaluation.evaluators import InstructionRetrievalEvaluator, utils
+from .AbsTask import AbsTask
+from .AbsTaskRetrieval import HFDataLoader
+
+logger = logging.getLogger(__name__)
+
+
+# Adapted from https://github.com/beir-cellar/beir/blob/f062f038c4bfd19a8ca942a9910b1e0d218759d4/beir/datasets/data_loader_hf.py#L10
+class HFDataLoaderInstructions(HFDataLoader):
+    def __init__(
+        self,
+        hf_repo: str = None,
+        hf_repo_qrels: str = None,
+        data_folder: str = None,
+        prefix: str = None,
+        corpus_file: str = "corpus.jsonl",
+        query_file: str = "queries.jsonl",
+        qrels_folder: str = "qrels",
+        qrels_file: str = "",
+        streaming: bool = False,
+        keep_in_memory: bool = False,
+    ):
+        self.corpus = {}
+        self.queries = {}
+        self.qrels = {}
+        self.og_instructions = {}
+        self.changed_instructions = {}
+        self.top_ranked = {}
+        self.hf_repo = hf_repo
+        if hf_repo:
+            # By default fetch qrels from same repo not a second repo with "-qrels" like in original
+            self.hf_repo_qrels = hf_repo_qrels if hf_repo_qrels else hf_repo
+        else:
+            # data folder would contain these files:
+            # (1) fiqa/corpus.jsonl  (format: jsonlines)
+            # (2) fiqa/queries.jsonl (format: jsonlines)
+            # (3) fiqa/qrels/test.tsv (format: tsv ("\t"))
+            if prefix:
+                query_file = prefix + "-" + query_file
+                qrels_folder = prefix + "-" + qrels_folder
+
+            self.corpus_file = (
+                os.path.join(data_folder, corpus_file) if data_folder else corpus_file
+            )
+            self.query_file = (
+                os.path.join(data_folder, query_file) if data_folder else query_file
+            )
+            self.qrels_folder = (
+                os.path.join(data_folder, qrels_folder) if data_folder else None
+            )
+            self.qrels_file = qrels_file
+        self.streaming = streaming
+        self.keep_in_memory = keep_in_memory
+
+    def load(
+        self, split="test"
+    ) -> Tuple[
+        Dict[str, Dict[str, str]],
+        Dict[str, str],
+        Dict[str, Dict[str, int]],
+        Dict[str, Dict[str, int]],
+    ]:
+        if not self.hf_repo:
+            self.og_qrels_file = os.path.join(self.qrels_folder + "_og", split + ".tsv")
+            self.changed_qrels_file = os.path.join(
+                self.qrels_folder + "_changed", split + ".tsv"
+            )
+            self.check(fIn=self.corpus_file, ext="jsonl")
+            self.check(fIn=self.query_file, ext="jsonl")
+            self.check(fIn=self.og_qrels_file, ext="tsv")
+            self.check(fIn=self.changed_qrels_file, ext="tsv")
+
+        if not len(self.corpus):
+            logger.info("Loading Corpus...")
+            self._load_corpus()
+            logger.info("Loaded %d %s Documents.", len(self.corpus), split.upper())
+            logger.info("Doc Example: %s", self.corpus[0])
+
+        if not len(self.queries):
+            logger.info("Loading Queries...")
+            self._load_queries()
+
+        self._load_qrels(split, changed=False)
+        self._load_qrels(split, changed=True)
+        # filter queries with no qrels
+        og_qrels_dict = defaultdict(dict)
+        changed_qrels_dict = defaultdict(dict)
+
+        def qrels_dict_init(row):
+            og_qrels_dict[row["query-id"]][row["corpus-id"]] = int(row["score"])
+
+        def qrels_changed_dict_init(row):
+            changed_qrels_dict[row["query-id"]][row["corpus-id"]] = int(row["score"])
+
+        self.changed_qrels.map(qrels_dict_init)
+        self.og_qrels.map(qrels_changed_dict_init)
+        self.og_qrels = og_qrels_dict
+        self.changed_qrels = changed_qrels_dict
+        self.queries = self.queries.filter(lambda x: x["id"] in self.og_qrels)
+        logger.info("Loaded %d %s Queries.", len(self.queries), split.upper())
+        logger.info("Query Example: %s", self.queries[0])
+
+        # load top_ranked
+        self.load_top_ranked()
+
+        return (
+            self.corpus,
+            self.queries,
+            self.og_qrels,
+            self.changed_qrels,
+            self.top_ranked,
+        )
+
+    def load_top_ranked(self) -> Dict[str, Dict[str, str]]:
+        if self.hf_repo:
+            top_ranked_ds = load_dataset(
+                self.hf_repo,
+                "top_ranked",
+                keep_in_memory=self.keep_in_memory,
+                streaming=self.streaming,
+            )
+        else:
+            top_ranked_ds = load_dataset(
+                "json",
+                data_files=self.top_ranked_file,
+                streaming=self.streaming,
+                keep_in_memory=self.keep_in_memory,
+            )
+        top_ranked_ds = next(iter(top_ranked_ds.values()))  # get first split
+        top_ranked_ds = top_ranked_ds.cast_column("qid", Value("string"))
+        top_ranked_ds = top_ranked_ds.cast_column("pid", Value("string"))
+        top_ranked_ds = top_ranked_ds.remove_columns(
+            [col for col in top_ranked_ds.column_names if col not in ["qid", "pid"]]
+        )
+        self.top_ranked = top_ranked_ds
+
+    def _load_queries(self):
+        if self.hf_repo:
+            queries_ds = load_dataset(
+                self.hf_repo,
+                "queries",
+                keep_in_memory=self.keep_in_memory,
+                streaming=self.streaming,
+            )
+        else:
+            queries_ds = load_dataset(
+                "json",
+                data_files=self.query_file,
+                streaming=self.streaming,
+                keep_in_memory=self.keep_in_memory,
+            )
+        queries_ds = next(iter(queries_ds.values()))  # get first split
+        queries_ds = queries_ds.cast_column("_id", Value("string"))
+        queries_ds = queries_ds.rename_column("_id", "id")
+        queries_ds = queries_ds.remove_columns(
+            [
+                col
+                for col in queries_ds.column_names
+                if col
+                not in [
+                    "id",
+                    "text",
+                    "instruction_og",
+                    "instruction_changed",
+                    "keywords",
+                    "short_query",
+                ]
+            ]
+        )
+        self.queries = queries_ds
+
+    def _load_qrels(self, split, changed=False):
+        if self.hf_repo:
+            qrels_ds = load_dataset(
+                self.hf_repo_qrels,
+                "qrels_og" if not changed else "qrels_changed",
+                keep_in_memory=self.keep_in_memory,
+                streaming=self.streaming,
+            )[split]
+        else:
+            qrels_file = self.og_qrels_file if not changed else self.changed_qrels_file
+            qrels_ds = load_dataset(
+                "csv",
+                data_files=qrels_file,
+                delimiter="\t",
+                keep_in_memory=self.keep_in_memory,
+            )
+        features = Features(
+            {
+                "query-id": Value("string"),
+                "corpus-id": Value("string"),
+                "score": Value("float"),
+            }
+        )
+        qrels_ds = qrels_ds.cast(features)
+
+        if changed:
+            self.changed_qrels = qrels_ds
+        else:
+            self.og_qrels = qrels_ds
+
+
+class AbsTaskInstructionRetrieval(AbsTask):
+    """
+    Abstract class for retrieval tasks that use instructions.
+    Child-classes must implement the following properties:
+    self.corpus = Dict[id, Dict[str, str]] #id => dict with document datas like title and text
+    self.queries = Dict[id, str] #id => query
+    self.relevant_docs = List[id, id, score]
+    self.og_instructions = Dict[str, str] query => original instruction
+    self.changed_instructions = Dict[str, str] query => changed instruction
+    self.top_ranked = Dict[id, List[id]] #id => list of top ranked document ids
+
+    See https://arxiv.org/abs/2403.15246 for more details
+    """
+
+    def __init__(
+        self,
+        hf_repo: str = None,
+        hf_repo_qrels: str = None,
+        data_folder: str = None,
+        prefix: str = None,
+        corpus_file: str = "corpus.jsonl",
+        query_file: str = "queries.jsonl",
+        qrels_folder: str = "qrels",
+        qrels_file: str = "",
+        streaming: bool = False,
+        keep_in_memory: bool = False,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.do_length_ablation = kwargs.get("do_length_ablation", False)
+
+    def load_data(self, **kwargs):
+        if self.data_loaded:
+            return
+        self.corpus, self.queries, self.og_relevant_docs, self.changed_relevant_docs = (
+            {},
+            {},
+            {},
+            {},
+        )
+        self.og_instructions, self.changed_instructions = {}, {}
+        self.top_ranked = {}
+        if self.do_length_ablation:
+            self.keywords, self.short_instructions = {}, {}
+
+        self.hf_repo_qrels = self.hf_repo_qrels if self.hf_repo_qrels else self.hf_repo
+        for split in kwargs.get("eval_splits", self.metadata_dict["eval_splits"]):
+            corpus, queries, og_qrels, changed_qrels, top_ranked_init = (
+                HFDataLoaderInstructions(
+                    hf_repo=self.metadata_dict["hf_hub_name"],
+                    hf_repo_qrels=self.hf_repo_qrels,
+                    streaming=False,
+                    keep_in_memory=False,
+                ).load(split=split)
+            )
+
+            # Conversion from DataSet
+            top_ranked = defaultdict(list)
+            [
+                top_ranked[cur_inst["qid"]].append(cur_inst["pid"])
+                for cur_inst in top_ranked_init
+            ]
+            og_instructions = {
+                query["text"]: query["instruction_og"] for query in queries
+            }
+            changed_instructions = {
+                query["text"]: query["instruction_changed"] for query in queries
+            }
+            queries = {query["id"]: query["text"] for query in queries}
+            corpus = {
+                doc["id"]: {"title": doc["title"], "text": doc["text"]}
+                for doc in corpus
+            }
+            if self.length_ablation:
+                keywords = {query["text"]: query["keywords"] for query in queries}
+                short_instructions = {
+                    query["text"]: query["short_query"] for query in queries
+                }
+            assert (
+                len(top_ranked) == len(queries)
+            ), f"Top ranked not loaded properly! Expected {len(self.queries)} but got {len(self.top_ranked)}."
+
+            (
+                self.corpus[split],
+                self.queries[split],
+                self.og_relevant_docs[split],
+                self.changed_relevant_docs[split],
+            ) = corpus, queries, og_qrels, changed_qrels
+            self.changed_instructions[split], self.og_instructions[split] = (
+                changed_instructions,
+                og_instructions,
+            )
+            self.top_ranked[split] = top_ranked
+
+            if self.do_length_ablation:
+                self.keywords[split], self.short_instructions[split] = (
+                    keywords,
+                    short_instructions,
+                )
+
+        self.data_loaded = True
+
+    def evaluate(self, model, split="test", **kwargs):
+        retriever = InstructionRetrievalEvaluator(model, **kwargs)
+
+        scores_og = {}
+        scores_changed = {}
+        results_og = {}
+        results_changed = {}
+        scores_base = {}
+        results_base = {}
+        overall_changed_scores = {}
+        if self.is_multilingual:
+            for lang in self.langs:
+                logger.info(f"Language: {lang}")
+                corpus, queries = self.corpus[lang][split], self.queries[lang][split]
+                og_relevant_docs, changed_relevant_docs = (
+                    self.og_relevant_docs[lang][split],
+                    self.changed_relevant_docs[lang][split],
+                )
+                og_instructions, changed_instructions = (
+                    self.og_instructions[lang][split],
+                    self.changed_instructions[lang][split],
+                )
+
+                if self.do_length_ablation:
+                    keywords, short_instructions = (
+                        self.keywords[lang][split],
+                        self.short_instructions[lang][split],
+                    )
+
+                top_ranked = self.top_ranked[lang][split]
+                scores_og[lang], results_og[lang] = self._evaluate_monolingual(
+                    retriever,
+                    corpus,
+                    queries,
+                    og_relevant_docs,
+                    "og",
+                    og_instructions,
+                    top_ranked,
+                    lang,
+                    **kwargs,
+                )
+                scores_changed[lang], results_changed[lang] = (
+                    self._evaluate_monolingual(
+                        retriever,
+                        corpus,
+                        queries,
+                        changed_relevant_docs,
+                        "changed",
+                        changed_instructions,
+                        top_ranked,
+                        lang,
+                        **kwargs,
+                    )
+                )
+
+                newly_irrelevant_qrels = self.create_qrel_diff(
+                    self.og_relevant_docs[lang][split],
+                    self.changed_relevant_docs[lang][split],
+                )
+                overall_changed_scores[lang] = utils.evaluate_change(
+                    results_og[lang], results_changed[lang], newly_irrelevant_qrels
+                )
+
+                overall_changed_scores[lang]["individual"] = {
+                    "original": scores_og[lang],
+                    "changed": scores_changed[lang],
+                }
+
+                if self.do_length_ablation:
+                    scores_base[lang], results_base[lang] = self._evaluate_monolingual(
+                        retriever,
+                        corpus,
+                        queries,
+                        og_relevant_docs,
+                        "base",
+                        defaultdict(str),
+                        top_ranked,
+                        lang,
+                        **kwargs,
+                    )
+                    scores_w_keywords = self._evaluate_monolingual(
+                        retriever,
+                        corpus,
+                        queries,
+                        og_relevant_docs,
+                        "keywords",
+                        keywords,
+                        top_ranked,
+                        lang,
+                        **kwargs,
+                    )
+                    scores_w_short_instr = self._evaluate_monolingual(
+                        retriever,
+                        corpus,
+                        queries,
+                        og_relevant_docs,
+                        "short_instructions",
+                        short_instructions,
+                        top_ranked,
+                        lang,
+                        **kwargs,
+                    )
+                    overall_changed_scores[lang]["length_ablation"] = {
+                        "keywords": scores_w_keywords,
+                        "short_instructions": scores_w_short_instr,
+                        "base": scores_base[lang],
+                    }
+        else:
+            corpus, queries = self.corpus[split], self.queries[split]
+            og_relevant_docs, changed_relevant_docs = (
+                self.og_relevant_docs[split],
+                self.changed_relevant_docs[split],
+            )
+            og_instructions, changed_instructions = (
+                self.og_instructions[split],
+                self.changed_instructions[split],
+            )
+            top_ranked = self.top_ranked[split]
+            if self.do_length_ablation:
+                keywords, short_instructions = (
+                    self.keywords[split],
+                    self.short_instructions[split],
+                )
+
+            scores_og, results_og = self._evaluate_monolingual(
+                retriever,
+                corpus,
+                queries,
+                og_relevant_docs,
+                "og",
+                og_instructions,
+                top_ranked,
+                None,
+                **kwargs,
+            )
+            scores_changed, results_changed = self._evaluate_monolingual(
+                retriever,
+                corpus,
+                queries,
+                changed_relevant_docs,
+                "changed",
+                changed_instructions,
+                top_ranked,
+                None,
+                **kwargs,
+            )
+
+            newly_irrelevant_qrels = self.create_qrel_diff(
+                self.og_relevant_docs[split], self.changed_relevant_docs[split]
+            )
+            overall_changed_scores = utils.evaluate_change(
+                results_og, results_changed, newly_irrelevant_qrels
+            )
+
+            overall_changed_scores["individual"] = {
+                "original": scores_og,
+                "changed": scores_changed,
+                "base": scores_base,
+            }
+
+            if self.do_length_ablation:
+                scores_w_keywords = self._evaluate_monolingual(
+                    retriever,
+                    corpus,
+                    queries,
+                    og_relevant_docs,
+                    "keywords",
+                    keywords,
+                    top_ranked,
+                    None,
+                    **kwargs,
+                )
+                scores_w_short_instr = self._evaluate_monolingual(
+                    retriever,
+                    corpus,
+                    queries,
+                    og_relevant_docs,
+                    "short_instructions",
+                    short_instructions,
+                    top_ranked,
+                    None,
+                    **kwargs,
+                )
+                scores_base, results_base = self._evaluate_monolingual(
+                    retriever,
+                    corpus,
+                    queries,
+                    og_relevant_docs,
+                    "base",
+                    defaultdict(str),
+                    top_ranked,
+                    None,
+                    **kwargs,
+                )
+                overall_changed_scores["length_ablation"] = {
+                    "keywords": scores_w_keywords,
+                    "short_instructions": scores_w_short_instr,
+                    "base": scores_base,
+                }
+
+        return overall_changed_scores
+
+    def _evaluate_monolingual(
+        self,
+        retriever: InstructionRetrievalEvaluator,
+        corpus: Dict[str, Dict[str, str]],
+        queries: Dict[str, str],
+        relevant_docs: Dict[str, Dict[str, int]],
+        qrels_name: str,
+        instructions: Dict[str, str],
+        top_ranked: Dict[str, List[str]],
+        lang=None,
+        **kwargs,
+    ):
+        start_time = time()
+
+        # do the results by query and relevant docs only
+        all_results = []
+        for query_id in tqdm.tqdm(list(queries.keys()), leave=True):
+            cur_queries = {query_id: queries[query_id]}
+            cur_instructions = {queries[query_id]: instructions[queries[query_id]]}
+            cur_docs = {
+                key: value
+                for (key, value) in corpus.items()
+                if key in top_ranked[query_id]
+            }
+            all_results.append(
+                retriever(
+                    cur_docs, cur_queries, instructions=cur_instructions, qid=query_id
+                )
+            )
+
+        # combine all the results (which are {'qid' -> {'doc_id' -> score} mappings)
+        # we know all are unique qids, so we can smash together
+        results = {k: v for d in all_results for k, v in d.items()}
+
+        end_time = time()
+        logger.info(
+            "Time taken to retrieve: {:.2f} seconds".format(end_time - start_time)
+        )
+
+        if kwargs.get("save_qrels", False):
+            output_folder = kwargs.get("output_folder", "results")
+            if not os.path.isdir(output_folder):
+                os.makedirs(output_folder)
+            top_k = kwargs.get("top_k", None)
+            if top_k is not None:
+                for qid in list(results.keys()):
+                    doc_ids = set(
+                        sorted(
+                            results[qid], key=lambda x: results[qid][x], reverse=True
+                        )[:top_k]
+                    )
+                    results[qid] = {
+                        k: v for k, v in results[qid].items() if k in doc_ids
+                    }
+            if lang is None:
+                qrels_save_path = (
+                    f"{output_folder}/{self.metadata_dict['name']}_qrels.json"
+                )
+            else:
+                qrels_save_path = (
+                    f"{output_folder}/{self.metadata_dict['name']}_{lang}_qrels.json"
+                )
+
+            with open(qrels_save_path, "w") as f:
+                json.dump(results, f)
+
+        ndcg, _map, recall, precision = retriever.evaluate(
+            relevant_docs,
+            results,
+            retriever.k_values,
+            ignore_identical_ids=kwargs.get("ignore_identical_ids", True),
+        )
+        mrr = retriever.evaluate_custom(
+            relevant_docs, results, retriever.k_values, "mrr"
+        )
+        scores = {
+            **{f"ndcg_at_{k.split('@')[1]}": v for (k, v) in ndcg.items()},
+            **{f"map_at_{k.split('@')[1]}": v for (k, v) in _map.items()},
+            **{f"recall_at_{k.split('@')[1]}": v for (k, v) in recall.items()},
+            **{f"precision_at_{k.split('@')[1]}": v for (k, v) in precision.items()},
+            **{f"mrr_at_{k.split('@')[1]}": v for (k, v) in mrr.items()},
+        }
+        return scores
+
+    def create_qrel_diff(self, og_qrels, changed_qrels):
+        newly_irrelevant_qrels = {}
+        for qid in og_qrels:
+            newly_irrelevant_qrels[qid] = []
+            for doc_id in og_qrels[qid]:
+                if changed_qrels[qid][doc_id] != og_qrels[qid][doc_id]:
+                    newly_irrelevant_qrels[qid].append(doc_id)
+
+        return newly_irrelevant_qrels

--- a/mteb/abstasks/TaskMetadata.py
+++ b/mteb/abstasks/TaskMetadata.py
@@ -82,6 +82,7 @@ TASK_TYPE = Literal[
     "Retrieval",
     "STS",
     "Summarization",
+    "InstructionRetrieval"
 ]
 
 TASK_CATEGORY = Literal[

--- a/mteb/abstasks/__init__.py
+++ b/mteb/abstasks/__init__.py
@@ -4,6 +4,7 @@ from .AbsTask import *
 from .AbsTaskBitextMining import *
 from .AbsTaskClassification import *
 from .AbsTaskClustering import *
+from .AbsTaskInstructionRetrieval import *
 from .AbsTaskPairClassification import *
 from .AbsTaskReranking import *
 from .AbsTaskRetrieval import *

--- a/mteb/evaluation/evaluators/InstructionRetrievalEvaluator.py
+++ b/mteb/evaluation/evaluators/InstructionRetrievalEvaluator.py
@@ -2,10 +2,7 @@ import logging
 from typing import Dict, List
 
 from .RetrievalEvaluator import (
-    DenseRetrievalExactSearch,
-    DRESModel,
     RetrievalEvaluator,
-    is_dres_compatible,
 )
 
 logger = logging.getLogger(__name__)

--- a/mteb/evaluation/evaluators/InstructionRetrievalEvaluator.py
+++ b/mteb/evaluation/evaluators/InstructionRetrievalEvaluator.py
@@ -11,27 +11,9 @@ from .RetrievalEvaluator import (
 logger = logging.getLogger(__name__)
 
 
-# Adapted from https://github.com/beir-cellar/beir/blob/f062f038c4bfd19a8ca942a9910b1e0d218759d4/beir/retrieval/evaluation.py#L9
-class InstructionRetrievalEvaluator(RetrievalEvaluator):
-    def __init__(
-        self,
-        retriever,
-        k_values: List[int] = [1, 3, 5, 10, 20, 100, 1000],
-        score_function: str = "cos_sim",
-        **kwargs,
-    ):
-        super().__init__(**kwargs)
-        if is_dres_compatible(retriever):
-            logger.info(
-                "The custom encode_queries and encode_corpus functions of the model will be used"
-            )
-            self.retriever = DenseRetrievalExactSearch(retriever, **kwargs)
-        else:
-            self.retriever = DenseRetrievalExactSearch(DRESModel(retriever), **kwargs)
-        self.k_values = k_values
-        self.top_k = max(k_values)
-        self.score_function = score_function
 
+class InstructionRetrievalEvaluator(RetrievalEvaluator):
+    # only added to extend the RetrievalEvaluator to pass along the instructions
     def __call__(
         self,
         corpus: Dict[str, Dict[str, str]],

--- a/mteb/evaluation/evaluators/InstructionRetrievalEvaluator.py
+++ b/mteb/evaluation/evaluators/InstructionRetrievalEvaluator.py
@@ -1,0 +1,51 @@
+import logging
+from typing import Dict, List
+
+from .RetrievalEvaluator import (
+    DenseRetrievalExactSearch,
+    DRESModel,
+    RetrievalEvaluator,
+    is_dres_compatible,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Adapted from https://github.com/beir-cellar/beir/blob/f062f038c4bfd19a8ca942a9910b1e0d218759d4/beir/retrieval/evaluation.py#L9
+class InstructionRetrievalEvaluator(RetrievalEvaluator):
+    def __init__(
+        self,
+        retriever,
+        k_values: List[int] = [1, 3, 5, 10, 20, 100, 1000],
+        score_function: str = "cos_sim",
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        if is_dres_compatible(retriever):
+            logger.info(
+                "The custom encode_queries and encode_corpus functions of the model will be used"
+            )
+            self.retriever = DenseRetrievalExactSearch(retriever, **kwargs)
+        else:
+            self.retriever = DenseRetrievalExactSearch(DRESModel(retriever), **kwargs)
+        self.k_values = k_values
+        self.top_k = max(k_values)
+        self.score_function = score_function
+
+    def __call__(
+        self,
+        corpus: Dict[str, Dict[str, str]],
+        queries: Dict[str, str],
+        instructions: Dict[str, str],
+        **kwargs,
+    ) -> Dict[str, Dict[str, float]]:
+        if not self.retriever:
+            raise ValueError("Model/Technique has not been provided!")
+        return self.retriever.search(
+            corpus,
+            queries,
+            self.top_k,
+            self.score_function,
+            instructions=instructions,
+            **kwargs,
+        )

--- a/mteb/evaluation/evaluators/RetrievalEvaluator.py
+++ b/mteb/evaluation/evaluators/RetrievalEvaluator.py
@@ -198,7 +198,7 @@ class DRESModel:
             ]
 
         corpus_embeddings = self.model.encode(
-            sentences, batch_size=batch_size
+            sentences, batch_size=batch_size, **kwargs
         )
         if self.save_corpus_embeddings and "qid" in kwargs:
             if type(corpus_embeddings) == torch.tensor:

--- a/mteb/evaluation/evaluators/RetrievalEvaluator.py
+++ b/mteb/evaluation/evaluators/RetrievalEvaluator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import heapq
 import logging
 from typing import Dict, List, Tuple
+from collections import defaultdict
 
 import pytrec_eval
 import torch
@@ -32,6 +33,7 @@ class DenseRetrievalExactSearch:
         self.show_progress_bar = kwargs.get("show_progress_bar", True)
         self.convert_to_tensor = kwargs.get("convert_to_tensor", True)
         self.save_corpus_embeddings = kwargs.get("save_corpus_embeddings", False)
+        self.corpus_embeddings = defaultdict(list)
         self.results = {}
 
     def search(
@@ -62,6 +64,7 @@ class DenseRetrievalExactSearch:
             batch_size=self.batch_size,
             show_progress_bar=self.show_progress_bar,
             convert_to_tensor=self.convert_to_tensor,
+            **kwargs,
         )
 
         logger.info("Sorting Corpus by document length (Longest first)...")
@@ -95,7 +98,7 @@ class DenseRetrievalExactSearch:
             and "qid" in kwargs
             and len(self.corpus_embeddings[kwargs["qid"]])
         ):
-            sub_corpus_embeddings = self.corpus_embeddings[kwargs["qid"]][batch_num]
+            sub_corpus_embeddings = torch.tensor(self.corpus_embeddings[kwargs["qid"]][batch_num])
         else:
             # Encode chunk of corpus
             sub_corpus_embeddings = self.model.encode_corpus(
@@ -103,42 +106,42 @@ class DenseRetrievalExactSearch:
                 batch_size=self.batch_size,
                 show_progress_bar=self.show_progress_bar,
                 convert_to_tensor=self.convert_to_tensor,
+                **kwargs,
             )
             if self.save_corpus_embeddings and "qid" in kwargs:
                 self.corpus_embeddings[kwargs["qid"]].append(sub_corpus_embeddings)
 
-            # Compute similarites using either cosine-similarity or dot product
-            cos_scores = self.score_functions[score_function](
-                query_embeddings, sub_corpus_embeddings
-            )
-            cos_scores[torch.isnan(cos_scores)] = -1
+        # Compute similarites using either cosine-similarity or dot product
+        cos_scores = self.score_functions[score_function](
+            query_embeddings, sub_corpus_embeddings
+        )
+        cos_scores[torch.isnan(cos_scores)] = -1
 
-            # Get top-k values
-            cos_scores_top_k_values, cos_scores_top_k_idx = torch.topk(
-                cos_scores,
-                min(top_k + 1, len(cos_scores[1])),
-                dim=1,
-                largest=True,
-                sorted=return_sorted,
-            )
-            cos_scores_top_k_values = cos_scores_top_k_values.cpu().tolist()
-            cos_scores_top_k_idx = cos_scores_top_k_idx.cpu().tolist()
+        cos_scores_top_k_values, cos_scores_top_k_idx = torch.topk(
+            cos_scores,
+            min(top_k + 1, len(cos_scores[1]) if len(cos_scores) > 1 else len(cos_scores[-1])),
+            dim=1,
+            largest=True,
+            sorted=return_sorted,
+        )
+        cos_scores_top_k_values = cos_scores_top_k_values.cpu().tolist()
+        cos_scores_top_k_idx = cos_scores_top_k_idx.cpu().tolist()
 
-            for query_itr in range(len(query_embeddings)):
-                query_id = query_ids[query_itr]
-                for sub_corpus_id, score in zip(
-                    cos_scores_top_k_idx[query_itr], cos_scores_top_k_values[query_itr]
-                ):
-                    corpus_id = corpus_ids[corpus_start_idx + sub_corpus_id]
-                    if corpus_id != query_id:
-                        if len(result_heaps[query_id]) < top_k:
-                            # Push item on the heap
-                            heapq.heappush(result_heaps[query_id], (score, corpus_id))
-                        else:
-                            # If item is larger than the smallest in the heap, push it on the heap then pop the smallest element
-                            heapq.heappushpop(
-                                result_heaps[query_id], (score, corpus_id)
-                            )
+        for query_itr in range(len(query_embeddings)):
+            query_id = query_ids[query_itr]
+            for sub_corpus_id, score in zip(
+                cos_scores_top_k_idx[query_itr], cos_scores_top_k_values[query_itr]
+            ):
+                corpus_id = corpus_ids[corpus_start_idx + sub_corpus_id]
+                if corpus_id != query_id:
+                    if len(result_heaps[query_id]) < top_k:
+                        # Push item on the heap
+                        heapq.heappush(result_heaps[query_id], (score, corpus_id))
+                    else:
+                        # If item is larger than the smallest in the heap, push it on the heap then pop the smallest element
+                        heapq.heappushpop(
+                            result_heaps[query_id], (score, corpus_id)
+                        )
 
         for qid in result_heaps:
             for score, corpus_id in result_heaps[qid]:
@@ -158,6 +161,7 @@ class DRESModel:
         self.sep = sep
         self.use_sbert_model = isinstance(model, SentenceTransformer)
         self.save_corpus_embeddings = kwargs.get("save_corpus_embeddings", False)
+        self.corpus_embeddings = {}
 
     def encode_queries(self, queries: List[str], batch_size: int, **kwargs):
         if self.use_sbert_model:

--- a/mteb/evaluation/evaluators/RetrievalEvaluator.py
+++ b/mteb/evaluation/evaluators/RetrievalEvaluator.py
@@ -105,8 +105,7 @@ class DenseRetrievalExactSearch:
                 corpus[corpus_start_idx:corpus_end_idx],
                 batch_size=self.batch_size,
                 show_progress_bar=self.show_progress_bar,
-                convert_to_tensor=self.convert_to_tensor,
-                **kwargs,
+                convert_to_tensor=self.convert_to_tensor
             )
             if self.save_corpus_embeddings and "qid" in kwargs:
                 self.corpus_embeddings[kwargs["qid"]].append(sub_corpus_embeddings)
@@ -199,7 +198,7 @@ class DRESModel:
             ]
 
         corpus_embeddings = self.model.encode(
-            sentences, batch_size=batch_size, **kwargs
+            sentences, batch_size=batch_size
         )
         if self.save_corpus_embeddings and "qid" in kwargs:
             if type(corpus_embeddings) == torch.tensor:

--- a/mteb/evaluation/evaluators/utils.py
+++ b/mteb/evaluation/evaluators/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Dict, List, Tuple
 
+import pandas as pd
 import torch
 
 
@@ -189,3 +190,59 @@ def top_k_accuracy(
         logging.info("Accuracy@{}: {:.4f}".format(k, top_k_acc[f"Accuracy@{k}"]))
 
     return top_k_acc
+
+
+def get_rank_from_dict(
+    dict_of_results: dict[str, float], doc_id: str
+) -> Tuple[int, float]:
+    tuple_of_id_score = dict_of_results.items()
+    sorted_by_score = sorted(tuple_of_id_score, key=lambda x: x[1], reverse=True)
+    for i, (id, score) in enumerate(sorted_by_score):
+        if id == doc_id:
+            return i + 1, score
+
+    return len(sorted_by_score) + 1, 0
+
+
+def evaluate_change(
+    original_run: pd.DataFrame,
+    new_run: pd.DataFrame,
+    changed_qrels: dict[str, List[str]],
+) -> dict[str, float]:
+    changes = []
+    for qid in changed_qrels.keys():
+        original_qid_run = original_run[qid]
+        new_qid_run = new_run[qid]
+        for idx, changed_doc in enumerate(changed_qrels[qid]):
+            original_rank, original_score = get_rank_from_dict(
+                original_qid_run, changed_doc
+            )
+            new_rank, new_score = get_rank_from_dict(new_qid_run, changed_doc)
+            change = int(original_rank - new_rank)
+            changes.append(
+                {
+                    "qid": qid,
+                    "doc_id": changed_doc,
+                    "change": change,
+                    "relevance": 0,
+                    "og_rank": original_rank,
+                    "new_rank": new_rank,
+                    "og_score": original_score,
+                    "new_score": new_score,
+                }
+            )
+
+    # we now have a DF of [qid, doc_id, change] to run our calculations with
+    changes_df = pd.DataFrame(changes)
+    changes_df["p-MRR"] = changes_df.apply(lambda x: rank_score(x), axis=1)
+    qid_wise = changes_df.groupby("qid").agg({"p-MRR": "mean"})
+    return {
+        "p-MRR": qid_wise["p-MRR"].mean(),
+    }
+
+
+def rank_score(x: dict[str, float]) -> float:
+    if x["og_rank"] >= x["new_rank"]:
+        return ((1 / x["og_rank"]) / (1 / x["new_rank"])) - 1
+    else:
+        return 1 - ((1 / x["new_rank"]) / (1 / x["og_rank"]))

--- a/mteb/tasks/InstructionRetrieval/__init__.py
+++ b/mteb/tasks/InstructionRetrieval/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .eng.Core17InstructionRetrieval import *
+from .eng.News21InstructionRetrieval import *
+from .eng.Robust04InstructionRetrieval import *

--- a/mteb/tasks/InstructionRetrieval/eng/Core17InstructionRetrieval.py
+++ b/mteb/tasks/InstructionRetrieval/eng/Core17InstructionRetrieval.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+from ....abstasks.AbsTaskInstructionRetrieval import AbsTaskInstructionRetrieval
+
+
+class Core17InstructionRetrieval(AbsTaskInstructionRetrieval):
+    metadata = TaskMetadata(
+        name="Core17InstructionRetrieval",
+        description="Measuring retrieval instruction following ability on Core17 narratives.",
+        reference="https://arxiv.org/abs/2403.15246",
+        dataset={
+            "path": "jhu-clsp/core17-instruction",
+            "revision": "e783a88ec6bc4bbdc1ba998edd85edeaf3d820f7",
+        },
+        type="InstructionRetrieval",
+        category="s2p",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="p-MRR",
+        date=("2023-08-01", "2024-04-01"),
+        form=["written"],
+        domains=["News"],
+        task_subtypes=None,
+        license="MIT",
+        socioeconomic_status="medium",
+        annotations_creators="derived",
+        dialect=None,
+        text_creation="found",
+        bibtex_citation="""@misc{weller2024followir,
+      title={FollowIR: Evaluating and Teaching Information Retrieval Models to Follow Instructions}, 
+      author={Orion Weller and Benjamin Chang and Sean MacAvaney and Kyle Lo and Arman Cohan and Benjamin Van Durme and Dawn Lawrie and Luca Soldaini},
+      year={2024},
+      eprint={2403.15246},
+      archivePrefix={arXiv},
+      primaryClass={cs.IR}
+}""",
+        n_samples=None,
+        avg_character_length=None,
+    )

--- a/mteb/tasks/InstructionRetrieval/eng/Core17InstructionRetrieval.py
+++ b/mteb/tasks/InstructionRetrieval/eng/Core17InstructionRetrieval.py
@@ -11,7 +11,7 @@ class Core17InstructionRetrieval(AbsTaskInstructionRetrieval):
         description="Measuring retrieval instruction following ability on Core17 narratives.",
         reference="https://arxiv.org/abs/2403.15246",
         dataset={
-            "path": "jhu-clsp/core17-instruction",
+            "path": "jhu-clsp/core17-instructions",
             "revision": "e783a88ec6bc4bbdc1ba998edd85edeaf3d820f7",
         },
         type="InstructionRetrieval",

--- a/mteb/tasks/InstructionRetrieval/eng/News21InstructionRetrieval.py
+++ b/mteb/tasks/InstructionRetrieval/eng/News21InstructionRetrieval.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+from ....abstasks.AbsTaskInstructionRetrieval import AbsTaskInstructionRetrieval
+
+
+class News21InstructionRetrieval(AbsTaskInstructionRetrieval):
+    metadata = TaskMetadata(
+        name="News21InstructionRetrieval",
+        description="Measuring retrieval instruction following ability on News21 narratives.",
+        reference="https://arxiv.org/abs/2403.15246",
+        dataset={
+            "path": "jhu-clsp/news21-instruction",
+            "revision": "374e11e7d416b2076f983d6b4af0a2389225f5e8",
+        },
+        type="InstructionRetrieval",
+        category="s2p",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="p-MRR",
+        date=("2023-08-01", "2024-04-01"),
+        form=["written"],
+        domains=["News"],
+        task_subtypes=None,
+        license="MIT",
+        socioeconomic_status="medium",
+        annotations_creators="derived",
+        dialect=None,
+        text_creation="found",
+        bibtex_citation="""@misc{weller2024followir,
+      title={FollowIR: Evaluating and Teaching Information Retrieval Models to Follow Instructions}, 
+      author={Orion Weller and Benjamin Chang and Sean MacAvaney and Kyle Lo and Arman Cohan and Benjamin Van Durme and Dawn Lawrie and Luca Soldaini},
+      year={2024},
+      eprint={2403.15246},
+      archivePrefix={arXiv},
+      primaryClass={cs.IR}
+}""",
+        n_samples=None,
+        avg_character_length=None,
+    )

--- a/mteb/tasks/InstructionRetrieval/eng/News21InstructionRetrieval.py
+++ b/mteb/tasks/InstructionRetrieval/eng/News21InstructionRetrieval.py
@@ -11,7 +11,7 @@ class News21InstructionRetrieval(AbsTaskInstructionRetrieval):
         description="Measuring retrieval instruction following ability on News21 narratives.",
         reference="https://arxiv.org/abs/2403.15246",
         dataset={
-            "path": "jhu-clsp/news21-instruction",
+            "path": "jhu-clsp/news21-instructions",
             "revision": "374e11e7d416b2076f983d6b4af0a2389225f5e8",
         },
         type="InstructionRetrieval",

--- a/mteb/tasks/InstructionRetrieval/eng/Robust04InstructionRetrieval.py
+++ b/mteb/tasks/InstructionRetrieval/eng/Robust04InstructionRetrieval.py
@@ -11,7 +11,7 @@ class Robust04InstructionRetrieval(AbsTaskInstructionRetrieval):
         description="Measuring retrieval instruction following ability on Robust04 narratives.",
         reference="https://arxiv.org/abs/2403.15246",
         dataset={
-            "path": "jhu-clsp/robust04-instruction",
+            "path": "jhu-clsp/robust04-instructions",
             "revision": "d25e82647b09251f4feaaf5462c9a18445072ba6",
         },
         type="InstructionRetrieval",

--- a/mteb/tasks/InstructionRetrieval/eng/Robust04InstructionRetrieval.py
+++ b/mteb/tasks/InstructionRetrieval/eng/Robust04InstructionRetrieval.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+from ....abstasks.AbsTaskInstructionRetrieval import AbsTaskInstructionRetrieval
+
+
+class Robust04InstructionRetrieval(AbsTaskInstructionRetrieval):
+    metadata = TaskMetadata(
+        name="Robust04InstructionRetrieval",
+        description="Measuring retrieval instruction following ability on Robust04 narratives.",
+        reference="https://arxiv.org/abs/2403.15246",
+        dataset={
+            "path": "jhu-clsp/robust04-instruction",
+            "revision": "d25e82647b09251f4feaaf5462c9a18445072ba6",
+        },
+        type="InstructionRetrieval",
+        category="s2p",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="p-MRR",
+        date=("2023-08-01", "2024-04-01"),
+        form=["written"],
+        domains=["News"],
+        task_subtypes=None,
+        license="MIT",
+        socioeconomic_status="medium",
+        annotations_creators="derived",
+        dialect=None,
+        text_creation="found",
+        bibtex_citation="""@misc{weller2024followir,
+      title={FollowIR: Evaluating and Teaching Information Retrieval Models to Follow Instructions}, 
+      author={Orion Weller and Benjamin Chang and Sean MacAvaney and Kyle Lo and Arman Cohan and Benjamin Van Durme and Dawn Lawrie and Luca Soldaini},
+      year={2024},
+      eprint={2403.15246},
+      archivePrefix={arXiv},
+      primaryClass={cs.IR}
+}""",
+        n_samples=None,
+        avg_character_length=None,
+    )

--- a/mteb/tasks/__init__.py
+++ b/mteb/tasks/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from .BitextMining import *
 from .Classification import *
 from .Clustering import *
+from .InstructionRetrieval import *
 from .PairClassification import *
 from .Reranking import *
 from .Retrieval import *


### PR DESCRIPTION
Real PR for FollowIR (draft in #356).

Re-uses as much of the `AbsTaskRetrieval` abstract task as possible, thanks to previous feedback.  Dataset task files are up to date with the newer MTEB metadata.

I left the sample and n_characters metadata empty, I'm updating the dataset slightly (should be done in a few days) and will make a new PR when it's finished to update the dataset revisions and this metadata.