### PR TITLE
Quick fix CI/CD issue due to dataset redirect

### DIFF
--- a/mteb/tasks/Classification/tha/WisesightSentimentClassification.py
+++ b/mteb/tasks/Classification/tha/WisesightSentimentClassification.py
@@ -10,7 +10,7 @@ class WisesightSentimentClassification(AbsTaskClassification):
         description="Wisesight Sentiment Corpus: Social media messages in Thai language with sentiment label (positive, neutral, negative, question)",
         reference="https://github.com/PyThaiNLP/wisesight-sentiment",
         dataset={
-            "path": "wisesight_sentiment",
+            "path": "pythainlp/wisesight_sentiment",
             "revision": "14aa5773afa135ba835cc5179bbc4a63657a42ae",
         },
         type="Classification",


### PR DESCRIPTION
You might have noticed that tests have been failing since earlier today. This is due to a dataset path that has been redirected. Changing the path fixes the issue. We may want to have better automated fix in the future.