### PR TITLE
fix: Add RUParaPhraserSTS

### DIFF
--- a/docs/mmteb/points/716.jsonl
+++ b/docs/mmteb/points/716.jsonl
@@ -1,0 +1,3 @@
+{"GitHub": "mrshu", "New dataset": 22}
+{"GitHub": "KranthiGV", "Review PR": 2}
+{"GitHub": "isaac-chung", "Review PR": 2}

--- a/mteb/tasks/STS/__init__.py
+++ b/mteb/tasks/STS/__init__.py
@@ -22,5 +22,6 @@ from .multilingual.STSBenchmarkMultilingualSTS import *
 from .pol.PolishSTS import *
 from .por.Assin2STS import *
 from .ron.RonSTS import *
+from .rus.RUParaPhraserSTS import *
 from .spa.STSES import *
 from .zho.CMTEBSTS import *

--- a/mteb/tasks/STS/rus/RUParaPhraserSTS.py
+++ b/mteb/tasks/STS/rus/RUParaPhraserSTS.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+from ....abstasks.AbsTaskSTS import AbsTaskSTS
+
+
+class RUParaPhraserSTS(AbsTaskSTS):
+    metadata = TaskMetadata(
+        name="RUParaPhraserSTS",
+        dataset={
+            "path": "merionum/ru_paraphraser",
+            "revision": "43265056790b8f7c59e0139acb4be0a8dad2c8f4",
+        },
+        description="ParaPhraser is a news headlines corpus with precise, near and non-paraphrases.",
+        reference="https://aclanthology.org/2020.ngt-1.6",
+        type="STS",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["rus-Cyrl"],
+        main_score="cosine_spearman",
+        date=("2009-01-01", "2019-01-01"),  # rough estimate,
+        form=["written"],
+        domains=["News"],
+        task_subtypes=[],
+        license="MIT",
+        socioeconomic_status="mixed",
+        annotations_creators="human-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""
+        @inproceedings{gudkov-etal-2020-automatically,
+          title = "Automatically Ranked {R}ussian Paraphrase Corpus for Text Generation",
+          author = "Gudkov, Vadim  and
+            Mitrofanova, Olga  and
+            Filippskikh, Elizaveta",
+          booktitle = "Proceedings of the Fourth Workshop on Neural Generation and Translation",
+          month = jul,
+          year = "2020",
+          address = "Online",
+          publisher = "Association for Computational Linguistics",
+          url = "https://aclanthology.org/2020.ngt-1.6",
+          doi = "10.18653/v1/2020.ngt-1.6",
+          pages = "54--59",
+        }
+        @inproceedings{pivovarova2017paraphraser,
+          title={ParaPhraser: Russian paraphrase corpus and shared task},
+          author={Pivovarova, Lidia and Pronoza, Ekaterina and Yagunova, Elena and Pronoza, Anton},
+          booktitle={Conference on artificial intelligence and natural language},
+          pages={211--225},
+          year={2017},
+          organization={Springer}
+        }
+        """,
+        n_samples={"test": 1924},
+        avg_character_length={"test": 61.25},
+    )
+
+    @property
+    def metadata_dict(self) -> dict[str, str]:
+        metadata_dict = super().metadata_dict
+        metadata_dict["min_score"] = -1
+        metadata_dict["max_score"] = 1
+        return metadata_dict
+
+    def dataset_transform(self):
+        self.dataset = self.dataset.rename_columns(
+            {
+                "text_1": "sentence1",
+                "text_2": "sentence2",
+                "class": "score",
+            }
+        )
+        self.dataset = self.dataset.map(lambda x: {"score": float(x["score"])})

--- a/results/intfloat__multilingual-e5-small/RUParaPhraserSTS.json
+++ b/results/intfloat__multilingual-e5-small/RUParaPhraserSTS.json
@@ -1,0 +1,20 @@
+{
+  "dataset_revision": "43265056790b8f7c59e0139acb4be0a8dad2c8f4",
+  "mteb_dataset_name": "RUParaPhraserSTS",
+  "mteb_version": "1.9.0",
+  "test": {
+    "cos_sim": {
+      "pearson": 0.6558707404884166,
+      "spearman": 0.7144624429385763
+    },
+    "euclidean": {
+      "pearson": 0.6881975018275212,
+      "spearman": 0.7144624423366885
+    },
+    "evaluation_time": 76.07,
+    "manhattan": {
+      "pearson": 0.6868163280138715,
+      "spearman": 0.7125534406847368
+    }
+  }
+}

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/RUParaPhraserSTS.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/RUParaPhraserSTS.json
@@ -1,0 +1,20 @@
+{
+  "dataset_revision": "43265056790b8f7c59e0139acb4be0a8dad2c8f4",
+  "mteb_dataset_name": "RUParaPhraserSTS",
+  "mteb_version": "1.9.0",
+  "test": {
+    "cos_sim": {
+      "pearson": 0.5571382281863957,
+      "spearman": 0.6186995399343924
+    },
+    "euclidean": {
+      "pearson": 0.6333631177537077,
+      "spearman": 0.6582684928784607
+    },
+    "evaluation_time": 127.83,
+    "manhattan": {
+      "pearson": 0.6318498604302736,
+      "spearman": 0.6565093331875179
+    }
+  }
+}


### PR DESCRIPTION


<!-- If you are not submitting for a dataset, feel free to remove the content below  -->


<!-- add additional description, question etc. related to the new dataset -->

## Checklist for adding MMTEB dataset

<!-- 
Before you commit here is a checklist you should complete before submitting
if you are not 
 -->
Reason for dataset addition:
<!-- Add reason for adding dataset here. E.g. it covers task/language/domain previously not covered -->

This is a new STS dataset in a language that has not been covered yet (Russian).

- [x] I have tested that the dataset runs with the `mteb` package.
- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
  - [x] `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
  - [x] `intfloat/multilingual-e5-small`
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [x] If the dataset is too big (e.g. >2048 examples), considering using `self.stratified_subsampling() under dataset_transform()`
- [x] I have filled out the metadata object in the dataset file (find documentation on it [here](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md#2-creating-the-metadata-object)).
- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 
- [ ] I have added points for my submission to the [points folder](https://github.com/embeddings-benchmark/mteb/blob/main/docs/mmteb/points.md) using the PR number as the filename (e.g. `438.jsonl`).
