### PR TITLE
add info for LongEmbed

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,5 +243,6 @@ You may also want to read and cite the amazing work that has extended MTEB & int
 - Shitao Xiao, Zheng Liu, Peitian Zhang, Niklas Muennighoff. "[C-Pack: Packaged Resources To Advance General Chinese Embedding](https://arxiv.org/abs/2309.07597)" arXiv 2023
 - Michael Günther, Jackmin Ong, Isabelle Mohr, Alaeddine Abdessalem, Tanguy Abel, Mohammad Kalim Akram, Susana Guzman, Georgios Mastrapas, Saba Sturua, Bo Wang, Maximilian Werk, Nan Wang, Han Xiao. "[Jina Embeddings 2: 8192-Token General-Purpose Text Embeddings for Long Documents](https://arxiv.org/abs/2310.19923)" arXiv 2023
 - Silvan Wehrli, Bert Arnrich, Christopher Irrgang. "[German Text Embedding Clustering Benchmark](https://arxiv.org/abs/2401.02709)" arXiv 2024
+- Dawei Zhu, Liang Wang, Nan Yang, Yifan Song, Wenhao Wu, Furu Wei, and Sujian Li. "[LongEmbed: Extending Embedding Models for Long Context Retrieval](https://arxiv.org/abs/2404.12096)" arXiv 2024
 
 For works that have used MTEB for benchmarking, you can find them on the [leaderboard](https://huggingface.co/spaces/mteb/leaderboard).

--- a/docs/mmteb/points.md
+++ b/docs/mmteb/points.md
@@ -67,3 +67,4 @@ Please also add your first name and last name are as you want them to appear in 
 | jaygala24         | Jay        | Gala       | jaygala24@gmail.com          | ~Jay_Gala1           | Nilekani Center at AI4Bharat                          |
 | digantamisra      | Diganta    | Misra      | diganta.misra@mila.quebec    | ~Diganta_Misra1       | Mila - Quebec AI Institute                           |
 | PranjalChitale    | Pranjal    | Chitale    | cs21s022@smail.iitm.ac.in    | ~Pranjal_A_Chitale1       | Indian Institute of Technology Madras            |
+| dwzhu-pku         | Dawei      | Zhu        | dwzhu@pku.edu.cn             | ~Dawei_Zhu2       | Peking University            |

--- a/docs/mmteb/points/393.jsonl
+++ b/docs/mmteb/points/393.jsonl
@@ -1,2 +1,3 @@
 {"GitHub": "dwzhu-pku", "New dataset": 12}
 {"GitHub": "KennethEnevoldsen", "Review PR": 2}
+{"GitHub": "isaac-chung", "Review PR": 2}

--- a/docs/mmteb/points/393.jsonl
+++ b/docs/mmteb/points/393.jsonl
@@ -1,0 +1,2 @@
+{"GitHub": "dwzhu-pku", "New dataset": 12}
+{"GitHub": "KennethEnevoldsen", "Review PR": 2}

--- a/mteb/tasks/Retrieval/eng/LEMBNeedleRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/LEMBNeedleRetrieval.py
@@ -40,7 +40,14 @@ class LEMBNeedleRetrieval(AbsTaskRetrieval):
         annotations_creators="derived",
         dialect=[],
         text_creation="found",
-        bibtex_citation=None,
+        bibtex_citation="""
+            @article{zhu2024longembed,
+            title={LongEmbed: Extending Embedding Models for Long Context Retrieval},
+            author={Zhu, Dawei and Wang, Liang and Yang, Nan and Song, Yifan and Wu, Wenhao and Wei, Furu and Li, Sujian},
+            journal={arXiv preprint arXiv:2404.12096},
+            year={2024}
+            }
+        """,
         n_samples={
             "test_256": 150,
             "test_512": 150,

--- a/mteb/tasks/Retrieval/eng/LEMBPasskeyRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/LEMBPasskeyRetrieval.py
@@ -40,7 +40,14 @@ class LEMBPasskeyRetrieval(AbsTaskRetrieval):
         annotations_creators="derived",
         dialect=[],
         text_creation="found",
-        bibtex_citation=None,
+        bibtex_citation="""
+            @article{zhu2024longembed,
+            title={LongEmbed: Extending Embedding Models for Long Context Retrieval},
+            author={Zhu, Dawei and Wang, Liang and Yang, Nan and Song, Yifan and Wu, Wenhao and Wei, Furu and Li, Sujian},
+            journal={arXiv preprint arXiv:2404.12096},
+            year={2024}
+            }
+        """,
         n_samples={
             "test_256": 150,
             "test_512": 150,


### PR DESCRIPTION
Hi there, I'm just adding more meta data for LongEmbed. I have also added a `393.jsonl` file in the points folder, though not quite sure about whether I have calculated the scores correctly. Relevant PR is #393 