### PR TITLE
docs: improve searchability in the advanced usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,13 @@ mteb run -m sentence-transformers/all-MiniLM-L6-v2 \
 
 * Using multiple GPUs in parallel can be done by just having a custom encode function that distributes the inputs to multiple GPUs like e.g. [here](https://github.com/microsoft/unilm/blob/b60c741f746877293bb85eed6806736fc8fa0ffd/e5/mteb_eval.py#L60) or [here](https://github.com/ContextualAI/gritlm/blob/09d8630f0c95ac6a456354bcb6f964d7b9b6a609/gritlm/gritlm.py#L75).
 
-<br /> 
-
-<details>
-  <summary> Advanced Usage (click to unfold) </summary>
 
 
 ## Advanced Usage
+<br /> 
 
+<details>
+  <summary>  Dataset selection (click to unfold) </summary>
 
 ### Dataset selection
 
@@ -127,6 +126,12 @@ from mteb import MTEB_MAIN_EN
 evaluation = mteb.MTEB(tasks=MTEB_MAIN_EN, task_langs=["en"])
 ```
 
+</details>
+
+<details>
+  <summary>  Passing in `encode` arguments (click to unfold) </summary>
+
+
 ### Passing in `encode` arguments
 
 To pass in arguments to the model's `encode` function, you can use the encode keyword arguments (`encode_kwargs`):
@@ -134,8 +139,13 @@ To pass in arguments to the model's `encode` function, you can use the encode ke
 ```python
 evaluation.run(model, encode_kwargs={"batch_size": 32}
 ```
+</details>
 
-### Evaluation split
+
+<details>
+  <summary>  Selecting evaluation split (click to unfold) </summary>
+
+### Selecting evaluation split
 You can evaluate only on `test` splits of all tasks by doing the following:
 
 ```python
@@ -143,6 +153,12 @@ evaluation.run(model, eval_splits=["test"])
 ```
 
 Note that the public leaderboard uses the test splits for all datasets except MSMARCO, where the "dev" split is used.
+
+</details>
+
+<details>
+  <summary>  Using a custom model (click to unfold) </summary>
+
 
 ### Using a custom model
 
@@ -197,6 +213,12 @@ class MyModel():
         """
         pass
 ```
+
+</details>
+
+<details>
+  <summary>  Evaluating on a custom dataset (click to unfold) </summary>
+
 
 ### Evaluating on a custom dataset
 

--- a/README.md
+++ b/README.md
@@ -72,10 +72,12 @@ mteb run -m sentence-transformers/all-MiniLM-L6-v2 \
 
 
 ## Advanced Usage
+Click on each section below to see the details.
+
 <br /> 
 
 <details>
-  <summary>  Dataset selection (click to unfold) </summary>
+  <summary>  Dataset selection </summary>
 
 ### Dataset selection
 
@@ -129,7 +131,7 @@ evaluation = mteb.MTEB(tasks=MTEB_MAIN_EN, task_langs=["en"])
 </details>
 
 <details>
-  <summary>  Passing in `encode` arguments (click to unfold) </summary>
+  <summary>  Passing in `encode` arguments </summary>
 
 
 ### Passing in `encode` arguments
@@ -143,7 +145,7 @@ evaluation.run(model, encode_kwargs={"batch_size": 32}
 
 
 <details>
-  <summary>  Selecting evaluation split (click to unfold) </summary>
+  <summary>  Selecting evaluation split </summary>
 
 ### Selecting evaluation split
 You can evaluate only on `test` splits of all tasks by doing the following:
@@ -157,7 +159,7 @@ Note that the public leaderboard uses the test splits for all datasets except MS
 </details>
 
 <details>
-  <summary>  Using a custom model (click to unfold) </summary>
+  <summary>  Using a custom model </summary>
 
 
 ### Using a custom model
@@ -217,7 +219,7 @@ class MyModel():
 </details>
 
 <details>
-  <summary>  Evaluating on a custom dataset (click to unfold) </summary>
+  <summary>  Evaluating on a custom dataset </summary>
 
 
 ### Evaluating on a custom dataset


### PR DESCRIPTION
Instead of having a single drop down for the advanced usage, I create a dropdown for each subsection. This makes the makes it much easier to see what is available in the docs.


## Checklist
<!-- Please do not delete this -->

- [ ] Run tests locally to make sure nothing is broken using `make test`. 
- [ ] Run the formatter to format the code using `make lint`. 
