### PR TITLE
Adding Arabic STS Benchmark

### DIFF
--- a/docs/mmteb/points/843.jsonl
+++ b/docs/mmteb/points/843.jsonl
@@ -1,0 +1,2 @@
+{"GitHub": "Ruqyai", "New dataset": 6}
+{"GitHub": " ", "Review PR": 2}

--- a/mteb/tasks/Classification/ara/OnlineStoreReviewSentimentClassification.py
+++ b/mteb/tasks/Classification/ara/OnlineStoreReviewSentimentClassification.py
@@ -11,7 +11,7 @@ class OnlineStoreReviewSentimentClassification(AbsTaskClassification):
         name="OnlineStoreReviewSentimentClassification",
         dataset={
             "path": "Ruqiya/Arabic_Reviews_of_SHEIN",
-            "revision": "8ea114aa27b82a52373203830dc2f5b540b6fcac",
+            "revision": "fb63ba1255f57054d411fe02bb5cec25cd6b150c",
         },
         description="This dataset contains Arabic reviews of products from the SHEIN online store.",
         reference="https://huggingface.co/datasets/Ruqiya/Arabic_Reviews_of_SHEIN",

--- a/mteb/tasks/STS/__init__.py
+++ b/mteb/tasks/STS/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from .ara.ArabicSTSBenchmarkSTS import *
 from .deu.GermanSTSBenchmarkSTS import *
 from .eng.BiossesSTS import *
 from .eng.SickrSTS import *

--- a/mteb/tasks/STS/ara/ArabicSTSBenchmarkSTS.py
+++ b/mteb/tasks/STS/ara/ArabicSTSBenchmarkSTS.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+from ....abstasks.AbsTaskSTS import AbsTaskSTS
+
+
+class ArabicSTSBenchmarkSTS(AbsTaskSTS):
+    metadata = TaskMetadata(
+        name="ArabicSTSBenchmarkSTS",
+        dataset={
+            "path": "Ruqiya/Arabic-stsbenchmark-sts-ar",
+            "revision": "0e9a3d792e7efffc5d7f393bea9abadb29259db3",
+        },
+        description="Semantic Textual Similarity Benchmark (STSbenchmark) dataset translated into Arabic. "
+        "Translations were originally done by Helsinki-NLP/opus-mt-en-ar model",
+        reference="https://huggingface.co/datasets/Ruqiya/Arabic-stsbenchmark-sts-ar",
+        type="STS",
+        category="s2s",
+        eval_splits=["validation", "test"],
+        eval_langs=["ara-Arab"],
+        main_score="cosine_spearman",
+        date=None,
+        form=None,
+        domains=None,
+        task_subtypes=None,
+        license=None,
+        socioeconomic_status=None,
+        annotations_creators=None,
+        dialect=None,
+        text_creation=None,
+        bibtex_citation=None,
+        n_samples=None,
+        avg_character_length=None,
+    )
+
+    @property
+    def metadata_dict(self) -> dict[str, str]:
+        metadata_dict = super().metadata_dict
+        metadata_dict["min_score"] = 0
+        metadata_dict["max_score"] = 5
+        return metadata_dict

--- a/results/intfloat/multilingual-e5-small/0a68dcd3dad5b4962a78daa930087728292b241d/ArabicSTSBenchmarkSTS.json
+++ b/results/intfloat/multilingual-e5-small/0a68dcd3dad5b4962a78daa930087728292b241d/ArabicSTSBenchmarkSTS.json
@@ -1,0 +1,51 @@
+{
+  "dataset_revision": "0e9a3d792e7efffc5d7f393bea9abadb29259db3",
+  "evaluation_time": 408.59459471702576,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.12.7",
+  "scores": {
+    "test": [
+      {
+        "cos_sim": {
+          "pearson": 0.6568513680344203,
+          "spearman": 0.6611334140429839
+        },
+        "euclidean": {
+          "pearson": 0.6566767370436454,
+          "spearman": 0.661132927654943
+        },
+        "hf_subset": "default",
+        "languages": [
+          "ara-Arab"
+        ],
+        "main_score": 0.6611334140429839,
+        "manhattan": {
+          "pearson": 0.6571377710010294,
+          "spearman": 0.6617502518352092
+        }
+      }
+    ],
+    "validation": [
+      {
+        "cos_sim": {
+          "pearson": 0.7207191044559348,
+          "spearman": 0.7230894638239727
+        },
+        "euclidean": {
+          "pearson": 0.7104156376987817,
+          "spearman": 0.7230894638239727
+        },
+        "hf_subset": "default",
+        "languages": [
+          "ara-Arab"
+        ],
+        "main_score": 0.7230894638239727,
+        "manhattan": {
+          "pearson": 0.7093681476999566,
+          "spearman": 0.721960842028593
+        }
+      }
+    ]
+  },
+  "task_name": "ArabicSTSBenchmarkSTS"
+}

--- a/results/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2/bf3bf13ab40c3157080a7ab344c831b9ad18b5eb/ArabicSTSBenchmarkSTS.json
+++ b/results/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2/bf3bf13ab40c3157080a7ab344c831b9ad18b5eb/ArabicSTSBenchmarkSTS.json
@@ -1,0 +1,51 @@
+{
+  "dataset_revision": "0e9a3d792e7efffc5d7f393bea9abadb29259db3",
+  "evaluation_time": 328.44370770454407,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.12.7",
+  "scores": {
+    "test": [
+      {
+        "cos_sim": {
+          "pearson": 0.7041699302857576,
+          "spearman": 0.7094791156381444
+        },
+        "euclidean": {
+          "pearson": 0.6966242599718911,
+          "spearman": 0.6925797372622226
+        },
+        "hf_subset": "default",
+        "languages": [
+          "ara-Arab"
+        ],
+        "main_score": 0.7094791156381444,
+        "manhattan": {
+          "pearson": 0.6952399562230598,
+          "spearman": 0.6916623194242272
+        }
+      }
+    ],
+    "validation": [
+      {
+        "cos_sim": {
+          "pearson": 0.7513328043387305,
+          "spearman": 0.7514072863609352
+        },
+        "euclidean": {
+          "pearson": 0.7302755973343675,
+          "spearman": 0.7338186885009172
+        },
+        "hf_subset": "default",
+        "languages": [
+          "ara-Arab"
+        ],
+        "main_score": 0.7514072863609352,
+        "manhattan": {
+          "pearson": 0.7291902089013564,
+          "spearman": 0.7321617976483081
+        }
+      }
+    ]
+  },
+  "task_name": "ArabicSTSBenchmarkSTS"
+}


### PR DESCRIPTION
### What I did?
### ArabicSTSBenchmarkSTS
- Translated the STS Benchmark dataset into Arabic. The translation process took a long time.
- Removed unnecessary columns.
- Uploaded the dataset to Hugging Face.
### OnlineStoreReviewSentimentClassification
- Updated the dataset that I used in OnlineStoreReviewSentimentClassification task .
- Uploaded the Updated data.
- Updated the reference to the new version in the task.


<!-- If you are not submitting for a dataset, feel free to remove the content below  -->


<!-- add additional description, question etc. related to the new dataset -->

## Checklist for adding MMTEB dataset

<!-- 
Before you commit here is a checklist you should complete before submitting
if you are not 
 -->
Reason for dataset addition:
<!-- Add reason for adding dataset here. E.g. it covers task/language/domain previously not covered -->


- [ ] I have tested that the dataset runs with the `mteb` package.
- [ ] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb -m {model_name} -t {task_name}` command.
  - [ ] `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
  - [ ] `intfloat/multilingual-e5-small`
- [ ] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [ ] If the dataset is too big (e.g. >2048 examples), considering using `self.stratified_subsampling() under dataset_transform()`
- [ ] I have filled out the metadata object in the dataset file (find documentation on it [here](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md#2-creating-the-metadata-object)).
- [ ] Run tests locally to make sure nothing is broken using `make test`. 
- [ ] Run the formatter to format the code using `make lint`. 
- [ ] I have added points for my submission to the [points folder](https://github.com/embeddings-benchmark/mteb/blob/main/docs/mmteb/points.md) using the PR number as the filename (e.g. `438.jsonl`).
