### PR TITLE
docs: Add missing points from PR reviews

### DIFF
--- a/docs/mmteb/points.md
+++ b/docs/mmteb/points.md
@@ -30,7 +30,7 @@
 | orionw            |              |             |          |                     |      14    |                |           |                |          |               |
 | mmhamdy           |              | 12          |          |                     |            |                |           |                |          |               |
 | manandey          |              | 12          |          |                     |            |                |           |                |          |               |
-| isaac-chung       |              | 36          |          |                     |            |                | 4         |                |          |               |
+| isaac-chung       |              | 36          |          |                     |            |                | 8         |                |          |               |
 | asparius          |              | 8           |          |                     |            |                |           |                |          |               |
 | rbroc             |              | 6           |          |                     |            |                |           |                |          |               |
 | dwzhu-pku         |              | 12          |          |                     |            |                |           |                |          |               |


### PR DESCRIPTION
Only 1 point instead of 2 points were assigned (ref: `docs/mmteb/readme.md`)
- https://github.com/embeddings-benchmark/mteb/pull/403
- https://github.com/embeddings-benchmark/mteb/pull/411
- https://github.com/embeddings-benchmark/mteb/pull/414
- https://github.com/embeddings-benchmark/mteb/pull/421

Luckily there aren't a lot yet 😅 