### PR TITLE
Fix pair classification inconsistency

### DIFF
--- a/mteb/abstasks/AbsTaskPairClassification.py
+++ b/mteb/abstasks/AbsTaskPairClassification.py
@@ -41,7 +41,11 @@ class AbsTaskPairClassification(AbsTask):
             "sentence_transformers.evaluation.PairClassificationEvaluator"
         ).setLevel(logging.WARN)
         evaluator = PairClassificationEvaluator(
-            data_split["sentence1"], data_split["sentence2"], data_split["labels"], task_name=self.metadata.name, **kwargs
+            data_split["sentence1"],
+            data_split["sentence2"],
+            data_split["labels"],
+            task_name=self.metadata.name,
+            **kwargs,
         )
         scores = evaluator.compute_metrics(model)
 

--- a/mteb/abstasks/AbsTaskPairClassification.py
+++ b/mteb/abstasks/AbsTaskPairClassification.py
@@ -19,8 +19,8 @@ class AbsTaskPairClassification(AbsTask):
     is computed to measure how well the methods can be used for pairwise pair classification.
 
     self.load_data() must generate a huggingface dataset with a split matching self.metadata_dict["eval_splits"], and assign it to self.dataset. It must contain the following columns:
-        sent1: list[str]
-        sent2: list[str]
+        sentence1: list[str]
+        sentence2: list[str]
         labels: list[int]
     """
 
@@ -41,11 +41,7 @@ class AbsTaskPairClassification(AbsTask):
             "sentence_transformers.evaluation.PairClassificationEvaluator"
         ).setLevel(logging.WARN)
         evaluator = PairClassificationEvaluator(
-            data_split["sent1"],
-            data_split["sent2"],
-            data_split["labels"],
-            task_name=self.metadata.name,
-            **kwargs,
+            data_split["sentence1"], data_split["sentence2"], data_split["labels"], task_name=self.metadata.name, **kwargs
         )
         scores = evaluator.compute_metrics(model)
 

--- a/mteb/tasks/PairClassification/ara/ArEntail.py
+++ b/mteb/tasks/PairClassification/ara/ArEntail.py
@@ -47,8 +47,8 @@ class ArEntail(AbsTaskPairClassification):
         for split in self.metadata.eval_splits:
             _dataset[split] = [
                 {
-                    "sent1": self.dataset[split]["premise"],
-                    "sent2": self.dataset[split]["hypothesis"],
+                    "sentence1": self.dataset[split]["premise"],
+                    "sentence2": self.dataset[split]["hypothesis"],
                     "labels": self.dataset[split]["label"],
                 }
             ]

--- a/mteb/tasks/PairClassification/ces/CTKFactsNLI.py
+++ b/mteb/tasks/PairClassification/ces/CTKFactsNLI.py
@@ -55,8 +55,8 @@ class CTKFactsNLI(AbsTaskPairClassification):
         for split in self.metadata.eval_splits:
             _dataset[split] = [
                 {
-                    "sent1": hf_dataset[split]["evidence"],
-                    "sent2": hf_dataset[split]["claim"],
+                    "sentence1": hf_dataset[split]["evidence"],
+                    "sentence2": hf_dataset[split]["claim"],
                     "labels": hf_dataset[split]["label"],
                 }
             ]

--- a/mteb/tasks/PairClassification/deu/FalseFriendsDeEnPC.py
+++ b/mteb/tasks/PairClassification/deu/FalseFriendsDeEnPC.py
@@ -48,8 +48,8 @@ class FalseFriendsDeEnPC(AbsTaskPairClassification):
 
             _dataset[split] = [
                 {
-                    "sent1": hf_dataset["sent1"],
-                    "sent2": hf_dataset["sent2"],
+                    "sentence1": hf_dataset["sent1"],
+                    "sentence2": hf_dataset["sent2"],
                     "labels": hf_dataset["labels"],
                 }
             ]

--- a/mteb/tasks/PairClassification/eng/LegalBenchPC.py
+++ b/mteb/tasks/PairClassification/eng/LegalBenchPC.py
@@ -137,12 +137,12 @@ class LegalBenchPC(AbsTaskPairClassification):
 
             _dataset = _dataset.rename_columns(
                 {
-                    dataset_col_map["sent1"]: "sent1",
-                    dataset_col_map["sent2"]: "sent2",
+                    dataset_col_map["sent1"]: "sentence1",
+                    dataset_col_map["sent2"]: "sentence2",
                     dataset_col_map["labels"]: "labels",
                 }
             )
-            _dataset = _dataset.select_columns(["labels", "sent1", "sent2"])
+            _dataset = _dataset.select_columns(["labels", "sentence1", "sentence2"])
             mapping = dataset_col_map["mapping"]
             _dataset = _dataset.map(
                 lambda example: {
@@ -174,8 +174,8 @@ class LegalBenchPC(AbsTaskPairClassification):
             hf_dataset = self.dataset[split]
             _dataset[split] = [
                 {
-                    "sent1": hf_dataset["sent1"],
-                    "sent2": hf_dataset["sent2"],
+                    "sentence1": hf_dataset["sentence1"],
+                    "sentence2": hf_dataset["sentence2"],
                     "labels": hf_dataset["labels"],
                 }
             ]

--- a/mteb/tasks/PairClassification/eng/SprintDuplicateQuestionsPC.py
+++ b/mteb/tasks/PairClassification/eng/SprintDuplicateQuestionsPC.py
@@ -4,7 +4,7 @@ from mteb.abstasks.TaskMetadata import TaskMetadata
 
 from ....abstasks.AbsTaskPairClassification import AbsTaskPairClassification
 
-# TODO sentence1
+
 class SprintDuplicateQuestionsPC(AbsTaskPairClassification):
     metadata = TaskMetadata(
         name="SprintDuplicateQuestions",
@@ -52,3 +52,7 @@ class SprintDuplicateQuestionsPC(AbsTaskPairClassification):
         n_samples={"validation": 101000, "test": 101000},
         avg_character_length={"validation": 65.2, "test": 67.9},
     )
+
+    def dataset_transform(self):
+        self.dataset = self.dataset.rename_column("sent1", "sentence1")
+        self.dataset = self.dataset.rename_column("sent2", "sentence2")

--- a/mteb/tasks/PairClassification/eng/SprintDuplicateQuestionsPC.py
+++ b/mteb/tasks/PairClassification/eng/SprintDuplicateQuestionsPC.py
@@ -4,7 +4,7 @@ from mteb.abstasks.TaskMetadata import TaskMetadata
 
 from ....abstasks.AbsTaskPairClassification import AbsTaskPairClassification
 
-
+# TODO sentence1
 class SprintDuplicateQuestionsPC(AbsTaskPairClassification):
     metadata = TaskMetadata(
         name="SprintDuplicateQuestions",

--- a/mteb/tasks/PairClassification/eng/TwitterSemEval2015PC.py
+++ b/mteb/tasks/PairClassification/eng/TwitterSemEval2015PC.py
@@ -4,7 +4,7 @@ from mteb.abstasks.TaskMetadata import TaskMetadata
 
 from ....abstasks.AbsTaskPairClassification import AbsTaskPairClassification
 
-
+# TODO sentence1
 class TwitterSemEval2015PC(AbsTaskPairClassification):
     metadata = TaskMetadata(
         name="TwitterSemEval2015",

--- a/mteb/tasks/PairClassification/eng/TwitterSemEval2015PC.py
+++ b/mteb/tasks/PairClassification/eng/TwitterSemEval2015PC.py
@@ -4,7 +4,7 @@ from mteb.abstasks.TaskMetadata import TaskMetadata
 
 from ....abstasks.AbsTaskPairClassification import AbsTaskPairClassification
 
-# TODO sentence1
+
 class TwitterSemEval2015PC(AbsTaskPairClassification):
     metadata = TaskMetadata(
         name="TwitterSemEval2015",
@@ -29,23 +29,27 @@ class TwitterSemEval2015PC(AbsTaskPairClassification):
         dialect=None,
         text_creation=None,
         bibtex_citation="""@inproceedings{xu-etal-2015-semeval,
-    title = "{S}em{E}val-2015 Task 1: Paraphrase and Semantic Similarity in {T}witter ({PIT})",
-    author = "Xu, Wei  and
-      Callison-Burch, Chris  and
-      Dolan, Bill",
-    editor = "Nakov, Preslav  and
-      Zesch, Torsten  and
-      Cer, Daniel  and
-      Jurgens, David",
-    booktitle = "Proceedings of the 9th International Workshop on Semantic Evaluation ({S}em{E}val 2015)",
-    month = jun,
-    year = "2015",
-    address = "Denver, Colorado",
-    publisher = "Association for Computational Linguistics",
-    url = "https://aclanthology.org/S15-2001",
-    doi = "10.18653/v1/S15-2001",
-    pages = "1--11",
-}""",
+        title = "{S}em{E}val-2015 Task 1: Paraphrase and Semantic Similarity in {T}witter ({PIT})",
+        author = "Xu, Wei  and
+        Callison-Burch, Chris  and
+        Dolan, Bill",
+        editor = "Nakov, Preslav  and
+        Zesch, Torsten  and
+        Cer, Daniel  and
+        Jurgens, David",
+        booktitle = "Proceedings of the 9th International Workshop on Semantic Evaluation ({S}em{E}val 2015)",
+        month = jun,
+        year = "2015",
+        address = "Denver, Colorado",
+        publisher = "Association for Computational Linguistics",
+        url = "https://aclanthology.org/S15-2001",
+        doi = "10.18653/v1/S15-2001",
+        pages = "1--11",
+    }""",
         n_samples={"test": 16777},
         avg_character_length={"test": 38.3},
     )
+
+    def dataset_transform(self):
+        self.dataset = self.dataset.rename_column("sent1", "sentence1")
+        self.dataset = self.dataset.rename_column("sent2", "sentence2")

--- a/mteb/tasks/PairClassification/eng/TwitterURLCorpusPC.py
+++ b/mteb/tasks/PairClassification/eng/TwitterURLCorpusPC.py
@@ -4,7 +4,7 @@ from mteb.abstasks.TaskMetadata import TaskMetadata
 
 from ....abstasks.AbsTaskPairClassification import AbsTaskPairClassification
 
-# TODO sentence1
+
 class TwitterURLCorpusPC(AbsTaskPairClassification):
     metadata = TaskMetadata(
         name="TwitterURLCorpus",
@@ -29,24 +29,28 @@ class TwitterURLCorpusPC(AbsTaskPairClassification):
         dialect=None,
         text_creation=None,
         bibtex_citation="""@inproceedings{lan-etal-2017-continuously,
-    title = "A Continuously Growing Dataset of Sentential Paraphrases",
-    author = "Lan, Wuwei  and
-      Qiu, Siyu  and
-      He, Hua  and
-      Xu, Wei",
-    editor = "Palmer, Martha  and
-      Hwa, Rebecca  and
-      Riedel, Sebastian",
-    booktitle = "Proceedings of the 2017 Conference on Empirical Methods in Natural Language Processing",
-    month = sep,
-    year = "2017",
-    address = "Copenhagen, Denmark",
-    publisher = "Association for Computational Linguistics",
-    url = "https://aclanthology.org/D17-1126",
-    doi = "10.18653/v1/D17-1126",
-    pages = "1224--1234",
-    abstract = "A major challenge in paraphrase research is the lack of parallel corpora. In this paper, we present a new method to collect large-scale sentential paraphrases from Twitter by linking tweets through shared URLs. The main advantage of our method is its simplicity, as it gets rid of the classifier or human in the loop needed to select data before annotation and subsequent application of paraphrase identification algorithms in the previous work. We present the largest human-labeled paraphrase corpus to date of 51,524 sentence pairs and the first cross-domain benchmarking for automatic paraphrase identification. In addition, we show that more than 30,000 new sentential paraphrases can be easily and continuously captured every month at {\textasciitilde}70{\%} precision, and demonstrate their utility for downstream NLP tasks through phrasal paraphrase extraction. We make our code and data freely available.",
-}""",
+            title = "A Continuously Growing Dataset of Sentential Paraphrases",
+            author = "Lan, Wuwei  and
+            Qiu, Siyu  and
+            He, Hua  and
+            Xu, Wei",
+            editor = "Palmer, Martha  and
+            Hwa, Rebecca  and
+            Riedel, Sebastian",
+            booktitle = "Proceedings of the 2017 Conference on Empirical Methods in Natural Language Processing",
+            month = sep,
+            year = "2017",
+            address = "Copenhagen, Denmark",
+            publisher = "Association for Computational Linguistics",
+            url = "https://aclanthology.org/D17-1126",
+            doi = "10.18653/v1/D17-1126",
+            pages = "1224--1234",
+            abstract = "A major challenge in paraphrase research is the lack of parallel corpora. In this paper, we present a new method to collect large-scale sentential paraphrases from Twitter by linking tweets through shared URLs. The main advantage of our method is its simplicity, as it gets rid of the classifier or human in the loop needed to select data before annotation and subsequent application of paraphrase identification algorithms in the previous work. We present the largest human-labeled paraphrase corpus to date of 51,524 sentence pairs and the first cross-domain benchmarking for automatic paraphrase identification. In addition, we show that more than 30,000 new sentential paraphrases can be easily and continuously captured every month at {\textasciitilde}70{\%} precision, and demonstrate their utility for downstream NLP tasks through phrasal paraphrase extraction. We make our code and data freely available.",
+        }""",
         n_samples={"test": 51534},
         avg_character_length={"test": 79.5},
     )
+
+    def dataset_transform(self):
+        self.dataset = self.dataset.rename_column("sent1", "sentence1")
+        self.dataset = self.dataset.rename_column("sent2", "sentence2")

--- a/mteb/tasks/PairClassification/eng/TwitterURLCorpusPC.py
+++ b/mteb/tasks/PairClassification/eng/TwitterURLCorpusPC.py
@@ -4,7 +4,7 @@ from mteb.abstasks.TaskMetadata import TaskMetadata
 
 from ....abstasks.AbsTaskPairClassification import AbsTaskPairClassification
 
-
+# TODO sentence1
 class TwitterURLCorpusPC(AbsTaskPairClassification):
     metadata = TaskMetadata(
         name="TwitterURLCorpus",

--- a/mteb/tasks/PairClassification/fas/FarsTail.py
+++ b/mteb/tasks/PairClassification/fas/FarsTail.py
@@ -64,8 +64,8 @@ class FarsTail(AbsTaskPairClassification):
         for split in self.metadata.eval_splits:
             _dataset[split] = [
                 {
-                    "sent1": self.dataset[split]["premise"],
-                    "sent2": self.dataset[split]["hypothesis"],
+                    "sentence1": self.dataset[split]["premise"],
+                    "sentence2": self.dataset[split]["hypothesis"],
                     "labels": self.dataset[split]["label"],
                 }
             ]

--- a/mteb/tasks/PairClassification/hye/ArmenianParaphrasePC.py
+++ b/mteb/tasks/PairClassification/hye/ArmenianParaphrasePC.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from mteb.abstasks.AbsTaskPairClassification import AbsTaskPairClassification
 from mteb.abstasks.TaskMetadata import TaskMetadata
 
-# TODO sentence1
+
 class ArmenianParaphrasePC(AbsTaskPairClassification):
     metadata = TaskMetadata(
         name="ArmenianParaphrasePC",
@@ -29,14 +29,18 @@ class ArmenianParaphrasePC(AbsTaskPairClassification):
         text_creation="found",
         bibtex_citation="""
         @misc{malajyan2020arpa,
-      title={ARPA: Armenian Paraphrase Detection Corpus and Models}, 
-      author={Arthur Malajyan and Karen Avetisyan and Tsolak Ghukasyan},
-      year={2020},
-      eprint={2009.12615},
-      archivePrefix={arXiv},
-      primaryClass={cs.CL}
-}
+            title={ARPA: Armenian Paraphrase Detection Corpus and Models}, 
+            author={Arthur Malajyan and Karen Avetisyan and Tsolak Ghukasyan},
+            year={2020},
+            eprint={2009.12615},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        }
         """,
         n_samples={"train": 4023, "test": 1470},
         avg_character_length={"train": 243.81, "test": 241.37},
     )
+
+    def dataset_transform(self):
+        self.dataset = self.dataset.rename_column("sent1", "sentence1")
+        self.dataset = self.dataset.rename_column("sent2", "sentence2")

--- a/mteb/tasks/PairClassification/hye/ArmenianParaphrasePC.py
+++ b/mteb/tasks/PairClassification/hye/ArmenianParaphrasePC.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from mteb.abstasks.AbsTaskPairClassification import AbsTaskPairClassification
 from mteb.abstasks.TaskMetadata import TaskMetadata
 
-
+# TODO sentence1
 class ArmenianParaphrasePC(AbsTaskPairClassification):
     metadata = TaskMetadata(
         name="ArmenianParaphrasePC",

--- a/mteb/tasks/PairClassification/ind/IndoNLI.py
+++ b/mteb/tasks/PairClassification/ind/IndoNLI.py
@@ -52,8 +52,8 @@ class IndoNLI(AbsTaskPairClassification):
             )
             _dataset[split] = [
                 {
-                    "sent1": hf_dataset["premise"],
-                    "sent2": hf_dataset["hypothesis"],
+                    "sentence1": hf_dataset["premise"],
+                    "sentence2": hf_dataset["hypothesis"],
                     "labels": hf_dataset["label"],
                 }
             ]

--- a/mteb/tasks/PairClassification/kor/KlueNLI.py
+++ b/mteb/tasks/PairClassification/kor/KlueNLI.py
@@ -50,8 +50,8 @@ class KlueNLI(AbsTaskPairClassification):
             )
             _dataset[split] = [
                 {
-                    "sent1": hf_dataset["premise"],
-                    "sent2": hf_dataset["hypothesis"],
+                    "sentence1": hf_dataset["premise"],
+                    "sentence2": hf_dataset["hypothesis"],
                     "labels": hf_dataset["label"],
                 }
             ]

--- a/mteb/tasks/PairClassification/multilingual/OpusparcusPC.py
+++ b/mteb/tasks/PairClassification/multilingual/OpusparcusPC.py
@@ -83,6 +83,6 @@ class OpusparcusPC(AbsTaskPairClassification, MultilingualTask):
                 del sent1[i]
                 del sent2[i]
             new_dict["labels"] = [labels]
-            new_dict["sent1"] = [sent1]
-            new_dict["sent2"] = [sent2]
+            new_dict["sentence1"] = [sent1]
+            new_dict["sentence2"] = [sent2]
             self.dataset[lang][split] = datasets.Dataset.from_dict(new_dict)

--- a/mteb/tasks/PairClassification/multilingual/PawsX.py
+++ b/mteb/tasks/PairClassification/multilingual/PawsX.py
@@ -58,8 +58,8 @@ class PawsX(MultilingualTask, AbsTaskPairClassification):
 
                 _dataset[lang][split] = [
                     {
-                        "sent1": hf_dataset["sentence1"],
-                        "sent2": hf_dataset["sentence2"],
+                        "sentence1": hf_dataset["sentence1"],
+                        "sentence2": hf_dataset["sentence2"],
                         "labels": hf_dataset["label"],
                     }
                 ]

--- a/mteb/tasks/PairClassification/multilingual/RTE3.py
+++ b/mteb/tasks/PairClassification/multilingual/RTE3.py
@@ -80,8 +80,8 @@ class RTE3(MultilingualTask, AbsTaskPairClassification):
                 )
                 _dataset[lang][split] = [
                     {
-                        "sent1": hf_dataset["premise"],
-                        "sent2": hf_dataset["hypothesis"],
+                        "sentence1": hf_dataset["premise"],
+                        "sentence2": hf_dataset["hypothesis"],
                         "labels": hf_dataset["label"],
                     }
                 ]

--- a/mteb/tasks/PairClassification/multilingual/XNLI.py
+++ b/mteb/tasks/PairClassification/multilingual/XNLI.py
@@ -84,8 +84,8 @@ class XNLI(MultilingualTask, AbsTaskPairClassification):
 
                 _dataset[lang][split] = [
                     {
-                        "sent1": hf_dataset["premise"],
-                        "sent2": hf_dataset["hypothesis"],
+                        "sentence1": hf_dataset["premise"],
+                        "sentence2": hf_dataset["hypothesis"],
                         "labels": hf_dataset["label"],
                     }
                 ]
@@ -166,8 +166,8 @@ class XNLIV2(MultilingualTask, AbsTaskPairClassification):
                 )
                 _dataset[lang][split] = [
                     {
-                        "sent1": hf_dataset["premise"],
-                        "sent2": hf_dataset["hypothesis"],
+                        "sentence1": hf_dataset["premise"],
+                        "sentence2": hf_dataset["hypothesis"],
                         "labels": hf_dataset["label"],
                     }
                 ]

--- a/mteb/tasks/PairClassification/multilingual/XStance.py
+++ b/mteb/tasks/PairClassification/multilingual/XStance.py
@@ -63,8 +63,8 @@ class XStance(MultilingualTask, AbsTaskPairClassification):
 
         def convert_example(example):
             return {
-                "sent1": example["question"],
-                "sent2": example["comment"],
+                "sentence1": example["question"],
+                "sentence2": example["comment"],
                 "labels": 1 if example["label"] == "FAVOR" else 0,
             }
 

--- a/mteb/tasks/PairClassification/pol/PolishPC.py
+++ b/mteb/tasks/PairClassification/pol/PolishPC.py
@@ -4,7 +4,7 @@ from mteb.abstasks.TaskMetadata import TaskMetadata
 
 from ....abstasks.AbsTaskPairClassification import AbsTaskPairClassification
 
-# TODO sentence1
+
 class SickePLPC(AbsTaskPairClassification):
     metadata = TaskMetadata(
         name="SICK-E-PL",
@@ -29,38 +29,42 @@ class SickePLPC(AbsTaskPairClassification):
         dialect=None,
         text_creation=None,
         bibtex_citation="""@inproceedings{dadas-etal-2020-evaluation,
-    title = "Evaluation of Sentence Representations in {P}olish",
-    author = "Dadas, Slawomir  and
-      Pere{\l}kiewicz, Micha{\l}  and
-      Po{\'s}wiata, Rafa{\l}",
-    editor = "Calzolari, Nicoletta  and
-      B{\'e}chet, Fr{\'e}d{\'e}ric  and
-      Blache, Philippe  and
-      Choukri, Khalid  and
-      Cieri, Christopher  and
-      Declerck, Thierry  and
-      Goggi, Sara  and
-      Isahara, Hitoshi  and
-      Maegaard, Bente  and
-      Mariani, Joseph  and
-      Mazo, H{\'e}l{\`e}ne  and
-      Moreno, Asuncion  and
-      Odijk, Jan  and
-      Piperidis, Stelios",
-    booktitle = "Proceedings of the Twelfth Language Resources and Evaluation Conference",
-    month = may,
-    year = "2020",
-    address = "Marseille, France",
-    publisher = "European Language Resources Association",
-    url = "https://aclanthology.org/2020.lrec-1.207",
-    pages = "1674--1680",
-    abstract = "Methods for learning sentence representations have been actively developed in recent years. However, the lack of pre-trained models and datasets annotated at the sentence level has been a problem for low-resource languages such as Polish which led to less interest in applying these methods to language-specific tasks. In this study, we introduce two new Polish datasets for evaluating sentence embeddings and provide a comprehensive evaluation of eight sentence representation methods including Polish and multilingual models. We consider classic word embedding models, recently developed contextual embeddings and multilingual sentence encoders, showing strengths and weaknesses of specific approaches. We also examine different methods of aggregating word vectors into a single sentence vector.",
-    language = "English",
-    ISBN = "979-10-95546-34-4",
-}""",
+            title = "Evaluation of Sentence Representations in {P}olish",
+            author = "Dadas, Slawomir  and
+            Pere{\l}kiewicz, Micha{\l}  and
+            Po{\'s}wiata, Rafa{\l}",
+            editor = "Calzolari, Nicoletta  and
+            B{\'e}chet, Fr{\'e}d{\'e}ric  and
+            Blache, Philippe  and
+            Choukri, Khalid  and
+            Cieri, Christopher  and
+            Declerck, Thierry  and
+            Goggi, Sara  and
+            Isahara, Hitoshi  and
+            Maegaard, Bente  and
+            Mariani, Joseph  and
+            Mazo, H{\'e}l{\`e}ne  and
+            Moreno, Asuncion  and
+            Odijk, Jan  and
+            Piperidis, Stelios",
+            booktitle = "Proceedings of the Twelfth Language Resources and Evaluation Conference",
+            month = may,
+            year = "2020",
+            address = "Marseille, France",
+            publisher = "European Language Resources Association",
+            url = "https://aclanthology.org/2020.lrec-1.207",
+            pages = "1674--1680",
+            abstract = "Methods for learning sentence representations have been actively developed in recent years. However, the lack of pre-trained models and datasets annotated at the sentence level has been a problem for low-resource languages such as Polish which led to less interest in applying these methods to language-specific tasks. In this study, we introduce two new Polish datasets for evaluating sentence embeddings and provide a comprehensive evaluation of eight sentence representation methods including Polish and multilingual models. We consider classic word embedding models, recently developed contextual embeddings and multilingual sentence encoders, showing strengths and weaknesses of specific approaches. We also examine different methods of aggregating word vectors into a single sentence vector.",
+            language = "English",
+            ISBN = "979-10-95546-34-4",
+        }""",
         n_samples=None,
         avg_character_length=None,
     )
+
+    def dataset_transform(self):
+        self.dataset = self.dataset.rename_column("sent1", "sentence1")
+        self.dataset = self.dataset.rename_column("sent2", "sentence2")
 
 
 class PpcPC(AbsTaskPairClassification):
@@ -98,6 +102,10 @@ class PpcPC(AbsTaskPairClassification):
         avg_character_length=None,
     )
 
+    def dataset_transform(self):
+        self.dataset = self.dataset.rename_column("sent1", "sentence1")
+        self.dataset = self.dataset.rename_column("sent2", "sentence2")
+
 
 class CdscePC(AbsTaskPairClassification):
     metadata = TaskMetadata(
@@ -123,24 +131,28 @@ class CdscePC(AbsTaskPairClassification):
         dialect=None,
         text_creation=None,
         bibtex_citation="""@inproceedings{wroblewska-krasnowska-kieras-2017-polish,
-    title = "{P}olish evaluation dataset for compositional distributional semantics models",
-    author = "Wr{\'o}blewska, Alina  and
-      Krasnowska-Kiera{\'s}, Katarzyna",
-    editor = "Barzilay, Regina  and
-      Kan, Min-Yen",
-    booktitle = "Proceedings of the 55th Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)",
-    month = jul,
-    year = "2017",
-    address = "Vancouver, Canada",
-    publisher = "Association for Computational Linguistics",
-    url = "https://aclanthology.org/P17-1073",
-    doi = "10.18653/v1/P17-1073",
-    pages = "784--792",
-    abstract = "The paper presents a procedure of building an evaluation dataset. for the validation of compositional distributional semantics models estimated for languages other than English. The procedure generally builds on steps designed to assemble the SICK corpus, which contains pairs of English sentences annotated for semantic relatedness and entailment, because we aim at building a comparable dataset. However, the implementation of particular building steps significantly differs from the original SICK design assumptions, which is caused by both lack of necessary extraneous resources for an investigated language and the need for language-specific transformation rules. The designed procedure is verified on Polish, a fusional language with a relatively free word order, and contributes to building a Polish evaluation dataset. The resource consists of 10K sentence pairs which are human-annotated for semantic relatedness and entailment. The dataset may be used for the evaluation of compositional distributional semantics models of Polish.",
-}""",
+            title = "{P}olish evaluation dataset for compositional distributional semantics models",
+            author = "Wr{\'o}blewska, Alina  and
+            Krasnowska-Kiera{\'s}, Katarzyna",
+            editor = "Barzilay, Regina  and
+            Kan, Min-Yen",
+            booktitle = "Proceedings of the 55th Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)",
+            month = jul,
+            year = "2017",
+            address = "Vancouver, Canada",
+            publisher = "Association for Computational Linguistics",
+            url = "https://aclanthology.org/P17-1073",
+            doi = "10.18653/v1/P17-1073",
+            pages = "784--792",
+            abstract = "The paper presents a procedure of building an evaluation dataset. for the validation of compositional distributional semantics models estimated for languages other than English. The procedure generally builds on steps designed to assemble the SICK corpus, which contains pairs of English sentences annotated for semantic relatedness and entailment, because we aim at building a comparable dataset. However, the implementation of particular building steps significantly differs from the original SICK design assumptions, which is caused by both lack of necessary extraneous resources for an investigated language and the need for language-specific transformation rules. The designed procedure is verified on Polish, a fusional language with a relatively free word order, and contributes to building a Polish evaluation dataset. The resource consists of 10K sentence pairs which are human-annotated for semantic relatedness and entailment. The dataset may be used for the evaluation of compositional distributional semantics models of Polish.",
+        }""",
         n_samples=None,
         avg_character_length=None,
     )
+
+    def dataset_transform(self):
+        self.dataset = self.dataset.rename_column("sent1", "sentence1")
+        self.dataset = self.dataset.rename_column("sent2", "sentence2")
 
 
 class PscPC(AbsTaskPairClassification):
@@ -167,27 +179,31 @@ class PscPC(AbsTaskPairClassification):
         dialect=None,
         text_creation=None,
         bibtex_citation="""@inproceedings{ogrodniczuk-kopec-2014-polish,
-    title = "The {P}olish Summaries Corpus",
-    author = "Ogrodniczuk, Maciej  and
-      Kope{\'c}, Mateusz",
-    editor = "Calzolari, Nicoletta  and
-      Choukri, Khalid  and
-      Declerck, Thierry  and
-      Loftsson, Hrafn  and
-      Maegaard, Bente  and
-      Mariani, Joseph  and
-      Moreno, Asuncion  and
-      Odijk, Jan  and
-      Piperidis, Stelios",
-    booktitle = "Proceedings of the Ninth International Conference on Language Resources and Evaluation ({LREC}'14)",
-    month = may,
-    year = "2014",
-    address = "Reykjavik, Iceland",
-    publisher = "European Language Resources Association (ELRA)",
-    url = "http://www.lrec-conf.org/proceedings/lrec2014/pdf/1211_Paper.pdf",
-    pages = "3712--3715",
-    abstract = "This article presents the Polish Summaries Corpus, a new resource created to support the development and evaluation of the tools for automated single-document summarization of Polish. The Corpus contains a large number of manual summaries of news articles, with many independently created summaries for a single text. Such approach is supposed to overcome the annotator bias, which is often described as a problem during the evaluation of the summarization algorithms against a single gold standard. There are several summarizers developed specifically for Polish language, but their in-depth evaluation and comparison was impossible without a large, manually created corpus. We present in detail the process of text selection, annotation process and the contents of the corpus, which includes both abstract free-word summaries, as well as extraction-based summaries created by selecting text spans from the original document. Finally, we describe how that resource could be used not only for the evaluation of the existing summarization tools, but also for studies on the human summarization process in Polish language.",
-}""",
+            title = "The {P}olish Summaries Corpus",
+            author = "Ogrodniczuk, Maciej  and
+            Kope{\'c}, Mateusz",
+            editor = "Calzolari, Nicoletta  and
+            Choukri, Khalid  and
+            Declerck, Thierry  and
+            Loftsson, Hrafn  and
+            Maegaard, Bente  and
+            Mariani, Joseph  and
+            Moreno, Asuncion  and
+            Odijk, Jan  and
+            Piperidis, Stelios",
+            booktitle = "Proceedings of the Ninth International Conference on Language Resources and Evaluation ({LREC}'14)",
+            month = may,
+            year = "2014",
+            address = "Reykjavik, Iceland",
+            publisher = "European Language Resources Association (ELRA)",
+            url = "http://www.lrec-conf.org/proceedings/lrec2014/pdf/1211_Paper.pdf",
+            pages = "3712--3715",
+            abstract = "This article presents the Polish Summaries Corpus, a new resource created to support the development and evaluation of the tools for automated single-document summarization of Polish. The Corpus contains a large number of manual summaries of news articles, with many independently created summaries for a single text. Such approach is supposed to overcome the annotator bias, which is often described as a problem during the evaluation of the summarization algorithms against a single gold standard. There are several summarizers developed specifically for Polish language, but their in-depth evaluation and comparison was impossible without a large, manually created corpus. We present in detail the process of text selection, annotation process and the contents of the corpus, which includes both abstract free-word summaries, as well as extraction-based summaries created by selecting text spans from the original document. Finally, we describe how that resource could be used not only for the evaluation of the existing summarization tools, but also for studies on the human summarization process in Polish language.",
+        }""",
         n_samples=None,
         avg_character_length=None,
     )
+
+    def dataset_transform(self):
+        self.dataset = self.dataset.rename_column("sent1", "sentence1")
+        self.dataset = self.dataset.rename_column("sent2", "sentence2")

--- a/mteb/tasks/PairClassification/pol/PolishPC.py
+++ b/mteb/tasks/PairClassification/pol/PolishPC.py
@@ -4,7 +4,7 @@ from mteb.abstasks.TaskMetadata import TaskMetadata
 
 from ....abstasks.AbsTaskPairClassification import AbsTaskPairClassification
 
-
+# TODO sentence1
 class SickePLPC(AbsTaskPairClassification):
     metadata = TaskMetadata(
         name="SICK-E-PL",

--- a/mteb/tasks/PairClassification/por/Assin2RTE.py
+++ b/mteb/tasks/PairClassification/por/Assin2RTE.py
@@ -50,8 +50,8 @@ class Assin2RTE(AbsTaskPairClassification):
         for split in self.metadata.eval_splits:
             _dataset[split] = [
                 {
-                    "sent1": self.dataset[split]["premise"],
-                    "sent2": self.dataset[split]["hypothesis"],
+                    "sentence1": self.dataset[split]["premise"],
+                    "sentence2": self.dataset[split]["hypothesis"],
                     "labels": self.dataset[split]["entailment_judgment"],
                 }
             ]

--- a/mteb/tasks/PairClassification/por/SickBrPC.py
+++ b/mteb/tasks/PairClassification/por/SickBrPC.py
@@ -30,25 +30,25 @@ class SickBrPC(AbsTaskPairClassification):
         dialect=[],
         text_creation="human-translated and localized",
         bibtex_citation="""
-@inproceedings{real18,
-  author="Real, Livy
-    and Rodrigues, Ana
-    and Vieira e Silva, Andressa
-    and Albiero, Beatriz
-    and Thalenberg, Bruna
-    and Guide, Bruno
-    and Silva, Cindy
-    and de Oliveira Lima, Guilherme
-    and C{\^a}mara, Igor C. S.
-    and Stanojevi{\'{c}}, Milo{\v{s}}
-    and Souza, Rodrigo
-    and de Paiva, Valeria"
-  year ="2018",
-  title="SICK-BR: A Portuguese Corpus for Inference",
-  booktitle="Computational Processing of the Portuguese Language. PROPOR 2018.",
-  doi ="10.1007/978-3-319-99722-3_31",
-  isbn="978-3-319-99722-3"
-}
+        @inproceedings{real18,
+        author="Real, Livy
+            and Rodrigues, Ana
+            and Vieira e Silva, Andressa
+            and Albiero, Beatriz
+            and Thalenberg, Bruna
+            and Guide, Bruno
+            and Silva, Cindy
+            and de Oliveira Lima, Guilherme
+            and C{\^a}mara, Igor C. S.
+            and Stanojevi{\'{c}}, Milo{\v{s}}
+            and Souza, Rodrigo
+            and de Paiva, Valeria"
+        year ="2018",
+        title="SICK-BR: A Portuguese Corpus for Inference",
+        booktitle="Computational Processing of the Portuguese Language. PROPOR 2018.",
+        doi ="10.1007/978-3-319-99722-3_31",
+        isbn="978-3-319-99722-3"
+        }
         """,
         n_samples={"test": N_SAMPLES},
         avg_character_length={"test": 54.89},
@@ -80,8 +80,8 @@ class SickBrPC(AbsTaskPairClassification):
             )
             _dataset[split] = [
                 {
-                    "sent1": hf_dataset["sentence_A"],
-                    "sent2": hf_dataset["sentence_B"],
+                    "sentence1": hf_dataset["sentence_A"],
+                    "sentence2": hf_dataset["sentence_B"],
                     "labels": hf_dataset["label"],
                 }
             ]

--- a/mteb/tasks/PairClassification/rus/TERRa.py
+++ b/mteb/tasks/PairClassification/rus/TERRa.py
@@ -4,7 +4,7 @@ from mteb.abstasks.TaskMetadata import TaskMetadata
 
 from ....abstasks.AbsTaskPairClassification import AbsTaskPairClassification
 
-# TODO sentence1
+
 class TERRa(AbsTaskPairClassification):
     metadata = TaskMetadata(
         name="TERRa",
@@ -47,3 +47,7 @@ class TERRa(AbsTaskPairClassification):
         n_samples={"dev": 307},
         avg_character_length={"dev": 138.2},
     )
+
+    def dataset_transform(self):
+        self.dataset = self.dataset.rename_column("sent1", "sentence1")
+        self.dataset = self.dataset.rename_column("sent2", "sentence2")

--- a/mteb/tasks/PairClassification/rus/TERRa.py
+++ b/mteb/tasks/PairClassification/rus/TERRa.py
@@ -4,7 +4,7 @@ from mteb.abstasks.TaskMetadata import TaskMetadata
 
 from ....abstasks.AbsTaskPairClassification import AbsTaskPairClassification
 
-
+# TODO sentence1
 class TERRa(AbsTaskPairClassification):
     metadata = TaskMetadata(
         name="TERRa",

--- a/mteb/tasks/PairClassification/zho/CMTEBPairClassification.py
+++ b/mteb/tasks/PairClassification/zho/CMTEBPairClassification.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from mteb.abstasks.AbsTaskPairClassification import AbsTaskPairClassification
 from mteb.abstasks.TaskMetadata import TaskMetadata
 
-
+# TODO sentence1
 class Ocnli(AbsTaskPairClassification):
     metadata = TaskMetadata(
         name="Ocnli",

--- a/mteb/tasks/PairClassification/zho/CMTEBPairClassification.py
+++ b/mteb/tasks/PairClassification/zho/CMTEBPairClassification.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from mteb.abstasks.AbsTaskPairClassification import AbsTaskPairClassification
 from mteb.abstasks.TaskMetadata import TaskMetadata
 
-# TODO sentence1
+
 class Ocnli(AbsTaskPairClassification):
     metadata = TaskMetadata(
         name="Ocnli",
@@ -28,16 +28,20 @@ class Ocnli(AbsTaskPairClassification):
         dialect=None,
         text_creation=None,
         bibtex_citation="""@misc{hu2020ocnli,
-      title={OCNLI: Original Chinese Natural Language Inference}, 
-      author={Hai Hu and Kyle Richardson and Liang Xu and Lu Li and Sandra Kuebler and Lawrence S. Moss},
-      year={2020},
-      eprint={2010.05444},
-      archivePrefix={arXiv},
-      primaryClass={cs.CL}
-}""",
+            title={OCNLI: Original Chinese Natural Language Inference}, 
+            author={Hai Hu and Kyle Richardson and Liang Xu and Lu Li and Sandra Kuebler and Lawrence S. Moss},
+            year={2020},
+            eprint={2010.05444},
+            archivePrefix={arXiv},
+            primaryClass={cs.CL}
+        }""",
         n_samples=None,
         avg_character_length=None,
     )
+
+    def dataset_transform(self):
+        self.dataset = self.dataset.rename_column("sent1", "sentence1")
+        self.dataset = self.dataset.rename_column("sent2", "sentence2")
 
 
 class Cmnli(AbsTaskPairClassification):
@@ -64,48 +68,52 @@ class Cmnli(AbsTaskPairClassification):
         dialect=None,
         text_creation=None,
         bibtex_citation="""@inproceedings{xu-etal-2020-clue,
-    title = "{CLUE}: A {C}hinese Language Understanding Evaluation Benchmark",
-    author = "Xu, Liang  and
-      Hu, Hai  and
-      Zhang, Xuanwei  and
-      Li, Lu  and
-      Cao, Chenjie  and
-      Li, Yudong  and
-      Xu, Yechen  and
-      Sun, Kai  and
-      Yu, Dian  and
-      Yu, Cong  and
-      Tian, Yin  and
-      Dong, Qianqian  and
-      Liu, Weitang  and
-      Shi, Bo  and
-      Cui, Yiming  and
-      Li, Junyi  and
-      Zeng, Jun  and
-      Wang, Rongzhao  and
-      Xie, Weijian  and
-      Li, Yanting  and
-      Patterson, Yina  and
-      Tian, Zuoyu  and
-      Zhang, Yiwen  and
-      Zhou, He  and
-      Liu, Shaoweihua  and
-      Zhao, Zhe  and
-      Zhao, Qipeng  and
-      Yue, Cong  and
-      Zhang, Xinrui  and
-      Yang, Zhengliang  and
-      Richardson, Kyle  and
-      Lan, Zhenzhong",
-    booktitle = "Proceedings of the 28th International Conference on Computational Linguistics",
-    month = dec,
-    year = "2020",
-    address = "Barcelona, Spain (Online)",
-    publisher = "International Committee on Computational Linguistics",
-    url = "https://aclanthology.org/2020.coling-main.419",
-    doi = "10.18653/v1/2020.coling-main.419",
-    pages = "4762--4772",
-}""",
+            title = "{CLUE}: A {C}hinese Language Understanding Evaluation Benchmark",
+            author = "Xu, Liang  and
+            Hu, Hai  and
+            Zhang, Xuanwei  and
+            Li, Lu  and
+            Cao, Chenjie  and
+            Li, Yudong  and
+            Xu, Yechen  and
+            Sun, Kai  and
+            Yu, Dian  and
+            Yu, Cong  and
+            Tian, Yin  and
+            Dong, Qianqian  and
+            Liu, Weitang  and
+            Shi, Bo  and
+            Cui, Yiming  and
+            Li, Junyi  and
+            Zeng, Jun  and
+            Wang, Rongzhao  and
+            Xie, Weijian  and
+            Li, Yanting  and
+            Patterson, Yina  and
+            Tian, Zuoyu  and
+            Zhang, Yiwen  and
+            Zhou, He  and
+            Liu, Shaoweihua  and
+            Zhao, Zhe  and
+            Zhao, Qipeng  and
+            Yue, Cong  and
+            Zhang, Xinrui  and
+            Yang, Zhengliang  and
+            Richardson, Kyle  and
+            Lan, Zhenzhong",
+            booktitle = "Proceedings of the 28th International Conference on Computational Linguistics",
+            month = dec,
+            year = "2020",
+            address = "Barcelona, Spain (Online)",
+            publisher = "International Committee on Computational Linguistics",
+            url = "https://aclanthology.org/2020.coling-main.419",
+            doi = "10.18653/v1/2020.coling-main.419",
+            pages = "4762--4772",
+        }""",
         n_samples=None,
         avg_character_length=None,
     )
+
+    def dataset_transform(self):
+        self.dataset = self.dataset.rename_column("sent1", "sentence1")
+        self.dataset = self.dataset.rename_column("sent2", "sentence2")


### PR DESCRIPTION
Addresses issue reported here #582. Brings consistency with standard followed in STS and BiText Mining tasks:  'sentence1', 'sentence2' and 'label'.