### PR TITLE
fix: add max_fraction_of_documents_to_embed to clustering datasets with `max_document_to_embed`

### DIFF
--- a/mteb/tasks/Clustering/deu/BlurbsClusteringP2P.py
+++ b/mteb/tasks/Clustering/deu/BlurbsClusteringP2P.py
@@ -48,6 +48,7 @@ class BlurbsClusteringP2PFast(AbsTaskClusteringFast):
     # a faster version of BlurbsClusteringP2P, since it does not sample from the same distribution we can't use the AbsTaskClusteringFast, instead we
     # simply downsample each cluster.
     max_document_to_embed = NUM_SAMPLES
+    max_fraction_of_documents_to_embed = None
 
     metadata = TaskMetadata(
         name="BlurbsClusteringP2P.v2",

--- a/mteb/tasks/Clustering/deu/BlurbsClusteringS2S.py
+++ b/mteb/tasks/Clustering/deu/BlurbsClusteringS2S.py
@@ -57,6 +57,7 @@ class BlurbsClusteringS2SFast(AbsTaskClusteringFast):
     # simply downsample each cluster.
 
     max_document_to_embed = NUM_SAMPLES
+    max_fraction_of_documents_to_embed = None
 
     metadata = TaskMetadata(
         name="BlurbsClusteringS2S.v2",

--- a/mteb/tasks/Clustering/deu/TenKGnadClusteringP2P.py
+++ b/mteb/tasks/Clustering/deu/TenKGnadClusteringP2P.py
@@ -38,6 +38,8 @@ class TenKGnadClusteringP2P(AbsTaskClustering):
 
 class TenKGnadClusteringP2PFast(AbsTaskClusteringFast):
     max_document_to_embed = 10275
+    max_fraction_of_documents_to_embed = None
+
     metadata = TaskMetadata(
         name="TenKGnadClusteringP2P.v2",
         description="Clustering of news article titles+subheadings+texts. Clustering of 10 splits on the news article category.",

--- a/mteb/tasks/Clustering/deu/TenKGnadClusteringS2S.py
+++ b/mteb/tasks/Clustering/deu/TenKGnadClusteringS2S.py
@@ -38,6 +38,7 @@ class TenKGnadClusteringS2S(AbsTaskClustering):
 
 class TenKGnadClusteringS2SFast(AbsTaskClusteringFast):
     max_document_to_embed = 10275
+    max_fraction_of_documents_to_embed = None
 
     metadata = TaskMetadata(
         name="TenKGnadClusteringS2S.v2",

--- a/mteb/tasks/Clustering/fra/AlloProfClusteringP2P.py
+++ b/mteb/tasks/Clustering/fra/AlloProfClusteringP2P.py
@@ -69,6 +69,8 @@ class AlloProfClusteringP2P(AbsTaskClustering):
 
 class AlloProfClusteringP2PFast(AbsTaskClusteringFast):
     max_document_to_embed = 2556
+    max_fraction_of_documents_to_embed = None
+
     metadata = TaskMetadata(
         name="AlloProfClusteringP2P.v2",
         description="Clustering of document titles and descriptions from Allo Prof dataset. Clustering of 10 sets on the document topic.",

--- a/mteb/tasks/Clustering/fra/AlloProfClusteringS2S.py
+++ b/mteb/tasks/Clustering/fra/AlloProfClusteringS2S.py
@@ -66,6 +66,7 @@ class AlloProfClusteringS2S(AbsTaskClustering):
 class AlloProfClusteringS2SFast(AbsTaskClusteringFast):
     max_depth = 1
     max_document_to_embed = 2556
+    max_fraction_of_documents_to_embed = None
 
     metadata = TaskMetadata(
         name="AlloProfClusteringS2S.v2",

--- a/mteb/tasks/Clustering/fra/HALClusteringS2S.py
+++ b/mteb/tasks/Clustering/fra/HALClusteringS2S.py
@@ -64,6 +64,8 @@ class HALClusteringS2S(AbsTaskClustering):
 
 class HALClusteringS2SFast(AbsTaskClusteringFast):
     max_document_to_embed = NUM_SAMPLES
+    max_fraction_of_documents_to_embed = None
+
     metadata = TaskMetadata(
         name="HALClusteringS2S.v2",
         description="Clustering of titles from HAL (https://huggingface.co/datasets/lyon-nlp/clustering-hal-s2s)",

--- a/mteb/tasks/Clustering/jpn/LivedoorNewsClustering.py
+++ b/mteb/tasks/Clustering/jpn/LivedoorNewsClustering.py
@@ -4,6 +4,8 @@ from mteb.abstasks.TaskMetadata import TaskMetadata
 
 class LivedoorNewsClustering(AbsTaskClusteringFast):
     max_document_to_embed = 1107
+    max_fraction_of_documents_to_embed = None
+
     metadata = TaskMetadata(
         name="LivedoorNewsClustering",
         description="Clustering of the news reports of a Japanese news site, Livedoor News by RONDHUIT Co, Ltd. in 2012. It contains over 7,000 news report texts across 9 categories (topics).",

--- a/mteb/tasks/Clustering/jpn/MewsC16JaClustering.py
+++ b/mteb/tasks/Clustering/jpn/MewsC16JaClustering.py
@@ -4,6 +4,8 @@ from mteb.abstasks.TaskMetadata import TaskMetadata
 
 class MewsC16JaClustering(AbsTaskClusteringFast):
     max_document_to_embed = 992
+    max_fraction_of_documents_to_embed = None
+
     metadata = TaskMetadata(
         name="MewsC16JaClustering",
         description="""MewsC-16 (Multilingual Short Text Clustering Dataset for News in 16 languages) is constructed from Wikinews.

--- a/mteb/tasks/Clustering/multilingual/MLSUMClusteringP2P.py
+++ b/mteb/tasks/Clustering/multilingual/MLSUMClusteringP2P.py
@@ -92,6 +92,8 @@ class MLSUMClusteringP2P(AbsTaskClustering, MultilingualTask):
 
 class MLSUMClusteringP2PFast(AbsTaskClustering, MultilingualTask):
     max_document_to_embed = N_SAMPLES
+    max_fraction_of_documents_to_embed = None
+
     metadata = TaskMetadata(
         name="MLSUMClusteringP2P.v2",
         description="Clustering of newspaper article contents and titles from MLSUM dataset. Clustering of 10 sets on the newpaper article topics.",

--- a/mteb/tasks/Clustering/multilingual/MLSUMClusteringS2S.py
+++ b/mteb/tasks/Clustering/multilingual/MLSUMClusteringS2S.py
@@ -88,6 +88,8 @@ class MLSUMClusteringS2S(AbsTaskClustering, MultilingualTask):
 
 class MLSUMClusteringS2SFast(AbsTaskClusteringFast, MultilingualTask):
     max_document_to_embed = N_SAMPLES
+    max_fraction_of_documents_to_embed = None
+
     metadata = TaskMetadata(
         name="MLSUMClusteringS2S.v2",
         description="Clustering of newspaper article contents and titles from MLSUM dataset. Clustering of 10 sets on the newpaper article topics.",

--- a/mteb/tasks/Clustering/multilingual/SIB200ClusteringS2S.py
+++ b/mteb/tasks/Clustering/multilingual/SIB200ClusteringS2S.py
@@ -209,6 +209,8 @@ _LANGS = {
 
 class SIB200ClusteringFast(MultilingualTask, AbsTaskClusteringFast):
     max_document_to_embed = 1004
+    max_fraction_of_documents_to_embed = None
+
     metadata = TaskMetadata(
         name="SIB200ClusteringS2S",
         description="""SIB-200 is the largest publicly available topic classification

--- a/mteb/tasks/Clustering/multilingual/WikiClusteringP2P.py
+++ b/mteb/tasks/Clustering/multilingual/WikiClusteringP2P.py
@@ -59,6 +59,7 @@ class WikiClusteringP2P(AbsTaskClustering, MultilingualTask):
 
 class WikiClusteringFastP2P(AbsTaskClusteringFast, MultilingualTask):
     max_document_to_embed = 2048
+    max_fraction_of_documents_to_embed = None
 
     metadata = TaskMetadata(
         name="WikiClusteringP2P.v2",

--- a/mteb/tasks/Clustering/nob/SNLHierarchicalClustering.py
+++ b/mteb/tasks/Clustering/nob/SNLHierarchicalClustering.py
@@ -13,6 +13,7 @@ def split_labels(record: dict) -> dict:
 
 class SNLHierarchicalClusteringP2P(AbsTaskClusteringFast):
     max_document_to_embed = 1300
+    max_fraction_of_documents_to_embed = None
 
     metadata = TaskMetadata(
         name="SNLHierarchicalClusteringP2P",
@@ -56,6 +57,8 @@ class SNLHierarchicalClusteringP2P(AbsTaskClusteringFast):
 
 class SNLHierarchicalClusteringS2S(AbsTaskClusteringFast):
     max_document_to_embed = 1300
+    max_fraction_of_documents_to_embed = None
+
     metadata = TaskMetadata(
         name="SNLHierarchicalClusteringS2S",
         dataset={

--- a/mteb/tasks/Clustering/nob/VGHierarchicalClustering.py
+++ b/mteb/tasks/Clustering/nob/VGHierarchicalClustering.py
@@ -13,6 +13,8 @@ def split_labels(record: dict) -> dict:
 
 class VGHierarchicalClusteringP2P(AbsTaskClusteringFast):
     max_document_to_embed = N_SAMPLES
+    max_fraction_of_documents_to_embed = None
+
     metadata = TaskMetadata(
         name="VGHierarchicalClusteringP2P",
         dataset={
@@ -58,6 +60,8 @@ class VGHierarchicalClusteringP2P(AbsTaskClusteringFast):
 
 class VGHierarchicalClusteringS2S(AbsTaskClusteringFast):
     max_document_to_embed = N_SAMPLES
+    max_fraction_of_documents_to_embed = None
+
     metadata = TaskMetadata(
         name="VGHierarchicalClusteringS2S",
         dataset={

--- a/mteb/tasks/Clustering/pol/PolishClustering.py
+++ b/mteb/tasks/Clustering/pol/PolishClustering.py
@@ -77,6 +77,8 @@ class EightTagsClustering(AbsTaskClustering):
 
 class EightTagsClusteringFast(AbsTaskClusteringFast):
     max_document_to_embed = N_SAMPLES
+    max_fraction_of_documents_to_embed = None
+
     metadata = TaskMetadata(
         name="EightTagsClustering.v2",
         description="Clustering of headlines from social media posts in Polish belonging to 8 categories: film, history, "

--- a/mteb/tasks/Clustering/rus/GeoreviewClusteringP2P.py
+++ b/mteb/tasks/Clustering/rus/GeoreviewClusteringP2P.py
@@ -7,6 +7,8 @@ from ....abstasks.AbsTaskClusteringFast import AbsTaskClusteringFast
 
 class GeoreviewClusteringP2P(AbsTaskClusteringFast):
     max_document_to_embed = 2000
+    max_fraction_of_documents_to_embed = None
+
     metadata = TaskMetadata(
         name="GeoreviewClusteringP2P",
         dataset={

--- a/mteb/tasks/Clustering/rus/RuSciBenchGRNTIClusteringP2P.py
+++ b/mteb/tasks/Clustering/rus/RuSciBenchGRNTIClusteringP2P.py
@@ -7,6 +7,7 @@ from ....abstasks.AbsTaskClusteringFast import AbsTaskClusteringFast
 
 class RuSciBenchGRNTIClusteringP2P(AbsTaskClusteringFast):
     max_document_to_embed = 2048
+    max_fraction_of_documents_to_embed = None
 
     metadata = TaskMetadata(
         name="RuSciBenchGRNTIClusteringP2P",

--- a/mteb/tasks/Clustering/rus/RuSciBenchOECDClusteringP2P.py
+++ b/mteb/tasks/Clustering/rus/RuSciBenchOECDClusteringP2P.py
@@ -7,6 +7,7 @@ from ....abstasks.AbsTaskClusteringFast import AbsTaskClusteringFast
 
 class RuSciBenchOECDClusteringP2P(AbsTaskClusteringFast):
     max_document_to_embed = 2048
+    max_fraction_of_documents_to_embed = None
 
     metadata = TaskMetadata(
         name="RuSciBenchOECDClusteringP2P",

--- a/mteb/tasks/Clustering/swe/SwednClustering.py
+++ b/mteb/tasks/Clustering/swe/SwednClustering.py
@@ -56,6 +56,7 @@ def dataset_transform(self):
 
 class SwednClusteringP2P(AbsTaskClusteringFast):
     max_document_to_embed = 2048
+    max_fraction_of_documents_to_embed = None
 
     metadata = TaskMetadata(
         name="SwednClusteringP2P",
@@ -96,6 +97,7 @@ class SwednClusteringP2P(AbsTaskClusteringFast):
 
 class SwednClusteringFastS2S(AbsTaskClusteringFast):
     max_document_to_embed = 2048
+    max_fraction_of_documents_to_embed = None
 
     metadata = TaskMetadata(
         name="SwednClusteringS2S",

--- a/mteb/tasks/Clustering/zho/CMTEBClustering.py
+++ b/mteb/tasks/Clustering/zho/CMTEBClustering.py
@@ -16,6 +16,8 @@ NUM_SAMPLES = 2048
 
 class CLSClusteringFastS2S(AbsTaskClusteringFast):
     max_document_to_embed = NUM_SAMPLES
+    max_fraction_of_documents_to_embed = None
+
     metadata = TaskMetadata(
         name="CLSClusteringS2S.v2",
         description="Clustering of titles from CLS dataset. Clustering of 13 sets on the main category.",
@@ -73,6 +75,8 @@ class CLSClusteringFastS2S(AbsTaskClusteringFast):
 
 class CLSClusteringFastP2P(AbsTaskClusteringFast):
     max_document_to_embed = NUM_SAMPLES
+    max_fraction_of_documents_to_embed = None
+
     metadata = TaskMetadata(
         name="CLSClusteringP2P.v2",
         description="Clustering of titles + abstract from CLS dataset. Clustering of 13 sets on the main category.",
@@ -202,6 +206,8 @@ class CLSClusteringP2P(AbsTaskClustering):
 
 class ThuNewsClusteringFastS2S(AbsTaskClusteringFast):
     max_document_to_embed = NUM_SAMPLES
+    max_fraction_of_documents_to_embed = None
+
     metadata = TaskMetadata(
         name="ThuNewsClusteringS2S.v2",
         dataset={
@@ -259,6 +265,8 @@ class ThuNewsClusteringFastS2S(AbsTaskClusteringFast):
 
 class ThuNewsClusteringFastP2P(AbsTaskClusteringFast):
     max_document_to_embed = NUM_SAMPLES
+    max_fraction_of_documents_to_embed = None
+
     metadata = TaskMetadata(
         name="ThuNewsClusteringP2P.v2",
         dataset={


### PR DESCRIPTION
## Checklist
- [X] Run tests locally to make sure nothing is broken using `make test`. 
- [X] Run the formatter to format the code using `make lint`. 


If I run the following code:
```python
import mteb

model = mteb.get_model(...)

tasks = ["GeoreviewClusteringP2P"]
evaluation = mteb.MTEB(tasks=tasks)
evaluation.run(model, output_folder="results", verbosity=2)
```
It would give error
```
Exception: Both max_document_to_embed and max_fraction_of_documents_to_embed are set. Please only set one.
```
Because for these datasets `max_document_to_embed` is set, but in parent class `max_fracton_of_documents_to_embed` is set too.