### PR TITLE
feat: update English benchmarks and mark MMTEB benchmarks as beta

### DIFF
--- a/mteb/benchmarks/benchmarks.py
+++ b/mteb/benchmarks/benchmarks.py
@@ -62,8 +62,60 @@ class Benchmark:
         return base_results.select_tasks(self.tasks)
 
 
-MTEB_MAIN_EN = Benchmark(
-    name="MTEB(eng)",
+MTEB_EN = Benchmark(
+    name="MTEB(eng, beta)",
+    tasks=get_tasks(
+        tasks=[
+            "AmazonCounterfactualClassification",
+            "ArguAna",
+            "ArXivHierarchicalClusteringP2P",
+            "ArXivHierarchicalClusteringS2S",
+            "AskUbuntuDupQuestions",
+            "BIOSSES",
+            "Banking77Classification",
+            "BiorxivClusteringP2P.v2",
+            "CQADupstackGamingRetrieval",
+            "CQADupstackUnixRetrieval",
+            "ClimateFEVERHardNegatives",
+            "FEVERHardNegatives",
+            "FiQA2018",
+            "HotpotQAHardNegatives",
+            "ImdbClassification",
+            "MTOPDomainClassification",
+            "MassiveIntentClassification",
+            "MassiveScenarioClassification",
+            "MedrxivClusteringP2P.v2",
+            "MedrxivClusteringS2S.v2",
+            "MindSmallReranking",
+            "SCIDOCS",
+            "SICK-R",
+            "STS12",
+            "STS13",
+            "STS14",
+            "STS15",
+            "STS17",
+            "STS22.v2",
+            "STSBenchmark",
+            "SprintDuplicateQuestions",
+            "StackExchangeClustering.v2",
+            "StackExchangeClusteringP2P.v2",
+            "TRECCOVID",
+            "Touche2020",
+            "ToxicConversationsClassification",
+            "TweetSentimentExtractionClassification",
+            "TwentyNewsgroupsClustering.v2",
+            "TwitterSemEval2015",
+            "TwitterURLCorpus",
+        ],
+        languages=["eng"],
+        eval_splits=["test"],
+    ),
+    description="English benchmarks from MTEB",
+    citation="",
+)
+
+MTEB_ENG_CLASSIC = Benchmark(
+    name="MTEB(eng, classic)",
     tasks=get_tasks(
         tasks=[
             "AmazonCounterfactualClassification",
@@ -137,7 +189,7 @@ MTEB_MAIN_EN = Benchmark(
         languages=["eng"],
         eval_splits=["test"],
     ),
-    description="Main English benchmarks from MTEB",
+    description="The original English benchmarks by Muennighoff et al., (2023).",
     citation="""@inproceedings{muennighoff-etal-2023-mteb,
     title = "{MTEB}: Massive Text Embedding Benchmark",
     author = "Muennighoff, Niklas  and
@@ -556,7 +608,7 @@ MTEB_code = Benchmark(
 
 
 MTEB_multilingual = Benchmark(
-    name="MTEB(Multilingual)",
+    name="MTEB(Multilingual, beta)",
     tasks=get_tasks(
         tasks=[
             "BornholmBitextMining",
@@ -734,7 +786,7 @@ MTEB_JPN = Benchmark(
 
 
 MTEB_INDIC = Benchmark(
-    name="MTEB(indic)",
+    name="MTEB(indic, beta)",
     tasks=get_tasks(
         tasks=[
             # Bitext
@@ -776,7 +828,7 @@ MTEB_INDIC = Benchmark(
 
 
 MTEB_EU = Benchmark(
-    name="MTEB(Europe)",
+    name="MTEB(Europe, beta)",
     tasks=get_tasks(
         tasks=[
             "BornholmBitextMining",

--- a/mteb/benchmarks/benchmarks.py
+++ b/mteb/benchmarks/benchmarks.py
@@ -106,6 +106,7 @@ MTEB_EN = Benchmark(
             "TwentyNewsgroupsClustering.v2",
             "TwitterSemEval2015",
             "TwitterURLCorpus",
+            "SummEvalSummarization.v2",
         ],
         languages=["eng"],
         eval_splits=["test"],


### PR DESCRIPTION
Seems like the original english benchmark have been overwritten with mteb(eng), which seems to have been a mistake. I have instead renamed it MTEB(eng, classic) and reverted to the original list.

I have additionally added MTEB(eng, beta) for the new MMTEB benchmark and marked MMTEB benchmarks as "beta" as well. This makes it clear that they are under development (which I believe is the best way to do it now).


<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->


## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 
