### PR TITLE
fix: update current dict and do not remove other splits

### DIFF
--- a/mteb/abstasks/AbsTask.py
+++ b/mteb/abstasks/AbsTask.py
@@ -65,16 +65,15 @@ class AbsTask(ABC):
         if not isinstance(dataset_dict[splits[0]].features[label], datasets.ClassLabel):
             dataset_dict = dataset_dict.class_encode_column(label)
 
-        ds_dict = {}
         for split in splits:
-            ds_dict.update(
+            dataset_dict.update(
                 {
                     split: dataset_dict[split].train_test_split(
                         test_size=n_samples, seed=seed, stratify_by_column=label
                     )["test"]
                 }
             )  ## only take the specified test split.
-        return datasets.DatasetDict(ds_dict)
+        return dataset_dict
 
     def load_data(self, **kwargs):
         """Load dataset from HuggingFace hub"""

--- a/mteb/tasks/Classification/fas/PersianFoodSentimentClassification.py
+++ b/mteb/tasks/Classification/fas/PersianFoodSentimentClassification.py
@@ -43,11 +43,6 @@ class PersianFoodSentimentClassification(AbsTaskClassification):
     )
 
     def dataset_transform(self):
-        self.dataset["validation"] = (
-            self.dataset["validation"]
-            .shuffle(seed=self.seed)
-            .select(range(TEST_SAMPLES))
-        )
-        self.dataset["test"] = (
-            self.dataset["test"].shuffle(seed=self.seed).select(range(TEST_SAMPLES))
+        self.dataset = self.stratified_subsampling(
+            self.dataset, seed=self.seed, splits=["validation", "test"]
         )

--- a/results/intfloat__multilingual-e5-small/PersianFoodSentimentClassification.json
+++ b/results/intfloat__multilingual-e5-small/PersianFoodSentimentClassification.json
@@ -1,25 +1,25 @@
 {
   "dataset_revision": "92ba517dfd22f6334111ad84154d16a2890f5b1d",
   "mteb_dataset_name": "PersianFoodSentimentClassification",
-  "mteb_version": "1.6.23",
+  "mteb_version": "1.7.13",
   "test": {
-    "accuracy": 0.76162109375,
-    "accuracy_stderr": 0.029608370076944144,
-    "ap": 0.7107301145647525,
-    "ap_stderr": 0.034055419244529754,
-    "evaluation_time": 12.65,
-    "f1": 0.7591600296974221,
-    "f1_stderr": 0.03217369721760639,
-    "main_score": 0.76162109375
+    "accuracy": 0.743701171875,
+    "accuracy_stderr": 0.027541356633721408,
+    "ap": 0.6905292631479201,
+    "ap_stderr": 0.02991974545843889,
+    "evaluation_time": 7.49,
+    "f1": 0.740601460820036,
+    "f1_stderr": 0.029892432663399013,
+    "main_score": 0.743701171875
   },
   "validation": {
-    "accuracy": 0.7482421875,
-    "accuracy_stderr": 0.027419676950723386,
-    "ap": 0.6907767680040339,
-    "ap_stderr": 0.03010830629103603,
-    "evaluation_time": 19.97,
-    "f1": 0.745168999799412,
-    "f1_stderr": 0.029181618331629827,
-    "main_score": 0.7482421875
+    "accuracy": 0.753564453125,
+    "accuracy_stderr": 0.032625848225642,
+    "ap": 0.7008866195287176,
+    "ap_stderr": 0.034855399642854494,
+    "evaluation_time": 8.44,
+    "f1": 0.7510130825181032,
+    "f1_stderr": 0.03460891571546719,
+    "main_score": 0.753564453125
   }
 }


### PR DESCRIPTION
Proposed fix for issue #520, the proposition is to update the splits of the current dataset dict instead of creating a new one. This should not update splits that are not mentioned in `splits` argument.