### PR TITLE
fix: Add Retrieval SK Quad dataset for Slovak search evaluation

### DIFF
--- a/mteb/tasks/Retrieval/__init__.py
+++ b/mteb/tasks/Retrieval/__init__.py
@@ -131,6 +131,7 @@ from .pol.SciFactPLRetrieval import *
 from .pol.TRECCOVIDPLRetrieval import *
 from .rus.RiaNewsRetrieval import *
 from .rus.RuBQRetrieval import *
+from .slk.SKQuadRetrieval import *
 from .slk.SlovakSumRetrieval import *
 from .spa.SpanishPassageRetrievalS2P import *
 from .spa.SpanishPassageRetrievalS2S import *

--- a/mteb/tasks/Retrieval/slk/SKQuadRetrieval.py
+++ b/mteb/tasks/Retrieval/slk/SKQuadRetrieval.py
@@ -22,6 +22,7 @@ class SKQuadRetrieval(AbsTaskRetrieval):
         },
         type="Retrieval",
         category="s2s",
+        modalities=["text"],
         eval_splits=["test"],
         eval_langs=["slk-Latn"],
         main_score="ndcg_at_10",
@@ -31,6 +32,7 @@ class SKQuadRetrieval(AbsTaskRetrieval):
         license="cc-by-nc-sa-4.0",
         annotations_creators="human-annotated",
         dialect=[],
+        sample_creation="found",
         bibtex_citation="",
         descriptive_stats={
             "n_samples": {"test": 1134},

--- a/mteb/tasks/Retrieval/slk/SKQuadRetrieval.py
+++ b/mteb/tasks/Retrieval/slk/SKQuadRetrieval.py
@@ -25,14 +25,15 @@ class SKQuadRetrieval(AbsTaskRetrieval):
         eval_splits=["test"],
         eval_langs=["slk-Latn"],
         main_score="ndcg_at_10",
-        date=None,
+        date=("2024-05-30", "2024-06-13"),
         domains=["Encyclopaedic"],
         task_subtypes=["Question answering"],
         license="cc-by-nc-sa-4.0",
         annotations_creators="human-annotated",
         dialect=[],
+        bibtex_citation="",
         descriptive_stats={
-            "n_samples": None,
+            "n_samples": {"test": 1134},
             "avg_character_length": {
                 "test": {
                     "average_document_length": 1180.5071792496526,
@@ -45,7 +46,7 @@ class SKQuadRetrieval(AbsTaskRetrieval):
         },
     )
 
-    def load_data(self, eval_splits=None):
+    def load_data(self, eval_splits=None, **kwargs):
         """Load and preprocess datasets for retrieval task."""
         eval_splits = eval_splits or ["test"]
 

--- a/mteb/tasks/Retrieval/slk/SKQuadRetrieval.py
+++ b/mteb/tasks/Retrieval/slk/SKQuadRetrieval.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from datasets import load_dataset
+
+from mteb.abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+
+class SKQuadRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="SKQuadRetrieval",
+        description=(
+            "Retrieval SK Quad evaluates Slovak search performance using questions and answers "
+            "derived from the SK-QuAD dataset. It measures relevance with scores assigned to answers "
+            "based on their relevancy to corresponding questions, which is vital for improving "
+            "Slovak language search systems."
+        ),
+        reference="https://huggingface.co/datasets/TUKE-KEMT/retrieval-skquad",
+        dataset={
+            "path": "TUKE-KEMT/retrieval-skquad",
+            "revision": "09f81f51dd5b8497da16d02c69c98d5cb5993ef2",
+        },
+        type="Retrieval",
+        category="s2s",
+        eval_splits=["test"],
+        eval_langs=["slk-Latn"],
+        main_score="ndcg_at_10",
+        date=None,
+        domains=["Encyclopaedic"],
+        task_subtypes=["Question answering"],
+        license="cc-by-nc-sa-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        descriptive_stats={
+            "n_samples": None,
+            "avg_character_length": {
+                "test": {
+                    "average_document_length": 1180.5071792496526,
+                    "average_query_length": 53.63403880070547,
+                    "num_documents": 6477,
+                    "num_queries": 1134,
+                    "average_relevant_docs_per_query": 11,
+                }
+            },
+        },
+    )
+
+    def load_data(self, eval_splits=None):
+        """Load and preprocess datasets for retrieval task."""
+        eval_splits = eval_splits or ["test"]
+
+        # Load datasets
+        ds_default = load_dataset("TUKE-KEMT/retrieval-skquad", "default")
+        ds_corpus = load_dataset("TUKE-KEMT/retrieval-skquad", "corpus")
+        ds_query = load_dataset("TUKE-KEMT/retrieval-skquad", "queries")
+
+        if "test" in eval_splits:
+            # Corpus, Queries, and Relevance dictionary for 'test' split
+            self.corpus = {
+                "test": {
+                    row["_id"]: {"text": row["text"], "title": row["title"]}
+                    for row in ds_corpus["corpus"]
+                }
+            }
+            self.queries = {
+                "test": {row["_id"]: row["text"] for row in ds_query["queries"]}
+            }
+            self.relevant_docs = {"test": {}}
+
+            for row in ds_default["test"]:
+                self.relevant_docs["test"].setdefault(row["query-id"], {})[
+                    row["corpus-id"]
+                ] = int(row["score"])
+
+            print(
+                f"Data Loaded:\n- Corpus size: {len(self.corpus['test'])}\n- Query size: {len(self.queries['test'])}\n- Relevance entries: {len(self.relevant_docs['test'])}"
+            )


### PR DESCRIPTION
This commit introduces the Retrieval SK Quad dataset, designed to assess Slovak search performance. The dataset is derived from SK-QuAD and includes questions with their best answers categorized post-annotation. This addition provides a significant resource for advancing Slovak language search evaluation and supporting further research and development.


<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->


## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 


### Adding datasets checklist
<!-- see also https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md -->

**Reason for dataset addition**: ... <!-- Add reason for adding dataset here. E.g. it covers task/language/domain previously not covered -->

- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb -m {model_name} -t {task_name}` command.
  - [x] `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
  - [x] `intfloat/multilingual-e5-small`
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [x] If the dataset is too big (e.g. >2048 examples), considering using `self.stratified_subsampling() under dataset_transform()`
- [x] I have filled out the metadata object in the dataset file (find documentation on it [here](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md#2-creating-the-metadata-object)).
- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 
