### PR TITLE
Disable `rich` output with `verbosity=0` on `evaluation.run`

### DIFF
--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -371,7 +371,10 @@ class MTEB:
 
         # Run selected tasks
         logger.info(f"\n\n## Evaluating {len(self.tasks)} tasks:")
-        self.print_selected_tasks()
+
+        if verbosity > 0:
+            self.print_selected_tasks()
+
         evaluation_results = []
         original_tasks = (
             self.tasks.copy()

--- a/mteb/leaderboard/table.py
+++ b/mteb/leaderboard/table.py
@@ -41,7 +41,7 @@ def format_n_parameters(n_parameters) -> str:
 
 def split_on_capital(s: str) -> str:
     """Splits on capital letters and joins with spaces"""
-    if all([c.isupper() for c in s]):
+    if all(c.isupper() for c in s):
         return s
     return " ".join(re.findall("[A-Z][^A-Z]*", s))
 


### PR DESCRIPTION
This PR add support for disabling `rich` output on console with `verbosity=0` on `evaluation.run()`.

This solves #1385 and partially solves #1046

## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 
