### PR TITLE
fix: Add LegalBench datasets - 4

### DIFF
--- a/mteb/tasks/Classification/eng/LegalBenchClassification.py
+++ b/mteb/tasks/Classification/eng/LegalBenchClassification.py
@@ -1078,3 +1078,437 @@ class CUADAuditRightsLegalBenchClassification(AbsTaskClassification):
             }
         )
         self.dataset = self.dataset.rename_column("answer", "label")
+
+
+class CUADCapOnLiabilityLegalBenchClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="CUADCapOnLiabilityLegalBenchClassification",
+        description="This task was constructed from the CUAD dataset. It consists of determining if the clause specifies a cap on liability upon the breach of a party's obligation. This includes time limitation for the counterparty to bring claims or maximum amount for recovery.",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "cuad_cap_on_liability",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2023-08-23", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{hendrycks2021cuad,
+            title={Cuad: An expert-annotated nlp dataset for legal contract review},
+            author={Hendrycks, Dan and Burns, Collin and Chen, Anya and Ball, Spencer},
+            journal={arXiv preprint arXiv:2103.06268},
+            year={2021}
+        }
+        """,
+        n_samples={"test": 1216},
+        avg_character_length={"test": 337.14},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")
+
+
+class CUADChangeOfControlLegalBenchClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="CUADChangeOfControlLegalBenchClassification",
+        description="This task was constructed from the CUAD dataset. It consists of determining if the clause gives one party the right to terminate or is consent or notice required of the counterparty if such party undergoes a change of control, such as a merger, stock sale, transfer of all or substantially all of its assets or business, or assignment by operation of law.",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "cuad_change_of_control",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2023-08-23", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{hendrycks2021cuad,
+            title={Cuad: An expert-annotated nlp dataset for legal contract review},
+            author={Hendrycks, Dan and Burns, Collin and Chen, Anya and Ball, Spencer},
+            journal={arXiv preprint arXiv:2103.06268},
+            year={2021}
+        }
+        """,
+        n_samples={"test": 1216},
+        avg_character_length={"test": 337.14},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")
+
+
+class CUADCompetitiveRestrictionExceptionLegalBenchClassification(
+    AbsTaskClassification
+):
+    metadata = TaskMetadata(
+        name="CUADCompetitiveRestrictionExceptionLegalBenchClassification",
+        description="This task was constructed from the CUAD dataset. It consists of determining if the clause mentions exceptions or carveouts to Non-Compete, Exclusivity and No-Solicit of Customers.",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "cuad_competitive_restriction_exception",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2023-08-23", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{hendrycks2021cuad,
+            title={Cuad: An expert-annotated nlp dataset for legal contract review},
+            author={Hendrycks, Dan and Burns, Collin and Chen, Anya and Ball, Spencer},
+            journal={arXiv preprint arXiv:2103.06268},
+            year={2021}
+        }
+        """,
+        n_samples={"test": 1216},
+        avg_character_length={"test": 337.14},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")
+
+
+class CUADCovenantNotToSueLegalBenchClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="CUADCovenantNotToSueLegalBenchClassification",
+        description="This task was constructed from the CUAD dataset. It consists of determining if the clause specifies that a party is restricted from contesting the validity of the counterparty's ownership of intellectual property or otherwise bringing a claim against the counterparty for matters unrelated to the contract.",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "cuad_covenant_not_to_sue",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2023-08-23", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{hendrycks2021cuad,
+            title={Cuad: An expert-annotated nlp dataset for legal contract review},
+            author={Hendrycks, Dan and Burns, Collin and Chen, Anya and Ball, Spencer},
+            journal={arXiv preprint arXiv:2103.06268},
+            year={2021}
+        }
+        """,
+        n_samples={"test": 1216},
+        avg_character_length={"test": 337.14},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")
+
+
+class CUADEffectiveDateLegalBenchClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="CUADEffectiveDateLegalBenchClassification",
+        description="This task was constructed from the CUAD dataset. It consists of determining if the clause specifies the date upon which the agreement becomes effective.",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "cuad_effective_date",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2023-08-23", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{hendrycks2021cuad,
+            title={Cuad: An expert-annotated nlp dataset for legal contract review},
+            author={Hendrycks, Dan and Burns, Collin and Chen, Anya and Ball, Spencer},
+            journal={arXiv preprint arXiv:2103.06268},
+            year={2021}
+        }
+        """,
+        n_samples={"test": 1216},
+        avg_character_length={"test": 337.14},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")
+
+
+class CUADExclusivityLegalBenchClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="CUADExclusivityLegalBenchClassification",
+        description="This task was constructed from the CUAD dataset. It consists of determining if the clause specifies exclusive dealing commitment with the counterparty. This includes a commitment to procure all 'requirements' from one party of certain technology, goods, or services or a prohibition on licensing or selling technology, goods or services to third parties, or a prohibition on collaborating or working with other parties), whether during the contract or after the contract ends (or both).",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "cuad_exclusivity",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2023-08-23", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{hendrycks2021cuad,
+            title={Cuad: An expert-annotated nlp dataset for legal contract review},
+            author={Hendrycks, Dan and Burns, Collin and Chen, Anya and Ball, Spencer},
+            journal={arXiv preprint arXiv:2103.06268},
+            year={2021}
+        }
+        """,
+        n_samples={"test": 1216},
+        avg_character_length={"test": 337.14},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")
+
+
+class CUADExpirationDateLegalBenchClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="CUADExpirationDateLegalBenchClassification",
+        description="This task was constructed from the CUAD dataset. It consists of determining if the clause specifies the date upon which the initial term expires.",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "cuad_expiration_date",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2023-08-23", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{hendrycks2021cuad,
+            title={Cuad: An expert-annotated nlp dataset for legal contract review},
+            author={Hendrycks, Dan and Burns, Collin and Chen, Anya and Ball, Spencer},
+            journal={arXiv preprint arXiv:2103.06268},
+            year={2021}
+        }
+        """,
+        n_samples={"test": 1216},
+        avg_character_length={"test": 337.14},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")
+
+
+class CUADGoverningLawLegalBenchClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="CUADGoverningLawLegalBenchClassification",
+        description="This task was constructed from the CUAD dataset. It consists of determining if the clause specifies which state/country’s law governs the contract.",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "cuad_governing_law",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2023-08-23", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{hendrycks2021cuad,
+            title={Cuad: An expert-annotated nlp dataset for legal contract review},
+            author={Hendrycks, Dan and Burns, Collin and Chen, Anya and Ball, Spencer},
+            journal={arXiv preprint arXiv:2103.06268},
+            year={2021}
+        }
+        """,
+        n_samples={"test": 1216},
+        avg_character_length={"test": 337.14},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")

--- a/mteb/tasks/Classification/eng/LegalBenchClassification.py
+++ b/mteb/tasks/Classification/eng/LegalBenchClassification.py
@@ -7,7 +7,7 @@ from mteb.abstasks.TaskMetadata import TaskMetadata
 class CanadaTaxCourtOutcomesLegalBenchClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="CanadaTaxCourtOutcomesLegalBenchClassification",
-        description="Canada Tax Court Outcomes LegalBench Classification Dataset",
+        description="The input is an excerpt of text from Tax Court of Canada decisions involving appeals of tax related matters. The task is to classify whether the excerpt includes the outcome of the appeal, and if so, to specify whether the appeal was allowed or dismissed. Partial success (e.g. appeal granted on one tax year but dismissed on another) counts as allowed (with the exception of costs orders which are disregarded). Where the excerpt does not clearly articulate an outcome, the system should indicate other as the outcome. Categorizing case outcomes is a common task that legal researchers complete in order to gather datasets involving outcomes in legal processes for the purposes of quantitative empirical legal research.",
         reference="https://huggingface.co/datasets/nguha/legalbench",
         dataset={
             "path": "nguha/legalbench",
@@ -50,7 +50,7 @@ class ContractNLIConfidentialityOfAgreementLegalBenchClassification(
 ):
     metadata = TaskMetadata(
         name="ContractNLIConfidentialityOfAgreementLegalBenchClassification",
-        description="Contract NLI Confidentiality Of Agreement LegalBench Classification Dataset",
+        description="This task is a subset of ContractNLI, and consists of determining whether a clause from an NDA provides that the Receiving Party shall not disclose the fact that Agreement was agreed or negotiated.",
         reference="https://huggingface.co/datasets/nguha/legalbench",
         dataset={
             "path": "nguha/legalbench",
@@ -103,7 +103,7 @@ class ContractNLIConfidentialityOfAgreementLegalBenchClassification(
 class ContractNLIExplicitIdentificationLegalBenchClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="ContractNLIExplicitIdentificationLegalBenchClassification",
-        description="Contract NLI Explicit Identification LegalBench Classification Dataset",
+        description="This task is a subset of ContractNLI, and consists of determining whether a clause from an NDA clause provides that all Confidential Information shall be expressly identified by the Disclosing Party.",
         reference="https://huggingface.co/datasets/nguha/legalbench",
         dataset={
             "path": "nguha/legalbench",
@@ -158,7 +158,7 @@ class ContractNLIInclusionOfVerballyConveyedInformationLegalBenchClassification(
 ):
     metadata = TaskMetadata(
         name="ContractNLIInclusionOfVerballyConveyedInformationLegalBenchClassification",
-        description="Contract NLI Inclusion of Verbally Conveyed Information LegalBench Classification Dataset",
+        description="This task is a subset of ContractNLI, and consists of determining whether a clause from an NDA clause provides that Confidential Information may include verbally conveyed information.",
         reference="https://huggingface.co/datasets/nguha/legalbench",
         dataset={
             "path": "nguha/legalbench",
@@ -211,7 +211,7 @@ class ContractNLIInclusionOfVerballyConveyedInformationLegalBenchClassification(
 class ContractNLILimitedUseLegalBenchClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="ContractNLILimitedUseLegalBenchClassification",
-        description="Contract NLI Limited Use LegalBench Classification Dataset",
+        description="This task is a subset of ContractNLI, and consists of determining whether a clause from an NDA clause provides that the Receiving Party shall not use any Confidential Information for any purpose other than the purposes stated in Agreement.",
         reference="https://huggingface.co/datasets/nguha/legalbench",
         dataset={
             "path": "nguha/legalbench",
@@ -264,7 +264,7 @@ class ContractNLILimitedUseLegalBenchClassification(AbsTaskClassification):
 class ContractNLINoLicensingLegalBenchClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="ContractNLINoLicensingLegalBenchClassification",
-        description="Contract NLI No Licensing LegalBench Classification Dataset",
+        description="This task is a subset of ContractNLI, and consists of determining whether a clause from an NDA clause provides that the Agreement shall not grant Receiving Party any right to Confidential Information.",
         reference="https://huggingface.co/datasets/nguha/legalbench",
         dataset={
             "path": "nguha/legalbench",
@@ -319,7 +319,7 @@ class ContractNLINoticeOnCompelledDisclosureLegalBenchClassification(
 ):
     metadata = TaskMetadata(
         name="ContractNLINoticeOnCompelledDisclosureLegalBenchClassification",
-        description="Contract NLI Notice on Compelled Disclosure LegalBench Classification Dataset",
+        description="This task is a subset of ContractNLI, and consists of determining whether a clause from an NDA clause provides that the Receiving Party shall notify Disclosing Party in case Receiving Party is required by law, regulation or judicial process to disclose any Confidential Information.",
         reference="https://huggingface.co/datasets/nguha/legalbench",
         dataset={
             "path": "nguha/legalbench",
@@ -374,7 +374,7 @@ class ContractNLIPermissibleAcquirementOfSimilarInformationLegalBenchClassificat
 ):
     metadata = TaskMetadata(
         name="ContractNLIPermissibleAcquirementOfSimilarInformationLegalBenchClassification",
-        description="Contract NLI Permissible Acquirement of Similar Information LegalBench Classification Dataset",
+        description="This task is a subset of ContractNLI, and consists of determining whether a clause from an NDA clause provides that the Receiving Party may acquire information similar to Confidential Information from a third party.",
         reference="https://huggingface.co/datasets/nguha/legalbench",
         dataset={
             "path": "nguha/legalbench",
@@ -427,7 +427,7 @@ class ContractNLIPermissibleAcquirementOfSimilarInformationLegalBenchClassificat
 class ContractNLIPermissibleCopyLegalBenchClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="ContractNLIPermissibleCopyLegalBenchClassification",
-        description="Contract NLI Permissible Copy LegalBench Classification Dataset",
+        description="This task is a subset of ContractNLI, and consists of determining whether a clause from an NDA clause provides that the Receiving Party may create a copy of some Confidential Information in some circumstances.",
         reference="https://huggingface.co/datasets/nguha/legalbench",
         dataset={
             "path": "nguha/legalbench",
@@ -482,7 +482,7 @@ class ContractNLIPermissibleDevelopmentOfSimilarInformationLegalBenchClassificat
 ):
     metadata = TaskMetadata(
         name="ContractNLIPermissibleDevelopmentOfSimilarInformationLegalBenchClassification",
-        description="Contract NLI Permissible Development of Similar Information LegalBench Classification Dataset",
+        description="This task is a subset of ContractNLI, and consists of determining whether a clause from an NDA clause provides that the Receiving Party may independently develop information similar to Confidential Information.",
         reference="https://huggingface.co/datasets/nguha/legalbench",
         dataset={
             "path": "nguha/legalbench",
@@ -537,7 +537,7 @@ class ContractNLIPermissiblePostAgreementPossessionLegalBenchClassification(
 ):
     metadata = TaskMetadata(
         name="ContractNLIPermissiblePostAgreementPossessionLegalBenchClassification",
-        description="Contract NLI Permissible Post Agreement Possession LegalBench Classification Dataset",
+        description="This task is a subset of ContractNLI, and consists of determining whether a clause from an NDA clause provides that the Receiving Party may retain some Confidential Information even after the return or destruction of Confidential Information.",
         reference="https://huggingface.co/datasets/nguha/legalbench",
         dataset={
             "path": "nguha/legalbench",
@@ -592,7 +592,7 @@ class ContractNLIReturnOfConfidentialInformationLegalBenchClassification(
 ):
     metadata = TaskMetadata(
         name="ContractNLIReturnOfConfidentialInformationLegalBenchClassification",
-        description="Contract NLI Return of Confidential Information LegalBench Classification Dataset",
+        description="This task is a subset of ContractNLI, and consists of determining whether a clause from an NDA clause provides that the Receiving Party shall destroy or return some Confidential Information upon the termination of Agreement.",
         reference="https://huggingface.co/datasets/nguha/legalbench",
         dataset={
             "path": "nguha/legalbench",
@@ -645,7 +645,7 @@ class ContractNLIReturnOfConfidentialInformationLegalBenchClassification(
 class ContractNLISharingWithEmployeesLegalBenchClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="ContractNLISharingWithEmployeesLegalBenchClassification",
-        description="Contract NLI Sharing With Employees LegalBench Classification Dataset",
+        description="This task is a subset of ContractNLI, and consists of determining whether a clause from an NDA clause provides that the Receiving Party may share some Confidential Information with some of Receiving Party's employees.",
         reference="https://huggingface.co/datasets/nguha/legalbench",
         dataset={
             "path": "nguha/legalbench",
@@ -698,7 +698,7 @@ class ContractNLISharingWithEmployeesLegalBenchClassification(AbsTaskClassificat
 class ContractNLISharingWithThirdPartiesLegalBenchClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="ContractNLISharingWithThirdPartiesLegalBenchClassification",
-        description="Contract NLI Sharing With Third Parties LegalBench Classification Dataset",
+        description="This task is a subset of ContractNLI, and consists of determining whether a clause from an NDA clause provides that the Receiving Party may share some Confidential Information with some third-parties (including consultants, agents and professional advisors).",
         reference="https://huggingface.co/datasets/nguha/legalbench",
         dataset={
             "path": "nguha/legalbench",
@@ -751,7 +751,7 @@ class ContractNLISharingWithThirdPartiesLegalBenchClassification(AbsTaskClassifi
 class ContractNLISurvivalOfObligationsLegalBenchClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="ContractNLISurvivalOfObligationsLegalBenchClassification",
-        description="Contract NLI Survival of Obligations LegalBench Classification Dataset",
+        description="This task is a subset of ContractNLI, and consists of determining whether a clause from an NDA clause provides that some obligations of Agreement may survive termination of Agreement.",
         reference="https://huggingface.co/datasets/nguha/legalbench",
         dataset={
             "path": "nguha/legalbench",
@@ -804,7 +804,7 @@ class ContractNLISurvivalOfObligationsLegalBenchClassification(AbsTaskClassifica
 class CorporateLobbyingLegalBenchClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="CorporateLobbyingLegalBenchClassification",
-        description="Corporate Lobbying LegalBench Classification Dataset",
+        description="The Corporate Lobbying task cosists of determining whether a proposed Congressional bill may be relevant to a company based on a company's self-description in its SEC 10K filing.",
         reference="https://huggingface.co/datasets/nguha/legalbench",
         dataset={
             "path": "nguha/legalbench",
@@ -867,7 +867,7 @@ class CorporateLobbyingLegalBenchClassification(AbsTaskClassification):
 class CUADAffiliateLicenseLicenseeLegalBenchClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="CUADAffiliateLicenseLicenseeLegalBenchClassification",
-        description="CUAD Affiliate License-Licensee LegalBench Classification Dataset",
+        description="This task was constructed from the CUAD dataset. It consists of determining if a clause describes a license grant to a licensee (incl. sublicensor) and the affiliates of such licensee/sublicensor.",
         reference="https://huggingface.co/datasets/nguha/legalbench",
         dataset={
             "path": "nguha/legalbench",
@@ -921,7 +921,7 @@ class CUADAffiliateLicenseLicenseeLegalBenchClassification(AbsTaskClassification
 class CUADAffiliateLicenseLicensorLegalBenchClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="CUADAffiliateLicenseLicensorLegalBenchClassification",
-        description="CUAD Affiliate License-Licensor LegalBench Classification Dataset",
+        description="This task was constructed from the CUAD dataset. It consists of determining if the clause describes a license grant by affiliates of the licensor or that includes intellectual property of affiliates of the licensor.",
         reference="https://huggingface.co/datasets/nguha/legalbench",
         dataset={
             "path": "nguha/legalbench",
@@ -975,7 +975,7 @@ class CUADAffiliateLicenseLicensorLegalBenchClassification(AbsTaskClassification
 class CUADAntiAssignmentLegalBenchClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="CUADAntiAssignmentLegalBenchClassification",
-        description="CUAD Anti-Assignment LegalBench Classification Dataset",
+        description="This task was constructed from the CUAD dataset. It consists of determining if the clause requires consent or notice of a party if the contract is assigned to a third party.",
         reference="https://huggingface.co/datasets/nguha/legalbench",
         dataset={
             "path": "nguha/legalbench",
@@ -1029,7 +1029,7 @@ class CUADAntiAssignmentLegalBenchClassification(AbsTaskClassification):
 class CUADAuditRightsLegalBenchClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="CUADAuditRightsLegalBenchClassification",
-        description="CUAD Audit Rights LegalBench Classification Dataset",
+        description="This task was constructed from the CUAD dataset. It consists of determining if the clause gives a party the right to audit the books, records, or physical locations of the counterparty to ensure compliance with the contract.",
         reference="https://huggingface.co/datasets/nguha/legalbench",
         dataset={
             "path": "nguha/legalbench",

--- a/mteb/tasks/Classification/eng/LegalBenchClassification.py
+++ b/mteb/tasks/Classification/eng/LegalBenchClassification.py
@@ -79,7 +79,13 @@ class ContractNLIConfidentialityOfAgreementLegalBenchClassification(
             eprint={2308.11462},
             archivePrefix={arXiv},
             primaryClass={cs.CL}
-            }""",
+        },
+        @article{koreeda2021contractnli,
+            title={ContractNLI: A dataset for document-level natural language inference for contracts},
+            author={Koreeda, Yuta and Manning, Christopher D},
+            journal={arXiv preprint arXiv:2110.01799},
+            year={2021}
+        }""",
         n_samples={"test": 82},
         avg_character_length={"test": 473.17},
     )
@@ -126,7 +132,13 @@ class ContractNLIExplicitIdentificationLegalBenchClassification(AbsTaskClassific
             eprint={2308.11462},
             archivePrefix={arXiv},
             primaryClass={cs.CL}
-            }""",
+        },
+        @article{koreeda2021contractnli,
+            title={ContractNLI: A dataset for document-level natural language inference for contracts},
+            author={Koreeda, Yuta and Manning, Christopher D},
+            journal={arXiv preprint arXiv:2110.01799},
+            year={2021}
+        }""",
         n_samples={"test": 109},
         avg_character_length={"test": 506.12},
     )
@@ -141,14 +153,16 @@ class ContractNLIExplicitIdentificationLegalBenchClassification(AbsTaskClassific
         self.dataset = self.dataset.rename_column("answer", "label")
 
 
-class CUADAuditRightsLegalBenchClassification(AbsTaskClassification):
+class ContractNLIInclusionOfVerballyConveyedInformationLegalBenchClassification(
+    AbsTaskClassification
+):
     metadata = TaskMetadata(
-        name="CUADAuditRightsLegalBenchClassification",
-        description="CUAD Audit Rights LegalBench Classification Dataset",
+        name="ContractNLIInclusionOfVerballyConveyedInformationLegalBenchClassification",
+        description="Contract NLI Inclusion of Verbally Conveyed Information LegalBench Classification Dataset",
         reference="https://huggingface.co/datasets/nguha/legalbench",
         dataset={
             "path": "nguha/legalbench",
-            "name": "cuad_audit_rights",
+            "name": "contract_nli_inclusion_of_verbally_conveyed_information",
             "revision": "12ca3b695563788fead87a982ad1a068284413f4",
         },
         type="Classification",
@@ -174,15 +188,14 @@ class CUADAuditRightsLegalBenchClassification(AbsTaskClassification):
             archivePrefix={arXiv},
             primaryClass={cs.CL}
         },
-        @article{hendrycks2021cuad,
-            title={Cuad: An expert-annotated nlp dataset for legal contract review},
-            author={Hendrycks, Dan and Burns, Collin and Chen, Anya and Ball, Spencer},
-            journal={arXiv preprint arXiv:2103.06268},
+        @article{koreeda2021contractnli,
+            title={ContractNLI: A dataset for document-level natural language inference for contracts},
+            author={Koreeda, Yuta and Manning, Christopher D},
+            journal={arXiv preprint arXiv:2110.01799},
             year={2021}
-        }
-        """,
-        n_samples={"test": 1216},
-        avg_character_length={"test": 337.14},
+        }""",
+        n_samples={"test": 139},
+        avg_character_length={"test": 525.75},
     )
 
     def dataset_transform(self):
@@ -195,14 +208,14 @@ class CUADAuditRightsLegalBenchClassification(AbsTaskClassification):
         self.dataset = self.dataset.rename_column("answer", "label")
 
 
-class CUADAntiAssignmentLegalBenchClassification(AbsTaskClassification):
+class ContractNLILimitedUseLegalBenchClassification(AbsTaskClassification):
     metadata = TaskMetadata(
-        name="CUADAntiAssignmentLegalBenchClassification",
-        description="CUAD Anti-Assignment LegalBench Classification Dataset",
+        name="ContractNLILimitedUseLegalBenchClassification",
+        description="Contract NLI Limited Use LegalBench Classification Dataset",
         reference="https://huggingface.co/datasets/nguha/legalbench",
         dataset={
             "path": "nguha/legalbench",
-            "name": "cuad_anti-assignment",
+            "name": "contract_nli_limited_use",
             "revision": "12ca3b695563788fead87a982ad1a068284413f4",
         },
         type="Classification",
@@ -228,15 +241,14 @@ class CUADAntiAssignmentLegalBenchClassification(AbsTaskClassification):
             archivePrefix={arXiv},
             primaryClass={cs.CL}
         },
-        @article{hendrycks2021cuad,
-            title={Cuad: An expert-annotated nlp dataset for legal contract review},
-            author={Hendrycks, Dan and Burns, Collin and Chen, Anya and Ball, Spencer},
-            journal={arXiv preprint arXiv:2103.06268},
+        @article{koreeda2021contractnli,
+            title={ContractNLI: A dataset for document-level natural language inference for contracts},
+            author={Koreeda, Yuta and Manning, Christopher D},
+            journal={arXiv preprint arXiv:2110.01799},
             year={2021}
-        }
-        """,
-        n_samples={"test": 1172},
-        avg_character_length={"test": 340.81},
+        }""",
+        n_samples={"test": 208},
+        avg_character_length={"test": 407.51},
     )
 
     def dataset_transform(self):
@@ -249,14 +261,14 @@ class CUADAntiAssignmentLegalBenchClassification(AbsTaskClassification):
         self.dataset = self.dataset.rename_column("answer", "label")
 
 
-class CUADAffiliateLicenseLicensorLegalBenchClassification(AbsTaskClassification):
+class ContractNLINoLicensingLegalBenchClassification(AbsTaskClassification):
     metadata = TaskMetadata(
-        name="CUADAffiliateLicenseLicensorLegalBenchClassification",
-        description="CUAD Affiliate License-Licensor LegalBench Classification Dataset",
+        name="ContractNLINoLicensingLegalBenchClassification",
+        description="Contract NLI No Licensing LegalBench Classification Dataset",
         reference="https://huggingface.co/datasets/nguha/legalbench",
         dataset={
             "path": "nguha/legalbench",
-            "name": "cuad_affiliate_license-licensor",
+            "name": "contract_nli_no_licensing",
             "revision": "12ca3b695563788fead87a982ad1a068284413f4",
         },
         type="Classification",
@@ -282,15 +294,14 @@ class CUADAffiliateLicenseLicensorLegalBenchClassification(AbsTaskClassification
             archivePrefix={arXiv},
             primaryClass={cs.CL}
         },
-        @article{hendrycks2021cuad,
-            title={Cuad: An expert-annotated nlp dataset for legal contract review},
-            author={Hendrycks, Dan and Burns, Collin and Chen, Anya and Ball, Spencer},
-            journal={arXiv preprint arXiv:2103.06268},
+        @article{koreeda2021contractnli,
+            title={ContractNLI: A dataset for document-level natural language inference for contracts},
+            author={Koreeda, Yuta and Manning, Christopher D},
+            journal={arXiv preprint arXiv:2110.01799},
             year={2021}
-        }
-        """,
-        n_samples={"test": 88},
-        avg_character_length={"test": 633.40},
+        }""",
+        n_samples={"test": 162},
+        avg_character_length={"test": 419.42},
     )
 
     def dataset_transform(self):
@@ -303,14 +314,16 @@ class CUADAffiliateLicenseLicensorLegalBenchClassification(AbsTaskClassification
         self.dataset = self.dataset.rename_column("answer", "label")
 
 
-class CUADAffiliateLicenseLicenseeLegalBenchClassification(AbsTaskClassification):
+class ContractNLINoticeOnCompelledDisclosureLegalBenchClassification(
+    AbsTaskClassification
+):
     metadata = TaskMetadata(
-        name="CUADAffiliateLicenseLicenseeLegalBenchClassification",
-        description="CUAD Affiliate License-Licensee LegalBench Classification Dataset",
+        name="ContractNLINoticeOnCompelledDisclosureLegalBenchClassification",
+        description="Contract NLI Notice on Compelled Disclosure LegalBench Classification Dataset",
         reference="https://huggingface.co/datasets/nguha/legalbench",
         dataset={
             "path": "nguha/legalbench",
-            "name": "cuad_affiliate_license-licensee",
+            "name": "contract_nli_notice_on_compelled_disclosure",
             "revision": "12ca3b695563788fead87a982ad1a068284413f4",
         },
         type="Classification",
@@ -336,15 +349,446 @@ class CUADAffiliateLicenseLicenseeLegalBenchClassification(AbsTaskClassification
             archivePrefix={arXiv},
             primaryClass={cs.CL}
         },
-        @article{hendrycks2021cuad,
-            title={Cuad: An expert-annotated nlp dataset for legal contract review},
-            author={Hendrycks, Dan and Burns, Collin and Chen, Anya and Ball, Spencer},
-            journal={arXiv preprint arXiv:2103.06268},
+        @article{koreeda2021contractnli,
+            title={ContractNLI: A dataset for document-level natural language inference for contracts},
+            author={Koreeda, Yuta and Manning, Christopher D},
+            journal={arXiv preprint arXiv:2110.01799},
             year={2021}
-        }
-        """,
-        n_samples={"test": 198},
-        avg_character_length={"test": 484.11},
+        }""",
+        n_samples={"test": 142},
+        avg_character_length={"test": 503.45},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")
+
+
+class ContractNLIPermissibleAcquirementOfSimilarInformationLegalBenchClassification(
+    AbsTaskClassification
+):
+    metadata = TaskMetadata(
+        name="ContractNLIPermissibleAcquirementOfSimilarInformationLegalBenchClassification",
+        description="Contract NLI Permissible Acquirement of Similar Information LegalBench Classification Dataset",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "contract_nli_permissible_acquirement_of_similar_information",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2023-08-23", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{koreeda2021contractnli,
+            title={ContractNLI: A dataset for document-level natural language inference for contracts},
+            author={Koreeda, Yuta and Manning, Christopher D},
+            journal={arXiv preprint arXiv:2110.01799},
+            year={2021}
+        }""",
+        n_samples={"test": 178},
+        avg_character_length={"test": 427.40},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")
+
+
+class ContractNLIPermissibleCopyLegalBenchClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="ContractNLIPermissibleCopyLegalBenchClassification",
+        description="Contract NLI Permissible Copy LegalBench Classification Dataset",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "contract_nli_permissible_copy",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2023-08-23", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{koreeda2021contractnli,
+            title={ContractNLI: A dataset for document-level natural language inference for contracts},
+            author={Koreeda, Yuta and Manning, Christopher D},
+            journal={arXiv preprint arXiv:2110.01799},
+            year={2021}
+        }""",
+        n_samples={"test": 87},
+        avg_character_length={"test": 386.84},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")
+
+
+class ContractNLIPermissibleDevelopmentOfSimilarInformationLegalBenchClassification(
+    AbsTaskClassification
+):
+    metadata = TaskMetadata(
+        name="ContractNLIPermissibleDevelopmentOfSimilarInformationLegalBenchClassification",
+        description="Contract NLI Permissible Development of Similar Information LegalBench Classification Dataset",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "contract_nli_permissible_development_of_similar_information",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2023-08-23", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{koreeda2021contractnli,
+            title={ContractNLI: A dataset for document-level natural language inference for contracts},
+            author={Koreeda, Yuta and Manning, Christopher D},
+            journal={arXiv preprint arXiv:2110.01799},
+            year={2021}
+        }""",
+        n_samples={"test": 136},
+        avg_character_length={"test": 396.40},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")
+
+
+class ContractNLIPermissiblePostAgreementPossessionLegalBenchClassification(
+    AbsTaskClassification
+):
+    metadata = TaskMetadata(
+        name="ContractNLIPermissiblePostAgreementPossessionLegalBenchClassification",
+        description="Contract NLI Permissible Post Agreement Possession LegalBench Classification Dataset",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "contract_nli_permissible_post-agreement_possession",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2023-08-23", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{koreeda2021contractnli,
+            title={ContractNLI: A dataset for document-level natural language inference for contracts},
+            author={Koreeda, Yuta and Manning, Christopher D},
+            journal={arXiv preprint arXiv:2110.01799},
+            year={2021}
+        }""",
+        n_samples={"test": 111},
+        avg_character_length={"test": 529.09},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")
+
+
+class ContractNLIReturnOfConfidentialInformationLegalBenchClassification(
+    AbsTaskClassification
+):
+    metadata = TaskMetadata(
+        name="ContractNLIReturnOfConfidentialInformationLegalBenchClassification",
+        description="Contract NLI Return of Confidential Information LegalBench Classification Dataset",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "contract_nli_return_of_confidential_information",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2023-08-23", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{koreeda2021contractnli,
+            title={ContractNLI: A dataset for document-level natural language inference for contracts},
+            author={Koreeda, Yuta and Manning, Christopher D},
+            journal={arXiv preprint arXiv:2110.01799},
+            year={2021}
+        }""",
+        n_samples={"test": 66},
+        avg_character_length={"test": 478.29},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")
+
+
+class ContractNLISharingWithEmployeesLegalBenchClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="ContractNLISharingWithEmployeesLegalBenchClassification",
+        description="Contract NLI Sharing With Employees LegalBench Classification Dataset",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "contract_nli_sharing_with_employees",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2023-08-23", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{koreeda2021contractnli,
+            title={ContractNLI: A dataset for document-level natural language inference for contracts},
+            author={Koreeda, Yuta and Manning, Christopher D},
+            journal={arXiv preprint arXiv:2110.01799},
+            year={2021}
+        }""",
+        n_samples={"test": 170},
+        avg_character_length={"test": 548.63},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")
+
+
+class ContractNLISharingWithThirdPartiesLegalBenchClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="ContractNLISharingWithThirdPartiesLegalBenchClassification",
+        description="Contract NLI Sharing With Third Parties LegalBench Classification Dataset",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "contract_nli_sharing_with_third-parties",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2023-08-23", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{koreeda2021contractnli,
+            title={ContractNLI: A dataset for document-level natural language inference for contracts},
+            author={Koreeda, Yuta and Manning, Christopher D},
+            journal={arXiv preprint arXiv:2110.01799},
+            year={2021}
+        }""",
+        n_samples={"test": 180},
+        avg_character_length={"test": 517.29},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")
+
+
+class ContractNLISurvivalOfObligationsLegalBenchClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="ContractNLISurvivalOfObligationsLegalBenchClassification",
+        description="Contract NLI Survival of Obligations LegalBench Classification Dataset",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "contract_nli_survival_of_obligations",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2023-08-23", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{koreeda2021contractnli,
+            title={ContractNLI: A dataset for document-level natural language inference for contracts},
+            author={Koreeda, Yuta and Manning, Christopher D},
+            journal={arXiv preprint arXiv:2110.01799},
+            year={2021}
+        }""",
+        n_samples={"test": 157},
+        avg_character_length={"test": 417.64},
     )
 
     def dataset_transform(self):
@@ -420,14 +864,14 @@ class CorporateLobbyingLegalBenchClassification(AbsTaskClassification):
         )
 
 
-class ContractNLISurvivalOfObligationsLegalBenchClassification(AbsTaskClassification):
+class CUADAffiliateLicenseLicenseeLegalBenchClassification(AbsTaskClassification):
     metadata = TaskMetadata(
-        name="ContractNLISurvivalOfObligationsLegalBenchClassification",
-        description="Contract NLI Survival of Obligations LegalBench Classification Dataset",
+        name="CUADAffiliateLicenseLicenseeLegalBenchClassification",
+        description="CUAD Affiliate License-Licensee LegalBench Classification Dataset",
         reference="https://huggingface.co/datasets/nguha/legalbench",
         dataset={
             "path": "nguha/legalbench",
-            "name": "contract_nli_survival_of_obligations",
+            "name": "cuad_affiliate_license-licensee",
             "revision": "12ca3b695563788fead87a982ad1a068284413f4",
         },
         type="Classification",
@@ -453,14 +897,15 @@ class ContractNLISurvivalOfObligationsLegalBenchClassification(AbsTaskClassifica
             archivePrefix={arXiv},
             primaryClass={cs.CL}
         },
-        @article{koreeda2021contractnli,
-            title={ContractNLI: A dataset for document-level natural language inference for contracts},
-            author={Koreeda, Yuta and Manning, Christopher D},
-            journal={arXiv preprint arXiv:2110.01799},
+        @article{hendrycks2021cuad,
+            title={Cuad: An expert-annotated nlp dataset for legal contract review},
+            author={Hendrycks, Dan and Burns, Collin and Chen, Anya and Ball, Spencer},
+            journal={arXiv preprint arXiv:2103.06268},
             year={2021}
-        }""",
-        n_samples={"test": 157},
-        avg_character_length={"test": 417.64},
+        }
+        """,
+        n_samples={"test": 198},
+        avg_character_length={"test": 484.11},
     )
 
     def dataset_transform(self):
@@ -473,14 +918,14 @@ class ContractNLISurvivalOfObligationsLegalBenchClassification(AbsTaskClassifica
         self.dataset = self.dataset.rename_column("answer", "label")
 
 
-class ContractNLISharingWithThirdPartiesLegalBenchClassification(AbsTaskClassification):
+class CUADAffiliateLicenseLicensorLegalBenchClassification(AbsTaskClassification):
     metadata = TaskMetadata(
-        name="ContractNLISharingWithThirdPartiesLegalBenchClassification",
-        description="Contract NLI Sharing With Third Parties LegalBench Classification Dataset",
+        name="CUADAffiliateLicenseLicensorLegalBenchClassification",
+        description="CUAD Affiliate License-Licensor LegalBench Classification Dataset",
         reference="https://huggingface.co/datasets/nguha/legalbench",
         dataset={
             "path": "nguha/legalbench",
-            "name": "contract_nli_sharing_with_third-parties",
+            "name": "cuad_affiliate_license-licensor",
             "revision": "12ca3b695563788fead87a982ad1a068284413f4",
         },
         type="Classification",
@@ -506,14 +951,15 @@ class ContractNLISharingWithThirdPartiesLegalBenchClassification(AbsTaskClassifi
             archivePrefix={arXiv},
             primaryClass={cs.CL}
         },
-        @article{koreeda2021contractnli,
-            title={ContractNLI: A dataset for document-level natural language inference for contracts},
-            author={Koreeda, Yuta and Manning, Christopher D},
-            journal={arXiv preprint arXiv:2110.01799},
+        @article{hendrycks2021cuad,
+            title={Cuad: An expert-annotated nlp dataset for legal contract review},
+            author={Hendrycks, Dan and Burns, Collin and Chen, Anya and Ball, Spencer},
+            journal={arXiv preprint arXiv:2103.06268},
             year={2021}
-        }""",
-        n_samples={"test": 180},
-        avg_character_length={"test": 517.29},
+        }
+        """,
+        n_samples={"test": 88},
+        avg_character_length={"test": 633.40},
     )
 
     def dataset_transform(self):
@@ -526,14 +972,14 @@ class ContractNLISharingWithThirdPartiesLegalBenchClassification(AbsTaskClassifi
         self.dataset = self.dataset.rename_column("answer", "label")
 
 
-class ContractNLISharingWithEmployeesLegalBenchClassification(AbsTaskClassification):
+class CUADAntiAssignmentLegalBenchClassification(AbsTaskClassification):
     metadata = TaskMetadata(
-        name="ContractNLISharingWithEmployeesLegalBenchClassification",
-        description="Contract NLI Sharing With Employees LegalBench Classification Dataset",
+        name="CUADAntiAssignmentLegalBenchClassification",
+        description="CUAD Anti-Assignment LegalBench Classification Dataset",
         reference="https://huggingface.co/datasets/nguha/legalbench",
         dataset={
             "path": "nguha/legalbench",
-            "name": "contract_nli_sharing_with_employees",
+            "name": "cuad_anti-assignment",
             "revision": "12ca3b695563788fead87a982ad1a068284413f4",
         },
         type="Classification",
@@ -559,14 +1005,15 @@ class ContractNLISharingWithEmployeesLegalBenchClassification(AbsTaskClassificat
             archivePrefix={arXiv},
             primaryClass={cs.CL}
         },
-        @article{koreeda2021contractnli,
-            title={ContractNLI: A dataset for document-level natural language inference for contracts},
-            author={Koreeda, Yuta and Manning, Christopher D},
-            journal={arXiv preprint arXiv:2110.01799},
+        @article{hendrycks2021cuad,
+            title={Cuad: An expert-annotated nlp dataset for legal contract review},
+            author={Hendrycks, Dan and Burns, Collin and Chen, Anya and Ball, Spencer},
+            journal={arXiv preprint arXiv:2103.06268},
             year={2021}
-        }""",
-        n_samples={"test": 170},
-        avg_character_length={"test": 548.63},
+        }
+        """,
+        n_samples={"test": 1172},
+        avg_character_length={"test": 340.81},
     )
 
     def dataset_transform(self):
@@ -579,16 +1026,14 @@ class ContractNLISharingWithEmployeesLegalBenchClassification(AbsTaskClassificat
         self.dataset = self.dataset.rename_column("answer", "label")
 
 
-class ContractNLIReturnOfConfidentialInformationLegalBenchClassification(
-    AbsTaskClassification
-):
+class CUADAuditRightsLegalBenchClassification(AbsTaskClassification):
     metadata = TaskMetadata(
-        name="ContractNLIReturnOfConfidentialInformationLegalBenchClassification",
-        description="Contract NLI Return of Confidential Information LegalBench Classification Dataset",
+        name="CUADAuditRightsLegalBenchClassification",
+        description="CUAD Audit Rights LegalBench Classification Dataset",
         reference="https://huggingface.co/datasets/nguha/legalbench",
         dataset={
             "path": "nguha/legalbench",
-            "name": "contract_nli_return_of_confidential_information",
+            "name": "cuad_audit_rights",
             "revision": "12ca3b695563788fead87a982ad1a068284413f4",
         },
         type="Classification",
@@ -614,436 +1059,15 @@ class ContractNLIReturnOfConfidentialInformationLegalBenchClassification(
             archivePrefix={arXiv},
             primaryClass={cs.CL}
         },
-        @article{koreeda2021contractnli,
-            title={ContractNLI: A dataset for document-level natural language inference for contracts},
-            author={Koreeda, Yuta and Manning, Christopher D},
-            journal={arXiv preprint arXiv:2110.01799},
+        @article{hendrycks2021cuad,
+            title={Cuad: An expert-annotated nlp dataset for legal contract review},
+            author={Hendrycks, Dan and Burns, Collin and Chen, Anya and Ball, Spencer},
+            journal={arXiv preprint arXiv:2103.06268},
             year={2021}
-        }""",
-        n_samples={"test": 66},
-        avg_character_length={"test": 478.29},
-    )
-
-    def dataset_transform(self):
-        mapping = {"yes": 1, "no": 0}
-        self.dataset = self.dataset.map(
-            lambda example: {
-                "answer": mapping.get(example["answer"].lower(), example["answer"])
-            }
-        )
-        self.dataset = self.dataset.rename_column("answer", "label")
-
-
-class ContractNLIPermissiblePostAgreementPossessionLegalBenchClassification(
-    AbsTaskClassification
-):
-    metadata = TaskMetadata(
-        name="ContractNLIPermissiblePostAgreementPossessionLegalBenchClassification",
-        description="Contract NLI Permissible Post Agreement Possession LegalBench Classification Dataset",
-        reference="https://huggingface.co/datasets/nguha/legalbench",
-        dataset={
-            "path": "nguha/legalbench",
-            "name": "contract_nli_permissible_post-agreement_possession",
-            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
-        },
-        type="Classification",
-        category="s2s",
-        eval_splits=["test"],
-        eval_langs=["eng-Latn"],
-        main_score="accuracy",
-        date=("2023-08-23", "2023-08-23"),
-        form=["written"],
-        domains=["Legal"],
-        task_subtypes=[],
-        license="cc-by-4.0",
-        socioeconomic_status="high",
-        annotations_creators="expert-annotated",
-        dialect=[],
-        text_creation="found",
-        bibtex_citation="""
-        @misc{guha2023legalbench,
-            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
-            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
-            year={2023},
-            eprint={2308.11462},
-            archivePrefix={arXiv},
-            primaryClass={cs.CL}
-        },
-        @article{koreeda2021contractnli,
-            title={ContractNLI: A dataset for document-level natural language inference for contracts},
-            author={Koreeda, Yuta and Manning, Christopher D},
-            journal={arXiv preprint arXiv:2110.01799},
-            year={2021}
-        }""",
-        n_samples={"test": 111},
-        avg_character_length={"test": 529.09},
-    )
-
-    def dataset_transform(self):
-        mapping = {"yes": 1, "no": 0}
-        self.dataset = self.dataset.map(
-            lambda example: {
-                "answer": mapping.get(example["answer"].lower(), example["answer"])
-            }
-        )
-        self.dataset = self.dataset.rename_column("answer", "label")
-
-
-class ContractNLIPermissibleDevelopmentOfSimilarInformationLegalBenchClassification(
-    AbsTaskClassification
-):
-    metadata = TaskMetadata(
-        name="ContractNLIPermissibleDevelopmentOfSimilarInformationLegalBenchClassification",
-        description="Contract NLI Permissible Development of Similar Information LegalBench Classification Dataset",
-        reference="https://huggingface.co/datasets/nguha/legalbench",
-        dataset={
-            "path": "nguha/legalbench",
-            "name": "contract_nli_permissible_development_of_similar_information",
-            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
-        },
-        type="Classification",
-        category="s2s",
-        eval_splits=["test"],
-        eval_langs=["eng-Latn"],
-        main_score="accuracy",
-        date=("2023-08-23", "2023-08-23"),
-        form=["written"],
-        domains=["Legal"],
-        task_subtypes=[],
-        license="cc-by-4.0",
-        socioeconomic_status="high",
-        annotations_creators="expert-annotated",
-        dialect=[],
-        text_creation="found",
-        bibtex_citation="""
-        @misc{guha2023legalbench,
-            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
-            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
-            year={2023},
-            eprint={2308.11462},
-            archivePrefix={arXiv},
-            primaryClass={cs.CL}
-        },
-        @article{koreeda2021contractnli,
-            title={ContractNLI: A dataset for document-level natural language inference for contracts},
-            author={Koreeda, Yuta and Manning, Christopher D},
-            journal={arXiv preprint arXiv:2110.01799},
-            year={2021}
-        }""",
-        n_samples={"test": 136},
-        avg_character_length={"test": 396.40},
-    )
-
-    def dataset_transform(self):
-        mapping = {"yes": 1, "no": 0}
-        self.dataset = self.dataset.map(
-            lambda example: {
-                "answer": mapping.get(example["answer"].lower(), example["answer"])
-            }
-        )
-        self.dataset = self.dataset.rename_column("answer", "label")
-
-
-class ContractNLIPermissibleCopyLegalBenchClassification(AbsTaskClassification):
-    metadata = TaskMetadata(
-        name="ContractNLIPermissibleCopyLegalBenchClassification",
-        description="Contract NLI Permissible Copy LegalBench Classification Dataset",
-        reference="https://huggingface.co/datasets/nguha/legalbench",
-        dataset={
-            "path": "nguha/legalbench",
-            "name": "contract_nli_permissible_copy",
-            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
-        },
-        type="Classification",
-        category="s2s",
-        eval_splits=["test"],
-        eval_langs=["eng-Latn"],
-        main_score="accuracy",
-        date=("2023-08-23", "2023-08-23"),
-        form=["written"],
-        domains=["Legal"],
-        task_subtypes=[],
-        license="cc-by-4.0",
-        socioeconomic_status="high",
-        annotations_creators="expert-annotated",
-        dialect=[],
-        text_creation="found",
-        bibtex_citation="""
-        @misc{guha2023legalbench,
-            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
-            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
-            year={2023},
-            eprint={2308.11462},
-            archivePrefix={arXiv},
-            primaryClass={cs.CL}
-        },
-        @article{koreeda2021contractnli,
-            title={ContractNLI: A dataset for document-level natural language inference for contracts},
-            author={Koreeda, Yuta and Manning, Christopher D},
-            journal={arXiv preprint arXiv:2110.01799},
-            year={2021}
-        }""",
-        n_samples={"test": 87},
-        avg_character_length={"test": 386.84},
-    )
-
-    def dataset_transform(self):
-        mapping = {"yes": 1, "no": 0}
-        self.dataset = self.dataset.map(
-            lambda example: {
-                "answer": mapping.get(example["answer"].lower(), example["answer"])
-            }
-        )
-        self.dataset = self.dataset.rename_column("answer", "label")
-
-
-class ContractNLIPermissibleAcquirementOfSimilarInformationLegalBenchClassification(
-    AbsTaskClassification
-):
-    metadata = TaskMetadata(
-        name="ContractNLIPermissibleAcquirementOfSimilarInformationLegalBenchClassification",
-        description="Contract NLI Permissible Acquirement of Similar Information LegalBench Classification Dataset",
-        reference="https://huggingface.co/datasets/nguha/legalbench",
-        dataset={
-            "path": "nguha/legalbench",
-            "name": "contract_nli_permissible_acquirement_of_similar_information",
-            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
-        },
-        type="Classification",
-        category="s2s",
-        eval_splits=["test"],
-        eval_langs=["eng-Latn"],
-        main_score="accuracy",
-        date=("2023-08-23", "2023-08-23"),
-        form=["written"],
-        domains=["Legal"],
-        task_subtypes=[],
-        license="cc-by-4.0",
-        socioeconomic_status="high",
-        annotations_creators="expert-annotated",
-        dialect=[],
-        text_creation="found",
-        bibtex_citation="""
-        @misc{guha2023legalbench,
-            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
-            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
-            year={2023},
-            eprint={2308.11462},
-            archivePrefix={arXiv},
-            primaryClass={cs.CL}
-        },
-        @article{koreeda2021contractnli,
-            title={ContractNLI: A dataset for document-level natural language inference for contracts},
-            author={Koreeda, Yuta and Manning, Christopher D},
-            journal={arXiv preprint arXiv:2110.01799},
-            year={2021}
-        }""",
-        n_samples={"test": 178},
-        avg_character_length={"test": 427.40},
-    )
-
-    def dataset_transform(self):
-        mapping = {"yes": 1, "no": 0}
-        self.dataset = self.dataset.map(
-            lambda example: {
-                "answer": mapping.get(example["answer"].lower(), example["answer"])
-            }
-        )
-        self.dataset = self.dataset.rename_column("answer", "label")
-
-
-class ContractNLINoticeOnCompelledDisclosureLegalBenchClassification(
-    AbsTaskClassification
-):
-    metadata = TaskMetadata(
-        name="ContractNLINoticeOnCompelledDisclosureLegalBenchClassification",
-        description="Contract NLI Notice on Compelled Disclosure LegalBench Classification Dataset",
-        reference="https://huggingface.co/datasets/nguha/legalbench",
-        dataset={
-            "path": "nguha/legalbench",
-            "name": "contract_nli_notice_on_compelled_disclosure",
-            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
-        },
-        type="Classification",
-        category="s2s",
-        eval_splits=["test"],
-        eval_langs=["eng-Latn"],
-        main_score="accuracy",
-        date=("2023-08-23", "2023-08-23"),
-        form=["written"],
-        domains=["Legal"],
-        task_subtypes=[],
-        license="cc-by-4.0",
-        socioeconomic_status="high",
-        annotations_creators="expert-annotated",
-        dialect=[],
-        text_creation="found",
-        bibtex_citation="""
-        @misc{guha2023legalbench,
-            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
-            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
-            year={2023},
-            eprint={2308.11462},
-            archivePrefix={arXiv},
-            primaryClass={cs.CL}
-        },
-        @article{koreeda2021contractnli,
-            title={ContractNLI: A dataset for document-level natural language inference for contracts},
-            author={Koreeda, Yuta and Manning, Christopher D},
-            journal={arXiv preprint arXiv:2110.01799},
-            year={2021}
-        }""",
-        n_samples={"test": 142},
-        avg_character_length={"test": 503.45},
-    )
-
-    def dataset_transform(self):
-        mapping = {"yes": 1, "no": 0}
-        self.dataset = self.dataset.map(
-            lambda example: {
-                "answer": mapping.get(example["answer"].lower(), example["answer"])
-            }
-        )
-        self.dataset = self.dataset.rename_column("answer", "label")
-
-
-class ContractNLINoLicensingLegalBenchClassification(AbsTaskClassification):
-    metadata = TaskMetadata(
-        name="ContractNLINoLicensingLegalBenchClassification",
-        description="Contract NLI No Licensing LegalBench Classification Dataset",
-        reference="https://huggingface.co/datasets/nguha/legalbench",
-        dataset={
-            "path": "nguha/legalbench",
-            "name": "contract_nli_no_licensing",
-            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
-        },
-        type="Classification",
-        category="s2s",
-        eval_splits=["test"],
-        eval_langs=["eng-Latn"],
-        main_score="accuracy",
-        date=("2023-08-23", "2023-08-23"),
-        form=["written"],
-        domains=["Legal"],
-        task_subtypes=[],
-        license="cc-by-4.0",
-        socioeconomic_status="high",
-        annotations_creators="expert-annotated",
-        dialect=[],
-        text_creation="found",
-        bibtex_citation="""
-        @misc{guha2023legalbench,
-            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
-            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
-            year={2023},
-            eprint={2308.11462},
-            archivePrefix={arXiv},
-            primaryClass={cs.CL}
-        },
-        @article{koreeda2021contractnli,
-            title={ContractNLI: A dataset for document-level natural language inference for contracts},
-            author={Koreeda, Yuta and Manning, Christopher D},
-            journal={arXiv preprint arXiv:2110.01799},
-            year={2021}
-        }""",
-        n_samples={"test": 162},
-        avg_character_length={"test": 419.42},
-    )
-
-    def dataset_transform(self):
-        mapping = {"yes": 1, "no": 0}
-        self.dataset = self.dataset.map(
-            lambda example: {
-                "answer": mapping.get(example["answer"].lower(), example["answer"])
-            }
-        )
-        self.dataset = self.dataset.rename_column("answer", "label")
-
-
-class ContractNLILimitedUseLegalBenchClassification(AbsTaskClassification):
-    metadata = TaskMetadata(
-        name="ContractNLILimitedUseLegalBenchClassification",
-        description="Contract NLI Limited Use LegalBench Classification Dataset",
-        reference="https://huggingface.co/datasets/nguha/legalbench",
-        dataset={
-            "path": "nguha/legalbench",
-            "name": "contract_nli_limited_use",
-            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
-        },
-        type="Classification",
-        category="s2s",
-        eval_splits=["test"],
-        eval_langs=["eng-Latn"],
-        main_score="accuracy",
-        date=("2023-08-23", "2023-08-23"),
-        form=["written"],
-        domains=["Legal"],
-        task_subtypes=[],
-        license="cc-by-4.0",
-        socioeconomic_status="high",
-        annotations_creators="expert-annotated",
-        dialect=[],
-        text_creation="found",
-        bibtex_citation="""
-        @misc{guha2023legalbench,
-            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
-            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
-            year={2023},
-            eprint={2308.11462},
-            archivePrefix={arXiv},
-            primaryClass={cs.CL}
-            }""",
-        n_samples={"test": 208},
-        avg_character_length={"test": 407.51},
-    )
-
-    def dataset_transform(self):
-        mapping = {"yes": 1, "no": 0}
-        self.dataset = self.dataset.map(
-            lambda example: {
-                "answer": mapping.get(example["answer"].lower(), example["answer"])
-            }
-        )
-        self.dataset = self.dataset.rename_column("answer", "label")
-
-
-class ContractNLIInclusionOfVerballyConveyedInformationLegalBenchClassification(
-    AbsTaskClassification
-):
-    metadata = TaskMetadata(
-        name="ContractNLIInclusionOfVerballyConveyedInformationLegalBenchClassification",
-        description="Contract NLI Inclusion of Verbally Conveyed Information LegalBench Classification Dataset",
-        reference="https://huggingface.co/datasets/nguha/legalbench",
-        dataset={
-            "path": "nguha/legalbench",
-            "name": "contract_nli_inclusion_of_verbally_conveyed_information",
-            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
-        },
-        type="Classification",
-        category="s2s",
-        eval_splits=["test"],
-        eval_langs=["eng-Latn"],
-        main_score="accuracy",
-        date=("2023-08-23", "2023-08-23"),
-        form=["written"],
-        domains=["Legal"],
-        task_subtypes=[],
-        license="cc-by-4.0",
-        socioeconomic_status="high",
-        annotations_creators="expert-annotated",
-        dialect=[],
-        text_creation="found",
-        bibtex_citation="""
-        @misc{guha2023legalbench,
-            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
-            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
-            year={2023},
-            eprint={2308.11462},
-            archivePrefix={arXiv},
-            primaryClass={cs.CL}
-            }""",
-        n_samples={"test": 139},
-        avg_character_length={"test": 525.75},
+        }
+        """,
+        n_samples={"test": 1216},
+        avg_character_length={"test": 337.14},
     )
 
     def dataset_transform(self):

--- a/results/intfloat__multilingual-e5-small/CUADCapOnLiabilityLegalBenchClassification.json
+++ b/results/intfloat__multilingual-e5-small/CUADCapOnLiabilityLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADCapOnLiabilityLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.8162118780096307,
+    "accuracy_stderr": 1.1102230246251565e-16,
+    "ap": 0.7569848913348112,
+    "ap_stderr": 0.0,
+    "evaluation_time": 158.31,
+    "f1": 0.8162060771662137,
+    "f1_stderr": 1.1102230246251565e-16,
+    "main_score": 0.8162118780096307
+  }
+}

--- a/results/intfloat__multilingual-e5-small/CUADChangeOfControlLegalBenchClassification.json
+++ b/results/intfloat__multilingual-e5-small/CUADChangeOfControlLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADChangeOfControlLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.71875,
+    "accuracy_stderr": 0.0,
+    "ap": 0.6503343621399178,
+    "ap_stderr": 1.1102230246251565e-16,
+    "evaluation_time": 67.31,
+    "f1": 0.7167449412504145,
+    "f1_stderr": 0.0,
+    "main_score": 0.71875
+  }
+}

--- a/results/intfloat__multilingual-e5-small/CUADCompetitiveRestrictionExceptionLegalBenchClassification.json
+++ b/results/intfloat__multilingual-e5-small/CUADCompetitiveRestrictionExceptionLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADCompetitiveRestrictionExceptionLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.6318181818181818,
+    "accuracy_stderr": 0.0,
+    "ap": 0.5834445371142618,
+    "ap_stderr": 0.0,
+    "evaluation_time": 56.82,
+    "f1": 0.6318105745986486,
+    "f1_stderr": 0.0,
+    "main_score": 0.6318181818181818
+  }
+}

--- a/results/intfloat__multilingual-e5-small/CUADCovenantNotToSueLegalBenchClassification.json
+++ b/results/intfloat__multilingual-e5-small/CUADCovenantNotToSueLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADCovenantNotToSueLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.6948051948051948,
+    "accuracy_stderr": 0.0,
+    "ap": 0.6221659696235967,
+    "ap_stderr": 1.1102230246251565e-16,
+    "evaluation_time": 58.82,
+    "f1": 0.671522577717268,
+    "f1_stderr": 0.0,
+    "main_score": 0.6948051948051948
+  }
+}

--- a/results/intfloat__multilingual-e5-small/CUADEffectiveDateLegalBenchClassification.json
+++ b/results/intfloat__multilingual-e5-small/CUADEffectiveDateLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADEffectiveDateLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.7542372881355932,
+    "accuracy_stderr": 0.0,
+    "ap": 0.7274754683318465,
+    "ap_stderr": 1.1102230246251565e-16,
+    "evaluation_time": 50.76,
+    "f1": 0.7461989171549359,
+    "f1_stderr": 0.0,
+    "main_score": 0.7542372881355932
+  }
+}

--- a/results/intfloat__multilingual-e5-small/CUADExclusivityLegalBenchClassification.json
+++ b/results/intfloat__multilingual-e5-small/CUADExclusivityLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADExclusivityLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.6706036745406825,
+    "accuracy_stderr": 1.1102230246251565e-16,
+    "ap": 0.6042254530470379,
+    "ap_stderr": 1.1102230246251565e-16,
+    "evaluation_time": 103.43,
+    "f1": 0.6449029833704343,
+    "f1_stderr": 0.0,
+    "main_score": 0.6706036745406825
+  }
+}

--- a/results/intfloat__multilingual-e5-small/CUADExpirationDateLegalBenchClassification.json
+++ b/results/intfloat__multilingual-e5-small/CUADExpirationDateLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADExpirationDateLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.886986301369863,
+    "accuracy_stderr": 0.0,
+    "ap": 0.8595543610195941,
+    "ap_stderr": 0.0,
+    "evaluation_time": 84.71,
+    "f1": 0.8867133360417071,
+    "f1_stderr": 1.1102230246251565e-16,
+    "main_score": 0.886986301369863
+  }
+}

--- a/results/intfloat__multilingual-e5-small/CUADGoverningLawLegalBenchClassification.json
+++ b/results/intfloat__multilingual-e5-small/CUADGoverningLawLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADGoverningLawLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.9714611872146118,
+    "accuracy_stderr": 0.0,
+    "ap": 0.9506461237614282,
+    "ap_stderr": 1.1102230246251565e-16,
+    "evaluation_time": 88.56,
+    "f1": 0.9714528169812724,
+    "f1_stderr": 1.1102230246251565e-16,
+    "main_score": 0.9714611872146118
+  }
+}

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADCapOnLiabilityLegalBenchClassification.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADCapOnLiabilityLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADCapOnLiabilityLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.7656500802568218,
+    "accuracy_stderr": 0.0,
+    "ap": 0.7040812610076719,
+    "ap_stderr": 0.0,
+    "evaluation_time": 96.48,
+    "f1": 0.7656446459857775,
+    "f1_stderr": 0.0,
+    "main_score": 0.7656500802568218
+  }
+}

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADChangeOfControlLegalBenchClassification.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADChangeOfControlLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADChangeOfControlLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.6706730769230769,
+    "accuracy_stderr": 0.0,
+    "ap": 0.6106875603476023,
+    "ap_stderr": 1.1102230246251565e-16,
+    "evaluation_time": 31.16,
+    "f1": 0.6688340742032018,
+    "f1_stderr": 1.1102230246251565e-16,
+    "main_score": 0.6706730769230769
+  }
+}

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADCompetitiveRestrictionExceptionLegalBenchClassification.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADCompetitiveRestrictionExceptionLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADCompetitiveRestrictionExceptionLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.5727272727272726,
+    "accuracy_stderr": 1.1102230246251565e-16,
+    "ap": 0.5401416765053128,
+    "ap_stderr": 1.1102230246251565e-16,
+    "evaluation_time": 43.08,
+    "f1": 0.5549242424242424,
+    "f1_stderr": 0.0,
+    "main_score": 0.5727272727272726
+  }
+}

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADCovenantNotToSueLegalBenchClassification.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADCovenantNotToSueLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADCovenantNotToSueLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.6980519480519479,
+    "accuracy_stderr": 1.1102230246251565e-16,
+    "ap": 0.6247305885603758,
+    "ap_stderr": 0.0,
+    "evaluation_time": 40.99,
+    "f1": 0.6756169099577589,
+    "f1_stderr": 1.1102230246251565e-16,
+    "main_score": 0.6980519480519479
+  }
+}

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADEffectiveDateLegalBenchClassification.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADEffectiveDateLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADEffectiveDateLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.7245762711864405,
+    "accuracy_stderr": 1.1102230246251565e-16,
+    "ap": 0.7166964020220041,
+    "ap_stderr": 0.0,
+    "evaluation_time": 36.27,
+    "f1": 0.7048581048581049,
+    "f1_stderr": 0.0,
+    "main_score": 0.7245762711864405
+  }
+}

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADExclusivityLegalBenchClassification.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADExclusivityLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADExclusivityLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.6325459317585301,
+    "accuracy_stderr": 0.0,
+    "ap": 0.5770864869678043,
+    "ap_stderr": 0.0,
+    "evaluation_time": 82.23,
+    "f1": 0.592824427480916,
+    "f1_stderr": 1.1102230246251565e-16,
+    "main_score": 0.6325459317585301
+  }
+}

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADExpirationDateLegalBenchClassification.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADExpirationDateLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADExpirationDateLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.8767123287671232,
+    "accuracy_stderr": 0.0,
+    "ap": 0.8554463102076891,
+    "ap_stderr": 1.1102230246251565e-16,
+    "evaluation_time": 66.29,
+    "f1": 0.8760084925690022,
+    "f1_stderr": 0.0,
+    "main_score": 0.8767123287671232
+  }
+}

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADGoverningLawLegalBenchClassification.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADGoverningLawLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADGoverningLawLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.9360730593607306,
+    "accuracy_stderr": 0.0,
+    "ap": 0.9099488668644657,
+    "ap_stderr": 1.1102230246251565e-16,
+    "evaluation_time": 69.84,
+    "f1": 0.936071726438699,
+    "f1_stderr": 1.1102230246251565e-16,
+    "main_score": 0.9360730593607306
+  }
+}


### PR DESCRIPTION
## Checklist for adding MMTEB dataset

Reason for dataset addition: Showcases the model's performance on the [LegalBench](https://hazyresearch.stanford.edu/legalbench/) datasets, enabling evaluation on domain-specific legal texts.

Follow up to #579

## Changes made:


- All the `LegalBenchClassification` tasks have been reorganized for better readability. Add additional citations for a few `ContractNLI` tasks.
- The descriptions for all the tasks have been updated to include more information about the task.

The following 8 datasets have been added in this PR:

1. [CUAD Cap on Liability](https://hazyresearch.stanford.edu/legalbench/tasks/cuad_cap_on_liability.html)
2. [CUAD Change of Control](https://hazyresearch.stanford.edu/legalbench/tasks/cuad_change_of_control.html)
3. [CUAD Competitive Restriction Exception](https://hazyresearch.stanford.edu/legalbench/tasks/cuad_competitive_restriction_exception.html)
4. [CUAD Covenant not to sue](https://hazyresearch.stanford.edu/legalbench/tasks/cuad_covenant_not_to_sue.html)
5. [CUAD Effective Date](https://hazyresearch.stanford.edu/legalbench/tasks/cuad_effective_date.html)
6. [CUAD Exclusivity](https://hazyresearch.stanford.edu/legalbench/tasks/cuad_exclusivity.html)
7. [CUAD Expiration Date](https://hazyresearch.stanford.edu/legalbench/tasks/cuad_expiration_date.html)
8. [CUAD Governing Law](https://hazyresearch.stanford.edu/legalbench/tasks/cuad_governing_law.html)



- [x] I have tested that the dataset runs with the `mteb` package.
- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
  - [x] `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
  - [x] `intfloat/multilingual-e5-small`
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [x] If the dataset is too big (e.g. >2048 examples), considering using `self.stratified_subsampling() under dataset_transform()`
- [x] I have filled out the metadata object in the dataset file (find documentation on it [here](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md#2-creating-the-metadata-object)).
- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 
- [ ] I have added points for my submission to the [points folder](https://github.com/embeddings-benchmark/mteb/blob/main/docs/mmteb/points.md) using the PR number as the filename (e.g. `438.jsonl`).
