### PR TITLE
fix: Add LegalBench datasets - 3

### DIFF
--- a/mteb/tasks/Classification/__init__.py
+++ b/mteb/tasks/Classification/__init__.py
@@ -24,6 +24,13 @@ from .eng.ContractNLIConfidentialityOfAgreementLegalBenchClassification import *
 from .eng.ContractNLIExplicitIdentificationLegalBenchClassification import *
 from .eng.ContractNLIInclusionOfVerballyConveyedInformationLegalBenchClassification import *
 from .eng.ContractNLILimitedUseLegalBenchClassification import *
+from .eng.ContractNLISharingWithThirdPartiesLegalBenchClassification import *
+from .eng.ContractNLISurvivalOfObligationsLegalBenchClassification import *
+from .eng.CorporateLobbyingLegalBenchClassification import *
+from .eng.CUADAffiliateLicenseLicenseeLegalBenchClassification import *
+from .eng.CUADAffiliateLicenseLicensorLegalBenchClassification import *
+from .eng.CUADAntiAssignmentLegalBenchClassification import *
+from .eng.CUADAuditRightsLegalBenchClassification import *
 from .eng.DBpediaClassification import *
 from .eng.EmotionClassification import *
 from .eng.FinancialPhrasebankClassification import *

--- a/mteb/tasks/Classification/eng/CUADAffiliateLicenseLicenseeLegalBenchClassification.py
+++ b/mteb/tasks/Classification/eng/CUADAffiliateLicenseLicenseeLegalBenchClassification.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from mteb.abstasks import AbsTaskClassification
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+
+class CUADAffiliateLicenseLicenseeLegalBenchClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="CUADAffiliateLicenseLicenseeLegalBenchClassification",
+        description="CUAD Affiliate License-Licensee LegalBench Classification Dataset",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "cuad_affiliate_license-licensee",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2023-08-23", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{hendrycks2021cuad,
+            title={Cuad: An expert-annotated nlp dataset for legal contract review},
+            author={Hendrycks, Dan and Burns, Collin and Chen, Anya and Ball, Spencer},
+            journal={arXiv preprint arXiv:2103.06268},
+            year={2021}
+        }
+        """,
+        n_samples={"test": 198},
+        avg_character_length={"test": 484.11},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")

--- a/mteb/tasks/Classification/eng/CUADAffiliateLicenseLicensorLegalBenchClassification.py
+++ b/mteb/tasks/Classification/eng/CUADAffiliateLicenseLicensorLegalBenchClassification.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from mteb.abstasks import AbsTaskClassification
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+
+class CUADAffiliateLicenseLicensorLegalBenchClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="CUADAffiliateLicenseLicensorLegalBenchClassification",
+        description="CUAD Affiliate License-Licensor LegalBench Classification Dataset",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "cuad_affiliate_license-licensor",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2023-08-23", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{hendrycks2021cuad,
+            title={Cuad: An expert-annotated nlp dataset for legal contract review},
+            author={Hendrycks, Dan and Burns, Collin and Chen, Anya and Ball, Spencer},
+            journal={arXiv preprint arXiv:2103.06268},
+            year={2021}
+        }
+        """,
+        n_samples={"test": 88},
+        avg_character_length={"test": 633.40},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")

--- a/mteb/tasks/Classification/eng/CUADAntiAssignmentLegalBenchClassification.py
+++ b/mteb/tasks/Classification/eng/CUADAntiAssignmentLegalBenchClassification.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from mteb.abstasks import AbsTaskClassification
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+
+class CUADAntiAssignmentLegalBenchClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="CUADAntiAssignmentLegalBenchClassification",
+        description="CUAD Anti-Assignment LegalBench Classification Dataset",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "cuad_anti-assignment",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2023-08-23", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{hendrycks2021cuad,
+            title={Cuad: An expert-annotated nlp dataset for legal contract review},
+            author={Hendrycks, Dan and Burns, Collin and Chen, Anya and Ball, Spencer},
+            journal={arXiv preprint arXiv:2103.06268},
+            year={2021}
+        }
+        """,
+        n_samples={"test": 1172},
+        avg_character_length={"test": 340.81},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")

--- a/mteb/tasks/Classification/eng/CUADAuditRightsLegalBenchClassification.py
+++ b/mteb/tasks/Classification/eng/CUADAuditRightsLegalBenchClassification.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from mteb.abstasks import AbsTaskClassification
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+
+class CUADAuditRightsLegalBenchClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="CUADAuditRightsLegalBenchClassification",
+        description="CUAD Audit Rights LegalBench Classification Dataset",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "cuad_audit_rights",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2023-08-23", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{hendrycks2021cuad,
+            title={Cuad: An expert-annotated nlp dataset for legal contract review},
+            author={Hendrycks, Dan and Burns, Collin and Chen, Anya and Ball, Spencer},
+            journal={arXiv preprint arXiv:2103.06268},
+            year={2021}
+        }
+        """,
+        n_samples={"test": 1216},
+        avg_character_length={"test": 337.14},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")

--- a/mteb/tasks/Classification/eng/ContractNLISharingWithThirdPartiesLegalBenchClassification.py
+++ b/mteb/tasks/Classification/eng/ContractNLISharingWithThirdPartiesLegalBenchClassification.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from mteb.abstasks import AbsTaskClassification
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+
+class ContractNLISharingWithThirdPartiesLegalBenchClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="ContractNLISharingWithThirdPartiesLegalBenchClassification",
+        description="Contract NLI Sharing With Third Parties LegalBench Classification Dataset",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "contract_nli_sharing_with_third-parties",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2023-08-23", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{koreeda2021contractnli,
+            title={ContractNLI: A dataset for document-level natural language inference for contracts},
+            author={Koreeda, Yuta and Manning, Christopher D},
+            journal={arXiv preprint arXiv:2110.01799},
+            year={2021}
+        }""",
+        n_samples={"test": 180},
+        avg_character_length={"test": 517.29},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")

--- a/mteb/tasks/Classification/eng/ContractNLISurvivalOfObligationsLegalBenchClassification.py
+++ b/mteb/tasks/Classification/eng/ContractNLISurvivalOfObligationsLegalBenchClassification.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from mteb.abstasks import AbsTaskClassification
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+
+class ContractNLISurvivalOfObligationsLegalBenchClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="ContractNLISurvivalOfObligationsLegalBenchClassification",
+        description="Contract NLI Survival of Obligations LegalBench Classification Dataset",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "contract_nli_survival_of_obligations",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2023-08-23", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{koreeda2021contractnli,
+            title={ContractNLI: A dataset for document-level natural language inference for contracts},
+            author={Koreeda, Yuta and Manning, Christopher D},
+            journal={arXiv preprint arXiv:2110.01799},
+            year={2021}
+        }""",
+        n_samples={"test": 157},
+        avg_character_length={"test": 417.64},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")

--- a/mteb/tasks/Classification/eng/CorporateLobbyingLegalBenchClassification.py
+++ b/mteb/tasks/Classification/eng/CorporateLobbyingLegalBenchClassification.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from mteb.abstasks import AbsTaskClassification
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+
+class CorporateLobbyingLegalBenchClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="CorporateLobbyingLegalBenchClassification",
+        description="Corporate Lobbying LegalBench Classification Dataset",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "corporate_lobbying",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2023-08-23", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        }
+        """,
+        n_samples={"test": 490},
+        avg_character_length={"test": 6039.85},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")
+
+        self.dataset = self.dataset.map(
+            lambda examples: {
+                "text": examples["bill_title"]
+                + "\n\n"
+                + examples["bill_summary"]
+                + "\n\n"
+                + examples["company_name"]
+                + "\n\n"
+                + examples["company_description"]
+            }
+        )
+        self.dataset = self.dataset.remove_columns(
+            ["bill_title", "bill_summary", "company_name", "company_description"]
+        )

--- a/mteb/tasks/PairClassification/__init__.py
+++ b/mteb/tasks/PairClassification/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from .deu.FalseFriendsDeEnPC import *
 from .eng.CitationPredictionLegalBenchPC import *
 from .eng.ConsumerContractsQALegalBenchPC import *
+from .eng.ContractQALegalBenchPC import *
 from .eng.SprintDuplicateQuestionsPC import *
 from .eng.TwitterSemEval2015PC import *
 from .eng.TwitterURLCorpusPC import *

--- a/mteb/tasks/PairClassification/eng/ContractQALegalBenchPC.py
+++ b/mteb/tasks/PairClassification/eng/ContractQALegalBenchPC.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from mteb.abstasks.AbsTaskPairClassification import AbsTaskPairClassification
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+
+class ContractQALegalBenchPC(AbsTaskPairClassification):
+    metadata = TaskMetadata(
+        name="ContractQALegalBenchPC",
+        description="Contract QA LegalBench Dataset",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "contract_qa",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="PairClassification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2023-08-23", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+            }""",
+        n_samples={"test": 80},
+        avg_character_length={"test": 263.88},
+    )
+
+    def dataset_transform(self):
+        _dataset = {}
+        mapping = {"yes": 1, "no": 0}
+        for split in self.metadata.eval_splits:
+            hf_dataset = self.dataset[split]
+            hf_dataset = hf_dataset.map(
+                lambda example: {
+                    "answer": mapping.get(example["answer"].lower(), example["answer"])
+                }
+            )
+
+            _dataset[split] = [
+                {
+                    "sent1": hf_dataset["text"],
+                    "sent2": hf_dataset["question"],
+                    "labels": hf_dataset["answer"],
+                }
+            ]
+        self.dataset = _dataset

--- a/results/intfloat__multilingual-e5-small/CUADAffiliateLicenseLicenseeLegalBenchClassification.json
+++ b/results/intfloat__multilingual-e5-small/CUADAffiliateLicenseLicenseeLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADAffiliateLicenseLicenseeLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.8434343434343434,
+    "accuracy_stderr": 0.0,
+    "ap": 0.7778696051423324,
+    "ap_stderr": 0.0,
+    "evaluation_time": 50.29,
+    "f1": 0.8429496200394034,
+    "f1_stderr": 1.1102230246251565e-16,
+    "main_score": 0.8434343434343434
+  }
+}

--- a/results/intfloat__multilingual-e5-small/CUADAffiliateLicenseLicensorLegalBenchClassification.json
+++ b/results/intfloat__multilingual-e5-small/CUADAffiliateLicenseLicensorLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADAffiliateLicenseLicensorLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.7840909090909091,
+    "accuracy_stderr": 0.0,
+    "ap": 0.7176015473887813,
+    "ap_stderr": 0.0,
+    "evaluation_time": 42.21,
+    "f1": 0.7838396897220428,
+    "f1_stderr": 0.0,
+    "main_score": 0.7840909090909091
+  }
+}

--- a/results/intfloat__multilingual-e5-small/CUADAntiAssignmentLegalBenchClassification.json
+++ b/results/intfloat__multilingual-e5-small/CUADAntiAssignmentLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADAntiAssignmentLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.8933447098976111,
+    "accuracy_stderr": 1.1102230246251565e-16,
+    "ap": 0.8618198151152887,
+    "ap_stderr": 0.0,
+    "evaluation_time": 91.14,
+    "f1": 0.8932383044931006,
+    "f1_stderr": 1.1102230246251565e-16,
+    "main_score": 0.8933447098976111
+  }
+}

--- a/results/intfloat__multilingual-e5-small/CUADAuditRightsLegalBenchClassification.json
+++ b/results/intfloat__multilingual-e5-small/CUADAuditRightsLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADAuditRightsLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.8933447098976111,
+    "accuracy_stderr": 1.1102230246251565e-16,
+    "ap": 0.8618198151152887,
+    "ap_stderr": 0.0,
+    "evaluation_time": 116.52,
+    "f1": 0.8932383044931006,
+    "f1_stderr": 1.1102230246251565e-16,
+    "main_score": 0.8933447098976111
+  }
+}

--- a/results/intfloat__multilingual-e5-small/ContractNLISharingWithThirdPartiesLegalBenchClassification.json
+++ b/results/intfloat__multilingual-e5-small/ContractNLISharingWithThirdPartiesLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "ContractNLISharingWithThirdPartiesLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.6166666666666668,
+    "accuracy_stderr": 1.1102230246251565e-16,
+    "ap": 0.4478090766823161,
+    "ap_stderr": 5.551115123125783e-17,
+    "evaluation_time": 37.36,
+    "f1": 0.5859861995399847,
+    "f1_stderr": 0.0,
+    "main_score": 0.6166666666666668
+  }
+}

--- a/results/intfloat__multilingual-e5-small/ContractNLISurvivalOfObligationsLegalBenchClassification.json
+++ b/results/intfloat__multilingual-e5-small/ContractNLISurvivalOfObligationsLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "ContractNLISurvivalOfObligationsLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.5605095541401274,
+    "accuracy_stderr": 0.0,
+    "ap": 0.5070174501318803,
+    "ap_stderr": 0.0,
+    "evaluation_time": 20.81,
+    "f1": 0.5602240896358543,
+    "f1_stderr": 0.0,
+    "main_score": 0.5605095541401274
+  }
+}

--- a/results/intfloat__multilingual-e5-small/ContractQALegalBenchPC.json
+++ b/results/intfloat__multilingual-e5-small/ContractQALegalBenchPC.json
@@ -1,0 +1,49 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "ContractQALegalBenchPC",
+  "mteb_version": "1.7.7",
+  "test": {
+    "cos_sim": {
+      "accuracy": 0.9875,
+      "accuracy_threshold": 0.8213544487953186,
+      "ap": 0.9943589743589744,
+      "f1": 0.9870129870129869,
+      "f1_threshold": 0.8213544487953186,
+      "precision": 1.0,
+      "recall": 0.9743589743589743
+    },
+    "dot": {
+      "accuracy": 0.9875,
+      "accuracy_threshold": 0.8213544487953186,
+      "ap": 0.9943589743589744,
+      "f1": 0.9870129870129869,
+      "f1_threshold": 0.8213544487953186,
+      "precision": 1.0,
+      "recall": 0.9743589743589743
+    },
+    "euclidean": {
+      "accuracy": 0.9875,
+      "accuracy_threshold": 0.5977367162704468,
+      "ap": 0.9943589743589744,
+      "f1": 0.9870129870129869,
+      "f1_threshold": 0.5977367162704468,
+      "precision": 1.0,
+      "recall": 0.9743589743589743
+    },
+    "evaluation_time": 3.91,
+    "manhattan": {
+      "accuracy": 0.95,
+      "accuracy_threshold": 9.19456672668457,
+      "ap": 0.9886061820706123,
+      "f1": 0.9487179487179487,
+      "f1_threshold": 9.317394256591797,
+      "precision": 0.9487179487179487,
+      "recall": 0.9487179487179487
+    },
+    "max": {
+      "accuracy": 0.9875,
+      "ap": 0.9943589743589744,
+      "f1": 0.9870129870129869
+    }
+  }
+}

--- a/results/intfloat__multilingual-e5-small/CorporateLobbyingLegalBenchClassification.json
+++ b/results/intfloat__multilingual-e5-small/CorporateLobbyingLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CorporateLobbyingLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.7040816326530612,
+    "accuracy_stderr": 0.0,
+    "ap": 0.2959183673469388,
+    "ap_stderr": 5.551115123125783e-17,
+    "evaluation_time": 288.63,
+    "f1": 0.4131736526946107,
+    "f1_stderr": 5.551115123125783e-17,
+    "main_score": 0.7040816326530612
+  }
+}

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADAffiliateLicenseLicenseeLegalBenchClassification.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADAffiliateLicenseLicenseeLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADAffiliateLicenseLicenseeLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.792929292929293,
+    "accuracy_stderr": 1.1102230246251565e-16,
+    "ap": 0.7149723036819811,
+    "ap_stderr": 0.0,
+    "evaluation_time": 21.13,
+    "f1": 0.7895746390523343,
+    "f1_stderr": 1.1102230246251565e-16,
+    "main_score": 0.792929292929293
+  }
+}

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADAffiliateLicenseLicensorLegalBenchClassification.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADAffiliateLicenseLicensorLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADAffiliateLicenseLicensorLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.5,
+    "accuracy_stderr": 0.0,
+    "ap": 0.5,
+    "ap_stderr": 0.0,
+    "evaluation_time": 17.38,
+    "f1": 0.4905263157894737,
+    "f1_stderr": 0.0,
+    "main_score": 0.5
+  }
+}

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADAntiAssignmentLegalBenchClassification.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADAntiAssignmentLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADAntiAssignmentLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.8745733788395904,
+    "accuracy_stderr": 0.0,
+    "ap": 0.8421244608986843,
+    "ap_stderr": 0.0,
+    "evaluation_time": 72.37,
+    "f1": 0.8742965461537956,
+    "f1_stderr": 1.1102230246251565e-16,
+    "main_score": 0.8745733788395904
+  }
+}

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADAuditRightsLegalBenchClassification.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADAuditRightsLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADAuditRightsLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.8745733788395904,
+    "accuracy_stderr": 0.0,
+    "ap": 0.8421244608986843,
+    "ap_stderr": 0.0,
+    "evaluation_time": 84.24,
+    "f1": 0.8742965461537956,
+    "f1_stderr": 1.1102230246251565e-16,
+    "main_score": 0.8745733788395904
+  }
+}

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/ContractNLISharingWithThirdPartiesLegalBenchClassification.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/ContractNLISharingWithThirdPartiesLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "ContractNLISharingWithThirdPartiesLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.5666666666666667,
+    "accuracy_stderr": 0.0,
+    "ap": 0.42693444618327253,
+    "ap_stderr": 5.551115123125783e-17,
+    "evaluation_time": 18.51,
+    "f1": 0.555921052631579,
+    "f1_stderr": 0.0,
+    "main_score": 0.5666666666666667
+  }
+}

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/ContractNLISurvivalOfObligationsLegalBenchClassification.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/ContractNLISurvivalOfObligationsLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "ContractNLISurvivalOfObligationsLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.6114649681528662,
+    "accuracy_stderr": 0.0,
+    "ap": 0.5407272056032703,
+    "ap_stderr": 1.1102230246251565e-16,
+    "evaluation_time": 15.44,
+    "f1": 0.6114649681528662,
+    "f1_stderr": 0.0,
+    "main_score": 0.6114649681528662
+  }
+}

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/ContractQALegalBenchPC.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/ContractQALegalBenchPC.json
@@ -1,0 +1,49 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "ContractQALegalBenchPC",
+  "mteb_version": "1.7.7",
+  "test": {
+    "cos_sim": {
+      "accuracy": 0.9,
+      "accuracy_threshold": 0.4227486550807953,
+      "ap": 0.9519395971292288,
+      "f1": 0.8974358974358975,
+      "f1_threshold": 0.4016370475292206,
+      "precision": 0.8974358974358975,
+      "recall": 0.8974358974358975
+    },
+    "dot": {
+      "accuracy": 0.8125,
+      "accuracy_threshold": 8.439628601074219,
+      "ap": 0.8969959731736563,
+      "f1": 0.7999999999999999,
+      "f1_threshold": 6.768938064575195,
+      "precision": 0.7391304347826086,
+      "recall": 0.8717948717948718
+    },
+    "euclidean": {
+      "accuracy": 0.9125,
+      "accuracy_threshold": 4.718072891235352,
+      "ap": 0.9675673426842629,
+      "f1": 0.9156626506024097,
+      "f1_threshold": 5.071141242980957,
+      "precision": 0.8636363636363636,
+      "recall": 0.9743589743589743
+    },
+    "evaluation_time": 4.53,
+    "manhattan": {
+      "accuracy": 0.9125,
+      "accuracy_threshold": 75.33625793457031,
+      "ap": 0.9642428430987486,
+      "f1": 0.9113924050632911,
+      "f1_threshold": 77.28935241699219,
+      "precision": 0.9,
+      "recall": 0.9230769230769231
+    },
+    "max": {
+      "accuracy": 0.9125,
+      "ap": 0.9675673426842629,
+      "f1": 0.9156626506024097
+    }
+  }
+}

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CorporateLobbyingLegalBenchClassification.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CorporateLobbyingLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CorporateLobbyingLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.7591836734693878,
+    "accuracy_stderr": 0.0,
+    "ap": 0.42160450387051374,
+    "ap_stderr": 0.0,
+    "evaluation_time": 44.73,
+    "f1": 0.6208126754282415,
+    "f1_stderr": 1.1102230246251565e-16,
+    "main_score": 0.7591836734693878
+  }
+}


### PR DESCRIPTION
<!-- If you are not submitting for a dataset, feel free to remove the content below  -->


<!-- add additional description, question etc. related to the new dataset -->

## Checklist for adding MMTEB dataset

<!-- 
Before you commit here is a checklist you should complete before submitting
if you are not 
 -->
Reason for dataset addition: Reason for dataset addition: Showcases the model's performance on the [LegalBench](https://hazyresearch.stanford.edu/legalbench/) datasets, enabling evaluation on domain-specific legal texts.

Follow up to #571

The following 8 datasets have been added in this PR:

1. [Contract NLI Sharing with third-parties](https://hazyresearch.stanford.edu/legalbench/tasks/contract_nli_sharing_with_third-parties.html)
2. [Contract NLI Survival of Obligations](https://hazyresearch.stanford.edu/legalbench/tasks/contract_nli_survival_of_obligations.html)
3. [Contract QA](https://hazyresearch.stanford.edu/legalbench/tasks/contract_qa.html)
4. [Corporate Lobbying](https://hazyresearch.stanford.edu/legalbench/tasks/corporate_lobbying.html)
5. [CUAD Affiliate License-Licensee](https://hazyresearch.stanford.edu/legalbench/tasks/cuad_affiliate_license-licensee.html)
6. [CUAD Affiliate License-Licensor](https://hazyresearch.stanford.edu/legalbench/tasks/cuad_affiliate_license-licensor.html)
7. [CUAD Anti-Assignment](https://hazyresearch.stanford.edu/legalbench/tasks/cuad_anti-assignment.html)
8. [CUAD Audit Rights](https://hazyresearch.stanford.edu/legalbench/tasks/cuad_audit_rights.html)

<!-- Add reason for adding dataset here. E.g. it covers task/language/domain previously not covered -->


- [x] I have tested that the dataset runs with the `mteb` package.
- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
  - [x] `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
  - [x] `intfloat/multilingual-e5-small`
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [x] If the dataset is too big (e.g. >2048 examples), considering using `self.stratified_subsampling() under dataset_transform()`
- [x] I have filled out the metadata object in the dataset file (find documentation on it [here](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md#2-creating-the-metadata-object)).
- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 
- [ ] I have added points for my submission to the [points folder](https://github.com/embeddings-benchmark/mteb/blob/main/docs/mmteb/points.md) using the PR number as the filename (e.g. `438.jsonl`).
