### PR TITLE
fix: dataset not available

### DIFF
--- a/mteb/tasks/Classification/eng/YelpReviewFullClassification.py
+++ b/mteb/tasks/Classification/eng/YelpReviewFullClassification.py
@@ -11,7 +11,7 @@ class YelpReviewFullClassification(AbsTaskClassification):
         description="Yelp Review Full is a dataset for sentiment analysis, containing 5 classes corresponding to ratings 1-5.",
         reference="https://arxiv.org/abs/1509.01626",
         dataset={
-            "path": "yelp_review_full",
+            "path": "Yelp/yelp_review_full",
             "revision": "c1f9ee939b7d05667af864ee1cb066393154bf85",
         },
         type="Classification",

--- a/mteb/tasks/Classification/kor/KlueTC.py
+++ b/mteb/tasks/Classification/kor/KlueTC.py
@@ -8,7 +8,7 @@ class KlueTC(AbsTaskClassification):
     metadata = TaskMetadata(
         name="KLUE-TC",
         dataset={
-            "path": "klue",
+            "path": "klue/klue",
             "name": "ynat",
             "revision": "349481ec73fff722f88e0453ca05c77a447d967c",
         },

--- a/mteb/tasks/PairClassification/kor/KlueNLI.py
+++ b/mteb/tasks/PairClassification/kor/KlueNLI.py
@@ -8,7 +8,7 @@ class KlueNLI(AbsTaskPairClassification):
     metadata = TaskMetadata(
         name="KLUE-NLI",
         dataset={
-            "path": "klue",
+            "path": "klue/klue",
             "name": "nli",
             "revision": "349481ec73fff722f88e0453ca05c77a447d967c",
         },

--- a/mteb/tasks/PairClassification/multilingual/PawsX.py
+++ b/mteb/tasks/PairClassification/multilingual/PawsX.py
@@ -10,7 +10,7 @@ class PawsX(MultilingualTask, AbsTaskPairClassification):
     metadata = TaskMetadata(
         name="PawsX",
         dataset={
-            "path": "paws-x",
+            "path": "google-research-datasets/paws-x",
             "revision": "8a04d940a42cd40658986fdd8e3da561533a3646",
         },
         description="",

--- a/mteb/tasks/Retrieval/eng/NarrativeQARetrieval.py
+++ b/mteb/tasks/Retrieval/eng/NarrativeQARetrieval.py
@@ -13,7 +13,7 @@ class NarrativeQARetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="NarrativeQARetrieval",
         dataset={
-            "path": "narrativeqa",
+            "path": "deepmind/narrativeqa",
             "revision": "2e643e7363944af1c33a652d1c87320d0871c4e4",
         },
         reference="https://metatext.io/datasets/narrativeqa",

--- a/mteb/tasks/STS/kor/KlueSTS.py
+++ b/mteb/tasks/STS/kor/KlueSTS.py
@@ -9,7 +9,7 @@ class KlueSTS(AbsTaskSTS):
     metadata = TaskMetadata(
         name="KLUE-STS",
         dataset={
-            "path": "klue",
+            "path": "klue/klue",
             "name": "sts",
             "revision": "349481ec73fff722f88e0453ca05c77a447d967c",
         },


### PR DESCRIPTION
https://github.com/embeddings-benchmark/mteb/actions/runs/9351588385/job/25737732045?pr=871


```
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================= slowest 5 durations ==============================
22.84s call     tests/test_mteb_rerank.py::test_reranker_same_ndcg1
14.42s call     tests/test_mteb.py::test_mteb_task[average_word_embeddings_levy_dependency-TwentyNewsgroupsClustering]
14.01s call     tests/test_cli.py::test_run_task
13.36s call     tests/test_reproducible_workflow.py::test_reproducibility_workflow[sentence-transformers/all-MiniLM-L6-v2-BornholmBitextMining]
9.37s call     tests/test_mteb.py::test_mteb_task[average_word_embeddings_levy_dependency-SciDocsRR]
=========================== short test summary info ============================
FAILED tests/test_all_abstasks.py::test_dataset_availability - AssertionError: Datasets not available on Hugging Face:
  yelp_review_full - revision c1f9ee939b7d05667af864ee1cb066393154bf85
  klue - revision 349481ec73fff722f88e0453ca05c77a447d967c
  narrativeqa - revision 2e643e7363944af1c33a652d1c87320d0871c4e4
  klue - revision 349481ec73fff722f88e0453ca05c77a447d967c
  paws-x - revision 8a04d940a42cd40658986fdd8e3da561533a3646
  klue - revision 349481ec73fff722f88e0453ca05c77a447d967c
assert False
===== 1 failed, 634 passed, 172 skipped, 76 warnings in 124.48s (0:02:04) ======
make: *** [Makefile:23: test] Error 1
```