### PR TITLE
Fix GritLM instructions

### DIFF
--- a/mteb/models/gritlm.py
+++ b/mteb/models/gritlm.py
@@ -3,19 +3,31 @@ from functools import partial
 
 from mteb.model_meta import ModelMeta
 
+from .instructions import task_to_instruction
+
 logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger(__name__)
 
+def gritlm_instruction(instruction):
+    return "<|user|>\n" + instruction + "\n<|embed|>\n" if instruction else "<|embed|>\n"
 
 def gritlm_loader(**kwargs):
     try:
         from gritlm import GritLM
+        class GritLMWrapper(GritLM):
+            def encode(*args, **kwargs):
+                if prompt_name in kwargs:
+                    instruction = gritlm_instruction(task_to_instruction(kwargs.pop("prompt_name")))
+                else:
+                    instruction = gritlm_instruction("")
+                kwargs["instruction"] = instruction
+                super().encode(*args, **kwargs)
     except ImportError:
         raise ImportError(
             "GritLM is not installed. Please install it with `pip install gritlm`."
         )
     kwargs.pop("device", None)  # GritLM does automatic device placement
-    return GritLM(**kwargs)
+    return GritLMWrapper(**kwargs)
 
 
 gritlm7b = ModelMeta(

--- a/mteb/models/gritlm.py
+++ b/mteb/models/gritlm.py
@@ -8,16 +8,23 @@ from .instructions import task_to_instruction
 logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger(__name__)
 
+
 def gritlm_instruction(instruction):
-    return "<|user|>\n" + instruction + "\n<|embed|>\n" if instruction else "<|embed|>\n"
+    return (
+        "<|user|>\n" + instruction + "\n<|embed|>\n" if instruction else "<|embed|>\n"
+    )
+
 
 def gritlm_loader(**kwargs):
     try:
         from gritlm import GritLM
+
         class GritLMWrapper(GritLM):
             def encode(*args, **kwargs):
-                if prompt_name in kwargs:
-                    instruction = gritlm_instruction(task_to_instruction(kwargs.pop("prompt_name")))
+                if "prompt_name" in kwargs:
+                    instruction = gritlm_instruction(
+                        task_to_instruction(kwargs.pop("prompt_name"))
+                    )
                 else:
                     instruction = gritlm_instruction("")
                 kwargs["instruction"] = instruction


### PR DESCRIPTION
if we care about exactly reproducing e5 & grit, I think we have another bug which is that they do not use an instruction for documents, but only queries for Retrieval. One solution could be to distinguish corpus & query prompts like here: https://github.com/ContextualAI/gritlm/blob/da37ccbace1aa4f4bf26273e4e9a7cea705ae951/evaluation/eval_mteb.py#L66 and then instead try to get the respective prompt in encode_corpus & encode_queries --- What do you think?


Fixes https://github.com/embeddings-benchmark/mteb/issues/973