### PR TITLE
Add STS22.v2 and LivedoorNewsClustering.v2

### DIFF
--- a/mteb/tasks/Clustering/jpn/LivedoorNewsClustering.py
+++ b/mteb/tasks/Clustering/jpn/LivedoorNewsClustering.py
@@ -41,7 +41,7 @@ class LivedoorNewsClusteringv2(AbsTaskClusteringFast):
         )
 
         for split in self.metadata.eval_splits:
-            # remove empty sentences (there is only one pr. split)
+            # remove empty sentences (there is only one per split)
             self.dataset[split] = self.dataset[split].filter(
                 lambda x: len(x["sentences"]) > 0
             )

--- a/mteb/tasks/Clustering/jpn/LivedoorNewsClustering.py
+++ b/mteb/tasks/Clustering/jpn/LivedoorNewsClustering.py
@@ -8,7 +8,7 @@ class LivedoorNewsClusteringv2(AbsTaskClusteringFast):
 
     metadata = TaskMetadata(
         name="LivedoorNewsClustering.v2",
-        description="Clustering of the news reports of a Japanese news site, Livedoor News by RONDHUIT Co, Ltd. in 2012. It contains over 7,000 news report texts across 9 categories (topics).",
+        description="Clustering of the news reports of a Japanese news site, Livedoor News by RONDHUIT Co, Ltd. in 2012. It contains over 7,000 news report texts across 9 categories (topics). Version 2 updated on LivedoorNewsClustering by removing pairs where one of entries contain an empty sentences.",
         reference="https://github.com/sbintuitions/JMTEB",
         dataset={
             "path": "sbintuitions/JMTEB",

--- a/mteb/tasks/Clustering/jpn/LivedoorNewsClustering.py
+++ b/mteb/tasks/Clustering/jpn/LivedoorNewsClustering.py
@@ -2,9 +2,55 @@ from mteb.abstasks.AbsTaskClusteringFast import AbsTaskClusteringFast
 from mteb.abstasks.TaskMetadata import TaskMetadata
 
 
+class LivedoorNewsClusteringv2(AbsTaskClusteringFast):
+    max_document_to_embed = 1107
+    max_fraction_of_documents_to_embed = None
+
+    metadata = TaskMetadata(
+        name="LivedoorNewsClustering.v2",
+        description="Clustering of the news reports of a Japanese news site, Livedoor News by RONDHUIT Co, Ltd. in 2012. It contains over 7,000 news report texts across 9 categories (topics).",
+        reference="https://github.com/sbintuitions/JMTEB",
+        dataset={
+            "path": "sbintuitions/JMTEB",
+            "name": "livedoor_news",
+            "revision": "e4af6c73182bebb41d94cb336846e5a452454ea7",
+            "trust_remote_code": True,
+        },
+        type="Clustering",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["jpn-Jpan"],
+        main_score="v_measure",
+        date=("2000-01-01", "2014-02-09"),
+        form=["written"],
+        domains=["News"],
+        task_subtypes=["Topic classification"],
+        license="cc-by-nd-2.1-jp",
+        socioeconomic_status="high",
+        annotations_creators="derived",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="",
+        n_samples={"test": 1106},
+        avg_character_length={"test": 1082.61},
+    )
+
+    def dataset_transform(self):
+        self.dataset = self.dataset.rename_columns(
+            {"text": "sentences", "label": "labels"}
+        )
+
+        for split in self.metadata.eval_splits:
+            # remove empty sentences (there is only one pr. split)
+            self.dataset[split] = self.dataset[split].filter(
+                lambda x: len(x["sentences"]) > 0
+            )
+
+
 class LivedoorNewsClustering(AbsTaskClusteringFast):
     max_document_to_embed = 1107
     max_fraction_of_documents_to_embed = None
+    superseded_by = "LivedoorNewsClustering.v2"
 
     metadata = TaskMetadata(
         name="LivedoorNewsClustering",

--- a/mteb/tasks/STS/multilingual/STS22CrosslingualSTS.py
+++ b/mteb/tasks/STS/multilingual/STS22CrosslingualSTS.py
@@ -26,7 +26,72 @@ _LANGUAGES = {
 }
 
 
+class STS22CrosslingualSTSv2(AbsTaskSTS, MultilingualTask):
+    fast_loading = True
+    metadata = TaskMetadata(
+        name="STS22.v2",
+        dataset={
+            "path": "mteb/sts22-crosslingual-sts",
+            "revision": "d31f33a128469b20e357535c39b82fb3c3f6f2bd",
+        },
+        description="SemEval 2022 Task 8: Multilingual News Article Similarity. Version 2 filters updated on STS22 by removing pairs where one of entries contain empty sentences.",
+        reference="https://competitions.codalab.org/competitions/33835",
+        type="STS",
+        category="p2p",
+        eval_splits=["test"],
+        eval_langs=_LANGUAGES,
+        main_score="cosine_spearman",
+        date=("2020-01-01", "2020-06-11"),
+        form=["written"],
+        domains=["News"],
+        task_subtypes=[],
+        license="Not specified",
+        socioeconomic_status="mixed",
+        annotations_creators="human-annotated",
+        dialect=[],
+        text_creation="found",
+        bibtex_citation="""@inproceedings{chen-etal-2022-semeval,
+    title = "{S}em{E}val-2022 Task 8: Multilingual news article similarity",
+    author = {Chen, Xi  and
+      Zeynali, Ali  and
+      Camargo, Chico  and
+      Fl{\"o}ck, Fabian  and
+      Gaffney, Devin  and
+      Grabowicz, Przemyslaw  and
+      Hale, Scott  and
+      Jurgens, David  and
+      Samory, Mattia},
+    editor = "Emerson, Guy  and
+      Schluter, Natalie  and
+      Stanovsky, Gabriel  and
+      Kumar, Ritesh  and
+      Palmer, Alexis  and
+      Schneider, Nathan  and
+      Singh, Siddharth  and
+      Ratan, Shyam",
+    booktitle = "Proceedings of the 16th International Workshop on Semantic Evaluation (SemEval-2022)",
+    month = jul,
+    year = "2022",
+    address = "Seattle, United States",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2022.semeval-1.155",
+    doi = "10.18653/v1/2022.semeval-1.155",
+    pages = "1094--1106",
+}""",
+        n_samples={"test": 3958},
+        avg_character_length={"test": 1993.6},
+    )
+
+    @property
+    def metadata_dict(self) -> dict[str, str]:
+        metadata_dict = super().metadata_dict
+        metadata_dict["min_score"] = 1
+        metadata_dict["max_score"] = 4
+        return metadata_dict
+
+
 class STS22CrosslingualSTS(AbsTaskSTS, MultilingualTask):
+    superseded_by = "STS22.v2"
     fast_loading = True
     metadata = TaskMetadata(
         name="STS22",


### PR DESCRIPTION
This pull request adds the STS22.v2 and LivedoorNewsClustering.v2 which removed duplicated from their base version.

fixes #1043 

## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 