### PR TITLE
fix: Remove non-existent eval split of CMNLI

### DIFF
--- a/mteb/tasks/PairClassification/zho/CMTEBPairClassification.py
+++ b/mteb/tasks/PairClassification/zho/CMTEBPairClassification.py
@@ -54,7 +54,7 @@ class Cmnli(AbsTaskPairClassification):
         type="PairClassification",
         category="s2s",
         modalities=["text"],
-        eval_splits=["validation", "test"],
+        eval_splits=["validation"],
         eval_langs=["cmn-Hans"],
         main_score="max_accuracy",
         date=None,


### PR DESCRIPTION
Fix the KeyError of [CMNLI dataset](https://huggingface.co/datasets/C-MTEB/CMNLI) in C-MTEB:  'test' does not exist.