### PR TITLE
fix: Add listing all available benchmarks CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ df = results_to_dataframe(results)
 | Documentation                  |                        |
 | ------------------------------ | ---------------------- |
 | 📋 [Tasks] | Overview of available tasks |
+| 📐 [Benchmarks] | Overview of available benchmarks |
 | 📈 [Leaderboard] | The interactive leaderboard of the benchmark |
 | 🤖 [Adding a model] | Information related to how to submit a model to the leaderboard |
 | 👩‍🔬 [Reproducible workflows] | Information related to how to reproduce and create reproducible workflows with MTEB |
@@ -387,6 +388,7 @@ df = results_to_dataframe(results)
 | 🌐 [MMTEB] | An open-source effort to extend MTEB to cover a broad set of languages |  
 
 [Tasks]: docs/tasks.md
+[Benchmarks]: docs/benchmarks.md
 [Contributing]: CONTRIBUTING.md
 [Adding a model]: docs/adding_a_model.md
 [Adding a dataset]: docs/adding_a_dataset.md

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,5 +1,5 @@
 ## Available benchmarks
-The following tables give you an overview of the benchmarks in MTEB.
+The following table gives you an overview of the benchmarks in MTEB.
 
 <details>
 

--- a/mteb/cli.py
+++ b/mteb/cli.py
@@ -30,6 +30,14 @@ mteb available_tasks # list all available tasks
 mteb available_tasks --task_types Clustering # list tasks of type Clustering
 ```
 
+## Listing Available Benchmarks
+
+To list the available benchmarks within MTEB, use the `mteb available_benchmarks` command. For example:
+
+```bash
+mteb available_benchmarks # list all available benchmarks
+```
+
 
 ## Creating Model Metadata
 
@@ -144,6 +152,12 @@ def run(args: argparse.Namespace) -> None:
     _save_model_metadata(model, Path(args.output_folder))
 
 
+def available_benchmarks(args: argparse.Namespace) -> None:
+    benchmarks = mteb.get_benchmarks()
+    eval = mteb.MTEB(tasks=benchmarks)
+    eval.mteb_benchmarks()
+
+
 def available_tasks(args: argparse.Namespace) -> None:
     tasks = mteb.get_tasks(
         categories=args.categories,
@@ -196,6 +210,15 @@ def add_available_tasks_parser(subparsers) -> None:
     add_task_selection_args(parser)
 
     parser.set_defaults(func=available_tasks)
+
+
+def add_available_benchmarks_parser(subparsers) -> None:
+    parser = subparsers.add_parser(
+        "available_benchmarks", help="List the available benchmarks within MTEB"
+    )
+    add_task_selection_args(parser)
+
+    parser.set_defaults(func=available_benchmarks)
 
 
 def add_run_parser(subparsers) -> None:
@@ -321,6 +344,7 @@ def main():
     )
     add_run_parser(subparsers)
     add_available_tasks_parser(subparsers)
+    add_available_benchmarks_parser(subparsers)
     add_create_meta_parser(subparsers)
 
     args = parser.parse_args()

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -168,6 +168,12 @@ class MTEB:
                     console.print(f"{prefix}{name}{category}{multilingual}")
                 console.print("\n")
 
+    def mteb_benchmarks(self):
+        """Get all benchmarks available in the MTEB."""
+        for benchmark in self._tasks:
+            name = benchmark.name
+            self._display_tasks(benchmark.tasks, name=name)
+
     @classmethod
     def mteb_tasks(cls):
         """Get all tasks available in the MTEB."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,6 +22,15 @@ def test_available_tasks():
     ), "Sample task Banking77Classification task not found in available tasks"
 
 
+def test_available_benchmarks():
+    command = f"{sys.executable} -m mteb available_benchmarks"
+    result = subprocess.run(command, shell=True, capture_output=True, text=True)
+    assert result.returncode == 0, "Command failed"
+    assert (
+        "MTEB(eng)" in result.stdout
+    ), "Sample benchmark MTEB(eng) task not found in available bencmarks"
+
+
 run_task_fixures = [
     (
         "average_word_embeddings_komninos",


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->
Addresses #1250 point 1. 

- Add benchmarks under the "Docs" section of README
- Add CLI option to list all available benchmarks
  - Headers will print the benchmark name
  - The tasks will be printed the same way as it is now
- Add test case for the added CLI option

## Example
This command should yield something like the following, starting with MTEB(eng):
```
mteb available_benchmarks
```
<details>
<summary>Full printout</summary>

```bash
>> mteb available_benchmarks
─────────────────────────────────────────────────────────────── MTEB(eng)  ────────────────────────────────────────────────────────────────
Summarization
    - SummEval, p2p


PairClassification
    - SprintDuplicateQuestions, s2s
    - TwitterSemEval2015, s2s
    - TwitterURLCorpus, s2s


Classification
    - AmazonCounterfactualClassification, s2s, multilingual 2 / 4 Subsets
    - AmazonPolarityClassification, p2p
    - AmazonReviewsClassification, s2s, multilingual 1 / 6 Subsets
    - Banking77Classification, s2s
    - EmotionClassification, s2s
    - ImdbClassification, p2p
    - MTOPDomainClassification, s2s, multilingual 1 / 6 Subsets
    - MTOPIntentClassification, s2s, multilingual 1 / 6 Subsets
    - MassiveIntentClassification, s2s, multilingual 1 / 51 Subsets
    - MassiveScenarioClassification, s2s, multilingual 1 / 51 Subsets
    - ToxicConversationsClassification, s2s
    - TweetSentimentExtractionClassification, s2s


Retrieval
    - ArguAna, s2p
    - CQADupstackAndroidRetrieval, s2p
    - CQADupstackEnglishRetrieval, s2p
    - CQADupstackGamingRetrieval, s2p
    - CQADupstackGisRetrieval, s2p
    - CQADupstackMathematicaRetrieval, s2p
    - CQADupstackPhysicsRetrieval, s2p
    - CQADupstackProgrammersRetrieval, s2p
    - CQADupstackStatsRetrieval, s2p
    - CQADupstackTexRetrieval, s2p
    - CQADupstackUnixRetrieval, s2p
    - CQADupstackWebmastersRetrieval, s2p
    - CQADupstackWordpressRetrieval, s2p
    - ClimateFEVER, s2p
    - DBPedia, s2p
    - FEVER, s2p
    - FiQA2018, s2p
    - HotpotQA, s2p
    - MSMARCO, s2p
    - NFCorpus, s2p
    - NQ, s2p
    - QuoraRetrieval, s2s
    - SCIDOCS, s2p
    - SciFact, s2p
    - TRECCOVID, s2p
    - Touche2020, s2p


STS
    - BIOSSES, s2s
    - SICK-R, s2s
    - STS12, s2s
    - STS13, s2s
    - STS14, s2s
    - STS15, s2s
    - STS16, s2s
    - STS17, s2s, multilingual 8 / 11 Subsets
    - STS22, p2p, multilingual 5 / 18 Subsets
    - STSBenchmark, s2s


Clustering
    - ArxivClusteringP2P, p2p
    - ArxivClusteringS2S, s2s
    - BiorxivClusteringP2P, p2p
    - BiorxivClusteringS2S, s2s
    - MedrxivClusteringP2P, p2p
    - MedrxivClusteringS2S, s2s
    - RedditClustering, s2s
    - RedditClusteringP2P, p2p
    - StackExchangeClustering, s2s
    - StackExchangeClusteringP2P, p2p
    - TwentyNewsgroupsClustering, s2s


Reranking
    - AskUbuntuDupQuestions, s2s
    - MindSmallReranking, s2s
    - SciDocsRR, s2s
    - StackOverflowDupQuestions, s2s


─────────────────────────────────────────────────────────────── MTEB(rus)  ────────────────────────────────────────────────────────────────
PairClassification
    - TERRa, s2s


Classification
    - GeoreviewClassification, p2p
    - HeadlineClassification, s2s
    - InappropriatenessClassification, s2s
    - KinopoiskClassification, p2p
    - MassiveIntentClassification, s2s, multilingual 1 / 51 Subsets
    - MassiveScenarioClassification, s2s, multilingual 1 / 51 Subsets
    - RuReviewsClassification, p2p
    - RuSciBenchGRNTIClassification, p2p
    - RuSciBenchOECDClassification, p2p


MultilabelClassification
    - CEDRClassification, s2s
    - SensitiveTopicsClassification, s2s


Retrieval
    - MIRACLRetrieval, s2p, multilingual 1 / 18 Subsets
    - RiaNewsRetrieval, s2p
    - RuBQRetrieval, s2p


STS
    - RUParaPhraserSTS, s2s
    - RuSTSBenchmarkSTS, s2s
    - STS22, p2p, multilingual 1 / 18 Subsets


Clustering
    - GeoreviewClusteringP2P, p2p
    - RuSciBenchGRNTIClusteringP2P, p2p
    - RuSciBenchOECDClusteringP2P, p2p


Reranking
    - MIRACLReranking, s2s, multilingual 1 / 18 Subsets
    - RuBQReranking, s2p


───────────────────────────────────────────────────── MTEB(Retrieval w/Instructions)  ─────────────────────────────────────────────────────
InstructionRetrieval
    - Robust04InstructionRetrieval, s2p
    - News21InstructionRetrieval, s2p
    - Core17InstructionRetrieval, s2p


─────────────────────────────────────────────────────────────── MTEB(law)  ────────────────────────────────────────────────────────────────
Retrieval
    - AILACasedocs, p2p
    - AILAStatutes, p2p
    - LegalSummarization, s2p
    - GerDaLIRSmall, p2p
    - LeCaRDv2, p2p
    - LegalBenchConsumerContractsQA, s2p
    - LegalBenchCorporateLobbying, s2p
    - LegalQuAD, s2p


─────────────────────────────────────────────────────────── MINERSBitextMining  ───────────────────────────────────────────────────────────
BitextMining
    - BUCC, s2s, multilingual 4 / 4 Subsets
    - LinceMTBitextMining, s2s, multilingual 1 / 1 Subsets
    - NollySentiBitextMining, s2s, multilingual 4 / 4 Subsets
    - NusaXBitextMining, s2s, multilingual 11 / 11 Subsets
    - NusaTranslationBitextMining, s2s, multilingual 11 / 11 Subsets
    - PhincBitextMining, s2s, multilingual 1 / 1 Subsets
    - Tatoeba, s2s, multilingual 112 / 112 Subsets


─────────────────────────────────────────────────────────── MTEB(Scandinavian)  ───────────────────────────────────────────────────────────
Classification
    - AngryTweetsClassification, s2s
    - DanishPoliticalCommentsClassification, s2s
    - DalajClassification, s2s
    - DKHateClassification, s2s
    - LccSentimentClassification, s2s
    - MassiveIntentClassification, s2s, multilingual 3 / 51 Subsets
    - MassiveScenarioClassification, s2s, multilingual 3 / 51 Subsets
    - NordicLangClassification, s2s
    - NoRecClassification, s2s
    - NorwegianParliamentClassification, s2s
    - ScalaClassification, s2s, multilingual 4 / 4 Subsets
    - SwedishSentimentClassification, s2s
    - SweRecClassification, s2s


BitextMining
    - BornholmBitextMining, s2s
    - NorwegianCourtsBitextMining, s2s


Retrieval
    - DanFEVER, p2p
    - NorQuadRetrieval, p2p
    - SNLRetrieval, p2p
    - SwednRetrieval, p2p
    - SweFaqRetrieval, s2s
    - TV2Nordretrieval, p2p
    - TwitterHjerneRetrieval, p2p


Clustering
    - SNLHierarchicalClusteringS2S, s2s
    - SNLHierarchicalClusteringP2P, p2p
    - SwednClusteringP2P, p2p
    - SwednClusteringS2S, s2s
    - VGHierarchicalClusteringS2S, p2p
    - VGHierarchicalClusteringP2P, p2p


────────────────────────────────────────────────────────────────── CoIR  ──────────────────────────────────────────────────────────────────
Retrieval
    - AppsRetrieval, p2p
    - CodeFeedbackMT, p2p
    - CodeFeedbackST, p2p
    - CodeSearchNetCCRetrieval, p2p, multilingual 6 / 6 Subsets
    - CodeTransOceanContest, p2p
    - CodeTransOceanDL, p2p
    - CosQA, p2p
    - COIRCodeSearchNetRetrieval, p2p, multilingual 6 / 6 Subsets
    - StackOverflowQA, p2p
    - SyntheticText2SQL, p2p


─────────────────────────────────────────────────────────────── MTEB(fra)  ────────────────────────────────────────────────────────────────
Summarization
    - SummEvalFr, p2p


PairClassification
    - OpusparcusPC, s2s, multilingual 1 / 6 Subsets
    - PawsXPairClassification, s2s, multilingual 1 / 7 Subsets


Classification
    - AmazonReviewsClassification, s2s, multilingual 1 / 6 Subsets
    - MasakhaNEWSClassification, s2s, multilingual 1 / 16 Subsets
    - MassiveIntentClassification, s2s, multilingual 1 / 51 Subsets
    - MassiveScenarioClassification, s2s, multilingual 1 / 51 Subsets
    - MTOPDomainClassification, s2s, multilingual 1 / 6 Subsets
    - MTOPIntentClassification, s2s, multilingual 1 / 6 Subsets


Retrieval
    - AlloprofRetrieval, s2p
    - BSARDRetrieval, s2p
    - MintakaRetrieval, s2p, multilingual 1 / 8 Subsets
    - SyntecRetrieval, s2p
    - XPQARetrieval, s2p, multilingual 3 / 36 Subsets


STS
    - SICKFr, s2s
    - STS22, p2p, multilingual 3 / 18 Subsets
    - STSBenchmarkMultilingualSTS, s2s, multilingual 1 / 10 Subsets


Clustering
    - AlloProfClusteringP2P, p2p
    - AlloProfClusteringS2S, s2s
    - HALClusteringS2S, s2s
    - MasakhaNEWSClusteringP2P, p2p, multilingual 1 / 16 Subsets
    - MasakhaNEWSClusteringS2S, s2s, multilingual 1 / 16 Subsets
    - MLSUMClusteringP2P, p2p, multilingual 1 / 4 Subsets
    - MLSUMClusteringS2S, s2s, multilingual 1 / 4 Subsets


Reranking
    - AlloprofReranking, s2p
    - SyntecReranking, s2p


─────────────────────────────────────────────────────────────── MTEB(deu)  ────────────────────────────────────────────────────────────────
PairClassification
    - FalseFriendsGermanEnglish, s2s
    - PawsXPairClassification, s2s, multilingual 1 / 7 Subsets


Classification
    - AmazonCounterfactualClassification, s2s, multilingual 1 / 4 Subsets
    - AmazonReviewsClassification, s2s, multilingual 1 / 6 Subsets
    - MTOPDomainClassification, s2s, multilingual 1 / 6 Subsets
    - MTOPIntentClassification, s2s, multilingual 1 / 6 Subsets
    - MassiveIntentClassification, s2s, multilingual 1 / 51 Subsets
    - MassiveScenarioClassification, s2s, multilingual 1 / 51 Subsets


Retrieval
    - GermanQuAD-Retrieval, s2p
    - GermanDPR, s2p
    - XMarket, s2p, multilingual 1 / 3 Subsets
    - GerDaLIR, s2p


STS
    - GermanSTSBenchmark, s2s
    - STS22, p2p, multilingual 4 / 18 Subsets


Clustering
    - BlurbsClusteringP2P, p2p
    - BlurbsClusteringS2S, s2s
    - TenKGnadClusteringP2P, p2p
    - TenKGnadClusteringS2S, s2s


Reranking
    - MIRACLReranking, s2s, multilingual 1 / 18 Subsets


─────────────────────────────────────────────────────────────── MTEB(kor)  ────────────────────────────────────────────────────────────────
Classification
    - KLUE-TC, s2s


Retrieval
    - MIRACLRetrieval, s2p, multilingual 1 / 18 Subsets
    - Ko-StrategyQA, s2p


STS
    - KLUE-STS, s2s
    - KorSTS, s2s


Reranking
    - MIRACLReranking, s2s, multilingual 1 / 18 Subsets


─────────────────────────────────────────────────────────────── MTEB(pol)  ────────────────────────────────────────────────────────────────
PairClassification
    - CDSC-E, s2s
    - PpcPC, s2s
    - PSC, s2s
    - SICK-E-PL, s2s


Classification
    - AllegroReviews, s2s
    - CBD, s2s
    - MassiveIntentClassification, s2s, multilingual 1 / 51 Subsets
    - MassiveScenarioClassification, s2s, multilingual 1 / 51 Subsets
    - PolEmo2.0-IN, s2s
    - PolEmo2.0-OUT, s2s
    - PAC, p2p


STS
    - CDSC-R, s2s
    - STS22, p2p, multilingual 4 / 18 Subsets
    - STSBenchmarkMultilingualSTS, s2s, multilingual 1 / 10 Subsets
    - SICK-R-PL, s2s


Clustering
    - EightTagsClustering, s2s
    - PlscClusteringS2S, s2s
    - PlscClusteringP2P, s2s


─────────────────────────────────────────────────────────────── MTEB(code)  ───────────────────────────────────────────────────────────────
Retrieval
    - AppsRetrieval, p2p
    - CodeEditSearchRetrieval, p2p, multilingual 13 / 13 Subsets
    - CodeFeedbackMT, p2p
    - CodeFeedbackST, p2p
    - CodeSearchNetCCRetrieval, p2p, multilingual 6 / 6 Subsets
    - CodeSearchNetRetrieval, p2p, multilingual 6 / 6 Subsets
    - CodeTransOceanContest, p2p
    - CodeTransOceanDL, p2p
    - CosQA, p2p
    - COIRCodeSearchNetRetrieval, p2p, multilingual 6 / 6 Subsets
    - StackOverflowQA, p2p
    - SyntheticText2SQL, p2p


─────────────────────────────────────────────────────────── MTEB(Multilingual)  ───────────────────────────────────────────────────────────
PairClassification
    - CTKFactsNLI, s2s
    - SprintDuplicateQuestions, s2s
    - TwitterURLCorpus, s2s
    - ArmenianParaphrasePC, s2s
    - indonli, s2s
    - OpusparcusPC, s2s, multilingual 6 / 6 Subsets
    - PawsXPairClassification, s2s, multilingual 7 / 7 Subsets
    - RTE3, s2s, multilingual 4 / 4 Subsets
    - XNLI, s2s, multilingual 14 / 14 Subsets
    - PpcPC, s2s
    - TERRa, s2s


Classification
    - BulgarianStoreReviewSentimentClassfication, s2s
    - CzechProductReviewSentimentClassification, s2s
    - GreekLegalCodeClassification, s2s
    - DBpediaClassification, s2s
    - FinancialPhrasebankClassification, s2s
    - PoemSentimentClassification, s2s
    - ToxicConversationsClassification, s2s
    - TweetTopicSingleClassification, s2s
    - EstonianValenceClassification, s2s
    - FilipinoShopeeReviewsClassification, s2s
    - GujaratiNewsClassification, s2s
    - SentimentAnalysisHindi, s2s
    - IndonesianIdClickbaitClassification, s2s
    - ItaCaseholdClassification, s2s
    - KorSarcasmClassification, s2s
    - KurdishSentimentClassification, s2s
    - MacedonianTweetSentimentClassification, s2s
    - AfriSentiClassification, s2s, multilingual 12 / 12 Subsets
    - AmazonCounterfactualClassification, s2s, multilingual 4 / 4 Subsets
    - CataloniaTweetClassification, s2s, multilingual 2 / 2 Subsets
    - CyrillicTurkicLangClassification, s2s
    - IndicLangClassification, s2s
    - MasakhaNEWSClassification, s2s, multilingual 16 / 16 Subsets
    - MassiveIntentClassification, s2s, multilingual 51 / 51 Subsets
    - MultiHateClassification, s2s, multilingual 11 / 11 Subsets
    - NordicLangClassification, s2s
    - NusaParagraphEmotionClassification, s2s, multilingual 10 / 10 Subsets
    - NusaX-senti, s2s, multilingual 12 / 12 Subsets
    - ScalaClassification, s2s, multilingual 4 / 4 Subsets
    - SwissJudgementClassification, s2s, multilingual 3 / 3 Subsets
    - NepaliNewsClassification, s2s
    - OdiaNewsClassification, s2s
    - PunjabiNewsClassification, s2s
    - PolEmo2.0-OUT, s2s
    - PAC, p2p
    - SinhalaNewsClassification, s2s
    - CSFDSKMovieReviewSentimentClassification, s2s
    - SiswatiNewsClassification, s2s
    - SlovakMovieReviewSentimentClassification, s2s
    - SwahiliNewsClassification, s2s
    - DalajClassification, s2s
    - TswanaNewsClassification, s2s
    - IsiZuluNewsClassification, s2s


BitextMining
    - BornholmBitextMining, s2s
    - BibleNLPBitextMining, s2s, multilingual 1656 / 1656 Subsets
    - BUCC.v2, s2s, multilingual 4 / 4 Subsets
    - DiaBlaBitextMining, s2s, multilingual 2 / 2 Subsets
    - FloresBitextMining, s2s, multilingual 41412 / 41412 Subsets
    - IN22GenBitextMining, s2s, multilingual 506 / 506 Subsets
    - IndicGenBenchFloresBitextMining, s2s, multilingual 58 / 58 Subsets
    - NollySentiBitextMining, s2s, multilingual 4 / 4 Subsets
    - NorwegianCourtsBitextMining, s2s
    - NTREXBitextMining, s2s, multilingual 1916 / 1916 Subsets
    - NusaTranslationBitextMining, s2s, multilingual 11 / 11 Subsets
    - NusaXBitextMining, s2s, multilingual 11 / 11 Subsets
    - Tatoeba, s2s, multilingual 112 / 112 Subsets


MultilabelClassification
    - KorHateSpeechMLClassification, s2s
    - MalteseNewsClassification, s2s
    - MultiEURLEXMultilabelClassification, p2p, multilingual 23 / 23 Subsets
    - BrazilianToxicTweetsClassification, s2s
    - CEDRClassification, s2s


InstructionRetrieval
    - Core17InstructionRetrieval, s2p
    - News21InstructionRetrieval, s2p
    - Robust04InstructionRetrieval, s2p


Retrieval
    - StackOverflowQA, p2p
    - TwitterHjerneRetrieval, p2p
    - AILAStatutes, p2p
    - ArguAna, s2p
    - HagridRetrieval, s2p
    - LegalBenchCorporateLobbying, s2p
    - LEMBPasskeyRetrieval, s2p
    - SCIDOCS, s2p
    - SpartQA, s2s
    - TempReasonL1, s2s
    - TRECCOVID, s2p
    - WinoGrande, s2s
    - BelebeleRetrieval, s2p, multilingual 376 / 376 Subsets
    - MLQARetrieval, s2p, multilingual 49 / 49 Subsets
    - StatcanDialogueDatasetRetrieval, s2p, multilingual 2 / 2 Subsets
    - WikipediaRetrievalMultilingual, s2p, multilingual 16 / 16 Subsets
    - CovidRetrieval, s2p


STS
    - GermanSTSBenchmark, s2s
    - SICK-R, s2s
    - STS12, s2s
    - STS13, s2s
    - STS14, s2s
    - STS15, s2s
    - STSBenchmark, s2s
    - FaroeseSTS, s2s
    - FinParaSTS, s2s
    - JSICK, s2s
    - IndicCrosslingualSTS, s2s, multilingual 12 / 12 Subsets
    - SemRel24STS, s2s, multilingual 12 / 12 Subsets
    - STS17, s2s, multilingual 11 / 11 Subsets
    - STS22.v2, p2p, multilingual 18 / 18 Subsets
    - STSES, s2s
    - STSB, s2s


Clustering
    - WikiCitiesClustering, p2p
    - MasakhaNEWSClusteringS2S, s2s, multilingual 16 / 16 Subsets
    - RomaniBibleClustering, p2p
    - ArXivHierarchicalClusteringP2P, p2p
    - ArXivHierarchicalClusteringS2S, p2p
    - BigPatentClustering.v2, p2p
    - BiorxivClusteringP2P.v2, p2p
    - MedrxivClusteringP2P.v2, p2p
    - StackExchangeClustering.v2, s2s
    - AlloProfClusteringS2S.v2, s2s
    - HALClusteringS2S.v2, s2s
    - SIB200ClusteringS2S, s2s, multilingual 197 / 197 Subsets
    - WikiClusteringP2P.v2, p2p, multilingual 14 / 14 Subsets
    - SNLHierarchicalClusteringP2P, p2p
    - PlscClusteringP2P.v2, s2s
    - SwednClusteringP2P, p2p
    - CLSClusteringP2P.v2, p2p


Reranking
    - WebLINXCandidatesReranking, p2p
    - AlloprofReranking, s2p
    - VoyageMMarcoReranking, s2s
    - WikipediaRerankingMultilingual, s2p, multilingual 16 / 16 Subsets
    - RuBQReranking, s2p
    - T2Reranking, s2s

```

</details>

![image](https://github.com/user-attachments/assets/3d05c14f-8f40-4239-83bc-02afd7374292)


## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 
