### PR TITLE
The Swahili Classification Task

### DIFF
--- a/mteb/tasks/Classification/swa/SwahiliNewsClassification.py
+++ b/mteb/tasks/Classification/swa/SwahiliNewsClassification.py
@@ -9,7 +9,7 @@ class SwahiliNewsClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="SwahiliNewsClassification",
         description="Dataset for Swahili News Classification, categorized with 5 domains. Building and Optimizing Swahili Language Models: Techniques, Embeddings, and Datasets",
-        reference="https://zenodo.org/records/4300294",
+        reference="https://huggingface.co/datasets/Mollel/SwahiliNewsClassification",
         dataset={
             "path": "Mollel/SwahiliNewsClassification",
             "revision": "5bc5ef41a6232c5e3c84e1e9615099b70922d7be",

--- a/mteb/tasks/Classification/swa/SwahiliNewsClassification.py
+++ b/mteb/tasks/Classification/swa/SwahiliNewsClassification.py
@@ -8,11 +8,11 @@ from mteb.abstasks.TaskMetadata import TaskMetadata
 class SwahiliNewsClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="SwahiliNewsClassification",
-        description="Dataset for Swahili News Classification, categorized with 5 domains. Building and Optimizing Swahili Language Models: Techniques, Embeddings, and Datasets",
+        description="Dataset for Swahili News Classification, categorized with 6 domains (Local News (Kitaifa), International News (Kimataifa), Finance News (Uchumi), Health News (Afya), Sports News (Michezo), and Entertainment News (Burudani)). Building and Optimizing Swahili Language Models: Techniques, Embeddings, and Datasets",
         reference="https://huggingface.co/datasets/Mollel/SwahiliNewsClassification",
         dataset={
             "path": "Mollel/SwahiliNewsClassification",
-            "revision": "5bc5ef41a6232c5e3c84e1e9615099b70922d7be",
+            "revision": "cd89b0993ca6a71240f7fb16223c64f6fe4a27b7",
         },
         type="Classification",
         category="s2s",
@@ -29,6 +29,14 @@ class SwahiliNewsClassification(AbsTaskClassification):
         annotations_creators="derived",
         text_creation="found",
         bibtex_citation="""
+        @inproceedings{davis2020swahili,
+        title = "Swahili: News Classification Dataset (0.2)",
+        author = "Davis, David",
+        year = "2020",
+        publisher = "Zenodo",
+        doi = "10.5281/zenodo.5514203",
+        url = "https://doi.org/10.5281/zenodo.5514203"
+        }
         """,
         n_samples={"train": 2048},
         avg_character_length={"train": 2438.2308135942326},

--- a/mteb/tasks/Classification/swa/SwahiliNewsClassification.py
+++ b/mteb/tasks/Classification/swa/SwahiliNewsClassification.py
@@ -2,15 +2,17 @@ from __future__ import annotations
 
 from mteb.abstasks.TaskMetadata import TaskMetadata
 
-from ....abstasks import AbsTaskClassification
+# from ....abstasks import AbsTaskClassification
+from mteb.abstasks.AbsTaskClassification import AbsTaskClassification
 
 class SwahiliNewsClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="SwahiliNewsClassification",
-        description="Dataset for Swahili News Classification, categorized with 5 domains.",
-        reference="Building and Optimizing Swahili Language Models: Techniques, Embeddings, and Datasets",
+        description="Dataset for Swahili News Classification, categorized with 5 domains. Building and Optimizing Swahili Language Models: Techniques, Embeddings, and Datasets",
+        reference="https://www.sartify.com/",
         dataset={
-            "path": "Mollel/SwahiliNewsClassfication",
+            "path": "Mollel/SwahiliNewsClassification",
+            "revision": "fadfd9f2989740dc6c9aa020cac97b318ec41cc3",
         },
         type="Classification",
         category="s2s",

--- a/mteb/tasks/Classification/swa/SwahiliNewsClassification.py
+++ b/mteb/tasks/Classification/swa/SwahiliNewsClassification.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-# from ....abstasks import AbsTaskClassification
 from mteb.abstasks.AbsTaskClassification import AbsTaskClassification
 from mteb.abstasks.TaskMetadata import TaskMetadata
 

--- a/mteb/tasks/Classification/swa/SwahiliNewsClassification.py
+++ b/mteb/tasks/Classification/swa/SwahiliNewsClassification.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from mteb.abstasks.TaskMetadata import TaskMetadata
-
 # from ....abstasks import AbsTaskClassification
 from mteb.abstasks.AbsTaskClassification import AbsTaskClassification
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
 
 class SwahiliNewsClassification(AbsTaskClassification):
     metadata = TaskMetadata(

--- a/mteb/tasks/Classification/swa/SwahiliNewsClassification.py
+++ b/mteb/tasks/Classification/swa/SwahiliNewsClassification.py
@@ -9,10 +9,10 @@ class SwahiliNewsClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="SwahiliNewsClassification",
         description="Dataset for Swahili News Classification, categorized with 5 domains. Building and Optimizing Swahili Language Models: Techniques, Embeddings, and Datasets",
-        reference="https://www.sartify.com/",
+        reference="https://zenodo.org/records/4300294",
         dataset={
             "path": "Mollel/SwahiliNewsClassification",
-            "revision": "fadfd9f2989740dc6c9aa020cac97b318ec41cc3",
+            "revision": "5bc5ef41a6232c5e3c84e1e9615099b70922d7be",
         },
         type="Classification",
         category="s2s",
@@ -31,7 +31,7 @@ class SwahiliNewsClassification(AbsTaskClassification):
         bibtex_citation="""
         """,
         n_samples={"train": 2048},
-        avg_character_length={"train": 2107.1962725684334},
+        avg_character_length={"train": 2438.2308135942326},
     )
 
     def dataset_transform(self) -> None:

--- a/mteb/tasks/Classification/swa/SwahiliNewsClassification.py
+++ b/mteb/tasks/Classification/swa/SwahiliNewsClassification.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+from ....abstasks import AbsTaskClassification
+
+class SwahiliNewsClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="SwahiliNewsClassification",
+        description="Dataset for Swahili News Classification, categorized with 5 domains.",
+        reference="Building and Optimizing Swahili Language Models: Techniques, Embeddings, and Datasets",
+        dataset={
+            "path": "Mollel/SwahiliNewsClassfication",
+        },
+        type="Classification",
+        category="s2s",
+        eval_splits=["train"],
+        eval_langs=["swa-Latn"],
+        main_score="accuracy",
+        date=("2019-01-01", "2023-05-01"),
+        form=["written"],
+        dialect=[],
+        domains=["News"],
+        task_subtypes=[],
+        license="CC BY-NC-SA 4.0",
+        socioeconomic_status="mixed",
+        annotations_creators="derived",
+        text_creation="found",
+        bibtex_citation="""
+        """,
+        n_samples={"train": 2048},
+        avg_character_length={"train": 2107.1962725684334},
+    )
+
+    def dataset_transform(self) -> None:
+        self.dataset = self.dataset.rename_columns(
+            {"content": "text", "category": "label"}
+        )
+        self.dataset = self.stratified_subsampling(
+            self.dataset, seed=self.seed, splits=["train"]
+        )


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->


## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 


### Adding datasets checklist
<!-- see also https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md -->

**Reason for dataset addition**: ... <!-- Add reason for adding dataset here. E.g. it covers task/language/domain previously not covered -->

- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb -m {model_name} -t {task_name}` command.
  - [x] `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
  - [x] `intfloat/multilingual-e5-small`
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [x] If the dataset is too big (e.g. >2048 examples), considering using `self.stratified_subsampling() under dataset_transform()`
- [x] I have filled out the metadata object in the dataset file (find documentation on it [here](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md#2-creating-the-metadata-object)).
- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 


### Adding a model checklist
<!-- 
When adding a model to the model registry
see also https://github.com/embeddings-benchmark/mteb/blob/main/docs/reproducible_workflow.md
-->

 - [ ] I have filled out the ModelMeta object to the extent possible
 - [ ] I have ensured that my model can be loaded using
   - [ ] `mteb.get_model(model_name, revision_id)` and
   - [ ] `mteb.get_model_meta(model_name, revision_id)`
 - [x] I have tested the implementation works on a representative set of tasks.