### PR TITLE
update reranking Fr tasks

### DIFF
--- a/mteb/tasks/Reranking/fra/AlloprofReranking.py
+++ b/mteb/tasks/Reranking/fra/AlloprofReranking.py
@@ -12,23 +12,68 @@ class AlloprofReranking(AbsTaskReranking):
         reference="https://huggingface.co/datasets/antoinelb7/alloprof",
         dataset={
             "path": "lyon-nlp/mteb-fr-reranking-alloprof-s2p",
-            "revision": "e40c8a63ce02da43200eccb5b0846fcaa888f562",
+            "revision": "65393d0d7a08a10b4e348135e824f385d420b0fd",
         },
         type="Reranking",
-        category="s2s",
+        category="s2p",
         eval_splits=["test"],
         eval_langs=["fra-Latn"],
         main_score="map",
-        date=None,
-        form=None,
-        domains=None,
+        date=("2022-12-01", "2022-12-02"), # TODO update
+        form=["written"],
+        domains=["Web", "Academic"],
         task_subtypes=None,
-        license=None,
+        license="CC BY-NC-SA 4.0",
         socioeconomic_status=None,
-        annotations_creators=None,
+        annotations_creators="expert-annotated",
         dialect=None,
-        text_creation=None,
-        bibtex_citation=None,
-        n_samples=None,
+        text_creation="found",
+        bibtex_citation="""@misc{lef23,
+            doi = {10.48550/ARXIV.2302.07738},
+            url = {https://arxiv.org/abs/2302.07738},
+            author = {Lefebvre-Brossard, Antoine and Gazaille, Stephane and Desmarais, Michel C.},
+            keywords = {Computation and Language (cs.CL), Information Retrieval (cs.IR), Machine Learning (cs.LG), FOS: Computer and information sciences, FOS: Computer and information sciences},
+            title = {Alloprof: a new French question-answer education dataset and its use in an information retrieval case study},
+            publisher = {arXiv},
+            year = {2023},
+            copyright = {Creative Commons Attribution Non Commercial Share Alike 4.0 International}
+            }""",
+        n_samples={"test": 2316, "train": 9264},
         avg_character_length=None,
     )
+
+    def load_data(self, **kwargs):
+
+        if self.data_loaded:
+            return
+
+        self.dataset = datasets.load_dataset(
+            name="queries",
+            **self.metadata_dict["dataset"],
+            split=self.metadata.eval_splits[0]
+        )
+        documents = datasets.load_dataset(
+            name="documents",
+            **self.metadata_dict["dataset"],
+            split="test"
+        )
+        # replace documents ids in positive and negative column by their respective texts
+        doc_id2txt = dict(list(zip(documents["doc_id"], documents["text"])))
+
+        self.dataset = self.dataset.map(lambda x: {
+            "positive": [
+                doc_id2txt[docid] for docid in x["positive"]
+            ],
+            "negative": [
+                doc_id2txt[docid] for docid in x["negative"]
+            ]
+        })
+        self.dataset = datasets.DatasetDict({"test": self.dataset})
+
+        self.data_loaded = True
+
+
+    def dataset_transform(self):
+        self.dataset = self.stratified_subsampling(
+            self.dataset, seed=self.seed,
+        )

--- a/mteb/tasks/Reranking/fra/AlloprofReranking.py
+++ b/mteb/tasks/Reranking/fra/AlloprofReranking.py
@@ -71,7 +71,3 @@ class AlloprofReranking(AbsTaskReranking):
 
         self.data_loaded = True
 
-    def dataset_transform(self):
-        self.dataset = self.stratified_subsampling(
-            self.dataset, seed=self.seed, splits=["test"]
-        )

--- a/mteb/tasks/Reranking/fra/AlloprofReranking.py
+++ b/mteb/tasks/Reranking/fra/AlloprofReranking.py
@@ -21,7 +21,7 @@ class AlloprofReranking(AbsTaskReranking):
         eval_splits=["test"],
         eval_langs=["fra-Latn"],
         main_score="map",
-        date=("2020-01-01", "2023-04-14"), # supposition
+        date=("2020-01-01", "2023-04-14"),  # supposition
         form=["written"],
         domains=["Web", "Academic"],
         task_subtypes=None,
@@ -45,37 +45,32 @@ class AlloprofReranking(AbsTaskReranking):
     )
 
     def load_data(self, **kwargs):
-
         if self.data_loaded:
             return
 
         self.dataset = datasets.load_dataset(
             name="queries",
             **self.metadata_dict["dataset"],
-            split=self.metadata.eval_splits[0]
+            split=self.metadata.eval_splits[0],
         )
         documents = datasets.load_dataset(
-            name="documents",
-            **self.metadata_dict["dataset"],
-            split="test"
+            name="documents", **self.metadata_dict["dataset"], split="test"
         )
         # replace documents ids in positive and negative column by their respective texts
         doc_id2txt = dict(list(zip(documents["doc_id"], documents["text"])))
 
-        self.dataset = self.dataset.map(lambda x: {
-            "positive": [
-                doc_id2txt[docid] for docid in x["positive"]
-            ],
-            "negative": [
-                doc_id2txt[docid] for docid in x["negative"]
-            ]
-        })
+        self.dataset = self.dataset.map(
+            lambda x: {
+                "positive": [doc_id2txt[docid] for docid in x["positive"]],
+                "negative": [doc_id2txt[docid] for docid in x["negative"]],
+            }
+        )
         self.dataset = datasets.DatasetDict({"test": self.dataset})
 
         self.data_loaded = True
 
-
     def dataset_transform(self):
         self.dataset = self.stratified_subsampling(
-            self.dataset, seed=self.seed,
+            self.dataset,
+            seed=self.seed,
         )

--- a/mteb/tasks/Reranking/fra/AlloprofReranking.py
+++ b/mteb/tasks/Reranking/fra/AlloprofReranking.py
@@ -67,10 +67,11 @@ class AlloprofReranking(AbsTaskReranking):
         )
         self.dataset = datasets.DatasetDict({"test": self.dataset})
 
+        self.dataset_transform()
+
         self.data_loaded = True
 
     def dataset_transform(self):
         self.dataset = self.stratified_subsampling(
-            self.dataset,
-            seed=self.seed,
+            self.dataset, seed=self.seed, splits=["test"]
         )

--- a/mteb/tasks/Reranking/fra/AlloprofReranking.py
+++ b/mteb/tasks/Reranking/fra/AlloprofReranking.py
@@ -70,4 +70,3 @@ class AlloprofReranking(AbsTaskReranking):
         self.dataset_transform()
 
         self.data_loaded = True
-

--- a/mteb/tasks/Reranking/fra/AlloprofReranking.py
+++ b/mteb/tasks/Reranking/fra/AlloprofReranking.py
@@ -21,7 +21,7 @@ class AlloprofReranking(AbsTaskReranking):
         eval_splits=["test"],
         eval_langs=["fra-Latn"],
         main_score="map",
-        date=("2022-12-01", "2022-12-02"), # TODO update
+        date=("2020-01-01", "2023-04-14"), # supposition
         form=["written"],
         domains=["Web", "Academic"],
         task_subtypes=None,

--- a/mteb/tasks/Reranking/fra/AlloprofReranking.py
+++ b/mteb/tasks/Reranking/fra/AlloprofReranking.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import datasets
+
 from mteb.abstasks.TaskMetadata import TaskMetadata
 
 from ....abstasks.AbsTaskReranking import AbsTaskReranking

--- a/mteb/tasks/Reranking/fra/SyntecReranking.py
+++ b/mteb/tasks/Reranking/fra/SyntecReranking.py
@@ -58,4 +58,6 @@ class SyntecReranking(AbsTaskReranking):
         )
         self.dataset = datasets.DatasetDict({"test": self.dataset})
 
+        self.dataset_transform()
+
         self.data_loaded = True

--- a/mteb/tasks/Reranking/fra/SyntecReranking.py
+++ b/mteb/tasks/Reranking/fra/SyntecReranking.py
@@ -36,31 +36,26 @@ class SyntecReranking(AbsTaskReranking):
     )
 
     def load_data(self, **kwargs):
-
         if self.data_loaded:
             return
 
         self.dataset = datasets.load_dataset(
             name="queries",
             **self.metadata_dict["dataset"],
-            split=self.metadata.eval_splits[0]
+            split=self.metadata.eval_splits[0],
         )
         documents = datasets.load_dataset(
-            name="documents",
-            **self.metadata_dict["dataset"],
-            split="test"
+            name="documents", **self.metadata_dict["dataset"], split="test"
         )
         # replace documents ids in positive and negative column by their respective texts
         doc_id2txt = dict(list(zip(documents["doc_id"], documents["text"])))
 
-        self.dataset = self.dataset.map(lambda x: {
-            "positive": [
-                doc_id2txt[docid] for docid in x["positive"]
-            ],
-            "negative": [
-                doc_id2txt[docid] for docid in x["negative"]
-            ]
-        })
+        self.dataset = self.dataset.map(
+            lambda x: {
+                "positive": [doc_id2txt[docid] for docid in x["positive"]],
+                "negative": [doc_id2txt[docid] for docid in x["negative"]],
+            }
+        )
         self.dataset = datasets.DatasetDict({"test": self.dataset})
 
         self.data_loaded = True

--- a/mteb/tasks/Reranking/fra/SyntecReranking.py
+++ b/mteb/tasks/Reranking/fra/SyntecReranking.py
@@ -12,23 +12,53 @@ class SyntecReranking(AbsTaskReranking):
         reference="https://huggingface.co/datasets/lyon-nlp/mteb-fr-reranking-syntec-s2p",
         dataset={
             "path": "lyon-nlp/mteb-fr-reranking-syntec-s2p",
-            "revision": "b205c5084a0934ce8af14338bf03feb19499c84d",
+            "revision": "daf0863838cd9e3ba50544cdce3ac2b338a1b0ad",
         },
         type="Reranking",
         category="s2p",
         eval_splits=["test"],
         eval_langs=["fra-Latn"],
         main_score="map",
-        date=None,
-        form=None,
-        domains=None,
+        date=("2022-12-01", "2022-12-02"),
+        form=["written"],
+        domains=["Legal"],
         task_subtypes=None,
-        license=None,
+        license="CC BY-NC-SA 4.0",
         socioeconomic_status=None,
-        annotations_creators=None,
+        annotations_creators="human-annotated",
         dialect=None,
-        text_creation=None,
+        text_creation="found",
         bibtex_citation=None,
         n_samples=None,
         avg_character_length=None,
     )
+
+    def load_data(self, **kwargs):
+
+        if self.data_loaded:
+            return
+
+        self.dataset = datasets.load_dataset(
+            name="queries",
+            **self.metadata_dict["dataset"],
+            split=self.metadata.eval_splits[0]
+        )
+        documents = datasets.load_dataset(
+            name="documents",
+            **self.metadata_dict["dataset"],
+            split="test"
+        )
+        # replace documents ids in positive and negative column by their respective texts
+        doc_id2txt = dict(list(zip(documents["doc_id"], documents["text"])))
+
+        self.dataset = self.dataset.map(lambda x: {
+            "positive": [
+                doc_id2txt[docid] for docid in x["positive"]
+            ],
+            "negative": [
+                doc_id2txt[docid] for docid in x["negative"]
+            ]
+        })
+        self.dataset = datasets.DatasetDict({"test": self.dataset})
+
+        self.data_loaded = True

--- a/mteb/tasks/Reranking/fra/SyntecReranking.py
+++ b/mteb/tasks/Reranking/fra/SyntecReranking.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import datasets
+
 from mteb.abstasks.TaskMetadata import TaskMetadata
 
 from ....abstasks.AbsTaskReranking import AbsTaskReranking

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mteb"
-version = "1.11.15"
+version = "1.11.16"
 description = "Massive Text Embedding Benchmark"
 readme = "README.md"
 authors = [

--- a/results/intfloat__multilingual-e5-small/AlloprofReranking.json
+++ b/results/intfloat__multilingual-e5-small/AlloprofReranking.json
@@ -1,0 +1,20 @@
+{
+  "dataset_revision": "65393d0d7a08a10b4e348135e824f385d420b0fd",
+  "evaluation_time": 14.704835414886475,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.11.16",
+  "scores": {
+    "test": [
+      {
+        "hf_subset": "default",
+        "languages": [
+          "fra-Latn"
+        ],
+        "main_score": 0.6527671789828227,
+        "map": 0.6527671789828227,
+        "mrr": 0.6673253008745237
+      }
+    ]
+  },
+  "task_name": "AlloprofReranking"
+}

--- a/results/intfloat__multilingual-e5-small/SyntecReranking.json
+++ b/results/intfloat__multilingual-e5-small/SyntecReranking.json
@@ -1,0 +1,20 @@
+{
+  "dataset_revision": "daf0863838cd9e3ba50544cdce3ac2b338a1b0ad",
+  "evaluation_time": 1.1864006519317627,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.11.16",
+  "scores": {
+    "test": [
+      {
+        "hf_subset": "default",
+        "languages": [
+          "fra-Latn"
+        ],
+        "main_score": 0.8181666666666665,
+        "map": 0.8181666666666665,
+        "mrr": 0.8181666666666665
+      }
+    ]
+  },
+  "task_name": "SyntecReranking"
+}

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/AlloprofReranking.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/AlloprofReranking.json
@@ -1,8 +1,8 @@
 {
   "dataset_revision": "65393d0d7a08a10b4e348135e824f385d420b0fd",
-  "evaluation_time": 10.011885643005371,
+  "evaluation_time": 5.980164289474487,
   "kg_co2_emissions": null,
-  "mteb_version": "1.7.56",
+  "mteb_version": "1.11.16",
   "scores": {
     "test": [
       {

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/SyntecReranking.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/SyntecReranking.json
@@ -1,8 +1,8 @@
 {
   "dataset_revision": "daf0863838cd9e3ba50544cdce3ac2b338a1b0ad",
-  "evaluation_time": 3.2158687114715576,
+  "evaluation_time": 0.9324522018432617,
   "kg_co2_emissions": null,
-  "mteb_version": "1.7.56",
+  "mteb_version": "1.11.16",
   "scores": {
     "test": [
       {


### PR DESCRIPTION
Update the French reranking datasets (alloprof & syntec) by sampling the negative documents using BM25.

Indeed, using an embedding model to sample negative documents through cosine similarity could induce a bias favoring the models that are trained on the same data as the model used to generate the dataset. Moreover, it makes evaluation of the reranking of the latter irrelevant.

- [x] Update the datasets by using BM25 instead
- [x] Update the ranking tasks to implement a load_dataset() method
- [x] Update the tasks metadata


<!-- add additional description, question etc. related to the new dataset -->

## Checklist for adding MMTEB dataset

<!-- 
Before you commit here is a checklist you should complete before submitting
if you are not 
 -->
Reason for dataset addition:
<!-- Add reason for adding dataset here. E.g. it covers task/language/domain previously not covered -->


- [x] I have tested that the dataset runs with the `mteb` package.
- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb -m {model_name} -t {task_name}` command.
  - [x] `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
  - [ ] `intfloat/multilingual-e5-small`
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [x] If the dataset is too big (e.g. >2048 examples), considering using `self.stratified_subsampling() under dataset_transform()`
- [x] I have filled out the metadata object in the dataset file (find documentation on it [here](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md#2-creating-the-metadata-object)).
- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 
- [ ] I have added points for my submission to the [points folder](https://github.com/embeddings-benchmark/mteb/blob/main/docs/mmteb/points.md) using the PR number as the filename (e.g. `438.jsonl`).
