### PR TITLE
Set the min Pydantic version to 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "tqdm",
     "rich",
     "pytrec-eval-terrier>=0.5.6",
-    "pydantic",
+    "pydantic>=2.0.0",
     "typing_extensions",
     "eval_type_backport",
 ]


### PR DESCRIPTION
I was trying to use this package with Pydantic 1.10, and realized I had an import error because it doesn't have `BeforeValidator`. I saw this was available from Pydantic 2, so I set the minimum to 2.

Note I didn't check further, so chances are that a greater minimum is needed (e.g., 2.1).