### PR TITLE
fix: make sure test is the default split for FEVER

### DIFF
--- a/mteb/tasks/Retrieval/eng/FEVERRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/FEVERRetrieval.py
@@ -23,7 +23,7 @@ class FEVER(AbsTaskRetrieval):
         type="Retrieval",
         category="s2p",
         modalities=["text"],
-        eval_splits=["train", "dev", "test"],
+        eval_splits=["test"],
         eval_langs=["eng-Latn"],
         main_score="ndcg_at_10",
         date=None,


### PR DESCRIPTION
The other splits can still be run as long as they are specified.

Adresses #1343
