### PR TITLE
BUG: if the model defines a similarity score, STS pearson and spearman are written as arrays, not as scores.

### DIFF
--- a/mteb/evaluation/evaluators/STSEvaluator.py
+++ b/mteb/evaluation/evaluators/STSEvaluator.py
@@ -77,8 +77,8 @@ class STSEvaluator(Evaluator):
             similarity_scores = np.array(_similarity_scores)
 
         if similarity_scores is not None:
-            pearson = pearsonr(self.gold_scores, similarity_scores)
-            spearman = spearmanr(self.gold_scores, similarity_scores)
+            pearson, _ = pearsonr(self.gold_scores, similarity_scores)
+            spearman, _ = spearmanr(self.gold_scores, similarity_scores)
         else:
             # if model does not have a similarity function, we assume the cosine similarity
             pearson = cosine_pearson


### PR DESCRIPTION
Fixes #1206


<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->


## Checklist
<!-- Please do not delete this -->

- [ ] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 
