### PR TITLE
fix: Ensure that MLSUMClusteringP2P.v2 use the fast implementation as was intended

### DIFF
--- a/mteb/cli.py
+++ b/mteb/cli.py
@@ -319,7 +319,11 @@ def create_meta(args: argparse.Namespace) -> None:
     ]
 
     task_results = [MTEBResults.from_disk(path) for path in json_files]
-    task_results = [results for results in task_results if results.task_name not in ["GPUSpeedTask", "CPUSpeedTask"]
+    task_results = [
+        results
+        for results in task_results
+        if results.task_name not in ["GPUSpeedTask", "CPUSpeedTask"]
+    ]
     potentially_add_cqadupstack_to_results(
         task_results
     )  # We should ideally find better way in the future to aggregate scores for tasks like CQADupstack

--- a/mteb/tasks/Clustering/multilingual/MLSUMClusteringP2P.py
+++ b/mteb/tasks/Clustering/multilingual/MLSUMClusteringP2P.py
@@ -5,6 +5,7 @@ import numpy as np
 from datasets import Dataset, DatasetDict
 
 from mteb.abstasks import AbsTaskClustering, MultilingualTask, TaskMetadata
+from mteb.abstasks.AbsTaskClusteringFast import AbsTaskClusteringFast
 
 _LANGUAGES = {
     "de": ["deu-Latn"],
@@ -91,7 +92,7 @@ class MLSUMClusteringP2P(AbsTaskClustering, MultilingualTask):
         self.dataset[lang] = _dataset
 
 
-class MLSUMClusteringP2PFast(AbsTaskClustering, MultilingualTask):
+class MLSUMClusteringP2PFast(AbsTaskClusteringFast, MultilingualTask):
     max_document_to_embed = N_SAMPLES
     max_fraction_of_documents_to_embed = None
 


### PR DESCRIPTION
fixes: #1110

## Checklist
<!-- Please do not delete this -->

- [ ] Run tests locally to make sure nothing is broken using `make test`. 
- [ ] Run the formatter to format the code using `make lint`. 

