### PR TITLE
docs: Updated review points

### DIFF
--- a/docs/mmteb/points.md
+++ b/docs/mmteb/points.md
@@ -2,22 +2,22 @@
 
 | GitHub            | Total points | New dataset | New task | Dataset annotations | (Bug)fixes | Running Models | Review PR |  Paper Writing | Ideation | Coordination |
 |-------------------| ------------ |-------------| -------- | ------------------- | ---------- | -------------- |-----------| -------------- | -------- | ------------- |
-| KennethEnevoldsen |              | 54          |          |                   8 |         18 |                | 38        |                |          |             5 |
+| KennethEnevoldsen |              | 54          |          |                   8 |         18 |                | 70        |                |          |             5 |
 | x-tabdeveloping   |              | 48          |          |                     |            |                |           |                |          |               |
-| imenelydiaker     |              | 88          |          |                     |          3 |                | 18        |                |          |               |
-| wissam-sib        |              | 88          |          |                     |            |                | 1         |                |          |               |
+| imenelydiaker     |              | 88          |          |                     |          3 |                | 36        |                |          |               |
+| wissam-sib        |              | 88          |          |                     |            |                | 2         |                |          |               |
 | GabrielSequeira   |              | 88          |          |                     |            |                |           |                |          |               |
 | schmarion         |              | 88          |          |                     |            |                |           |                |          |               |
 | MathieuCiancone   |              | 88          |          |                     |            |                |           |                |          |               |
-| Sakshamrzt        |              | 10          |          |                     |            |                | 2         |                |          |               |
-| MartinBernstorff  |              | 2           |          |                     | 7          |                | 4         |                |          |               |
+| Sakshamrzt        |              | 10          |          |                     |            |                | 4         |                |          |               |
+| MartinBernstorff  |              | 2           |          |                     | 7          |                | 8         |                |          |               |
 | guenthermi        |              | 12          |          |                     |            |                |           |                |          |               |
-| Muennighoff       |              |             |          |                     |            |                | 8         |                |          |               |
+| Muennighoff       |              |             |          |                     |            |                | 16        |                |          |               |
 | rasdani           |              | 4           |          |                     |            |                |           |                |          |               |
-| PhilipMay         |              |             |          |                     |            |                | 1         |                |          |               |
+| PhilipMay         |              |             |          |                     |            |                | 2         |                |          |               |
 | slvnwhrl          |              | 12          |          |                     |            |                |           |                |          |               |
 | staoxiao          |              | 50          |          |                     |            |                |           |                |          |               |
-| NouamaneTazi      |              |             |          |                     |            |                | 1         |                |          |               |
+| NouamaneTazi      |              |             |          |                     |            |                | 2         |                |          |               |
 | rafalposwiata     |              | 32          |          |                     |            |                |           |                |          |               |
 | violenil          |              | 26          |          |                     |            |                |           |                |          |               |
 | hanhainebula      |              | 2           |          |                     |            |                |           |                |          |               |
@@ -30,7 +30,7 @@
 | orionw            |              |             |          |                     |      14    |                |           |                |          |               |
 | mmhamdy           |              | 14          |          |                     |            |                |           |                |          |               |
 | manandey          |              | 12          |          |                     |            |                |           |                |          |               |
-| isaac-chung       |              | 36          |          |                     |            |                | 10        |                |          |               |
+| isaac-chung       |              | 36          |          |                     |            |                | 20        |                |          |               |
 | asparius          |              | 8           |          |                     |            |                |           |                |          |               |
 | rbroc             |              | 12          |          |                     |            |                |           |                |          |               |
 | dwzhu-pku         |              | 12          |          |                     |            |                |           |                |          |               |


### PR DESCRIPTION
Seems like we have wrongly assigned review points as 1 point rather than 2. 

Thus I have duplicated all the review scores. This might lead. I realized this yesterday and have had 2 prs with 2 points (thus the subtraction in my score).

Let me know if you find any issues in the review scores.

Adding pr reviewers here to let people know about the change, but will merge it in to avoid merge conflicts.