### PR TITLE
Adding PawsX-Maltese dataset

### DIFF
--- a/mteb/tasks/PairClassification/__init__.py
+++ b/mteb/tasks/PairClassification/__init__.py
@@ -6,6 +6,7 @@ from .eng.SprintDuplicateQuestionsPC import *
 from .eng.TwitterSemEval2015PC import *
 from .eng.TwitterURLCorpusPC import *
 from .hye.ArmenianParaphrasePC import *
+from .mlt.PawsXMaltese import *
 from .multilingual.OpusparcusPC import *
 from .multilingual.PawsX import *
 from .multilingual.XNLI import *

--- a/mteb/tasks/PairClassification/mlt/PawsXMaltese.py
+++ b/mteb/tasks/PairClassification/mlt/PawsXMaltese.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from mteb.abstasks.AbsTaskPairClassification import AbsTaskPairClassification
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+
+class PawsXMaltese(AbsTaskPairClassification):
+    metadata = TaskMetadata(
+        name="PawsXMaltese",
+        description="amitness/PAWS-X-maltese",
+        reference="https://aclanthology.org/D19-1382/",
+        dataset={
+            "path": "amitness/PAWS-X-maltese",
+            "revision": "632ced95db1e042e3487c9f8ea3ef4187f666299",
+        },
+        type="PairClassification",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["mlt-Latn"],
+        main_score="ap",
+        date=("2023-05-03", "2023-05-03"),
+        form=["written"],
+        domains=["Encyclopaedic"],
+        task_subtypes=[],
+        license="Not specified",
+        socioeconomic_status=None,
+        annotations_creators=None,
+        dialect=None,
+        text_creation=None,
+        bibtex_citation=None,
+        n_samples={"train": 49175, "validation": 2000, "test": 2000},
+        avg_character_length={"train": 114.21, "validation": 113.44, "test": 114.62},
+    )
+
+    def dataset_transform(self):
+        _dataset = {}
+        for split in self.metadata.eval_splits:
+            hf_dataset = self.dataset[split]
+            _dataset[split] = [
+                {
+                    "sent1": hf_dataset["sentence1_mt"],
+                    "sent2": hf_dataset["sentence2_mt"],
+                    "labels": hf_dataset["label"],
+                }
+            ]
+        self.dataset = _dataset

--- a/results/intfloat__multilingual-e5-small/PawsXMaltese.json
+++ b/results/intfloat__multilingual-e5-small/PawsXMaltese.json
@@ -1,0 +1,49 @@
+{
+  "dataset_revision": "632ced95db1e042e3487c9f8ea3ef4187f666299",
+  "mteb_dataset_name": "PawsXMaltese",
+  "mteb_version": "1.7.52",
+  "test": {
+    "cos_sim": {
+      "accuracy": 0.5685,
+      "accuracy_threshold": 0.9931389093399048,
+      "ap": 0.5281319204003251,
+      "f1": 0.6255172413793103,
+      "f1_threshold": 0.8650588393211365,
+      "precision": 0.45509282488710484,
+      "recall": 1.0
+    },
+    "dot": {
+      "accuracy": 0.5685,
+      "accuracy_threshold": 0.99313884973526,
+      "ap": 0.5281325149300351,
+      "f1": 0.6255172413793103,
+      "f1_threshold": 0.8650587797164917,
+      "precision": 0.45509282488710484,
+      "recall": 1.0
+    },
+    "euclidean": {
+      "accuracy": 0.5685,
+      "accuracy_threshold": 0.11714193224906921,
+      "ap": 0.5281315801047479,
+      "f1": 0.6255172413793103,
+      "f1_threshold": 0.5194970965385437,
+      "precision": 0.45509282488710484,
+      "recall": 1.0
+    },
+    "evaluation_time": 16.8,
+    "manhattan": {
+      "accuracy": 0.5685,
+      "accuracy_threshold": 1.7497398853302002,
+      "ap": 0.5285664908821571,
+      "f1": 0.6254319281271596,
+      "f1_threshold": 7.733060359954834,
+      "precision": 0.4554604932058379,
+      "recall": 0.9977949283351709
+    },
+    "max": {
+      "accuracy": 0.5685,
+      "ap": 0.5285664908821571,
+      "f1": 0.6255172413793103
+    }
+  }
+}

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/PawsXMaltese.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/PawsXMaltese.json
@@ -1,0 +1,49 @@
+{
+  "dataset_revision": "632ced95db1e042e3487c9f8ea3ef4187f666299",
+  "mteb_dataset_name": "PawsXMaltese",
+  "mteb_version": "1.7.52",
+  "test": {
+    "cos_sim": {
+      "accuracy": 0.5725,
+      "accuracy_threshold": 0.9790642261505127,
+      "ap": 0.5310433334089725,
+      "f1": 0.6254746289264757,
+      "f1_threshold": 0.4101191759109497,
+      "precision": 0.4552763819095477,
+      "recall": 0.9988974641675854
+    },
+    "dot": {
+      "accuracy": 0.5465,
+      "accuracy_threshold": 19.625829696655273,
+      "ap": 0.4626698138458746,
+      "f1": 0.6244406196213426,
+      "f1_threshold": 1.586690068244934,
+      "precision": 0.45395395395395394,
+      "recall": 1.0
+    },
+    "euclidean": {
+      "accuracy": 0.569,
+      "accuracy_threshold": 0.6147043108940125,
+      "ap": 0.5307153217193683,
+      "f1": 0.62538913870633,
+      "f1_threshold": 3.5841565132141113,
+      "precision": 0.45564516129032256,
+      "recall": 0.9966923925027563
+    },
+    "evaluation_time": 16.01,
+    "manhattan": {
+      "accuracy": 0.57,
+      "accuracy_threshold": 9.666176795959473,
+      "ap": 0.5312739698612479,
+      "f1": 0.625215889464594,
+      "f1_threshold": 60.10087585449219,
+      "precision": 0.4552313883299799,
+      "recall": 0.9977949283351709
+    },
+    "max": {
+      "accuracy": 0.5725,
+      "ap": 0.5312739698612479,
+      "f1": 0.6254746289264757
+    }
+  }
+}


### PR DESCRIPTION
Adding PawsX-Maltese dataset as suggested here: https://github.com/embeddings-benchmark/mteb/issues/419

- [ ] I have tested that the dataset runs with the `mteb` package.
- [ ] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
  - [ ] `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
  - [ ] `intfloat/multilingual-e5-small`
- [ ] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [ ] If the dataset is too big (e.g. >2048 examples), considering using `self.stratified_subsampling() under dataset_transform()`
- [ ] I have filled out the metadata object in the dataset file (find documentation on it [here](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md#2-creating-the-metadata-object)).
- [ ] Run tests locally to make sure nothing is broken using `make test`. 
- [ ] Run the formatter to format the code using `make lint`. 
- [ ] I have added points for my submission to the [points folder](https://github.com/embeddings-benchmark/mteb/blob/main/docs/mmteb/points.md) using the PR number as the filename (e.g. `438.jsonl`).
