### PR TITLE
ci: Only create table in ci when pushing to main

### DIFF
--- a/.github/workflows/mmteb.yml
+++ b/.github/workflows/mmteb.yml
@@ -6,7 +6,6 @@ name: mmteb
 on:
   push:
     branches: [main]
-  pull_request:
 
 jobs:
   check-points:

--- a/.github/workflows/mmteb.yml
+++ b/.github/workflows/mmteb.yml
@@ -6,6 +6,7 @@ name: mmteb
 on:
   push:
     branches: [main]
+  pull_request:
 
 jobs:
   check-points:
@@ -29,10 +30,13 @@ jobs:
       - name: Validate jsonl points files
         run: python docs/mmteb/validate_points.py
 
+  create-table:
+    runs-on: ubuntu-latest
+    needs: check-points
+    steps:
       - name: Create table
         run: python docs/mmteb/create_points_table.py
-
-        
+    
       - name: Push table
         # only run on push to main
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/mmteb.yml
+++ b/.github/workflows/mmteb.yml
@@ -13,6 +13,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+          cache: "pip"
+
+      - name: Validate jsonl points files
+        run: python docs/mmteb/validate_points.py
+
+  create-table:
+    runs-on: ubuntu-latest
+    needs: check-points
+    steps:
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.RELEASE }}
 
@@ -26,14 +40,6 @@ jobs:
           make install
           pip install tabulate # for the table creation
 
-
-      - name: Validate jsonl points files
-        run: python docs/mmteb/validate_points.py
-
-  create-table:
-    runs-on: ubuntu-latest
-    needs: check-points
-    steps:
       - name: Create table
         run: python docs/mmteb/create_points_table.py
     

--- a/.github/workflows/mmteb.yml
+++ b/.github/workflows/mmteb.yml
@@ -27,6 +27,8 @@ jobs:
         run: python docs/mmteb/validate_points.py
 
   create-table:
+    # only run on push to main
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: check-points
     steps:
@@ -48,8 +50,6 @@ jobs:
         run: python docs/mmteb/create_points_table.py
     
       - name: Push table
-        # only run on push to main
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"

--- a/.github/workflows/mmteb.yml
+++ b/.github/workflows/mmteb.yml
@@ -18,6 +18,10 @@ jobs:
         with:
           python-version: "3.8"
           cache: "pip"
+      
+      - name: Install dependencies
+        run: |
+          make install
 
       - name: Validate jsonl points files
         run: python docs/mmteb/validate_points.py

--- a/.github/workflows/mmteb.yml
+++ b/.github/workflows/mmteb.yml
@@ -39,7 +39,6 @@ jobs:
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
-          git add docs/mmteb/points_table.md
           # check if the branch is up to date with the remote if not push the changes
-          git diff --exit-code || git commit -m "Update points table" && git push
+          git diff --exit-code || git add docs/mmteb/points_table.md && git commit -m "Update points table" && git push
           

--- a/docs/mmteb/points/473.jsonl
+++ b/docs/mmteb/points/473.jsonl
@@ -1,0 +1,1 @@
+{"GitHub": "isaac-chung", "Bug fixes": 2}

--- a/docs/mmteb/points/473.jsonl
+++ b/docs/mmteb/points/473.jsonl
@@ -1,1 +1,2 @@
 {"GitHub": "isaac-chung", "Bug fixes": 2}
+{"GitHub": "KennethEnevoldsen", "Review PR": 2}


### PR DESCRIPTION
Fix for  #471 and https://github.com/embeddings-benchmark/mteb/commit/22ca0e4e941b14d62d543d866fb4daecacdd2805.

## issue
1. For users without MTEB push access, the `check-points` CI step will face this error in the PR:
```
Error: Input required and not supplied: token
```
2. Even when new points files were added, the ci workflow did not register changes at the `git diff` step, so it always exits.

Fix is to 
1. split check points into 2 jobs: a) check points, b) create table
2. only run che when pushing to the main branch.
3. run `git add` after `git diff`