### PR TITLE
fix: nomic models using prefix correctly

### DIFF
--- a/mteb/models/nomic_models.py
+++ b/mteb/models/nomic_models.py
@@ -47,7 +47,7 @@ class NomicWrapper:
 
         emb = self.mdl.encode(sentences, batch_size=batch_size, **kwargs)
         # v1.5 has a non-trainable layer norm to unit normalize the embeddings for binary quantization
-        # the outputs are similary to if we just normalized but keeping the same for consistency
+        # the outputs are similar to if we just normalized but keeping the same for consistency
         if self.model_name == "nomic-ai/nomic-embed-text-v1.5":
             if not isinstance(emb, torch.Tensor):
                 emb = torch.tensor(emb)

--- a/mteb/models/nomic_models.py
+++ b/mteb/models/nomic_models.py
@@ -19,8 +19,6 @@ class NomicWrapper:
         self.model_name = model_name
         self.mdl = SentenceTransformer(model_name, revision=revision, **kwargs)
 
-        # if v1.5, layer norm
-
     def to(self, device: torch.device) -> None:
         self.mdl.to(device)
 

--- a/mteb/models/nomic_models.py
+++ b/mteb/models/nomic_models.py
@@ -49,8 +49,12 @@ class NomicWrapper:
         # v1.5 has a non-trainable layer norm to unit normalize the embeddings for binary quantization
         # the outputs are similary to if we just normalized but keeping the same for consistency
         if self.model_name == "nomic-ai/nomic-embed-text-v1.5":
+            if not isinstance(emb, torch.Tensor):
+                emb = torch.tensor(emb)
             emb = F.layer_norm(emb, normalized_shape=(emb.shape[1],))
             emb = F.normalize(emb, p=2, dim=1)
+            if kwargs.get("convert_to_tensor", False):
+                emb = emb.cpu().detach().numpy()
 
         return emb
 

--- a/mteb/models/nomic_models.py
+++ b/mteb/models/nomic_models.py
@@ -1,31 +1,90 @@
 from __future__ import annotations
 
 from functools import partial
+from typing import Any, Optional
 
+import torch
+import torch.nn.functional as F
 from sentence_transformers import SentenceTransformer
 
+import mteb
 from mteb.model_meta import ModelMeta
+from mteb.models.text_formatting_utils import corpus_to_texts
 
 
-class SentenceTransformerWithNormalization(SentenceTransformer):
-    def encode(self, sentences, *args, **kwargs):
-        if "normalize_embeddings" not in kwargs:
-            kwargs["normalize_embeddings"] = True
+class NomicWrapper:
+    """following the hf model card documentation."""
 
-        return super().encode(sentences, *args, **kwargs)
+    def __init__(self, model_name: str, revision: str, **kwargs: Any):
+        self.model_name = model_name
+        self.mdl = SentenceTransformer(model_name, revision=revision, **kwargs)
+
+        # if v1.5, layer norm
+
+    def to(self, device: torch.device) -> None:
+        self.mdl.to(device)
+
+    def encode(  # type: ignore
+        self,
+        sentences: list[str],
+        *,
+        prompt_name: str | None = None,
+        batch_size: int = 32,
+        input_type: Optional[str] = None,
+        **kwargs: Any,
+    ):
+        if prompt_name:
+            task = mteb.get_task(prompt_name)
+            task_type = task.metadata.type
+            if task_type in ["Classification", "MultilabelClassification"]:
+                input_type = "classification"
+            elif task_type == "Clustering":
+                input_type = "clustering"
+
+        # default to search_document if input_type and prompt_name are not provided
+        if input_type is None:
+            input_type = "search_document"
+
+        sentences = [f"{input_type}: {sentence}" for sentence in sentences]
+
+        emb = self.mdl.encode(sentences, batch_size=batch_size, **kwargs)
+        # v1.5 has a non-trainable layer norm to unit normalize the embeddings for binary quantization
+        # the outputs are similary to if we just normalized but keeping the same for consistency
+        if self.model_name == "nomic-ai/nomic-embed-text-v1.5":
+            emb = F.layer_norm(emb, normalized_shape=(emb.shape[1],))
+            emb = F.normalize(emb, p=2, dim=1)
+
+        return emb
+
+    def encode_queries(self, queries: list[str], batch_size: int = 32, **kwargs: Any):
+        if "prompt_name" in kwargs:
+            kwargs.pop("prompt_name")
+
+        emb = self.encode(
+            queries, batch_size=batch_size, input_type="search_query", **kwargs
+        )
+
+        return emb
+
+    def encode_corpus(
+        self,
+        corpus: list[dict[str, str]] | dict[str, list[str]],
+        batch_size: int = 32,
+        **kwargs: Any,
+    ):
+        if "prompt_name" in kwargs:
+            kwargs.pop("prompt_name")
+
+        sentences = corpus_to_texts(corpus)
+        emb = self.encode(
+            sentences, batch_size=batch_size, input_type="search_document", **kwargs
+        )
+        return emb
 
 
-def sentence_transformers_loader(
-    model_name: str, revision: str | None, **kwargs
-) -> SentenceTransformer:
-    return SentenceTransformerWithNormalization(
-        model_name_or_path=model_name, revision=revision, **kwargs
-    )
-
-
-nomic_embed = ModelMeta(
+nomic_embed_v1_5 = ModelMeta(
     loader=partial(  # type: ignore
-        sentence_transformers_loader,
+        NomicWrapper,
         trust_remote_code=True,
         model_name="nomic-ai/nomic-embed-text-v1.5",
         revision="b0753ae76394dd36bcfb912a46018088bca48be0",
@@ -37,8 +96,33 @@ nomic_embed = ModelMeta(
     release_date="2024-02-10",  # first commit
 )
 
-if __name__ == "__main__":
-    import mteb
+nomic_embed_v1 = ModelMeta(
+    loader=partial(  # type: ignore
+        NomicWrapper,
+        trust_remote_code=True,
+        model_name="nomic-ai/nomic-embed-text-v1",
+        revision="0759316f275aa0cb93a5b830973843ca66babcf5",
+    ),
+    name="nomic-ai/nomic-embed-text-v1",
+    languages=["eng-Latn"],
+    open_source=True,
+    revision="0759316f275aa0cb93a5b830973843ca66babcf5",
+    release_date="2024-01-31",  # first commit
+)
 
-    mdl = mteb.get_model(nomic_embed.name, nomic_embed.revision)
+if __name__ == "__main__":
+    mdl = mteb.get_model(nomic_embed_v1_5.name, nomic_embed_v1_5.revision)
     emb = mdl.encode(["test"], convert_to_tensor=True)
+    print(emb.shape)
+    emb = mdl.encode_queries(["test"], convert_to_tensor=True)
+    print(emb.shape)
+    emb = mdl.encode(
+        ["test"],
+        convert_to_tensor=True,
+        prompt_name="AmazonCounterfactualClassification",
+    )
+    print(emb.shape)
+
+    mdl = mteb.get_model(nomic_embed_v1.name, nomic_embed_v1.revision)
+    emb = mdl.encode(["test"], convert_to_tensor=True)
+    print(emb.shape)


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->


## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 


### Adding datasets checklist
<!-- see also https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md -->

**Reason for dataset addition**: ... <!-- Add reason for adding dataset here. E.g. it covers task/language/domain previously not covered -->

- [ ] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb -m {model_name} -t {task_name}` command.
  - [ ] `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
  - [ ] `intfloat/multilingual-e5-small`
- [ ] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [ ] If the dataset is too big (e.g. >2048 examples), considering using `self.stratified_subsampling() under dataset_transform()`
- [ ] I have filled out the metadata object in the dataset file (find documentation on it [here](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md#2-creating-the-metadata-object)).
- [ ] Run tests locally to make sure nothing is broken using `make test`. 
- [ ] Run the formatter to format the code using `make lint`. 


### Adding a model checklist
<!-- 
When adding a model to the model registry
see also https://github.com/embeddings-benchmark/mteb/blob/main/docs/reproducible_workflow.md
-->

 - [ ] I have filled out the ModelMeta object to the extent possible
 - [ ] I have ensured that my model can be loaded using
   - [ ] `mteb.get_model(model_name, revision_id)` and
   - [ ] `mteb.get_model_meta(model_name, revision_id)`
 - [ ] I have tested the implementation works on a representative set of tasks.