### PR TITLE
Update ruMTEB tasks list

### DIFF
--- a/mteb/benchmarks.py
+++ b/mteb/benchmarks.py
@@ -119,38 +119,41 @@ MTEB_MAIN_EN = Benchmark(
 
 MTEB_MAIN_RU = Benchmark(
     name="MTEB(rus)",
-    tasks=[
-        # Classification
-        "GeoreviewClassification",
-        "HeadlineClassification",
-        "InappropriatenessClassification",
-        "KinopoiskClassification",
-        "MassiveIntentClassification",
-        "MassiveScenarioClassification",
-        "RuReviewsClassification",
-        "RuSciBenchGRNTIClassification",
-        "RuSciBenchOECDClassification",
-        # Clustering
-        "GeoreviewClusteringP2P",
-        "RuSciBenchGRNTIClusteringP2P",
-        "RuSciBenchOECDClusteringP2P",
-        # MultiLabelClassification
-        "CEDRClassification",
-        "SensitiveTopicsClassification",
-        # PairClassification
-        "TERRa",
-        # Reranking
-        "MIRACLReranking",
-        "RuBQReranking",
-        # Retrieval
-        "MIRACLRetrieval",
-        "RiaNewsRetrieval",
-        "RuBQRetrieval",
-        # STS
-        "RUParaPhraserSTS",
-        "RuSTSBenchmarkSTS",
-        "STS22",
-    ],
+    tasks=get_tasks(
+        languages=["rus"],
+        tasks=[
+            # Classification
+            "GeoreviewClassification",
+            "HeadlineClassification",
+            "InappropriatenessClassification",
+            "KinopoiskClassification",
+            "MassiveIntentClassification",
+            "MassiveScenarioClassification",
+            "RuReviewsClassification",
+            "RuSciBenchGRNTIClassification",
+            "RuSciBenchOECDClassification",
+            # Clustering
+            "GeoreviewClusteringP2P",
+            "RuSciBenchGRNTIClusteringP2P",
+            "RuSciBenchOECDClusteringP2P",
+            # MultiLabelClassification
+            "CEDRClassification",
+            "SensitiveTopicsClassification",
+            # PairClassification
+            "TERRa",
+            # Reranking
+            "MIRACLReranking",
+            "RuBQReranking",
+            # Retrieval
+            "MIRACLRetrieval",
+            "RiaNewsRetrieval",
+            "RuBQRetrieval",
+            # STS
+            "RUParaPhraserSTS",
+            "RuSTSBenchmarkSTS",
+            "STS22",
+        ],
+    ),
     description="Main Russian benchmarks from MTEB",
     reference="https://aclanthology.org/2023.eacl-main.148/",
     citation=None,

--- a/mteb/benchmarks.py
+++ b/mteb/benchmarks.py
@@ -120,23 +120,36 @@ MTEB_MAIN_EN = Benchmark(
 MTEB_MAIN_RU = Benchmark(
     name="MTEB(rus)",
     tasks=[
+        # Classification
         "GeoreviewClassification",
-        "GeoreviewClusteringP2P",
         "HeadlineClassification",
         "InappropriatenessClassification",
         "KinopoiskClassification",
         "MassiveIntentClassification",
         "MassiveScenarioClassification",
-        "RiaNewsRetrieval",
-        "RuBQRetrieval",
         "RuReviewsClassification",
         "RuSciBenchGRNTIClassification",
-        "RuSciBenchGRNTIClusteringP2P",
         "RuSciBenchOECDClassification",
+        # Clustering
+        "GeoreviewClusteringP2P",
+        "RuSciBenchGRNTIClusteringP2P",
         "RuSciBenchOECDClusteringP2P",
+        # MultiLabelClassification
+        "CEDRClassification",
+        "SensitiveTopicsClassification",
+        # PairClassification
+        "TERRa",
+        # Reranking
+        "MIRACLReranking",
+        "RuBQReranking",
+        # Retrieval
+        "MIRACLRetrieval",
+        "RiaNewsRetrieval",
+        "RuBQRetrieval",
+        # STS
+        "RUParaPhraserSTS",
         "RuSTSBenchmarkSTS",
         "STS22",
-        "TERRa",
     ],
     description="Main Russian benchmarks from MTEB",
     reference="https://aclanthology.org/2023.eacl-main.148/",

--- a/mteb/models/instructions.py
+++ b/mteb/models/instructions.py
@@ -56,6 +56,15 @@ TASKNAME2INSTRUCTIONS = {
     "JDReview": "Classify the customer review for iPhone on e-commerce platform into positive or negative",
     "OnlineShopping": "Classify the customer review for online shopping into positive or negative",
     "Waimai": "Classify the customer review from a food takeaway platform into positive or negative",
+    "RuReviewsClassification": "Classify product reviews into positive, negative or neutral sentiment",
+    "KinopoiskClassification": "Classify the sentiment expressed in the given movie review text",
+    "HeadlineClassification": "Classify the topic or theme of the given news headline",
+    "CEDRClassification": "Given a comment as query, find expressed emotions (joy, sadness, surprise, fear, and anger)",
+    "GeoreviewClassification": "Classify the organization rating based on the reviews",
+    "InappropriatenessClassification": "Classify the given message as either sensitive topic or not",
+    "RuSciBenchGRNTIClassification": "Classify the category of scientific papers based on the titles and abstracts",
+    "RuSciBenchOECDClassification": "Classify the category of scientific papers based on the titles and abstracts",
+    "SensitiveTopicsClassification": "Given a sentence as query, find sensitive topics",
     # Clustering
     "VGHierarchicalClusteringP2P": "Identify the categories (e.g. sports) of given articles in Norwegian",
     "VGHierarchicalClusteringS2S": "Identify the categories (e.g. sports) of given articles in Norwegian",
@@ -78,6 +87,9 @@ TASKNAME2INSTRUCTIONS = {
     "CLSClusteringP2P": "Identify the main category of scholar papers based on the titles and abstracts",
     "ThuNewsClusteringS2S": "Identify the topic or theme of the given news articles based on the titles",
     "ThuNewsClusteringP2P": "Identify the topic or theme of the given news articles based on the titles and contents",
+    "GeoreviewClusteringP2P": "Identify the organization category based on the reviews",
+    "RuSciBenchOECDClusteringP2P": "Identify the category of scientific papers based on the titles and abstracts",
+    "RuSciBenchGRNTIClusteringP2P": "Identify the category of scientific papers based on the titles and abstracts",
     # Reranking and pair classification
     "AskUbuntuDupQuestions": "Retrieve duplicate questions from AskUbuntu forum",
     "MindSmallReranking": "Retrieve relevant news articles based on user browsing history",
@@ -93,6 +105,15 @@ TASKNAME2INSTRUCTIONS = {
     "CMedQAv2": "Given a Chinese community medical question, retrieve replies that best answer the question",
     "Ocnli": "Retrieve semantically similar text.",
     "Cmnli": "Retrieve semantically similar text.",
+    "TERRa": "Given a premise, retrieve a hypothesis that is entailed by the premise",
+    "RuBQReranking": (
+        "Given a question, retrieve Wikipedia passages that answer the question",
+        "",
+    ),
+    "MIRACLReranking": (
+        "Given a question, retrieve Wikipedia passages that answer the question",
+        "",
+    ),
     # Retrieval - 1st item is query instruction; 2nd is corpus instruction
     "TwitterHjerneRetrieval": (
         "Retrieve answers to questions asked in Danish tweets",
@@ -266,6 +287,15 @@ TASKNAME2INSTRUCTIONS = {
         "Given the following sentence, retrieve an appropriate answer to fill in the missing underscored part.",
         "",
     ),
+    "RuBQRetrieval": (
+        "Given a question, retrieve Wikipedia passages that answer the question",
+        "",
+    ),
+    "MIRACLRetrieval": (
+        "Given a question, retrieve Wikipedia passages that answer the question",
+        "",
+    ),
+    "RiaNewsRetrieval": ("Given a news title, retrieve relevant news article", ""),
 }
 
 

--- a/scripts/task_selection/task_selection_example.ipynb
+++ b/scripts/task_selection/task_selection_example.ipynb
@@ -146,7 +146,9 @@
    "outputs": [],
    "source": [
     "# load results from mteb/results repository\n",
-    "mteb_results = mteb.load_results(models=models, tasks=danish_tasks, download_latest=False)"
+    "mteb_results = mteb.load_results(\n",
+    "    models=models, tasks=danish_tasks, download_latest=False\n",
+    ")"
    ]
   },
   {
@@ -1095,7 +1097,6 @@
     "\n",
     "def is_candidate_valid_removal(current_tasks: list[str], task_to_remove: str) -> bool:\n",
     "    \"\"\"Determine if target task should be removed. This simply checks that all task types are present in the current tasks or whether the task is in the tasks_to_keep list.\"\"\"\n",
-    "\n",
     "    if task_to_remove in tasks_to_keep:\n",
     "        return False\n",
     "\n",
@@ -1622,13 +1623,11 @@
     }
    ],
    "source": [
-    "\n",
     "import mteb.task_aggregation as task_aggregation\n",
-    "\n",
     "\n",
     "mean = task_aggregation.mean(mteb_results)\n",
     "weighted_mean = task_aggregation.task_category_weighted_mean(mteb_results)\n",
-    "borda = task_aggregation.borda_count(mteb_results) "
+    "borda = task_aggregation.borda_count(mteb_results)"
    ]
   },
   {
@@ -1820,19 +1819,18 @@
     "data = []\n",
     "for model_name, revisions in borda.items():\n",
     "    for rev, avg_score in revisions.items():\n",
-    "            data.append(\n",
+    "        data.append(\n",
     "            {\n",
     "                \"model\": model_name,\n",
     "                \"revision\": rev,\n",
     "                \"mean\": mean[model_name][rev],\n",
     "                \"weighted_mean\": weighted_mean[model_name][rev],\n",
     "                \"borda_count\": avg_score,\n",
-    "\n",
     "            }\n",
     "        )\n",
     "\n",
     "df = pd.DataFrame(data)\n",
-    "df.sort_values(\"borda_count\", ascending=False)\n"
+    "df.sort_values(\"borda_count\", ascending=False)"
    ]
   }
  ],


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

This PR updates composition of tasks in Russian part of MTEB. Namely, it adds recently merged MIRACL (#833, #830), RuBQReranking, Multi-label tasks CEDR and SensitiveTopics (#881) and RuParaphraser (#716). 

Also, PR adds instructions (in English) for all tasks from the benchmark, which allows better test the potential of instructional models (e.g. e5-instruct models).

## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 