### PR TITLE
fix: Select benchmarks CLI option

### DIFF
--- a/mteb/cli.py
+++ b/mteb/cli.py
@@ -122,12 +122,19 @@ def run(args: argparse.Namespace) -> None:
 
     model = mteb.get_model(args.model, args.model_revision, device=device)
 
-    tasks = mteb.get_tasks(
-        categories=args.categories,
-        task_types=args.task_types,
-        languages=args.languages,
-        tasks=args.tasks,
-    )
+    if args.benchmarks:
+        tasks = mteb.get_benchmarks(names=args.benchmarks)
+    else:
+        tasks = mteb.get_tasks(
+            categories=args.categories,
+            task_types=args.task_types,
+            languages=args.languages,
+            tasks=args.tasks,
+        )
+
+    import pdb
+
+    pdb.set_trace()
     eval = mteb.MTEB(tasks=tasks)
 
     encode_kwargs = {}
@@ -153,7 +160,7 @@ def run(args: argparse.Namespace) -> None:
 
 
 def available_benchmarks(args: argparse.Namespace) -> None:
-    benchmarks = mteb.get_benchmarks()
+    benchmarks = mteb.get_benchmarks(names=args.benchmarks)
     eval = mteb.MTEB(tasks=benchmarks)
     eval.mteb_benchmarks()
 
@@ -167,6 +174,18 @@ def available_tasks(args: argparse.Namespace) -> None:
     )
     eval = mteb.MTEB(tasks=tasks)
     eval.mteb_tasks()
+
+
+def add_benchmark_selection_args(parser: argparse.ArgumentParser) -> None:
+    """Adds arguments to the parser for filtering benchmarks by name."""
+    parser.add_argument(
+        "-b",
+        "--benchmarks",
+        nargs="+",
+        type=str,
+        default=None,
+        help="List of benchmark to be evaluated.",
+    )
 
 
 def add_task_selection_args(parser: argparse.ArgumentParser) -> None:
@@ -216,7 +235,7 @@ def add_available_benchmarks_parser(subparsers) -> None:
     parser = subparsers.add_parser(
         "available_benchmarks", help="List the available benchmarks within MTEB"
     )
-    add_task_selection_args(parser)
+    add_benchmark_selection_args(parser)
 
     parser.set_defaults(func=available_benchmarks)
 
@@ -232,6 +251,7 @@ def add_run_parser(subparsers) -> None:
     )
 
     add_task_selection_args(parser)
+    add_benchmark_selection_args(parser)
 
     parser.add_argument(
         "--device", type=int, default=None, help="Device to use for computation"

--- a/mteb/cli.py
+++ b/mteb/cli.py
@@ -132,9 +132,6 @@ def run(args: argparse.Namespace) -> None:
             tasks=args.tasks,
         )
 
-    import pdb
-
-    pdb.set_trace()
     eval = mteb.MTEB(tasks=tasks)
 
     encode_kwargs = {}

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -6,6 +6,7 @@ import os
 import traceback
 from copy import copy
 from datetime import datetime
+from itertools import chain
 from pathlib import Path
 from time import time
 from typing import Any, Iterable
@@ -58,6 +59,10 @@ class MTEB:
 
         if tasks is not None:
             self._tasks = tasks
+            if not isinstance(
+                tasks[0], AbsTask
+            ):  # So that passing in a list of Benchmarks works too. Trying to import Benchmark causes circular import.
+                self._tasks = list(chain.from_iterable(tasks))
             assert (
                 task_types is None and task_categories is None
             ), "Cannot specify both `tasks` and `task_types`/`task_categories`"

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -53,15 +53,15 @@ class MTEB:
             err_logs_path: Path to save error logs.
             kwargs: Additional arguments to be passed to the tasks
         """
+        from mteb.benchmarks import Benchmark
+
         self.deprecation_warning(
             task_types, task_categories, task_langs, tasks, version
         )
 
         if tasks is not None:
             self._tasks = tasks
-            if (
-                not isinstance(tasks[0], AbsTask) and not isinstance(tasks[0], str)
-            ):  # So that passing in a list of Benchmarks works too. Trying to import Benchmark causes circular import.
+            if isinstance(tasks[0], Benchmark):
                 self.benchmarks = tasks
                 self._tasks = list(chain.from_iterable(tasks))
             assert (

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -59,8 +59,8 @@ class MTEB:
 
         if tasks is not None:
             self._tasks = tasks
-            if not isinstance(
-                tasks[0], AbsTask
+            if (
+                not isinstance(tasks[0], AbsTask) and not isinstance(tasks[0], str)
             ):  # So that passing in a list of Benchmarks works too. Trying to import Benchmark causes circular import.
                 self.benchmarks = tasks
                 self._tasks = list(chain.from_iterable(tasks))

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -62,6 +62,7 @@ class MTEB:
             if not isinstance(
                 tasks[0], AbsTask
             ):  # So that passing in a list of Benchmarks works too. Trying to import Benchmark causes circular import.
+                self.benchmarks = tasks
                 self._tasks = list(chain.from_iterable(tasks))
             assert (
                 task_types is None and task_categories is None
@@ -175,7 +176,7 @@ class MTEB:
 
     def mteb_benchmarks(self):
         """Get all benchmarks available in the MTEB."""
-        for benchmark in self._tasks:
+        for benchmark in self.benchmarks:
             name = benchmark.name
             self._display_tasks(benchmark.tasks, name=name)
 

--- a/tests/test_benchmark/test_benchmark.py
+++ b/tests/test_benchmark/test_benchmark.py
@@ -159,6 +159,19 @@ def test_run_using_benchmark(model: mteb.Encoder):
     )  # we just want to test that it runs
 
 
+@pytest.mark.parametrize("model", [MockNumpyEncoder()])
+def test_run_using_list_of_benchmark(model: mteb.Encoder):
+    """Test that a list of benchmark objects can be run using the MTEB class."""
+    bench = [
+        Benchmark(name="test_bench", tasks=mteb.get_tasks(tasks=["STS12", "SummEval"]))
+    ]
+
+    eval = mteb.MTEB(tasks=bench)
+    eval.run(
+        model, output_folder="tests/results", overwrite_results=True
+    )  # we just want to test that it runs
+
+
 def test_benchmark_names_must_be_unique():
     import mteb.benchmarks.benchmarks as benchmark_module
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,6 +65,7 @@ def test_run_task(
         co2_tracker=None,
         overwrite=True,
         eval_splits=None,
+        benchmarks=None,
     )
 
     run(args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,7 +28,7 @@ def test_available_benchmarks():
     assert result.returncode == 0, "Command failed"
     assert (
         "MTEB(eng)" in result.stdout
-    ), "Sample benchmark MTEB(eng) task not found in available bencmarks"
+    ), "Sample benchmark MTEB(eng) task not found in available benchmarks"
 
 
 run_task_fixures = [

--- a/tests/test_tasks/test_mteb_rerank.py
+++ b/tests/test_tasks/test_mteb_rerank.py
@@ -351,7 +351,7 @@ def test_mteb_rerank(tmp_path: Path):
     tmp_file.unlink()
 
     # read in the results
-    with open("tests/results/SciFact_default_predictions.json") as f:
+    with open("tests/results/SciFact_predictions.json") as f:
         results = json.load(f)
 
     # check that only the top two results are re-orderd

--- a/tests/test_tasks/test_mteb_rerank.py
+++ b/tests/test_tasks/test_mteb_rerank.py
@@ -351,7 +351,7 @@ def test_mteb_rerank(tmp_path: Path):
     tmp_file.unlink()
 
     # read in the results
-    with open("tests/results/SciFact_predictions.json") as f:
+    with open("tests/results/SciFact_default_predictions.json") as f:
         results = json.load(f)
 
     # check that only the top two results are re-orderd


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->
Address #1250 point 2.
- Added test cases for a list of Benchmark objects passed into the task parameter
- Added command line option to select Benchmarks

The following can now run. 1) script
```python
from sentence_transformers import SentenceTransformer
import mteb

model_name = "average_word_embeddings_komninos"
model = SentenceTransformer(model_name)
benchmark = mteb.get_benchmarks(names=["MTEB(eng)"])
evaluation = mteb.MTEB(tasks=benchmark)
results = evaluation.run(model)
```
and command line:
```
mteb run -m average_word_embeddings_komninos -b 'MTEB(eng)'
```

## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 
