### PR TITLE
ci: Use if-else instead for points table creation

### DIFF
--- a/.github/workflows/mmteb.yml
+++ b/.github/workflows/mmteb.yml
@@ -54,5 +54,6 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
           # check if the branch is up to date with the remote if not push the changes
-          git diff --exit-code || git add docs/mmteb/points_table.md && git commit -m "Update points table" && git push
+          git add docs/mmteb/points_table.md
+          git diff-index --quiet HEAD || git commit -m "Update points table" && git push
           

--- a/.github/workflows/mmteb.yml
+++ b/.github/workflows/mmteb.yml
@@ -21,7 +21,7 @@ jobs:
       
       - name: Install dependencies
         run: |
-          make install
+          pip install jsonlines pydantic
 
       - name: Validate jsonl points files
         run: python docs/mmteb/validate_points.py
@@ -43,8 +43,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          make install
-          pip install tabulate # for the table creation
+          pip install pandas tabulate # for the table creation
 
       - name: Create table
         run: python docs/mmteb/create_points_table.py
@@ -53,7 +52,12 @@ jobs:
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
-          # check if the branch is up to date with the remote if not push the changes
-          git add docs/mmteb/points_table.md
-          git diff-index --quiet HEAD || git commit -m "Update points table" && git push
+          # Check if changes exist in points_table.md
+          if git diff --quiet; then
+            echo "No changes detected"
+          else
+            git add docs/mmteb/points_table.md
+            git commit -m "Update points table"
+            git push
+          fi
           


### PR DESCRIPTION
## Issue
While the fix/feature PR would run smoothly through CI, the github-actions bot would fail on the `create-table` job, specifically on the last step. 
```
nothing to commit, working tree clean
Error: Process completed with exit code 1.
```

## Fix
Use an if statement to explicitly check the exit status of `git diff --quiet` and allow proper branching based on whether changes are detected or not.

Also replaced `make install` with pip installing only the needed packages to speed up CI.
