### PR TITLE
fix: derive `results_directory` path from `results_repo` name

### DIFF
--- a/mteb/load_results/load_results.py
+++ b/mteb/load_results/load_results.py
@@ -44,7 +44,7 @@ def download_of_results(
         cache_directory.mkdir(parents=True)
 
     # if "results" folder already exists update it
-    results_directory = cache_directory / "results"
+    results_directory = cache_directory / os.path.basename(results_repo)
     if results_directory.exists():
         if download_latest:
             logger.info(


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->

The `load_results` function includes a `results_repo` parameter, allowing the use of an alternative Git repository for storing the benchmarking results. This parameter is then passed to the `download_of_results` function. However, the current implementation requires the alternative repository to be named _results_, as this name is hardcoded.

This PR updates the code to derive the results_directory path from the repository name, removing the hardcoded requirement and giving more flexibility in naming the alternative repository.

## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 