### PR TITLE
Re-upload dataset to hub to avoid using script upload

### DIFF
--- a/mteb/benchmarks/benchmarks.py
+++ b/mteb/benchmarks/benchmarks.py
@@ -63,6 +63,7 @@ class Benchmark:
             base_results = load_results()
         return base_results.select_tasks(self.tasks)
 
+
 MTEB_MAIN_EN = Benchmark(
     name="MTEB(eng)",
     tasks=get_tasks(

--- a/mteb/tasks/Clustering/multilingual/MLSUMClusteringP2P.py
+++ b/mteb/tasks/Clustering/multilingual/MLSUMClusteringP2P.py
@@ -26,11 +26,10 @@ class MLSUMClusteringP2P(AbsTaskClustering, MultilingualTask):
     metadata = TaskMetadata(
         name="MLSUMClusteringP2P",
         description="Clustering of newspaper article contents and titles from MLSUM dataset. Clustering of 10 sets on the newpaper article topics.",
-        reference="https://huggingface.co/datasets/reciTAL/mlsum",
+        reference="https://huggingface.co/datasets/mteb/mlsum",
         dataset={
-            "path": "reciTAL/mlsum",
-            "revision": "b5d54f8f3b61ae17845046286940f03c6bc79bc7",
-            "trust_remote_code": True,
+            "path": "mteb/mlsum",
+            "revision": "b4efe498c4d0b9d7bdd2905f6fff4e22ae251d00",
         },
         type="Clustering",
         category="p2p",
@@ -101,11 +100,10 @@ class MLSUMClusteringP2PFast(AbsTaskClusteringFast, MultilingualTask):
     metadata = TaskMetadata(
         name="MLSUMClusteringP2P.v2",
         description="Clustering of newspaper article contents and titles from MLSUM dataset. Clustering of 10 sets on the newpaper article topics.",
-        reference="https://huggingface.co/datasets/mlsum",
+        reference="https://huggingface.co/datasets/mteb/mlsum",
         dataset={
-            "path": "reciTAL/mlsum",
-            "revision": "b5d54f8f3b61ae17845046286940f03c6bc79bc7",
-            "trust_remote_code": True,
+            "path": "mteb/mlsum",
+            "revision": "b4efe498c4d0b9d7bdd2905f6fff4e22ae251d00",
         },
         type="Clustering",
         category="p2p",

--- a/mteb/tasks/Clustering/multilingual/MLSUMClusteringS2S.py
+++ b/mteb/tasks/Clustering/multilingual/MLSUMClusteringS2S.py
@@ -26,11 +26,10 @@ class MLSUMClusteringS2S(AbsTaskClustering, MultilingualTask):
     metadata = TaskMetadata(
         name="MLSUMClusteringS2S",
         description="Clustering of newspaper article contents and titles from MLSUM dataset. Clustering of 10 sets on the newpaper article topics.",
-        reference="https://huggingface.co/datasets/reciTAL/mlsum",
+        reference="https://huggingface.co/datasets/mteb/mlsum",
         dataset={
-            "path": "reciTAL/mlsum",
-            "revision": "b5d54f8f3b61ae17845046286940f03c6bc79bc7",
-            "trust_remote_code": True,
+            "path": "mteb/mlsum",
+            "revision": "b4efe498c4d0b9d7bdd2905f6fff4e22ae251d00",
         },
         type="Clustering",
         category="s2s",
@@ -96,11 +95,10 @@ class MLSUMClusteringS2SFast(AbsTaskClusteringFast, MultilingualTask):
     metadata = TaskMetadata(
         name="MLSUMClusteringS2S.v2",
         description="Clustering of newspaper article contents and titles from MLSUM dataset. Clustering of 10 sets on the newpaper article topics.",
-        reference="https://huggingface.co/datasets/mlsum",
+        reference="https://huggingface.co/datasets/mteb/mlsum",
         dataset={
-            "path": "reciTAL/mlsum",
-            "revision": "b5d54f8f3b61ae17845046286940f03c6bc79bc7",
-            "trust_remote_code": True,
+            "path": "mteb/mlsum",
+            "revision": "b4efe498c4d0b9d7bdd2905f6fff4e22ae251d00",
         },
         type="Clustering",
         category="s2s",


### PR DESCRIPTION
This should solve issue #1311.
I re-uploaded the dataset to parquet format here: https://huggingface.co/datasets/mteb/mlsum as suggested by @lhoestq, to avoid using the script generation for loading.