### PR TITLE
fix: Remove unavailable test split from OCNLI 

### DIFF
--- a/mteb/evaluation/evaluators/PairClassificationEvaluator.py
+++ b/mteb/evaluation/evaluators/PairClassificationEvaluator.py
@@ -140,7 +140,7 @@ class PairClassificationEvaluator(Evaluator):
                 max_scores[metric_name].append(metric_value)
 
         for metric in max_scores:
-            if metric in ["f1", "ap", "f1", "precision", "recall"]:
+            if metric in ["f1", "ap", "f1", "precision", "recall", "accuracy"]:
                 output_scores[f"max_{metric}"] = max(max_scores[metric])
 
         return output_scores

--- a/mteb/tasks/PairClassification/zho/CMTEBPairClassification.py
+++ b/mteb/tasks/PairClassification/zho/CMTEBPairClassification.py
@@ -16,7 +16,7 @@ class Ocnli(AbsTaskPairClassification):
         type="PairClassification",
         category="s2s",
         modalities=["text"],
-        eval_splits=["validation", "test"],
+        eval_splits=["validation"],
         eval_langs=["cmn-Hans"],
         main_score="max_accuracy",
         date=None,


### PR DESCRIPTION
Fix https://github.com/embeddings-benchmark/mteb/pull/1061#issuecomment-2303061402

Removed test split, because [OCNLI](https://huggingface.co/datasets/C-MTEB/OCNLI) doesn't have it.


## Checklist
<!-- Please do not delete this -->

- [X] Run tests locally to make sure nothing is broken using `make test`. 
- [X] Run the formatter to format the code using `make lint`. 
