### PR TITLE
Fix abstention metric for small datasets

### DIFF
--- a/mteb/evaluation/evaluators/utils.py
+++ b/mteb/evaluation/evaluators/utils.py
@@ -360,8 +360,10 @@ def nAUC(
         abst_curve = np.zeros(len(abstention_rates))
 
         for i, rate in enumerate(abstention_rates):
-            num_instances_abst = min(round(rate * len(conf_scores_argsort)), len(conf_scores) - 1)
-            abst_curve[i] = metrics[conf_scores_argsort[num_instances_abst :]].mean()
+            num_instances_abst = min(
+                round(rate * len(conf_scores_argsort)), len(conf_scores) - 1
+            )
+            abst_curve[i] = metrics[conf_scores_argsort[num_instances_abst:]].mean()
 
         return abst_curve
 

--- a/tests/test_RerankingEvaluator.py
+++ b/tests/test_RerankingEvaluator.py
@@ -53,6 +53,6 @@ class TestRerankingEvaluator:
         conf_scores = [self.evaluator.conf_scores(x) for x in pred_scores]
         nauc_scores_map = self.evaluator.nAUC_scores(conf_scores, ap_scores, "map")
 
-        assert nauc_scores_map["nAUC_map_max"] == pytest.approx(0.69555, TOL)
-        assert nauc_scores_map["nAUC_map_std"] == pytest.approx(0.86172, TOL)
-        assert nauc_scores_map["nAUC_map_diff1"] == pytest.approx(0.68961, TOL)
+        assert nauc_scores_map["nAUC_map_max"] == pytest.approx(0.86943, TOL)
+        assert nauc_scores_map["nAUC_map_std"] == pytest.approx(0.94065, TOL)
+        assert nauc_scores_map["nAUC_map_diff1"] == pytest.approx(0.85460, TOL)

--- a/tests/test_RetrievalEvaluator.py
+++ b/tests/test_RetrievalEvaluator.py
@@ -59,6 +59,8 @@ class TestRetrievalEvaluator:
             [1, 2, 3],
         )
 
-        assert naucs["nAUC_NDCG@3_max"] == pytest.approx(0.62792, TOL)
-        assert naucs["nAUC_NDCG@3_std"] == pytest.approx(0.06211, TOL)
-        assert naucs["nAUC_NDCG@3_diff1"] == pytest.approx(0.06600, TOL)
+        print(naucs["nAUC_NDCG@3_max"], naucs["nAUC_NDCG@3_std"], naucs["nAUC_NDCG@3_diff1"])
+        
+        assert naucs["nAUC_NDCG@3_max"] == pytest.approx(0.50843, TOL)
+        assert naucs["nAUC_NDCG@3_std"] == pytest.approx(0.18322, TOL)
+        assert naucs["nAUC_NDCG@3_diff1"] == pytest.approx(0.21416, TOL)

--- a/tests/test_RetrievalEvaluator.py
+++ b/tests/test_RetrievalEvaluator.py
@@ -59,8 +59,12 @@ class TestRetrievalEvaluator:
             [1, 2, 3],
         )
 
-        print(naucs["nAUC_NDCG@3_max"], naucs["nAUC_NDCG@3_std"], naucs["nAUC_NDCG@3_diff1"])
-        
+        print(
+            naucs["nAUC_NDCG@3_max"],
+            naucs["nAUC_NDCG@3_std"],
+            naucs["nAUC_NDCG@3_diff1"],
+        )
+
         assert naucs["nAUC_NDCG@3_max"] == pytest.approx(0.50843, TOL)
         assert naucs["nAUC_NDCG@3_std"] == pytest.approx(0.18322, TOL)
         assert naucs["nAUC_NDCG@3_diff1"] == pytest.approx(0.21416, TOL)


### PR DESCRIPTION
Hi MTEB team!
I recently added abstention/calibration metrics to the Retrieval and Reranking tasks and just noticed that there was a slight issue when evaluating on very small datasets (less than 10 samples).
I've made the necessary changes to make it work in this edge case.
Cheers!