### PR TITLE
replace get_tasks as default filtering.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ tasks = mteb.get_tasks(categories=["s2s", "p2p"]) # Only select sentence2sentenc
 * by their languages
 
 ```python
-tasks = mteb.get_tasks(languages=["eng", "deu"]) # Only select datasets which contain "eng" or "deu"
+tasks = mteb.get_tasks(languages=["eng", "deu"]) # Only select datasets which contain "eng" or "deu" (iso 639-3 codes)
 ```
 
 You can also specify which languages to load for multilingual/cross-lingual tasks like below:
@@ -117,6 +117,7 @@ evaluation = mteb.MTEB(tasks=[
         AmazonReviewsClassification(hf_subsets=["en", "fr"]) # Only load "en" and "fr" subsets of Amazon Reviews
         BUCCBitextMining(hf_subsets=["de-en"]), # Only load "de-en" subset of BUCC
 ])
+# for an example of a HF subset see "Subset" in the dataset viewer at: https://huggingface.co/datasets/mteb/bucc-bitext-mining
 ```
 
 There are also presets available for certain task collections, e.g. to select the 56 English datasets that form the "Overall MTEB English leaderboard":

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pip install mteb
 * Using a python script (see [scripts/run_mteb_english.py](https://github.com/embeddings-benchmark/mteb/blob/main/scripts/run_mteb_english.py) and [mteb/mtebscripts](https://github.com/embeddings-benchmark/mtebscripts) for more):
 
 ```python
-from mteb import MTEB
+import mteb
 from sentence_transformers import SentenceTransformer
 
 # Define the sentence-transformers model name
@@ -50,7 +50,8 @@ model_name = "average_word_embeddings_komninos"
 # model_name = "sentence-transformers/all-MiniLM-L6-v2"
 
 model = SentenceTransformer(model_name)
-evaluation = MTEB(tasks=["Banking77Classification"])
+tasks = mteb.get_tasks(tasks=["Banking77Classification"])
+evaluation = mteb.MTEB(tasks=tasks)
 results = evaluation.run(model, output_folder=f"results/{model_name}")
 ```
 
@@ -84,27 +85,35 @@ Datasets can be selected by providing the list of datasets, but also
 * by their task (e.g. "Clustering" or "Classification")
 
 ```python
-evaluation = MTEB(task_types=['Clustering', 'Retrieval']) # Only select clustering and retrieval tasks
+tasks = mteb.get_tasks(task_types=["Clustering", "Retrieval"]) # Only select clustering and retrieval tasks
 ```
 
-* by their categories e.g. "S2S" (sentence to sentence) or "P2P" (paragraph to paragraph)
+* by their categories e.g. "s2s" (sentence to sentence) or "p2p" (paragraph to paragraph)
 
 ```python
-evaluation = MTEB(task_categories=['S2S']) # Only select sentence2sentence datasets
+tasks = mteb.get_tasks(categories=["s2s", "p2p"]) # Only select sentence2sentence and paragraph2paragraph datasets
 ```
 
 * by their languages
 
 ```python
-evaluation = MTEB(task_langs=["en", "de"]) # Only select datasets which are "en", "de" or "en-de"
+tasks = mteb.get_tasks(languages=["eng", "deu"]) # Only select datasets which contain "eng" or "deu"
 ```
 
 You can also specify which languages to load for multilingual/cross-lingual tasks like below:
 
 ```python
+import mteb
+
+tasks = [
+    mteb.get_task("AmazonReviewsClassification", languages = ["eng", "fra"]),
+    mteb.get_task("BUCCBitextMining", languages = ["deu"]), # all subsets containing "deu"
+]
+
+# or you can select specific huggingface subsets like this:
 from mteb.tasks import AmazonReviewsClassification, BUCCBitextMining
 
-evaluation = MTEB(tasks=[
+evaluation = mteb.MTEB(tasks=[
         AmazonReviewsClassification(hf_subsets=["en", "fr"]) # Only load "en" and "fr" subsets of Amazon Reviews
         BUCCBitextMining(hf_subsets=["de-en"]), # Only load "de-en" subset of BUCC
 ])
@@ -114,7 +123,7 @@ There are also presets available for certain task collections, e.g. to select th
 
 ```python
 from mteb import MTEB_MAIN_EN
-evaluation = MTEB(tasks=MTEB_MAIN_EN, task_langs=["en"])
+evaluation = mteb.MTEB(tasks=MTEB_MAIN_EN, task_langs=["en"])
 ```
 
 
@@ -148,7 +157,8 @@ class MyModel():
         pass
 
 model = MyModel()
-evaluation = MTEB(tasks=["Banking77Classification"])
+tasks = mteb.get_task("Banking77Classification")
+evaluation = MTEB(tasks=tasks)
 evaluation.run(model)
 ```
 

--- a/mteb/__init__.py
+++ b/mteb/__init__.py
@@ -8,7 +8,7 @@ from mteb.benchmarks import (
     MTEB_RETRIEVAL_WITH_INSTRUCTIONS,
 )
 from mteb.evaluation import *
-from mteb.overview import TASKS_REGISTRY, get_tasks
+from mteb.overview import TASKS_REGISTRY, get_task, get_tasks
 
 __version__ = version("mteb")  # fetch version from install metadata
 
@@ -19,4 +19,5 @@ __all__ = [
     "MTEB_RETRIEVAL_WITH_INSTRUCTIONS",
     "TASKS_REGISTRY",
     "get_tasks",
+    "get_task",
 ]

--- a/mteb/abstasks/TaskMetadata.py
+++ b/mteb/abstasks/TaskMetadata.py
@@ -8,6 +8,7 @@ from pydantic import AnyUrl, BaseModel, BeforeValidator, TypeAdapter, field_vali
 from typing_extensions import Annotated, Literal
 
 from ..languages import (
+    ISO_LANGUAGE_SCRIPT,
     ISO_TO_LANGUAGE,
     ISO_TO_SCRIPT,
     path_to_lang_codes,
@@ -109,9 +110,6 @@ STR_DATE = Annotated[
 ]  # Allows the type to be a string, but ensures that the string is a valid date
 
 SPLIT_NAME = str
-ISO_LANGUAGE_SCRIPT = str  # a 3-letter ISO 639-3 language code followed by a 4-letter ISO 15924 script code (e.g. "eng-Latn")
-ISO_LANGUAGE = str  # a 3-letter ISO 639-3 language code
-ISO_SCRIPT = str  # a 4-letter ISO 15924 script code
 HFSubset = str
 LANGUAGES = Union[
     List[ISO_LANGUAGE_SCRIPT], Mapping[HFSubset, List[ISO_LANGUAGE_SCRIPT]]

--- a/mteb/encoder_interface.py
+++ b/mteb/encoder_interface.py
@@ -26,6 +26,7 @@ class Encoder(Protocol):
         ...
 
 
+@runtime_checkable
 class EncoderWithQueryCorpusEncode(Encoder, Protocol):
     """The interface for an encoder that supports encoding queries and a corpus."""
 

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -85,18 +85,18 @@ class MTEB:
         if task_types is not None:
             logger.warning(
                 "The `task_types` argument is deprecated and will be removed in the next release. "
-                + "Please use the `tasks = mteb.get_tasks(... task_types = [...])` to filter tasks instead."
+                + "Please use `tasks = mteb.get_tasks(... task_types = [...])` to filter tasks instead."
             )
         if task_categories is not None:
             logger.warning(
                 "The `task_categories` argument is deprecated and will be removed in the next release. "
-                + "Please use the `tasks = mteb.get_tasks(... categories = [...])` to filter tasks instead."
+                + "Please use `tasks = mteb.get_tasks(... categories = [...])` to filter tasks instead."
             )
         if task_langs is not None:
             logger.warning(
                 "The `task_langs` argument is deprecated and will be removed in the next release. "
-                + "Please use the `tasks = mteb.get_tasks(... languages = [...])` to filter tasks instead. "
-                + "Note that this uses 3 letter language codes."
+                + "Please use `tasks = mteb.get_tasks(... languages = [...])` to filter tasks instead. "
+                + "Note that this uses 3 letter language codes (ISO 639-3)."
             )
         if version is not None:
             logger.warning(
@@ -106,7 +106,7 @@ class MTEB:
         if task_contains_strings:
             logger.warning(
                 "Passing task names as strings is deprecated and will be removed in the next release. "
-                + "Please use the `tasks = mteb.get_tasks(tasks=[...])` method to get tasks instead."
+                + "Please use `tasks = mteb.get_tasks(tasks=[...])` method to get tasks instead."
             )
 
     @property

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -51,9 +51,12 @@ class MTEB:
             tasks: List of tasks to be evaluated. If specified, we filter tasks based on `task_langs` only
             version: Version of the benchmark to use. If None, latest is used
             err_logs_path: Path to save error logs
-            co2_tracker: Whether to enable or disable CO2 emissions tracker
             kwargs: Additional arguments to be passed to the tasks
         """
+        self.deprecation_warning(
+            task_types, task_categories, task_langs, tasks, version
+        )
+
         if tasks is not None:
             self._tasks = tasks
             assert (
@@ -75,6 +78,36 @@ class MTEB:
         self.err_logs_path = err_logs_path
 
         self.select_tasks(**kwargs)
+
+    def deprecation_warning(
+        self, task_types, task_categories, task_langs, tasks, version
+    ):
+        if task_types is not None:
+            logger.warning(
+                "The `task_types` argument is deprecated and will be removed in the next release. "
+                + "Please use the `tasks = mteb.get_tasks(... task_types = [...])` to filter tasks instead."
+            )
+        if task_categories is not None:
+            logger.warning(
+                "The `task_categories` argument is deprecated and will be removed in the next release. "
+                + "Please use the `tasks = mteb.get_tasks(... categories = [...])` to filter tasks instead."
+            )
+        if task_langs is not None:
+            logger.warning(
+                "The `task_langs` argument is deprecated and will be removed in the next release. "
+                + "Please use the `tasks = mteb.get_tasks(... languages = [...])` to filter tasks instead. "
+                + "Note that this uses 3 letter language codes."
+            )
+        if version is not None:
+            logger.warning(
+                "The `version` argument is deprecated and will be removed in the next release."
+            )
+        task_contains_strings = any(isinstance(x, str) for x in tasks or [])
+        if task_contains_strings:
+            logger.warning(
+                "Passing task names as strings is deprecated and will be removed in the next release. "
+                + "Please use the `tasks = mteb.get_tasks(tasks=[...])` method to get tasks instead."
+            )
 
     @property
     def available_tasks(self):

--- a/mteb/languages.py
+++ b/mteb/languages.py
@@ -8,6 +8,13 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 
+# Language typings
+ISO_LANGUAGE_SCRIPT = str  # a 3-letter ISO 639-3 language code followed by a 4-letter ISO 15924 script code (e.g. "eng-Latn")
+ISO_LANGUAGE = str  # a 3-letter ISO 639-3 language code
+ISO_SCRIPT = str  # a 4-letter ISO 15924 script code
+
+
+# Language mappings
 path_to_lang_codes = Path(__file__).parent / "iso_639_3_to_language.json"
 path_to_lang_scripts = Path(__file__).parent / "iso_15924_to_script.json"
 

--- a/mteb/overview.py
+++ b/mteb/overview.py
@@ -161,6 +161,7 @@ def get_tasks(
     domains: list[TASK_DOMAIN] | None = None,
     task_types: list[TASK_TYPE] | None = None,
     categories: list[TASK_CATEGORY] | None = None,
+    tasks: list[str] | None = None,
     exclude_superseeded: bool = True,
 ) -> MTEBTasks:
     """Get a list of tasks based on the specified filters.
@@ -174,6 +175,7 @@ def get_tasks(
         task_types: A string specifying the type of task. If None, all tasks are included.
         categories: A list of task categories these include "s2s" (sentence to sentence), "s2p" (sentence to paragraph) and "p2p" (paragraph to
             paragraph).
+        tasks: A list of task names to include. If None, all tasks which pass the filters are included.
         exclude_superseeded: A boolean flag to exclude datasets which are superseeded by another.
 
     Returns:
@@ -184,20 +186,45 @@ def get_tasks(
         >>> get_tasks(languages=["eng"], script=["Latn"], task_types=["Classification"])
         >>> get_tasks(languages=["eng"], script=["Latn"], task_types=["Clustering"], exclude_superseeded=False)
     """
-    _tasks = create_task_list()
-    tasks = [cls().filter_languages(languages, script) for cls in _tasks]
+    if tasks:
+        _tasks = [get_task(task, languages, script) for task in tasks]
+        return MTEBTasks(_tasks)
+
+    _tasks = [cls().filter_languages(languages, script) for cls in create_task_list()]
 
     if languages:
-        tasks = filter_tasks_by_languages(tasks, languages)
+        _tasks = filter_tasks_by_languages(_tasks, languages)
     if script:
-        tasks = filter_tasks_by_script(tasks, script)
+        _tasks = filter_tasks_by_script(_tasks, script)
     if domains:
-        tasks = filter_tasks_by_domains(tasks, domains)
+        _tasks = filter_tasks_by_domains(_tasks, domains)
     if task_types:
-        tasks = filter_tasks_by_task_types(tasks, task_types)
+        _tasks = filter_tasks_by_task_types(_tasks, task_types)
     if categories:
-        tasks = filter_task_by_categories(tasks, categories)
+        _tasks = filter_task_by_categories(_tasks, categories)
     if exclude_superseeded:
-        tasks = filter_superseeded_datasets(tasks)
+        _tasks = filter_superseeded_datasets(_tasks)
 
-    return MTEBTasks(tasks)
+    return MTEBTasks(_tasks)
+
+
+def get_task(
+    task_name: str,
+    languages: list[str] | None = None,
+    script: list[str] | None = None,
+) -> AbsTask:
+    """Get a task by name.
+
+    Args:
+        task_name: The name of the task to fetch.
+        languages: A list of languages either specified as 3 letter languages codes (ISO 639-3, e.g. "eng") or as script languages codes e.g.
+            "eng-Latn". For multilingual tasks this will also remove languages that are not in the specified list.
+        script: A list of script codes (ISO 15924 codes). If None, all scripts are included. For multilingual tasks this will also remove scripts
+
+    Returns:
+        An initialized task object.
+
+    Examples:
+        >>> get_task("BornholmBitextMining")
+    """
+    return TASKS_REGISTRY[task_name]().filter_languages(languages, script)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mteb"
-version = "1.11.13"
+version = "1.11.14"
 description = "Massive Text Embedding Benchmark"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
The intention here is to:

1) move complexity away from the MTEB object
2) ensure that the filters are applied in the same way across the benchmark (currently MTEB filters slightly differently due to not handling the new language codes)
3) deprecate filtering in MTEB going forward (only with a warning atm.)
4) doing it in a two step fashion ensure that users are able to inspect the tasks before they are run (also allow for much more custom filtering on the user end)
