### PR TITLE
fix export type

### DIFF
--- a/mteb/cli.py
+++ b/mteb/cli.py
@@ -292,7 +292,7 @@ def potentially_add_cqadupstack_to_results(results: list[mteb.MTEBResults]) -> N
 
     result = mteb.MTEBResults(
         task_name="CQADupstackRetrieval",
-        dataset_revision="CQADupstackRetrieval_is_a_combined dataset",
+        dataset_revision="CQADupstackRetrieval_is_a_combined_dataset",
         mteb_version="NA",
         scores=scores,
         evaluation_time=evaluation_time,

--- a/mteb/load_results/mteb_results.py
+++ b/mteb/load_results/mteb_results.py
@@ -38,7 +38,7 @@ class CQADupstackRetrievalDummy:
         },
         dataset={
             "revision": "revision not applicable",
-            "path": "CQADupstackRetrieval is a combined dataset",
+            "path": "CQADupstackRetrieval_is_a_combined_dataset",
         },
     )
 
@@ -53,7 +53,7 @@ class ScalaNbClassificationDummy:
         hf_subsets_to_langscripts={
             "default": ["nob-Latn"],
         },
-        dataset={"revision": "revision not applicable"},
+        dataset={"revision": "revision_not_applicable"},
     )
 
 
@@ -67,7 +67,7 @@ class ScalaNnClassificationDummy:
         hf_subsets_to_langscripts={
             "default": ["nno-Latn"],
         },
-        dataset={"revision": "revision not applicable"},
+        dataset={"revision": "revision_not_applicable"},
     )
 
 
@@ -81,7 +81,7 @@ class ScalaDaClassificationDummy:
         hf_subsets_to_langscripts={
             "default": ["dan-Latn"],
         },
-        dataset={"revision": "revision not applicable"},
+        dataset={"revision": "revision_not_applicable"},
     )
 
 
@@ -95,7 +95,7 @@ class ScalaSvClassificationDummy:
         hf_subsets_to_langscripts={
             "default": ["swe-Latn"],
         },
-        dataset={"revision": "revision not applicable"},
+        dataset={"revision": "revision_not_applicable"},
     )
 
 


### PR DESCRIPTION
Closes #1111
I've run `mteb create_meta` and got `type: CQADupstackRetrieval_is_a_combined_dataset` in type. I think that other datasets have same problems