### PR TITLE
fix: Ensure seed is based on RNG State

### DIFF
--- a/mteb/abstasks/AbsTaskClassification.py
+++ b/mteb/abstasks/AbsTaskClassification.py
@@ -190,7 +190,8 @@ class AbsTaskClassification(AbsTask):
         y_sampled = []
         if idxs is None:
             idxs = np.arange(len(y))
-        np.random.shuffle(idxs)
+        rng_state = np.random.default_rng(self.seed)
+        rng_state.shuffle(idxs)
         label_counter = defaultdict(int)
         for i in idxs:
             if label_counter[y[i]] < samples_per_label:


### PR DESCRIPTION
The global seed (see also #942) cause variance in performance estimation depending on the order in which tasks are run, we see an example here:

https://github.com/embeddings-benchmark/results/pull/19#discussion_r1741573217

In #942 I propose a more general fix to this issue, but this PR as well as using a consistent seed will naturally causes slightly different scores as RNG states changes. 

We might want to avoid merging this change until we change the major version (and then do #942 fully).

## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 

