### PR TITLE
Fix query format

### DIFF
--- a/mteb/tasks/Retrieval/multilingual/WikipediaRetrievalMultilingual.py
+++ b/mteb/tasks/Retrieval/multilingual/WikipediaRetrievalMultilingual.py
@@ -69,7 +69,7 @@ def _load_data(
         # don't pass on titles to make task harder
         corpus_lang_dict = {doc["_id"]: {"text": doc["text"]} for doc in corpus_lang}
         queries_lang_dict = {
-            query["_id"]: {"text": query["text"]} for query in queries_lang
+            query["_id"]: query["text"] for query in queries_lang
         }
         # qrels_lang_dict = {qrel["query-id"]: {qrel["corpus-id"]: qrel["score"]} for qrel in qrels_lang}
 

--- a/mteb/tasks/Retrieval/multilingual/WikipediaRetrievalMultilingual.py
+++ b/mteb/tasks/Retrieval/multilingual/WikipediaRetrievalMultilingual.py
@@ -68,9 +68,7 @@ def _load_data(
         )
         # don't pass on titles to make task harder
         corpus_lang_dict = {doc["_id"]: {"text": doc["text"]} for doc in corpus_lang}
-        queries_lang_dict = {
-            query["_id"]: query["text"] for query in queries_lang
-        }
+        queries_lang_dict = {query["_id"]: query["text"] for query in queries_lang}
         # qrels_lang_dict = {qrel["query-id"]: {qrel["corpus-id"]: qrel["score"]} for qrel in qrels_lang}
 
         qrels_lang_dict = {}


### PR DESCRIPTION
The EncoderInterface only accepts list of strings for queries
https://github.com/embeddings-benchmark/mteb/blob/4fc945a76d11b7e9d63412f63322cfca16f679bf/mteb/encoder_interface.py#L95

however 
https://github.com/embeddings-benchmark/mteb/blob/4fc945a76d11b7e9d63412f63322cfca16f679bf/mteb/tasks/Retrieval/multilingual/WikipediaRetrievalMultilingual.py#L72
will pass a dict like for documents. For docs that's fine but not for queries given our interface.

This is a simple fix but it may be missing some subtleties. We could also adapt the interface to also accept dicts for queries but not needed here i think since there's nothing else in the dict anyways besides the text so maybe if this comes up again in the future



cc @rasdani