### PR TITLE
Use old datasets to match revisions

### DIFF
--- a/docs/mmteb/points/567.jsonl
+++ b/docs/mmteb/points/567.jsonl
@@ -1,0 +1,2 @@
+{"GitHub": "isaac-chung", "Bug fixes": 2}
+{"GitHub": "imenelydiaker", "Review PR": 2}

--- a/mteb/tasks/InstructionRetrieval/eng/Core17InstructionRetrieval.py
+++ b/mteb/tasks/InstructionRetrieval/eng/Core17InstructionRetrieval.py
@@ -11,7 +11,7 @@ class Core17InstructionRetrieval(AbsTaskInstructionRetrieval):
         description="Measuring retrieval instruction following ability on Core17 narratives.",
         reference="https://arxiv.org/abs/2403.15246",
         dataset={
-            "path": "jhu-clsp/core17-instructions",
+            "path": "jhu-clsp/core17-instructions-old",
             "revision": "e39ff896cf3efbbdeeb950e6bd7c79f266995b07",
         },
         type="InstructionRetrieval",

--- a/mteb/tasks/InstructionRetrieval/eng/News21InstructionRetrieval.py
+++ b/mteb/tasks/InstructionRetrieval/eng/News21InstructionRetrieval.py
@@ -11,7 +11,7 @@ class News21InstructionRetrieval(AbsTaskInstructionRetrieval):
         description="Measuring retrieval instruction following ability on News21 narratives.",
         reference="https://arxiv.org/abs/2403.15246",
         dataset={
-            "path": "jhu-clsp/news21-instructions",
+            "path": "jhu-clsp/news21-instructions-old",
             "revision": "e0144086b45fe31ac125e9ac1a83b6a409bb6ca6",
         },
         type="InstructionRetrieval",

--- a/mteb/tasks/InstructionRetrieval/eng/Robust04InstructionRetrieval.py
+++ b/mteb/tasks/InstructionRetrieval/eng/Robust04InstructionRetrieval.py
@@ -11,7 +11,7 @@ class Robust04InstructionRetrieval(AbsTaskInstructionRetrieval):
         description="Measuring retrieval instruction following ability on Robust04 narratives.",
         reference="https://arxiv.org/abs/2403.15246",
         dataset={
-            "path": "jhu-clsp/robust04-instructions",
+            "path": "jhu-clsp/robust04-instructions-old",
             "revision": "a5a1c4fe2bc528ac12e83f8cdf82178da85d2f1d",
         },
         type="InstructionRetrieval",


### PR DESCRIPTION
Addresses https://github.com/embeddings-benchmark/mteb/issues/566 for now.