### PR TITLE
Move speedtask imports

### DIFF
--- a/docs/mmteb/points/982.jsonl
+++ b/docs/mmteb/points/982.jsonl
@@ -1,0 +1,1 @@
+{"GitHub": "Samoed", "Bug fixes": 2}

--- a/docs/mmteb/points/982.jsonl
+++ b/docs/mmteb/points/982.jsonl
@@ -1,1 +1,2 @@
 {"GitHub": "Samoed", "Bug fixes": 2}
+{"GitHub": "isaac-chung", "Review PR": 2}

--- a/mteb/abstasks/AbsTaskSpeedTask.py
+++ b/mteb/abstasks/AbsTaskSpeedTask.py
@@ -45,8 +45,13 @@ class AbsTaskSpeedTask(AbsTask):
 
     def get_system_info(self) -> dict[str, str]:
         """Returns a dictionary with system information."""
-        import GPUtil
-        import psutil
+        try:
+            import GPUtil
+            import psutil
+        except ImportError as e:
+            raise ImportError(
+                "GPUtil and psutil is not installed. Please install them `pip install GPUtil psutil` or `pip install mteb[speedtask]`"
+            ) from e
 
         info = {}
         info["platform"] = platform.system()

--- a/mteb/abstasks/AbsTaskSpeedTask.py
+++ b/mteb/abstasks/AbsTaskSpeedTask.py
@@ -5,9 +5,7 @@ import platform
 import time
 from pathlib import Path
 
-import GPUtil
 import numpy as np
-import psutil
 
 from mteb.encoder_interface import Encoder, EncoderWithQueryCorpusEncode
 from mteb.MTEBResults import ScoresDict
@@ -47,6 +45,9 @@ class AbsTaskSpeedTask(AbsTask):
 
     def get_system_info(self) -> dict[str, str]:
         """Returns a dictionary with system information."""
+        import GPUtil
+        import psutil
+
         info = {}
         info["platform"] = platform.system()
         info["platform_release"] = platform.release()


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->


## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 


## Description
To run MTEB, `psutil` and `GPUtil` are now required because all abstract tasks are imported for each run. When attempting to import `AbsTaskSpeedTask`, it fails due to `psutil` and `GPUtil` not being installed.
