### PR TITLE
fix: Get meta from CrossEncoder

### DIFF
--- a/mteb/models/__init__.py
+++ b/mteb/models/__init__.py
@@ -72,7 +72,7 @@ def get_model_meta(model_name: str, revision: str | None = None) -> ModelMeta:
                 f"Model revision {revision} not found for model {model_name}. Expected {models[model_name].revision}."
             )
         return models[model_name]
-    
+
     # assume it is a sentence-transformers model
     logger.info(
         "Model not found in model registry, assuming it is a sentence-transformers model."
@@ -80,9 +80,7 @@ def get_model_meta(model_name: str, revision: str | None = None) -> ModelMeta:
     logger.info(
         f"Attempting to extract metadata by loading the model ({model_name}) using sentence-transformers."
     )
-    model = SentenceTransformer(
-        model_name, revision=revision, trust_remote_code=True
-    )
+    model = SentenceTransformer(model_name, revision=revision, trust_remote_code=True)
     meta = model_meta_from_sentence_transformers(model)
 
     meta.revision = revision
@@ -90,7 +88,9 @@ def get_model_meta(model_name: str, revision: str | None = None) -> ModelMeta:
     return meta
 
 
-def model_meta_from_sentence_transformers(model: CrossEncoder | SentenceTransformer) -> ModelMeta:
+def model_meta_from_sentence_transformers(
+    model: CrossEncoder | SentenceTransformer,
+) -> ModelMeta:
     if isinstance(model, SentenceTransformer):
         name = (
             model.model_card_data.model_name

--- a/mteb/models/__init__.py
+++ b/mteb/models/__init__.py
@@ -72,20 +72,21 @@ def get_model_meta(model_name: str, revision: str | None = None) -> ModelMeta:
                 f"Model revision {revision} not found for model {model_name}. Expected {models[model_name].revision}."
             )
         return models[model_name]
-    else:  # assume it is a sentence-transformers model
-        logger.info(
-            "Model not found in model registry, assuming it is a sentence-transformers model."
-        )
-        logger.info(
-            f"Attempting to extract metadata by loading the model ({model_name}) using sentence-transformers."
-        )
-        model = SentenceTransformer(
-            model_name, revision=revision, trust_remote_code=True
-        )
-        meta = model_meta_from_sentence_transformers(model)
+    
+    # assume it is a sentence-transformers model
+    logger.info(
+        "Model not found in model registry, assuming it is a sentence-transformers model."
+    )
+    logger.info(
+        f"Attempting to extract metadata by loading the model ({model_name}) using sentence-transformers."
+    )
+    model = SentenceTransformer(
+        model_name, revision=revision, trust_remote_code=True
+    )
+    meta = model_meta_from_sentence_transformers(model)
 
-        meta.revision = revision
-        meta.name = model_name
+    meta.revision = revision
+    meta.name = model_name
     return meta
 
 

--- a/tests/test_tasks/test_mteb_rerank.py
+++ b/tests/test_tasks/test_mteb_rerank.py
@@ -390,7 +390,7 @@ def test_reranker_same_ndcg1():
         stage1 = json.load(f)
 
     with open(
-        "tests/results/stage2/no_model_name_available/no_revision_available/SciFact.json"
+        "tests/results/stage2/cross-encoder__ms-marco-TinyBERT-L-2-v2/no_revision_available/SciFact.json"
     ) as f:
         stage2 = json.load(f)
 


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->
Address #1192. Running the snipper in the issue description should return no WARNINGs now.

- Use the config attribute of [CrossEncoder](https://github.com/UKPLab/sentence-transformers/blob/master/sentence_transformers/cross_encoder/CrossEncoder.py) to get model name
- Small cosmetic fix on indent after return statement

## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 

CC @orionw @Muennighoff as you were part of the discussion in the last PR.