### PR TITLE
fix Incorrect handling of qrel_revision fix: #909

### DIFF
--- a/docs/mmteb/points/911.jsonl
+++ b/docs/mmteb/points/911.jsonl
@@ -1,0 +1,2 @@
+{"GitHub": "henilp105", "Bug fixes": 3}
+{"GitHub": "KennethEnevoldsen", "Review PR": 2}

--- a/docs/mmteb/points/911.jsonl
+++ b/docs/mmteb/points/911.jsonl
@@ -1,2 +1,0 @@
-{"GitHub": "henilp105", "Bug fixes": 3}
-{"GitHub": "KennethEnevoldsen", "Review PR": 2}

--- a/mteb/tasks/Retrieval/zho/CMTEBRetrieval.py
+++ b/mteb/tasks/Retrieval/zho/CMTEBRetrieval.py
@@ -34,7 +34,7 @@ class T2Retrieval(AbsTaskRetrieval):
         dataset={
             "path": "C-MTEB/T2Retrieval",
             "revision": "8731a845f1bf500a4f111cf1070785c793d10e64",
-            "qrel_revision":"1c83b8d1544e529875e3f6930f3a1fcf749a8e97"
+            "qrel_revision": "1c83b8d1544e529875e3f6930f3a1fcf749a8e97",
         },
         type="Retrieval",
         category="s2p",
@@ -83,7 +83,7 @@ class MMarcoRetrieval(AbsTaskRetrieval):
         dataset={
             "path": "C-MTEB/MMarcoRetrieval",
             "revision": "539bbde593d947e2a124ba72651aafc09eb33fc2",
-            "qrel_revision":"bae08bb7bddbedb96c7e7db52018a55167b67f89"
+            "qrel_revision": "bae08bb7bddbedb96c7e7db52018a55167b67f89",
         },
         type="Retrieval",
         category="s2p",
@@ -132,7 +132,7 @@ class DuRetrieval(AbsTaskRetrieval):
         dataset={
             "path": "C-MTEB/DuRetrieval",
             "revision": "a1a333e290fe30b10f3f56498e3a0d911a693ced",
-            "qrel_revision":"497b7bd1bbb25cb3757ff34d95a8be50a3de2279"
+            "qrel_revision": "497b7bd1bbb25cb3757ff34d95a8be50a3de2279",
         },
         type="Retrieval",
         category="s2p",
@@ -181,7 +181,7 @@ class CovidRetrieval(AbsTaskRetrieval):
         dataset={
             "path": "C-MTEB/CovidRetrieval",
             "revision": "1271c7809071a13532e05f25fb53511ffce77117",
-            "qrel_revision":"a9f41b7cdf24785531d12417ce0d1157ed4b39ca"
+            "qrel_revision": "a9f41b7cdf24785531d12417ce0d1157ed4b39ca",
         },
         type="Retrieval",
         category="s2p",
@@ -223,7 +223,7 @@ class CmedqaRetrieval(AbsTaskRetrieval):
         dataset={
             "path": "C-MTEB/CmedqaRetrieval",
             "revision": "cd540c506dae1cf9e9a59c3e06f42030d54e7301",
-            "qrel_revision":"279d737f36c731c8ff6e2b055f31fe02216fa23d"
+            "qrel_revision": "279d737f36c731c8ff6e2b055f31fe02216fa23d",
         },
         type="Retrieval",
         category="s2p",
@@ -265,7 +265,7 @@ class EcomRetrieval(AbsTaskRetrieval):
         dataset={
             "path": "C-MTEB/EcomRetrieval",
             "revision": "687de13dc7294d6fd9be10c6945f9e8fec8166b9",
-            "qrel_revision":"39c90699b034ec22ac45b3abf5b0bbb5ffd421f9"
+            "qrel_revision": "39c90699b034ec22ac45b3abf5b0bbb5ffd421f9",
         },
         type="Retrieval",
         category="s2p",
@@ -307,7 +307,7 @@ class MedicalRetrieval(AbsTaskRetrieval):
         dataset={
             "path": "C-MTEB/MedicalRetrieval",
             "revision": "2039188fb5800a9803ba5048df7b76e6fb151fc6",
-            "qrel_revision":"37b8efec53c54c3d9c6af212f6710b62ccdf895c"
+            "qrel_revision": "37b8efec53c54c3d9c6af212f6710b62ccdf895c",
         },
         type="Retrieval",
         category="s2p",
@@ -349,7 +349,7 @@ class VideoRetrieval(AbsTaskRetrieval):
         dataset={
             "path": "C-MTEB/VideoRetrieval",
             "revision": "58c2597a5943a2ba48f4668c3b90d796283c5639",
-            "qrel_revision":"faa71382b6a29cf1778d1f436b963e75cb5b927c"
+            "qrel_revision": "faa71382b6a29cf1778d1f436b963e75cb5b927c",
         },
         type="Retrieval",
         category="s2p",

--- a/mteb/tasks/Retrieval/zho/CMTEBRetrieval.py
+++ b/mteb/tasks/Retrieval/zho/CMTEBRetrieval.py
@@ -9,10 +9,10 @@ from mteb.abstasks.TaskMetadata import TaskMetadata
 from ....abstasks.AbsTaskRetrieval import AbsTaskRetrieval
 
 
-def load_retrieval_data(dataset_path, revision, eval_splits):
+def load_retrieval_data(dataset_path, dataset_revision, qrel_revision, eval_splits):
     eval_split = eval_splits[0]
-    dataset = load_dataset(dataset_path, revision=revision)
-    qrels = load_dataset(dataset_path + "-qrels", revision=revision)[eval_split]
+    dataset = load_dataset(dataset_path, revision=dataset_revision)
+    qrels = load_dataset(dataset_path + "-qrels", revision=qrel_revision)[eval_split]
 
     corpus = {e["id"]: {"text": e["text"]} for e in dataset["corpus"]}
     queries = {e["id"]: e["text"] for e in dataset["queries"]}
@@ -34,6 +34,7 @@ class T2Retrieval(AbsTaskRetrieval):
         dataset={
             "path": "C-MTEB/T2Retrieval",
             "revision": "8731a845f1bf500a4f111cf1070785c793d10e64",
+            "qrel_revision":"1c83b8d1544e529875e3f6930f3a1fcf749a8e97"
         },
         type="Retrieval",
         category="s2p",
@@ -68,6 +69,7 @@ class T2Retrieval(AbsTaskRetrieval):
         self.corpus, self.queries, self.relevant_docs = load_retrieval_data(
             self.metadata_dict["dataset"]["path"],
             self.metadata_dict["dataset"]["revision"],
+            self.metadata_dict["dataset"]["qrel_revision"],
             self.metadata_dict["eval_splits"],
         )
         self.data_loaded = True
@@ -81,6 +83,7 @@ class MMarcoRetrieval(AbsTaskRetrieval):
         dataset={
             "path": "C-MTEB/MMarcoRetrieval",
             "revision": "539bbde593d947e2a124ba72651aafc09eb33fc2",
+            "qrel_revision":"bae08bb7bddbedb96c7e7db52018a55167b67f89"
         },
         type="Retrieval",
         category="s2p",
@@ -115,6 +118,7 @@ class MMarcoRetrieval(AbsTaskRetrieval):
         self.corpus, self.queries, self.relevant_docs = load_retrieval_data(
             self.metadata_dict["dataset"]["path"],
             self.metadata_dict["dataset"]["revision"],
+            self.metadata_dict["dataset"]["qrel_revision"],
             self.metadata_dict["eval_splits"],
         )
         self.data_loaded = True
@@ -128,6 +132,7 @@ class DuRetrieval(AbsTaskRetrieval):
         dataset={
             "path": "C-MTEB/DuRetrieval",
             "revision": "a1a333e290fe30b10f3f56498e3a0d911a693ced",
+            "qrel_revision":"497b7bd1bbb25cb3757ff34d95a8be50a3de2279"
         },
         type="Retrieval",
         category="s2p",
@@ -162,6 +167,7 @@ class DuRetrieval(AbsTaskRetrieval):
         self.corpus, self.queries, self.relevant_docs = load_retrieval_data(
             self.metadata_dict["dataset"]["path"],
             self.metadata_dict["dataset"]["revision"],
+            self.metadata_dict["dataset"]["qrel_revision"],
             self.metadata_dict["eval_splits"],
         )
         self.data_loaded = True
@@ -175,6 +181,7 @@ class CovidRetrieval(AbsTaskRetrieval):
         dataset={
             "path": "C-MTEB/CovidRetrieval",
             "revision": "1271c7809071a13532e05f25fb53511ffce77117",
+            "qrel_revision":"a9f41b7cdf24785531d12417ce0d1157ed4b39ca"
         },
         type="Retrieval",
         category="s2p",
@@ -202,6 +209,7 @@ class CovidRetrieval(AbsTaskRetrieval):
         self.corpus, self.queries, self.relevant_docs = load_retrieval_data(
             self.metadata_dict["dataset"]["path"],
             self.metadata_dict["dataset"]["revision"],
+            self.metadata_dict["dataset"]["qrel_revision"],
             self.metadata_dict["eval_splits"],
         )
         self.data_loaded = True
@@ -215,6 +223,7 @@ class CmedqaRetrieval(AbsTaskRetrieval):
         dataset={
             "path": "C-MTEB/CmedqaRetrieval",
             "revision": "cd540c506dae1cf9e9a59c3e06f42030d54e7301",
+            "qrel_revision":"279d737f36c731c8ff6e2b055f31fe02216fa23d"
         },
         type="Retrieval",
         category="s2p",
@@ -242,6 +251,7 @@ class CmedqaRetrieval(AbsTaskRetrieval):
         self.corpus, self.queries, self.relevant_docs = load_retrieval_data(
             self.metadata_dict["dataset"]["path"],
             self.metadata_dict["dataset"]["revision"],
+            self.metadata_dict["dataset"]["qrel_revision"],
             self.metadata_dict["eval_splits"],
         )
         self.data_loaded = True
@@ -255,6 +265,7 @@ class EcomRetrieval(AbsTaskRetrieval):
         dataset={
             "path": "C-MTEB/EcomRetrieval",
             "revision": "687de13dc7294d6fd9be10c6945f9e8fec8166b9",
+            "qrel_revision":"39c90699b034ec22ac45b3abf5b0bbb5ffd421f9"
         },
         type="Retrieval",
         category="s2p",
@@ -282,6 +293,7 @@ class EcomRetrieval(AbsTaskRetrieval):
         self.corpus, self.queries, self.relevant_docs = load_retrieval_data(
             self.metadata_dict["dataset"]["path"],
             self.metadata_dict["dataset"]["revision"],
+            self.metadata_dict["dataset"]["qrel_revision"],
             self.metadata_dict["eval_splits"],
         )
         self.data_loaded = True
@@ -295,6 +307,7 @@ class MedicalRetrieval(AbsTaskRetrieval):
         dataset={
             "path": "C-MTEB/MedicalRetrieval",
             "revision": "2039188fb5800a9803ba5048df7b76e6fb151fc6",
+            "qrel_revision":"37b8efec53c54c3d9c6af212f6710b62ccdf895c"
         },
         type="Retrieval",
         category="s2p",
@@ -322,6 +335,7 @@ class MedicalRetrieval(AbsTaskRetrieval):
         self.corpus, self.queries, self.relevant_docs = load_retrieval_data(
             self.metadata_dict["dataset"]["path"],
             self.metadata_dict["dataset"]["revision"],
+            self.metadata_dict["dataset"]["qrel_revision"],
             self.metadata_dict["eval_splits"],
         )
         self.data_loaded = True
@@ -335,6 +349,7 @@ class VideoRetrieval(AbsTaskRetrieval):
         dataset={
             "path": "C-MTEB/VideoRetrieval",
             "revision": "58c2597a5943a2ba48f4668c3b90d796283c5639",
+            "qrel_revision":"faa71382b6a29cf1778d1f436b963e75cb5b927c"
         },
         type="Retrieval",
         category="s2p",
@@ -362,6 +377,7 @@ class VideoRetrieval(AbsTaskRetrieval):
         self.corpus, self.queries, self.relevant_docs = load_retrieval_data(
             self.metadata_dict["dataset"]["path"],
             self.metadata_dict["dataset"]["revision"],
+            self.metadata_dict["dataset"]["qrel_revision"],
             self.metadata_dict["eval_splits"],
         )
         self.data_loaded = True


### PR DESCRIPTION
fix Incorrect handling of qrel_revision, the revision would differ if the  dataset repo is different for  `qrels`. Thus, added an attribute to handle `qrel_revision`.  and added their revisions.

fixes: #909

<!-- add additional description, question etc. related to the new dataset -->


## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 

CC: @Muennighoff @KennethEnevoldsen @dzqoo 


