### PR TITLE
fix:  remove BrazilianToxicTweetsClassification from test grid

### DIFF
--- a/tests/test_benchmark/task_grid.py
+++ b/tests/test_benchmark/task_grid.py
@@ -56,7 +56,7 @@ TASK_TEST_GRID = [
     "SciDocsRR",  # reranking
     "FarsTail",  # pair classification
     "TwitterHjerneRetrieval",  # retrieval
-    "BrazilianToxicTweetsClassification",  # multilabel classification
+    "CEDRClassification",  # multilabel classification
     "FaroeseSTS",  # STS
     "SummEval",  # summarization
 ]


### PR DESCRIPTION
## Checklist
<!-- Please do not delete this -->

- [X] Run tests locally to make sure nothing is broken using `make test`. 
- [X] Run the formatter to format the code using `make lint`. 


Currently, there is no way to download `BrazilianToxicTweetsClassification` and because of this tests fails. Later I will try to reupload it somewhere