### PR TITLE
ci: Splitting doc CI in two to ensure that it runs on PRs AND on main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,8 @@ on:
   pull_request:
 
 jobs:
-  create-table:
+  create-table-on-pr:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -27,6 +28,7 @@ jobs:
           make build-docs
 
   create-table-and-push:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -47,7 +49,6 @@ jobs:
           make build-docs
       
       - name: Push table
-        if: github.event_name == 'push'
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,19 +23,34 @@ jobs:
           make install
 
       - name: Create table
-        run: python docs/create_tasks_table.py
+        run: |
+          make build-docs
 
-      - name: Configure Git (for push only)
+  create-table-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.RELEASE }}
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          make install
+
+      - name: Create table
+        run: |
+          make build-docs
+      
+      - name: Push table
         if: github.event_name == 'push'
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
-
-      - name: Push table
-        if: github.event_name == 'push'
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE }}
-        run: |
           # Check if changes exist
           if git diff --quiet; then
             echo "No changes detected"
@@ -44,3 +59,4 @@ jobs:
             git commit -m "Update tasks table"
             git push
           fi
+          

--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,9 @@ pr:
 	@echo "--- 🚀 Running requirements for a PR ---"
 	make lint
 	make test
+
+
+build-docs:
+	@echo "--- 📚 Building documentation ---"
+	# since we do not have a documentation site, this just build tables for the .md files
+	python docs/create_tasks_table.py


### PR DESCRIPTION
I am having a few issues with this CI. I believe this should work, but I am not sure exactly why the previous CI doesn't work (it did for a short while). It might be due to the token not being passed correctly. 

This configuration essentially just takes the previous CI that did work on main and adds a completely separate CI for PRs. 

To avoid having to change stuff in the future it convert the build command into `make build-docs`.

@isaac-chung would love a second pair of eyes on this if you have the time