### PR TITLE
fix: Add LegalBench datasets - 7

### DIFF
--- a/docs/mmteb/points/644.jsonl
+++ b/docs/mmteb/points/644.jsonl
@@ -1,0 +1,1 @@
+{"GitHub": "awinml", "New dataset": 20}

--- a/docs/mmteb/points/644.jsonl
+++ b/docs/mmteb/points/644.jsonl
@@ -1,1 +1,2 @@
 {"GitHub": "awinml", "New dataset": 20}
+{"GitHub": "KennethEnevoldsen", "Review PR": 2}

--- a/mteb/tasks/Classification/eng/LegalBenchClassification.py
+++ b/mteb/tasks/Classification/eng/LegalBenchClassification.py
@@ -2376,3 +2376,543 @@ class CUADPriceRestrictionsLegalBenchClassification(AbsTaskClassification):
             }
         )
         self.dataset = self.dataset.rename_column("answer", "label")
+
+
+class CUADRenewalTermLegalBenchClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="CUADRenewalTermLegalBenchClassification",
+        description="This task was constructed from the CUAD dataset. It consists of determining if the clause specifies a renewal term.",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "cuad_renewal_term",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2000-01-01", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{hendrycks2021cuad,
+            title={Cuad: An expert-annotated nlp dataset for legal contract review},
+            author={Hendrycks, Dan and Burns, Collin and Chen, Anya and Ball, Spencer},
+            journal={arXiv preprint arXiv:2103.06268},
+            year={2021}
+        }
+        """,
+        n_samples={"test": 386},
+        avg_character_length={"test": 340.87},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")
+
+
+class CUADRevenueProfitSharingLegalBenchClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="CUADRevenueProfitSharingLegalBenchClassification",
+        description="This task was constructed from the CUAD dataset. It consists of determining if the clause require a party to share revenue or profit with the counterparty for any technology, goods, or services.",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "cuad_revenue-profit_sharing",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2000-01-01", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{hendrycks2021cuad,
+            title={Cuad: An expert-annotated nlp dataset for legal contract review},
+            author={Hendrycks, Dan and Burns, Collin and Chen, Anya and Ball, Spencer},
+            journal={arXiv preprint arXiv:2103.06268},
+            year={2021}
+        }
+        """,
+        n_samples={"test": 774},
+        avg_character_length={"test": 371.55},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")
+
+
+class CUADRofrRofoRofnLegalBenchClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="CUADRofrRofoRofnLegalBenchClassification",
+        description="This task was constructed from the CUAD dataset. It consists of determining if the clause grant one party a right of first refusal, right of first offer or right of first negotiation to purchase, license, market, or distribute equity interest, technology, assets, products or services.",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "cuad_rofr-rofo-rofn",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2000-01-01", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{hendrycks2021cuad,
+            title={Cuad: An expert-annotated nlp dataset for legal contract review},
+            author={Hendrycks, Dan and Burns, Collin and Chen, Anya and Ball, Spencer},
+            journal={arXiv preprint arXiv:2103.06268},
+            year={2021}
+        }
+        """,
+        n_samples={"test": 690},
+        avg_character_length={"test": 395.46},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")
+
+
+class CUADSourceCodeEscrowLegalBenchClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="CUADSourceCodeEscrowLegalBenchClassification",
+        description="This task was constructed from the CUAD dataset. It consists of determining if the clause requires one party to deposit its source code into escrow with a third party, which can be released to the counterparty upon the occurrence of certain events (bankruptcy, insolvency, etc.).",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "cuad_source_code_escrow",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2000-01-01", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{hendrycks2021cuad,
+            title={Cuad: An expert-annotated nlp dataset for legal contract review},
+            author={Hendrycks, Dan and Burns, Collin and Chen, Anya and Ball, Spencer},
+            journal={arXiv preprint arXiv:2103.06268},
+            year={2021}
+        }
+        """,
+        n_samples={"test": 118},
+        avg_character_length={"test": 399.18},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")
+
+
+class CUADTerminationForConvenienceLegalBenchClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="CUADTerminationForConvenienceLegalBenchClassification",
+        description="This task was constructed from the CUAD dataset. It consists of determining if the clause specifies that one party can terminate this contract without cause (solely by giving a notice and allowing a waiting period to expire).",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "cuad_termination_for_convenience",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2000-01-01", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{hendrycks2021cuad,
+            title={Cuad: An expert-annotated nlp dataset for legal contract review},
+            author={Hendrycks, Dan and Burns, Collin and Chen, Anya and Ball, Spencer},
+            journal={arXiv preprint arXiv:2103.06268},
+            year={2021}
+        }
+        """,
+        n_samples={"test": 430},
+        avg_character_length={"test": 326.30},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")
+
+
+class CUADThirdPartyBeneficiaryLegalBenchClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="CUADThirdPartyBeneficiaryLegalBenchClassification",
+        description="This task was constructed from the CUAD dataset. It consists of determining if the clause specifies that that there a non-contracting party who is a beneficiary to some or all of the clauses in the contract and therefore can enforce its rights against a contracting party.",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "cuad_third_party_beneficiary",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2000-01-01", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{hendrycks2021cuad,
+            title={Cuad: An expert-annotated nlp dataset for legal contract review},
+            author={Hendrycks, Dan and Burns, Collin and Chen, Anya and Ball, Spencer},
+            journal={arXiv preprint arXiv:2103.06268},
+            year={2021}
+        }
+        """,
+        n_samples={"test": 68},
+        avg_character_length={"test": 261.04},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")
+
+
+class CUADUncappedLiabilityLegalBenchClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="CUADUncappedLiabilityLegalBenchClassification",
+        description="This task was constructed from the CUAD dataset. It consists of determining if the clause specifies that a party's liability is uncapped upon the breach of its obligation in the contract. This also includes uncap liability for a particular type of breach such as IP infringement or breach of confidentiality obligation.",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "cuad_uncapped_liability",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2000-01-01", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{hendrycks2021cuad,
+            title={Cuad: An expert-annotated nlp dataset for legal contract review},
+            author={Hendrycks, Dan and Burns, Collin and Chen, Anya and Ball, Spencer},
+            journal={arXiv preprint arXiv:2103.06268},
+            year={2021}
+        }
+        """,
+        n_samples={"test": 294},
+        avg_character_length={"test": 441.04},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")
+
+
+class CUADUnlimitedAllYouCanEatLicenseLegalBenchClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="CUADUnlimitedAllYouCanEatLicenseLegalBenchClassification",
+        description="This task was constructed from the CUAD dataset. It consists of determining if the clause grants one party an “enterprise,” “all you can eat” or unlimited usage license.",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "cuad_unlimited-all-you-can-eat-license",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2000-01-01", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{hendrycks2021cuad,
+            title={Cuad: An expert-annotated nlp dataset for legal contract review},
+            author={Hendrycks, Dan and Burns, Collin and Chen, Anya and Ball, Spencer},
+            journal={arXiv preprint arXiv:2103.06268},
+            year={2021}
+        }
+        """,
+        n_samples={"test": 48},
+        avg_character_length={"test": 368.08},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")
+
+
+class CUADVolumeRestrictionLegalBenchClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="CUADVolumeRestrictionLegalBenchClassification",
+        description="This task was constructed from the CUAD dataset. It consists of determining if the clause specifies a fee increase or consent requirement, etc. if one party's use of the product/services exceeds certain threshold.",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "cuad_volume_restriction",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2000-01-01", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{hendrycks2021cuad,
+            title={Cuad: An expert-annotated nlp dataset for legal contract review},
+            author={Hendrycks, Dan and Burns, Collin and Chen, Anya and Ball, Spencer},
+            journal={arXiv preprint arXiv:2103.06268},
+            year={2021}
+        }
+        """,
+        n_samples={"test": 322},
+        avg_character_length={"test": 306.27},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")
+
+
+class CUADWarrantyDurationLegalBenchClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="CUADWarrantyDurationLegalBenchClassification",
+        description="This task was constructed from the CUAD dataset. It consists of determining if the clause specifies a duration of any warranty against defects or errors in technology, products, or services provided under the contract.",
+        reference="https://huggingface.co/datasets/nguha/legalbench",
+        dataset={
+            "path": "nguha/legalbench",
+            "name": "cuad_warranty_duration",
+            "revision": "12ca3b695563788fead87a982ad1a068284413f4",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2000-01-01", "2023-08-23"),
+        form=["written"],
+        domains=["Legal"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        socioeconomic_status="high",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @misc{guha2023legalbench,
+            title={LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models}, 
+            author={Neel Guha and Julian Nyarko and Daniel E. Ho and Christopher Ré and Adam Chilton and Aditya Narayana and Alex Chohlas-Wood and Austin Peters and Brandon Waldon and Daniel N. Rockmore and Diego Zambrano and Dmitry Talisman and Enam Hoque and Faiz Surani and Frank Fagan and Galit Sarfaty and Gregory M. Dickinson and Haggai Porat and Jason Hegland and Jessica Wu and Joe Nudell and Joel Niklaus and John Nay and Jonathan H. Choi and Kevin Tobia and Margaret Hagan and Megan Ma and Michael Livermore and Nikon Rasumov-Rahe and Nils Holzenberger and Noam Kolt and Peter Henderson and Sean Rehaag and Sharad Goel and Shang Gao and Spencer Williams and Sunny Gandhi and Tom Zur and Varun Iyer and Zehua Li},
+            year={2023},
+            eprint={2308.11462},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        },
+        @article{hendrycks2021cuad,
+            title={Cuad: An expert-annotated nlp dataset for legal contract review},
+            author={Hendrycks, Dan and Burns, Collin and Chen, Anya and Ball, Spencer},
+            journal={arXiv preprint arXiv:2103.06268},
+            year={2021}
+        }
+        """,
+        n_samples={"test": 320},
+        avg_character_length={"test": 352.27},
+    )
+
+    def dataset_transform(self):
+        mapping = {"yes": 1, "no": 0}
+        self.dataset = self.dataset.map(
+            lambda example: {
+                "answer": mapping.get(example["answer"].lower(), example["answer"])
+            }
+        )
+        self.dataset = self.dataset.rename_column("answer", "label")

--- a/results/intfloat__multilingual-e5-small/CUADRenewalTermLegalBenchClassification.json
+++ b/results/intfloat__multilingual-e5-small/CUADRenewalTermLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADRenewalTermLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.8937823834196891,
+    "accuracy_stderr": 0.0,
+    "ap": 0.8527633851468048,
+    "ap_stderr": 0.0,
+    "evaluation_time": 73.0,
+    "f1": 0.8937816705258564,
+    "f1_stderr": 1.1102230246251565e-16,
+    "main_score": 0.8937823834196891
+  }
+}

--- a/results/intfloat__multilingual-e5-small/CUADRevenueProfitSharingLegalBenchClassification.json
+++ b/results/intfloat__multilingual-e5-small/CUADRevenueProfitSharingLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADRevenueProfitSharingLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.8863049095607234,
+    "accuracy_stderr": 1.1102230246251565e-16,
+    "ap": 0.8595864143749674,
+    "ap_stderr": 0.0,
+    "evaluation_time": 134.96,
+    "f1": 0.8860004418587526,
+    "f1_stderr": 1.1102230246251565e-16,
+    "main_score": 0.8863049095607234
+  }
+}

--- a/results/intfloat__multilingual-e5-small/CUADRofrRofoRofnLegalBenchClassification.json
+++ b/results/intfloat__multilingual-e5-small/CUADRofrRofoRofnLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADRofrRofoRofnLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.6753623188405797,
+    "accuracy_stderr": 0.0,
+    "ap": 0.6199286375049556,
+    "ap_stderr": 1.1102230246251565e-16,
+    "evaluation_time": 95.15,
+    "f1": 0.6751876665461791,
+    "f1_stderr": 1.1102230246251565e-16,
+    "main_score": 0.6753623188405797
+  }
+}

--- a/results/intfloat__multilingual-e5-small/CUADSourceCodeEscrowLegalBenchClassification.json
+++ b/results/intfloat__multilingual-e5-small/CUADSourceCodeEscrowLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADSourceCodeEscrowLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.7796610169491525,
+    "accuracy_stderr": 1.1102230246251565e-16,
+    "ap": 0.7340020754064337,
+    "ap_stderr": 1.1102230246251565e-16,
+    "evaluation_time": 46.5,
+    "f1": 0.7780671296296295,
+    "f1_stderr": 0.0,
+    "main_score": 0.7796610169491525
+  }
+}

--- a/results/intfloat__multilingual-e5-small/CUADTerminationForConvenienceLegalBenchClassification.json
+++ b/results/intfloat__multilingual-e5-small/CUADTerminationForConvenienceLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADTerminationForConvenienceLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.9116279069767442,
+    "accuracy_stderr": 0.0,
+    "ap": 0.8817997977755307,
+    "ap_stderr": 1.1102230246251565e-16,
+    "evaluation_time": 67.68,
+    "f1": 0.9115973078837456,
+    "f1_stderr": 0.0,
+    "main_score": 0.9116279069767442
+  }
+}

--- a/results/intfloat__multilingual-e5-small/CUADThirdPartyBeneficiaryLegalBenchClassification.json
+++ b/results/intfloat__multilingual-e5-small/CUADThirdPartyBeneficiaryLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADThirdPartyBeneficiaryLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.8529411764705882,
+    "accuracy_stderr": 0.0,
+    "ap": 0.7823529411764706,
+    "ap_stderr": 0.0,
+    "evaluation_time": 29.86,
+    "f1": 0.8517872711421098,
+    "f1_stderr": 0.0,
+    "main_score": 0.8529411764705882
+  }
+}

--- a/results/intfloat__multilingual-e5-small/CUADUncappedLiabilityLegalBenchClassification.json
+++ b/results/intfloat__multilingual-e5-small/CUADUncappedLiabilityLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADUncappedLiabilityLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.8503401360544217,
+    "accuracy_stderr": 0.0,
+    "ap": 0.7706331209732571,
+    "ap_stderr": 1.1102230246251565e-16,
+    "evaluation_time": 73.28,
+    "f1": 0.8472222222222223,
+    "f1_stderr": 0.0,
+    "main_score": 0.8503401360544217
+  }
+}

--- a/results/intfloat__multilingual-e5-small/CUADUnlimitedAllYouCanEatLicenseLegalBenchClassification.json
+++ b/results/intfloat__multilingual-e5-small/CUADUnlimitedAllYouCanEatLicenseLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADUnlimitedAllYouCanEatLicenseLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.75,
+    "accuracy_stderr": 0.0,
+    "ap": 0.6691176470588236,
+    "ap_stderr": 0.0,
+    "evaluation_time": 26.37,
+    "f1": 0.7386569872958259,
+    "f1_stderr": 1.1102230246251565e-16,
+    "main_score": 0.75
+  }
+}

--- a/results/intfloat__multilingual-e5-small/CUADVolumeRestrictionLegalBenchClassification.json
+++ b/results/intfloat__multilingual-e5-small/CUADVolumeRestrictionLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADVolumeRestrictionLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.8012422360248447,
+    "accuracy_stderr": 0.0,
+    "ap": 0.7604726100966703,
+    "ap_stderr": 0.0,
+    "evaluation_time": 49.84,
+    "f1": 0.7997278911564625,
+    "f1_stderr": 1.1102230246251565e-16,
+    "main_score": 0.8012422360248447
+  }
+}

--- a/results/intfloat__multilingual-e5-small/CUADWarrantyDurationLegalBenchClassification.json
+++ b/results/intfloat__multilingual-e5-small/CUADWarrantyDurationLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADWarrantyDurationLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.815625,
+    "accuracy_stderr": 0.0,
+    "ap": 0.753255988023952,
+    "ap_stderr": 0.0,
+    "evaluation_time": 47.81,
+    "f1": 0.8155367314437572,
+    "f1_stderr": 0.0,
+    "main_score": 0.815625
+  }
+}

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADRenewalTermLegalBenchClassification.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADRenewalTermLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADRenewalTermLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.8860103626943004,
+    "accuracy_stderr": 1.1102230246251565e-16,
+    "ap": 0.8694332305540545,
+    "ap_stderr": 0.0,
+    "evaluation_time": 62.59,
+    "f1": 0.8853176318063959,
+    "f1_stderr": 1.1102230246251565e-16,
+    "main_score": 0.8860103626943004
+  }
+}

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADRevenueProfitSharingLegalBenchClassification.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADRevenueProfitSharingLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADRevenueProfitSharingLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.8074935400516796,
+    "accuracy_stderr": 0.0,
+    "ap": 0.7902830807204289,
+    "ap_stderr": 0.0,
+    "evaluation_time": 110.87,
+    "f1": 0.8028328902490106,
+    "f1_stderr": 1.1102230246251565e-16,
+    "main_score": 0.8074935400516796
+  }
+}

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADRofrRofoRofnLegalBenchClassification.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADRofrRofoRofnLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADRofrRofoRofnLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.6275362318840579,
+    "accuracy_stderr": 0.0,
+    "ap": 0.5781568190263843,
+    "ap_stderr": 0.0,
+    "evaluation_time": 82.12,
+    "f1": 0.6259452618256605,
+    "f1_stderr": 0.0,
+    "main_score": 0.6275362318840579
+  }
+}

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADSourceCodeEscrowLegalBenchClassification.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADSourceCodeEscrowLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADSourceCodeEscrowLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.576271186440678,
+    "accuracy_stderr": 0.0,
+    "ap": 0.5417484388938448,
+    "ap_stderr": 0.0,
+    "evaluation_time": 40.71,
+    "f1": 0.5327842888818498,
+    "f1_stderr": 1.1102230246251565e-16,
+    "main_score": 0.576271186440678
+  }
+}

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADTerminationForConvenienceLegalBenchClassification.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADTerminationForConvenienceLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADTerminationForConvenienceLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.9,
+    "accuracy_stderr": 0.0,
+    "ap": 0.8702970297029703,
+    "ap_stderr": 0.0,
+    "evaluation_time": 52.37,
+    "f1": 0.8999085156254228,
+    "f1_stderr": 0.0,
+    "main_score": 0.9
+  }
+}

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADThirdPartyBeneficiaryLegalBenchClassification.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADThirdPartyBeneficiaryLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADThirdPartyBeneficiaryLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.8529411764705882,
+    "accuracy_stderr": 0.0,
+    "ap": 0.7823529411764706,
+    "ap_stderr": 0.0,
+    "evaluation_time": 27.29,
+    "f1": 0.8517872711421098,
+    "f1_stderr": 0.0,
+    "main_score": 0.8529411764705882
+  }
+}

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADUncappedLiabilityLegalBenchClassification.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADUncappedLiabilityLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADUncappedLiabilityLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.7687074829931972,
+    "accuracy_stderr": 0.0,
+    "ap": 0.6861290857806537,
+    "ap_stderr": 0.0,
+    "evaluation_time": 44.73,
+    "f1": 0.7593412942989215,
+    "f1_stderr": 0.0,
+    "main_score": 0.7687074829931972
+  }
+}

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADUnlimitedAllYouCanEatLicenseLegalBenchClassification.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADUnlimitedAllYouCanEatLicenseLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADUnlimitedAllYouCanEatLicenseLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.6041666666666667,
+    "accuracy_stderr": 1.1102230246251565e-16,
+    "ap": 0.5581395348837209,
+    "ap_stderr": 0.0,
+    "evaluation_time": 20.31,
+    "f1": 0.5306227483273289,
+    "f1_stderr": 0.0,
+    "main_score": 0.6041666666666667
+  }
+}

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADVolumeRestrictionLegalBenchClassification.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADVolumeRestrictionLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADVolumeRestrictionLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.7795031055900621,
+    "accuracy_stderr": 0.0,
+    "ap": 0.765527950310559,
+    "ap_stderr": 0.0,
+    "evaluation_time": 49.74,
+    "f1": 0.7712953792903374,
+    "f1_stderr": 0.0,
+    "main_score": 0.7795031055900621
+  }
+}

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADWarrantyDurationLegalBenchClassification.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/CUADWarrantyDurationLegalBenchClassification.json
@@ -1,0 +1,15 @@
+{
+  "dataset_revision": "12ca3b695563788fead87a982ad1a068284413f4",
+  "mteb_dataset_name": "CUADWarrantyDurationLegalBenchClassification",
+  "mteb_version": "1.7.7",
+  "test": {
+    "accuracy": 0.690625,
+    "accuracy_stderr": 0.0,
+    "ap": 0.6267398648648649,
+    "ap_stderr": 0.0,
+    "evaluation_time": 31.95,
+    "f1": 0.6887251289609433,
+    "f1_stderr": 0.0,
+    "main_score": 0.690625
+  }
+}


### PR DESCRIPTION
## Checklist for adding MMTEB dataset

Reason for dataset addition: Showcases the model's performance on the [LegalBench](https://hazyresearch.stanford.edu/legalbench/) datasets, enabling evaluation on domain-specific legal texts.

Follow up to #622 


## Changes Made:

The following 10 datasets have been added in this PR:

1. [CUAD Renewal Term](https://hazyresearch.stanford.edu/legalbench/tasks/cuad_renewal_term.html)
2. [CUAD Revenue Profit Sharing](https://hazyresearch.stanford.edu/legalbench/tasks/cuad_revenue-profit_sharing.html)
3. [CUAD Rofr Rofo Rofn](https://hazyresearch.stanford.edu/legalbench/tasks/cuad_rofr-rofo-rofn.html)
4. [CUAD Source Code Escrow](https://hazyresearch.stanford.edu/legalbench/tasks/cuad_source_code_escrow.html)
5. [CUAD Termination For Convenience](https://hazyresearch.stanford.edu/legalbench/tasks/cuad_termination_for_convenience.html)
6. [CUAD Third Party Beneficiary](https://hazyresearch.stanford.edu/legalbench/tasks/cuad_third_party_beneficiary.html)
7. [CUAD Uncapped Liability](https://hazyresearch.stanford.edu/legalbench/tasks/cuad_uncapped_liability.html)
8. [CUAD Unlimited All You Can Eat License](https://hazyresearch.stanford.edu/legalbench/tasks/cuad_unlimited-all-you-can-eat-license.html)
9. [CUAD Volume Restriction](https://hazyresearch.stanford.edu/legalbench/tasks/cuad_volume_restriction.html)
10. [CUAD Warranty Duration](https://hazyresearch.stanford.edu/legalbench/tasks/cuad_warranty_duration.html)


- [x] I have tested that the dataset runs with the `mteb` package.
- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
  - [x] `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
  - [x] `intfloat/multilingual-e5-small`
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [x] If the dataset is too big (e.g. >2048 examples), considering using `self.stratified_subsampling() under dataset_transform()`
- [x] I have filled out the metadata object in the dataset file (find documentation on it [here](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md#2-creating-the-metadata-object)).
- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 
- [x] I have added points for my submission to the [points folder](https://github.com/embeddings-benchmark/mteb/blob/main/docs/mmteb/points.md) using the PR number as the filename (e.g. `438.jsonl`).
