### PR TITLE
fix: fix bug-causing spelling error in function name of e5-mistral-instruct

### DIFF
--- a/mteb/models/e5_instruct.py
+++ b/mteb/models/e5_instruct.py
@@ -193,7 +193,7 @@ class E5MistralWrapper(E5InstructWrapper):
             sequence_lengths,
         ]
 
-    def get_embbeding_from_output(
+    def get_embedding_from_output(
         self, output: ModelOutput, batch_dict: BatchEncoding
     ) -> torch.Tensor:
         return self.last_token_pool(


### PR DESCRIPTION
An error was found in the function's name, which caused a bug, and not all tasks were completed, due to an error in the model's embeddings. There were sometimes zeros and infinity values.