### PR TITLE
fix: removed test set for AFQMC with no gold labels

### DIFF
--- a/mteb/tasks/STS/zho/CMTEBSTS.py
+++ b/mteb/tasks/STS/zho/CMTEBSTS.py
@@ -238,7 +238,7 @@ class AFQMC(AbsTaskSTS):
         type="STS",
         category="s2s",
         modalities=["text"],
-        eval_splits=["validation", "test"],
+        eval_splits=["validation"],
         eval_langs=["cmn-Hans"],
         main_score="cosine_spearman",
         date=None,


### PR DESCRIPTION
The test set of AFQMC is hidden so has removed it from the default suite. This influences the C-MTEB. Who is the best person to contact for this? (@Muennighoff)


<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->


## Checklist
<!-- Please do not delete this -->

- [ ] Run tests locally to make sure nothing is broken using `make test`. 
- [ ] Run the formatter to format the code using `make lint`. 
