### PR TITLE
Remove secret token from documentation workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.RELEASE }}
 
       - uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
It seems that the workflow breaks when external contributors open PRs because they don't have access to the secret token. As far as I understand, this token is not required for this workflow.
Example https://github.com/embeddings-benchmark/mteb/actions/runs/9913313640/job/27390053173