### PR TITLE
fix: IWSLT2017BitextMining loading dataset.

### DIFF
--- a/mteb/tasks/BitextMining/__init__.py
+++ b/mteb/tasks/BitextMining/__init__.py
@@ -10,7 +10,7 @@ from .multilingual.FloresBitextMining import *
 from .multilingual.IN22ConvBitextMining import *
 from .multilingual.IN22GenBitextMining import *
 from .multilingual.IndicGenBenchFloresBitextMining import *
-from .multilingual.IWSLT2017BitextMinig import *
+from .multilingual.IWSLT2017BitextMining import *
 from .multilingual.LinceMTBitextMining import *
 from .multilingual.NollySentiBitextMining import *
 from .multilingual.NorwegianCourtsBitextMining import *

--- a/mteb/tasks/BitextMining/multilingual/IWSLT2017BitextMining.py
+++ b/mteb/tasks/BitextMining/multilingual/IWSLT2017BitextMining.py
@@ -95,7 +95,6 @@ class IWSLT2017BitextMining(AbsTaskBitextMining, MultilingualTask):
         self.dataset = {}
         for lang in self.hf_subsets:
             self.dataset[lang] = datasets.load_dataset(
-                split=_SPLITS,
                 name=f"iwslt2017-{lang}",
                 **self.metadata_dict["dataset"],
             )
@@ -111,7 +110,11 @@ class IWSLT2017BitextMining(AbsTaskBitextMining, MultilingualTask):
             return row
 
         # Convert to standard format
+        dataset = {}
         for lang in self.hf_subsets:
-            self.dataset[lang] = self.dataset[lang].map(
-                lambda x: create_columns(x, lang=lang)
-            )
+            dataset[lang] = {}
+            for split in _SPLITS:
+                dataset[lang][split] = self.dataset[lang][split].map(
+                    lambda x: create_columns(x, lang=lang)
+                )
+        self.dataset = dataset


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->


## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 


The present IWSTL2017BitextMining raises following error when the loading dataset.
```
ERROR:mteb.evaluation.MTEB:Error while evaluating IWSLT2017BitextMining: 'list' object has no attribute 'map'                             
Traceback (most recent call last):                                                                                                        
  File "/path/to/experiments/mteb_jpn.py", line 126, in <module>                                                    
    main(args)                                                                                                                            
  File "/path/to/experiments/mteb_jpn.py", line 111, in main                                                        
    evaluation.run(                                                                                                                       
  File "/home/path/to/mteb/evaluation/MTEB.py", line 422, in run                      
    raise e                                                                                                                               
  File "/path/to/mteb/evaluation/MTEB.py", line 352, in run                      
    task.load_data(eval_splits=task_eval_splits, **kwargs)                                                                                
  File "/path/to/mteb/tasks/BitextMining/multilingual/IWSLT2017BitextMinig.py", l
ine 104, in load_data
    self.dataset_transform()
  File "/path/to/mteb/tasks/BitextMining/multilingual/IWSLT2017BitextMinig.py", l
ine 116, in dataset_transform                                                                                                             
    self.dataset[lang] = self.dataset[lang].map(                                                                                          
                         ^^^^^^^^^^^^^^^^^^^^^^                                                                                           
AttributeError: 'list' object has no attribute 'map'  
```

This is because the splits is passed with list when loading dataset.
To fix it, I change the line where _SPLITS is used.