### PR TITLE
fix: change e5 default to use cuda if available

### DIFF
--- a/mteb/models/e5_instruct.py
+++ b/mteb/models/e5_instruct.py
@@ -41,7 +41,7 @@ class E5InstructWrapper(Encoder):
         revision: str,
         max_length: int,
         max_batch_size: Optional[int] = None,
-        device: str = "cpu",
+        device: str = torch.device("cuda" if torch.cuda.is_available() else "cpu"),
         **kwargs: Any,
     ):
         logger.info("Started loading e5 instruct model")


### PR DESCRIPTION
change e5 default to use cuda if available

Fixes #1021 


@Muennighoff adding you here. I will just set it to automerge but if there is any comments I will update it

## Checklist
<!-- Please do not delete this -->

- [ ] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 

