### PR TITLE
Add Bulgarian Sentiment Classification Dataset

### DIFF
--- a/mteb/tasks/Classification/__init__.py
+++ b/mteb/tasks/Classification/__init__.py
@@ -5,6 +5,7 @@ from .ara.RestaurantReviewSentimentClassification import *
 from .ara.TweetEmotionClassification import *
 from .ara.TweetSarcasmClassification import *
 from .ben.BengaliHateSpeechClassification import *
+from .bul.BulgarianSentimentClassification import *
 from .ces.CzechSubjectivityClassification import *
 from .dan.AngryTweetsClassification import *
 from .dan.DalajClassification import *

--- a/mteb/tasks/Classification/bul/BulgarianSentimentClassification.py
+++ b/mteb/tasks/Classification/bul/BulgarianSentimentClassification.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from mteb.abstasks import AbsTaskClassification
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+
+class BulgarianSentimentClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="BulgarianSentimentClassification",
+        description="An Bulgarian dataset for sentiment classification.",
+        reference="https://arxiv.org/abs/2009.08712",
+        dataset={
+            "path": "sepidmnorozy/Bulgarian_sentiment",
+            "revision": "c0d5c781a115d570b8acceb14928ffb99543bb74",
+        },
+        type="Classification",
+        category="s2s",
+        date=("2022-01-01", "2022-01-01"),
+        eval_splits=["validation", "test"],
+        eval_langs=["bul-Cyrl"],
+        main_score="accuracy",
+        form=["written"],
+        domains=["Reviews"],
+        task_subtypes=["Sentiment/Hate speech"],
+        license="Not specified",
+        socioeconomic_status="mixed",
+        annotations_creators="human-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""@inproceedings{mollanorozy-etal-2023-cross,
+    title = "Cross-lingual Transfer Learning with \{P\}ersian",
+    author = "Mollanorozy, Sepideh  and
+      Tanti, Marc  and
+      Nissim, Malvina",
+    editor = "Beinborn, Lisa  and
+      Goswami, Koustava  and
+      Murado{\\u{g}}lu, Saliha  and
+      Sorokin, Alexey  and
+      Kumar, Ritesh  and
+      Shcherbakov, Andreas  and
+      Ponti, Edoardo M.  and
+      Cotterell, Ryan  and
+      Vylomova, Ekaterina",
+    booktitle = "Proceedings of the 5th Workshop on Research in Computational Linguistic Typology and Multilingual NLP",
+    month = may,
+    year = "2023",
+    address = "Dubrovnik, Croatia",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2023.sigtyp-1.9",
+    doi = "10.18653/v1/2023.sigtyp-1.9",
+    pages = "89--95",
+}
+""",
+        n_samples={"validation": 838, "test": 1673},
+        avg_character_length={"validation": 43.3, "test": 46.3},
+    )

--- a/results/intfloat__multilingual-e5-small/BulgarianSentimentClassification.json
+++ b/results/intfloat__multilingual-e5-small/BulgarianSentimentClassification.json
@@ -1,0 +1,25 @@
+{
+  "dataset_revision": "c0d5c781a115d570b8acceb14928ffb99543bb74",
+  "mteb_dataset_name": "BulgarianSentimentClassification",
+  "mteb_version": "1.6.12",
+  "test": {
+    "accuracy": 0.7251046025104604,
+    "accuracy_stderr": 0.03945502514001783,
+    "ap": 0.8839028389202893,
+    "ap_stderr": 0.01775102786465037,
+    "evaluation_time": 3.3,
+    "f1": 0.6649167482675631,
+    "f1_stderr": 0.03895081321852516,
+    "main_score": 0.7251046025104604
+  },
+  "validation": {
+    "accuracy": 0.7316229116945108,
+    "accuracy_stderr": 0.040909907906665426,
+    "ap": 0.9371518735025541,
+    "ap_stderr": 0.008238480175131136,
+    "evaluation_time": 5.48,
+    "f1": 0.6300379798171928,
+    "f1_stderr": 0.03474752659073286,
+    "main_score": 0.7316229116945108
+  }
+}

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/BulgarianSentimentClassification.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/BulgarianSentimentClassification.json
@@ -1,0 +1,25 @@
+{
+  "dataset_revision": "c0d5c781a115d570b8acceb14928ffb99543bb74",
+  "mteb_dataset_name": "BulgarianSentimentClassification",
+  "mteb_version": "1.6.12",
+  "test": {
+    "accuracy": 0.7785415421398685,
+    "accuracy_stderr": 0.06046594589367263,
+    "ap": 0.9138203738562648,
+    "ap_stderr": 0.016358122993814245,
+    "evaluation_time": 3.34,
+    "f1": 0.7279047189447724,
+    "f1_stderr": 0.055918407384301656,
+    "main_score": 0.7785415421398685
+  },
+  "validation": {
+    "accuracy": 0.7890214797136038,
+    "accuracy_stderr": 0.06444753768326883,
+    "ap": 0.9570004694941152,
+    "ap_stderr": 0.010189851245946924,
+    "evaluation_time": 5.38,
+    "f1": 0.6974774929981921,
+    "f1_stderr": 0.06102218982582699,
+    "main_score": 0.7890214797136038
+  }
+}


### PR DESCRIPTION
<!-- If you are not submitting for a dataset, feel free to remove the content below  -->


<!-- add additional description, question etc. related to the new dataset -->

## Checklist for adding MMTEB dataset

<!-- 
Before you commit here is a checklist you should complete before submitting
if you are not 
 -->
Reason for dataset addition: Cover Bulgarian for Classification
<!-- Add reason for adding dataset here. E.g. it covers task/language/domain previously not covered -->


- [x] I have tested that the dataset runs with the `mteb` package.
- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
  - [x] `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
  - [x] `intfloat/multilingual-e5-small`
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [x] I have considered the size of the dataset and reduced it if it is too big (2048 examples is typically large enough for most tasks)
- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 
- [ ] I have added points for my submission to the [POINTS.md](https://github.com/embeddings-benchmark/mteb/blob/main/docs/mmteb/points.md) file.
