### PR TITLE
Update WikiClusteringP2P with 10 new languages

### DIFF
--- a/docs/mmteb/points/486.jsonl
+++ b/docs/mmteb/points/486.jsonl
@@ -1,2 +1,2 @@
 {"GitHub": "Rysias", "New dataset": 40}
-{"GitHub": "KennethEnevoldsen", "Review PR": 2}
+{"GitHub": "isaac-chung", "Review PR": 2}

--- a/docs/mmteb/points/486.jsonl
+++ b/docs/mmteb/points/486.jsonl
@@ -1,0 +1,2 @@
+{"GitHub": "Rysias", "New dataset": 40}
+{"GitHub": "KennethEnevoldsen", "Review PR": 2}

--- a/mteb/tasks/Clustering/multilingual/WikiClusteringP2P.py
+++ b/mteb/tasks/Clustering/multilingual/WikiClusteringP2P.py
@@ -4,10 +4,20 @@ from mteb.abstasks import AbsTaskClustering, MultilingualTask
 from mteb.abstasks.TaskMetadata import TaskMetadata
 
 _LANGUAGES = {
+    "bs": ["bos-Latn"],
+    "ca": ["cat-Latn"],
+    "cs": ["ces-Latn"],
     "da": ["dan-Latn"],
-    "lv": ["lav-Latn"],
+    "eu": ["eus-Latn"],
     "gv": ["glv-Latn"],
+    "ilo": ["ilo-Latn"],
+    "ku": ["kur-Latn"],
+    "lv": ["lav-Latn"],
+    "min": ["min-Latn"],
+    "mt": ["mlt-Latn"],
+    "sco": ["sco-Latn"],
     "sq": ["sqi-Latn"],
+    "wa": ["wln-Latn"],
 }
 
 
@@ -18,7 +28,7 @@ class WikiClusteringP2P(AbsTaskClustering, MultilingualTask):
         reference="https://github.com/Rysias/wiki-clustering",
         dataset={
             "path": "ryzzlestrizzle/multi-wiki-clustering-p2p",
-            "revision": "7f1d0674aff24ac2b8c3c216e9128ba0f91a5cf4",
+            "revision": "d4d92f8f28be71035be6a96bdfd4e200cf62faa8",
         },
         type="Clustering",
         category="p2p",
@@ -35,6 +45,6 @@ class WikiClusteringP2P(AbsTaskClustering, MultilingualTask):
         dialect=[],
         text_creation="created",
         bibtex_citation=None,  # None exists
-        n_samples={"test": 40960},
-        avg_character_length={"test": 570.6},
+        n_samples={"test": 71680},
+        avg_character_length={"test": 625.3},
     )

--- a/results/intfloat__multilingual-e5-small/WikiClusteringP2P.json
+++ b/results/intfloat__multilingual-e5-small/WikiClusteringP2P.json
@@ -1,28 +1,78 @@
 {
-  "dataset_revision": "7f1d0674aff24ac2b8c3c216e9128ba0f91a5cf4",
+  "dataset_revision": "d4d92f8f28be71035be6a96bdfd4e200cf62faa8",
   "mteb_dataset_name": "WikiClusteringP2P",
-  "mteb_version": "1.6.8",
+  "mteb_version": "1.7.5",
   "test": {
-    "da": {
-      "main_score": 0.208703723380471,
-      "v_measure": 0.208703723380471,
-      "v_measure_std": 0.0053354626858436146
+    "bs": {
+      "main_score": 0.2541167806837964,
+      "v_measure": 0.2541167806837964,
+      "v_measure_std": 0.016153106125673618
     },
-    "evaluation_time": 6921.89,
+    "ca": {
+      "main_score": 0.19698843822682827,
+      "v_measure": 0.19698843822682827,
+      "v_measure_std": 0.01536505661938565
+    },
+    "cs": {
+      "main_score": 0.3543566860998334,
+      "v_measure": 0.3543566860998334,
+      "v_measure_std": 0.015300825613371781
+    },
+    "da": {
+      "main_score": 0.23333257744001537,
+      "v_measure": 0.23333257744001537,
+      "v_measure_std": 0.014842753394608433
+    },
+    "eu": {
+      "main_score": 0.2856937944292046,
+      "v_measure": 0.2856937944292046,
+      "v_measure_std": 0.018507128070786562
+    },
+    "evaluation_time": 352.32,
     "gv": {
-      "main_score": 0.33919581633902696,
-      "v_measure": 0.33919581633902696,
-      "v_measure_std": 0.009884179157398467
+      "main_score": 0.3710762702991593,
+      "v_measure": 0.3710762702991593,
+      "v_measure_std": 0.014647012024861574
+    },
+    "ilo": {
+      "main_score": 0.44884594794214927,
+      "v_measure": 0.44884594794214927,
+      "v_measure_std": 0.01394859659438483
+    },
+    "ku": {
+      "main_score": 0.37989226170704965,
+      "v_measure": 0.37989226170704965,
+      "v_measure_std": 0.01825876969205146
     },
     "lv": {
-      "main_score": 0.17697386668241943,
-      "v_measure": 0.17697386668241943,
-      "v_measure_std": 0.010786696689272759
+      "main_score": 0.21182416585684516,
+      "v_measure": 0.21182416585684516,
+      "v_measure_std": 0.01801516689578491
+    },
+    "min": {
+      "main_score": 0.3716294970309941,
+      "v_measure": 0.3716294970309941,
+      "v_measure_std": 0.02181443506291785
+    },
+    "mt": {
+      "main_score": 0.2929435584400858,
+      "v_measure": 0.2929435584400858,
+      "v_measure_std": 0.0157110881658719
+    },
+    "sco": {
+      "main_score": 0.2861776047041981,
+      "v_measure": 0.2861776047041981,
+      "v_measure_std": 0.009199491611087079
     },
     "sq": {
-      "main_score": 0.3191568682002431,
-      "v_measure": 0.3191568682002431,
-      "v_measure_std": 0.013872366324268859
+      "main_score": 0.35186479139630167,
+      "v_measure": 0.35186479139630167,
+      "v_measure_std": 0.017748606469782047
+    },
+    "wa": {
+      "main_score": 0.01646572421709879,
+      "v_measure": 0.01646572421709879,
+      "v_measure_std": 0.004915403382998344
     }
   }
 }

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/WikiClusteringP2P.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/WikiClusteringP2P.json
@@ -1,28 +1,78 @@
 {
-  "dataset_revision": "7f1d0674aff24ac2b8c3c216e9128ba0f91a5cf4",
+  "dataset_revision": "d4d92f8f28be71035be6a96bdfd4e200cf62faa8",
   "mteb_dataset_name": "WikiClusteringP2P",
-  "mteb_version": "1.6.8",
+  "mteb_version": "1.7.5",
   "test": {
-    "da": {
-      "main_score": 0.1866469639285096,
-      "v_measure": 0.1866469639285096,
-      "v_measure_std": 0.008480544735113525
+    "bs": {
+      "main_score": 0.24275888183250097,
+      "v_measure": 0.24275888183250097,
+      "v_measure_std": 0.015923773084382017
     },
-    "evaluation_time": 1376.03,
+    "ca": {
+      "main_score": 0.17362456492247325,
+      "v_measure": 0.17362456492247325,
+      "v_measure_std": 0.0188346214305365
+    },
+    "cs": {
+      "main_score": 0.3159118782670882,
+      "v_measure": 0.3159118782670882,
+      "v_measure_std": 0.014511322068262012
+    },
+    "da": {
+      "main_score": 0.21090080440497236,
+      "v_measure": 0.21090080440497236,
+      "v_measure_std": 0.010478052976093074
+    },
+    "eu": {
+      "main_score": 0.2758573119978112,
+      "v_measure": 0.2758573119978112,
+      "v_measure_std": 0.016229995805791906
+    },
+    "evaluation_time": 170.4,
     "gv": {
-      "main_score": 0.32782398301274507,
-      "v_measure": 0.32782398301274507,
-      "v_measure_std": 0.016829612431199174
+      "main_score": 0.3572014125910568,
+      "v_measure": 0.3572014125910568,
+      "v_measure_std": 0.02075240129364877
+    },
+    "ilo": {
+      "main_score": 0.4371649379780739,
+      "v_measure": 0.4371649379780739,
+      "v_measure_std": 0.010976415624748968
+    },
+    "ku": {
+      "main_score": 0.35246170271724336,
+      "v_measure": 0.35246170271724336,
+      "v_measure_std": 0.017273345866917124
     },
     "lv": {
-      "main_score": 0.16787180766447457,
-      "v_measure": 0.16787180766447457,
-      "v_measure_std": 0.013668170009908375
+      "main_score": 0.20122765955725047,
+      "v_measure": 0.20122765955725047,
+      "v_measure_std": 0.01987977031597341
+    },
+    "min": {
+      "main_score": 0.3858865695992173,
+      "v_measure": 0.3858865695992173,
+      "v_measure_std": 0.034634767245333355
+    },
+    "mt": {
+      "main_score": 0.2359285188819086,
+      "v_measure": 0.2359285188819086,
+      "v_measure_std": 0.016140287940952694
+    },
+    "sco": {
+      "main_score": 0.2669069634406312,
+      "v_measure": 0.2669069634406312,
+      "v_measure_std": 0.011776969628845028
     },
     "sq": {
-      "main_score": 0.30617715975273596,
-      "v_measure": 0.30617715975273596,
-      "v_measure_std": 0.01227888333864974
+      "main_score": 0.32266107538169103,
+      "v_measure": 0.32266107538169103,
+      "v_measure_std": 0.0174343604712366
+    },
+    "wa": {
+      "main_score": 0.016384432077744614,
+      "v_measure": 0.016384432077744614,
+      "v_measure_std": 0.008457831902868128
     }
   }
 }


### PR DESCRIPTION
<!-- If you are not submitting for a dataset, feel free to remove the content below  -->

As described in the title, I have updated WikiClusteringP2P with 10 brand new languages (wuhuu!). These have the following codes: 

- bos-Latn
- cat-Latn
- ces-Latn
- eus-Latn
- ilo-Latn
- kur-Latn
- min-Latn
- mlt-Latn
- sco-Latn
- wln-Latn

Apart from wln, all of the languages are European and all of them are from low to extremely low resource. 

I have also somewhat reduced the size of each dataset from 10 x 1024 to 10 x 512 - as can be seen in the results, the std is still fairly slim. 

Maybe it makes sense for @KennethEnevoldsen to take a look, as you're already familiar?

- [x] I have tested that the dataset runs with the `mteb` package.
- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
  - [x] `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
  - [x] `intfloat/multilingual-e5-small`
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [x] I have considered the size of the dataset and reduced it if it is too big (2048 examples is typically large enough for most tasks)
- [x] I have filled out the metadata object in the dataset file (find documentation on it [here](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md#2-creating-the-metadata-object)).
- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [ ] Run the formatter to format the code using `make lint`. 
- [x] I have added points for my submission to the [points folder](https://github.com/embeddings-benchmark/mteb/blob/main/docs/mmteb/points.md) using the PR number as the filename (e.g. `438.jsonl`).
