### PR TITLE
fix: Allow more linient TaskMetadata

### DIFF
--- a/mteb/abstasks/TaskMetadata.py
+++ b/mteb/abstasks/TaskMetadata.py
@@ -174,40 +174,60 @@ class TaskMetadata(BaseModel):
 
     name: str
     description: str
-    type: TASK_TYPE
-    modalities: list[Literal["text"]]
-    category: TASK_CATEGORY
-    reference: STR_URL | None  # URL to documentation, e.g. published paper
+    type: TASK_TYPE | None = None
+    modalities: list[Literal["text"]] = ["text"]
+    category: TASK_CATEGORY | None = None
+    reference: STR_URL | None = None
 
-    eval_splits: list[str]
+    eval_splits: list[str] = ["test"]
     eval_langs: LANGUAGES
-    main_score: str  # Might want a literal here
+    main_score: str
 
-    date: tuple[STR_DATE, STR_DATE] | None  # When the data was collected
-    domains: list[TASK_DOMAIN] | None
-    task_subtypes: list[TASK_SUBTYPE] | None
-    license: str | None
+    date: tuple[STR_DATE, STR_DATE] | None = None
+    domains: list[TASK_DOMAIN] | None = None
+    task_subtypes: list[TASK_SUBTYPE] | None = None
+    license: str | None = None
 
-    annotations_creators: ANNOTATOR_TYPE | None
-    dialect: list[str] | None
+    annotations_creators: ANNOTATOR_TYPE | None = None
+    dialect: list[str] | None = None
 
-    sample_creation: SAMPLE_CREATION_METHOD | None
-    bibtex_citation: str | None
+    sample_creation: SAMPLE_CREATION_METHOD | None = None
+    bibtex_citation: str | None = None
 
-    descriptive_stats: dict[METRIC_NAME, Optional[dict[SPLIT_NAME, METRIC_VALUE]]]
+    descriptive_stats: dict[METRIC_NAME, Optional[dict[SPLIT_NAME, METRIC_VALUE]]] = {}
+
+    def validate_metadata(self):
+        self.dataset_path_is_specified(self.dataset)
+        self.dataset_revision_is_specified(self.dataset)
+        self.eval_langs_are_valid(self.eval_langs)
+        return True
 
     @field_validator("dataset")
-    def _check_dataset_path_is_specified(cls, dataset):
+    def _check_dataset_path_is_specified(
+        cls, dataset: dict[str, Any]
+    ) -> dict[str, Any]:
+        cls.dataset_path_is_specified(dataset)
+        return dataset
+
+    @field_validator("dataset")
+    def _check_dataset_revision_is_specified(
+        cls, dataset: dict[str, Any]
+    ) -> dict[str, Any]:
+        cls.dataset_revision_is_specified(dataset)
+        return dataset
+
+    @staticmethod
+    def dataset_path_is_specified(dataset: dict[str, Any]) -> bool:
         """This method checks that the dataset path is specified."""
         if "path" not in dataset or dataset["path"] is None:
             raise ValueError(
                 "You must specify the path to the dataset in the dataset dictionary. "
                 "See https://huggingface.co/docs/datasets/main/en/package_reference/loading_methods#datasets.load_dataset"
             )
-        return dataset
+        return True
 
-    @field_validator("dataset")
-    def _check_dataset_revision_is_specified(cls, dataset):
+    @staticmethod
+    def dataset_revision_is_specified(dataset: dict[str, Any]) -> bool:
         if "revision" not in dataset:
             raise ValueError(
                 "You must explicitly specify a revision for the dataset (either a SHA or None)."
@@ -217,19 +237,18 @@ class TaskMetadata(BaseModel):
                 "Revision missing for the dataset %s. It is encourage to specify a dataset revision for reproducability.",
                 dataset["path"],
             )
-        return dataset
+        return True
 
-    @field_validator("eval_langs")
-    def _check_eval_langs(cls, eval_langs):
+    def eval_langs_are_valid(self, eval_langs: LANGUAGES) -> bool:
         """This method checks that the eval_langs are specified as a list of languages."""
         if isinstance(eval_langs, dict):
             for langs in eval_langs.values():
                 for code in langs:
-                    cls._check_language_code(code)
+                    self._check_language_code(code)
         else:
             for code in eval_langs:
-                cls._check_language_code(code)
-        return eval_langs
+                self._check_language_code(code)
+        return True
 
     @staticmethod
     def _check_language_code(code):

--- a/mteb/abstasks/TaskMetadata.py
+++ b/mteb/abstasks/TaskMetadata.py
@@ -196,11 +196,10 @@ class TaskMetadata(BaseModel):
 
     descriptive_stats: dict[METRIC_NAME, Optional[dict[SPLIT_NAME, METRIC_VALUE]]] = {}
 
-    def validate_metadata(self):
+    def validate_metadata(self) -> None:
         self.dataset_path_is_specified(self.dataset)
         self.dataset_revision_is_specified(self.dataset)
         self.eval_langs_are_valid(self.eval_langs)
-        return True
 
     @field_validator("dataset")
     def _check_dataset_path_is_specified(
@@ -217,17 +216,16 @@ class TaskMetadata(BaseModel):
         return dataset
 
     @staticmethod
-    def dataset_path_is_specified(dataset: dict[str, Any]) -> bool:
+    def dataset_path_is_specified(dataset: dict[str, Any]) -> None:
         """This method checks that the dataset path is specified."""
         if "path" not in dataset or dataset["path"] is None:
             raise ValueError(
                 "You must specify the path to the dataset in the dataset dictionary. "
                 "See https://huggingface.co/docs/datasets/main/en/package_reference/loading_methods#datasets.load_dataset"
             )
-        return True
 
     @staticmethod
-    def dataset_revision_is_specified(dataset: dict[str, Any]) -> bool:
+    def dataset_revision_is_specified(dataset: dict[str, Any]) -> None:
         if "revision" not in dataset:
             raise ValueError(
                 "You must explicitly specify a revision for the dataset (either a SHA or None)."
@@ -237,9 +235,8 @@ class TaskMetadata(BaseModel):
                 "Revision missing for the dataset %s. It is encourage to specify a dataset revision for reproducability.",
                 dataset["path"],
             )
-        return True
 
-    def eval_langs_are_valid(self, eval_langs: LANGUAGES) -> bool:
+    def eval_langs_are_valid(self, eval_langs: LANGUAGES) -> None:
         """This method checks that the eval_langs are specified as a list of languages."""
         if isinstance(eval_langs, dict):
             for langs in eval_langs.values():
@@ -248,7 +245,6 @@ class TaskMetadata(BaseModel):
         else:
             for code in eval_langs:
                 self._check_language_code(code)
-        return True
 
     @staticmethod
     def _check_language_code(code):

--- a/mteb/models/google_models.py
+++ b/mteb/models/google_models.py
@@ -27,7 +27,7 @@ class GoogleTextEmbeddingModel(Encoder):
         """
         try:
             from vertexai.language_models import TextEmbeddingInput, TextEmbeddingModel
-        except:
+        except ImportError:
             raise ImportError(
                 "The `vertexai` package is required to run the google API, please install it using `pip install vertexai`"
             )

--- a/tests/test_TaskMetadata.py
+++ b/tests/test_TaskMetadata.py
@@ -389,7 +389,9 @@ def test_all_metadata_is_filled_and_valid():
     unfilled_metadata = []
     for task in all_tasks:
         if task.metadata.name not in _HISTORIC_DATASETS:
-            if not task.metadata.is_filled() and task.metadata.is_validated():
+            if not task.metadata.is_filled() and (
+                not task.metadata.validate_metadata()
+            ):
                 unfilled_metadata.append(task.metadata.name)
     if unfilled_metadata:
         raise ValueError(

--- a/tests/test_TaskMetadata.py
+++ b/tests/test_TaskMetadata.py
@@ -235,7 +235,7 @@ def test_given_dataset_config_then_it_is_valid():
 
 def test_given_missing_dataset_path_then_it_throws():
     with pytest.raises(ValueError):
-        TaskMetadata(
+        TaskMetadata(  # type: ignore
             name="MyTask",
             description="testing",
             reference=None,
@@ -383,13 +383,13 @@ def test_filled_metadata_is_filled():
     )
 
 
-def test_all_metadata_is_filled():
+def test_all_metadata_is_filled_and_valid():
     all_tasks = get_tasks()
 
     unfilled_metadata = []
     for task in all_tasks:
         if task.metadata.name not in _HISTORIC_DATASETS:
-            if not task.metadata.is_filled():
+            if not task.metadata.is_filled() and task.metadata.is_validated():
                 unfilled_metadata.append(task.metadata.name)
     if unfilled_metadata:
         raise ValueError(


### PR DESCRIPTION
This fix allows for more lenient TaskMetadata when using the package, but maintain the validation for the package within the tests.

This is intended to ensure flexibility and ease of use, while maintaining high-quality doucementation of tasks


<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->


## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 

Fixes #1121
