### PR TITLE
fix OpenAI BadRequestError by limiting input dimensions to 2048 elements

### DIFF
--- a/mteb/models/openai_models.py
+++ b/mteb/models/openai_models.py
@@ -31,14 +31,22 @@ class OpenAIWrapper:
                 "Reducing embedding size available only for text-embedding-3-* models"
             )
 
-        return self._to_numpy(
-            self._client.embeddings.create(
-                input=sentences,
+        max_batch_size = 2048
+        sublists = [sentences[i:i + max_batch_size]
+                    for i in range(0, len(sentences), max_batch_size)]
+
+        all_embeddings = []
+
+        for sublist in sublists:
+            response = self._client.embeddings.create(
+                input=sublist,
                 model=self._model_name,
                 encoding_format="float",
                 dimensions=self._embed_dim or NotGiven(),
             )
-        )
+            all_embeddings.extend(self._to_numpy(response))
+
+        return np.array(all_embeddings)
 
     def encode_queries(self, queries: list[str], **kwargs: Any) -> np.ndarray:
         return self.encode(queries, **kwargs)


### PR DESCRIPTION
- Ensure the `sentences` list passed to OpenAI API does not exceed 2048 elements, a fix to issue #1200 
- Reference: [OpenAI's Embedding API documentation](https://platform.openai.com/docs/api-reference/embeddings/create) on input limits

## Checklist
<!-- Please do not delete this -->

- [ ] Run tests locally to make sure nothing is broken using `make test`. 
`test_mulitple_mteb_tasks` fails, but the same test fails with the current MTEB repository.
- [x] Run the formatter to format the code using `make lint`. 