### PR TITLE
fix QBQTC in C-MTEB

### DIFF
--- a/mteb/tasks/STS/zho/CMTEBSTS.py
+++ b/mteb/tasks/STS/zho/CMTEBSTS.py
@@ -304,3 +304,10 @@ class QBQTC(AbsTaskSTS):
         bibtex_citation=None,
         descriptive_stats={"n_samples": None, "avg_character_length": None},
     )
+
+    @property
+    def metadata_dict(self) -> dict[str, str]:
+        metadata_dict = super().metadata_dict
+        metadata_dict["min_score"] = 0
+        metadata_dict["max_score"] = 2
+        return metadata_dict


### PR DESCRIPTION
When reproducing C-MTEB evaluation, found that the QBQTC class (in STS/zho) should add a metadata_dict() function.