### PR TITLE
fix MultilingualSentimentClassification

### DIFF
--- a/mteb/tasks/Classification/multilingual/MultilingualSentimentClassification.py
+++ b/mteb/tasks/Classification/multilingual/MultilingualSentimentClassification.py
@@ -96,8 +96,8 @@ class MultilingualSentimentClassification(AbsTaskClassification, MultilingualTas
     def dataset_transform(self):
         # create a train set from the test set for Welsh language (cym)
         lang = "cym"
-        _dataset = self.dataset[lang]
         if lang in self.dataset.keys():
+            _dataset = self.dataset[lang]
             _dataset = _dataset.class_encode_column("label")
             _dataset = _dataset["test"].train_test_split(
                 test_size=0.3, seed=self.seed, stratify_by_column="label"
@@ -105,4 +105,4 @@ class MultilingualSentimentClassification(AbsTaskClassification, MultilingualTas
             _dataset = self.stratified_subsampling(
                 dataset_dict=_dataset, seed=self.seed, splits=["test"]
             )
-        self.dataset[lang] = _dataset
+            self.dataset[lang] = _dataset


### PR DESCRIPTION
Now if run MultilingualSentimentClassification with any language as subset it will raise error

Example
```
tasks = mteb.get_tasks(tasks=["MultilingualSentimentClassification"], languages=["eng"])
evaluation = mteb.MTEB(tasks)
evaluation.run(model, output_folder="results", verbosity=2, overwrite_results=True)
```