### PR TITLE
install only ruff for lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
           cache: "pip"
 
       - name: Install dependencies
-        run: make install
+        run: pip install ruff
 
       - name: Lint
         id: lint


### PR DESCRIPTION
Install only ruff for lint workflow instead of all main dependencies.