### PR TITLE
fix: Speed up leaderboard by caching and skipping validation

### DIFF
--- a/mteb/benchmarks/benchmarks.py
+++ b/mteb/benchmarks/benchmarks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import Annotated
 
 from pydantic import AnyUrl, BeforeValidator, TypeAdapter
@@ -57,9 +58,15 @@ class Benchmark:
     def load_results(
         self, base_results: None | BenchmarkResults = None
     ) -> BenchmarkResults:
+        if not hasattr(self, "results_cache"):
+            self.results_cache = {}
+        if base_results in self.results_cache:
+            return self.results_cache[base_results]
         if base_results is None:
             base_results = load_results()
-        return base_results.select_tasks(self.tasks)
+        results = base_results.select_tasks(self.tasks)
+        self.results_cache[base_results] = results
+        return results
 
 
 MTEB_EN = Benchmark(

--- a/mteb/caching.py
+++ b/mteb/caching.py
@@ -1,0 +1,18 @@
+import json
+from functools import lru_cache
+from typing import Callable
+
+
+def json_cache(function: Callable):
+    """Caching decorator that can deal with anything json serializable"""
+    cached_results = {}
+
+    def wrapper(*args, **kwargs):
+        key = json.dumps({"__args": args, **kwargs})
+        if key in cached_results:
+            return cached_results[key]
+        result = function(*args, **kwargs)
+        cached_results[key] = result
+        return result
+
+    return wrapper

--- a/mteb/caching.py
+++ b/mteb/caching.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import json
-from functools import lru_cache
 from typing import Callable
 
 

--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from collections import defaultdict
 from pathlib import Path
 
@@ -17,7 +18,8 @@ def load_results():
         all_results.to_disk(results_cache_path)
         return all_results
     else:
-        return mteb.BenchmarkResults.from_disk(results_cache_path)
+        with results_cache_path.open() as cache_file:
+            return mteb.BenchmarkResults.from_validated(**json.load(cache_file))
 
 
 def update_citation(benchmark_name: str) -> str:

--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -8,6 +8,7 @@ import gradio as gr
 from gradio_rangeslider import RangeSlider
 
 import mteb
+from mteb.caching import json_cache
 from mteb.leaderboard.table import scores_to_tables
 
 
@@ -209,6 +210,7 @@ with gr.Blocks(fill_width=True, theme=gr.themes.Base(), head=head) as demo:
             domain_select,
         ],
     )
+    @json_cache
     def on_select_benchmark(benchmark_name):
         benchmark = mteb.get_benchmark(benchmark_name)
         benchmark_results = benchmark.load_results(base_results=all_results)
@@ -222,6 +224,7 @@ with gr.Blocks(fill_width=True, theme=gr.themes.Base(), head=head) as demo:
         inputs=[benchmark_select, lang_select, type_select, domain_select],
         outputs=[task_select],
     )
+    @json_cache
     def update_task_list(benchmark_name, languages, task_types, domains):
         benchmark = mteb.get_benchmark(benchmark_name)
         benchmark_results = benchmark.load_results(base_results=all_results)

--- a/mteb/load_results/benchmark_results.py
+++ b/mteb/load_results/benchmark_results.py
@@ -10,8 +10,7 @@ import numpy as np
 from pydantic import BaseModel, ConfigDict
 
 from mteb.abstasks.AbsTask import AbsTask, ScoresDict
-from mteb.abstasks.TaskMetadata import (ISO_LANGUAGE_SCRIPT, TASK_DOMAIN,
-                                        TASK_TYPE)
+from mteb.abstasks.TaskMetadata import ISO_LANGUAGE_SCRIPT, TASK_DOMAIN, TASK_TYPE
 from mteb.languages import ISO_LANGUAGE
 from mteb.load_results.task_results import TaskResult
 from mteb.models.overview import get_model_metas

--- a/mteb/load_results/benchmark_results.py
+++ b/mteb/load_results/benchmark_results.py
@@ -161,6 +161,9 @@ class BenchmarkResults(BaseModel):
         n_models = len(self.model_results)
         return f"BenchmarkResults(model_results=[...](#{n_models}))"
 
+    def __hash__(self) -> int:
+        return id(self)
+
     def filter_tasks(
         self,
         task_names: list[str] | None = None,

--- a/mteb/load_results/task_results.py
+++ b/mteb/load_results/task_results.py
@@ -510,5 +510,5 @@ class TaskResult(BaseModel):
         if seen_splits != set(splits):
             raise ValueError(f"Missing splits {set(splits) - seen_splits}")
         new_res = {**self.to_dict(), "scores": new_scores}
-        new_res = TaskResult.from_dict(new_res)
+        new_res = TaskResult.from_validated(**new_res)
         return new_res

--- a/mteb/load_results/task_results.py
+++ b/mteb/load_results/task_results.py
@@ -291,12 +291,8 @@ class TaskResult(BaseModel):
                 )
 
         pre_1_11_load = (
-            (
-                "mteb_version" in data
-                and Version(data["mteb_version"]) < Version("1.11.0")
-            )
-            or "mteb_version" not in data
-        )  # assume it is before 1.11.0 if the version is not present
+            "mteb_version" in data and Version(data["mteb_version"]) < Version("1.11.0")
+        ) or "mteb_version" not in data  # assume it is before 1.11.0 if the version is not present
         try:
             obj = cls.model_validate(data)
         except Exception as e:
@@ -465,6 +461,10 @@ class TaskResult(BaseModel):
                         break
 
             return aggregation(values)
+
+    @classmethod
+    def from_validated(cls, **data) -> TaskResult:
+        return cls.model_construct(**data)
 
     def __repr__(self) -> str:
         return f"TaskResult(task_name={self.task_name}, scores=...)"

--- a/mteb/load_results/task_results.py
+++ b/mteb/load_results/task_results.py
@@ -291,8 +291,12 @@ class TaskResult(BaseModel):
                 )
 
         pre_1_11_load = (
-            "mteb_version" in data and Version(data["mteb_version"]) < Version("1.11.0")
-        ) or "mteb_version" not in data  # assume it is before 1.11.0 if the version is not present
+            (
+                "mteb_version" in data
+                and Version(data["mteb_version"]) < Version("1.11.0")
+            )
+            or "mteb_version" not in data
+        )  # assume it is before 1.11.0 if the version is not present
         try:
             obj = cls.model_validate(data)
         except Exception as e:


### PR DESCRIPTION
fixes #1296 

I introduced the following optimizations:
 - Skipping validation, where unnecessary.
 - Caching results of large computations where possible.

This is a massive improvement, and I feel like the leaderboard is finally running at a rather usable speed.