### PR TITLE
fix: bug in calculate_metadata_metrics for some retrieval datasets

### DIFF
--- a/mteb/abstasks/AbsTaskRetrieval.py
+++ b/mteb/abstasks/AbsTaskRetrieval.py
@@ -405,13 +405,15 @@ def calculate_length_and_count(relevant_docs, queries, corpus):
     total_length = 0
     num_pairs = 0
     for query_id, docs in relevant_docs.items():
-        query = queries[query_id]
+        query = queries.get(query_id, "") or ""
         for doc_id in docs:
             # not relevant
             if docs[doc_id] == 0:
                 continue
-            doc = corpus[doc_id]
-            doc_text = doc["title"] + doc["text"]
+            doc = corpus.get(doc_id)
+            if doc is None:
+                continue
+            doc_text = doc.get("title", "") + doc["text"]
             total_length += len(query) + len(doc_text)
             num_pairs += 1
     return total_length, num_pairs

--- a/mteb/tasks/Retrieval/code/CodeEditSearchRetrieval.py
+++ b/mteb/tasks/Retrieval/code/CodeEditSearchRetrieval.py
@@ -73,12 +73,7 @@ class CodeEditSearchRetrieval(MultilingualTask, AbsTaskRetrieval):
         self.relevant_docs = {}
 
         for lang, sub in lang_subs.items():
-            sub = sub[
-                : min(
-                    len(sub),
-                    self.metadata_dict["n_samples"][self._EVAL_SPLIT] / len(_LANGS),
-                )
-            ]
+            sub = sub[:1000]
 
             self.queries[lang] = {
                 self._EVAL_SPLIT: {

--- a/mteb/tasks/Retrieval/multilingual/BelebeleRetrieval.py
+++ b/mteb/tasks/Retrieval/multilingual/BelebeleRetrieval.py
@@ -169,11 +169,11 @@ class BelebeleRetrieval(MultilingualTask, AbsTaskRetrieval):
 
         self.dataset = load_dataset(**self.metadata_dict["dataset"])
 
-        self.queries = {lang: {_EVAL_SPLIT: {}} for lang in self.langs}
-        self.corpus = {lang: {_EVAL_SPLIT: {}} for lang in self.langs}
-        self.relevant_docs = {lang: {_EVAL_SPLIT: {}} for lang in self.langs}
+        self.queries = {lang: {_EVAL_SPLIT: {}} for lang in self.hf_subsets}
+        self.corpus = {lang: {_EVAL_SPLIT: {}} for lang in self.hf_subsets}
+        self.relevant_docs = {lang: {_EVAL_SPLIT: {}} for lang in self.hf_subsets}
 
-        for lang in self.langs:
+        for lang in self.hf_subsets:
             belebele_lang = _LANGS[lang][0].replace("-", "_")
             ds = self.dataset[belebele_lang]
 

--- a/mteb/tasks/Retrieval/multilingual/IndicQARetrieval.py
+++ b/mteb/tasks/Retrieval/multilingual/IndicQARetrieval.py
@@ -72,7 +72,6 @@ class IndicQARetrieval(MultilingualTask, AbsTaskRetrieval):
                 name=f"indicqa.{lang}", **self.metadata_dict["dataset"]
             )[split]
             data = data.filter(lambda x: x["answers"]["text"] != "")
-            data = data.select(range(self.metadata.n_samples[split]))
 
             question_ids = {
                 question: sha256(question.encode("utf-8")).hexdigest()

--- a/mteb/tasks/Retrieval/zho/CMTEBRetrieval.py
+++ b/mteb/tasks/Retrieval/zho/CMTEBRetrieval.py
@@ -185,7 +185,7 @@ class CovidRetrieval(AbsTaskRetrieval):
         },
         type="Retrieval",
         category="s2p",
-        eval_splits=["test"],
+        eval_splits=["dev"],
         eval_langs=["cmn-Hans"],
         main_score="ndcg_at_10",
         date=None,


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->
Addresses #964 

## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 


## How
Run the following and fixed one by one:
```python
from mteb import get_tasks

TASKS = [
    "BelebeleRetrieval",
    "NorQuadRetrieval",
    "SwednRetrieval",
    "PublicHealthQA",
    "CovidRetrieval",
    "CrossLingualSemanticDiscriminationWMT19",
    "CrossLingualSemanticDiscriminationWMT21",
    "DanFEVER",
    "SweFaqRetrieval",
    "TV2Nordretrieval",
    "CodeEditSearchRetrieval",
    "TwitterHjerneRetrieval",
    "MLQARetrieval",
    "SNLRetrieval",
    "IndicQARetrieval",
    "XPQARetrieval",
]

exceptions = []
tasks = get_tasks(tasks=TASKS)
for task in tasks:
    task.calculate_metadata_metrics()
```

## Notes
- Half are resolved in #953 by adding `load_data`
- `CovidRetrieval` references a non-existent split
- Some faced index out of range
- `BelebeleRetrieval` still used `self.langs`
- Some did not have titles
- Some have `None` as queries or docs
