### PR TITLE
ci: fix slovaksum dir

### DIFF
--- a/mteb/tasks/Retrieval/slk/SlovakSumRetrieval.py
+++ b/mteb/tasks/Retrieval/slk/SlovakSumRetrieval.py
@@ -16,9 +16,9 @@ class SlovakSumRetrieval(AbsTaskRetrieval):
             Originally intended as a summarization task, but since no human annotations were provided
             here reformulated to a retrieval task.
         """,
-        reference="https://huggingface.co/datasets/kiviki/SlovakSum",
+        reference="https://huggingface.co/datasets/NaiveNeuron/slovaksum",
         dataset={
-            "path": "kiviki/SlovakSum",
+            "path": "NaiveNeuron/slovaksum",
             "revision": "85d6b32f2762313714618171b9d1a65eb7408835",
         },
         type="Retrieval",


### PR DESCRIPTION
Errors from main:

```
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================= slowest 5 durations ==============================
14.63s call     tests/test_mteb.py::test_mteb_task[average_word_embeddings_levy_dependency-TwentyNewsgroupsClustering]
11.19s call     tests/test_mteb.py::test_two_mteb_tasks
10.66s call     tests/test_mteb.py::test_mteb_task[average_word_embeddings_levy_dependency-Banking77Classification]
10.61s call     tests/test_mteb_rerank.py::test_mteb_rerank
9.44s call     tests/test_mteb.py::test_mteb_task[average_word_embeddings_levy_dependency-SciDocsRR]
=========================== short test summary info ============================
FAILED tests/test_all_abstasks.py::test_dataset_availability - AssertionError: Datasets not available on Hugging Face:
  kiviki/SlovakSum - revision 85d6b32f2762313714618171b9d1a65eb7408835
assert False
====== 1 failed, 539 passed, 157 skipped, 3 warnings in [99](https://github.com/embeddings-benchmark/mteb/actions/runs/9141620711/job/25136233474?pr=546#step:5:100).11s (0:01:39) =======
make: *** [Makefile:23: test] Error 1
Error: Process completed with exit code 2.
```