### PR TITLE
[mieb] Fix open clip for cv bench count

### DIFF
--- a/mteb/models/openclip_models.py
+++ b/mteb/models/openclip_models.py
@@ -77,7 +77,7 @@ def openclip_loader(**kwargs):
                     for i in tqdm(range(0, len(images), batch_size)):
                         batch_images = images[i : i + batch_size]
                         inputs = torch.vstack(
-                            [self.img_preprocess(b) for b in batch_images]
+                            [self.img_preprocess(b).unsqueeze(0) for b in batch_images]
                         )
                         image_outputs = self.model.encode_image(inputs.to(self.device))
                         all_image_embeddings.append(image_outputs.cpu())


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->
fixes #1393 by adding `unsqueeze(0)` after applying preprocessing.

Running `mteb run -m laion/CLIP-ViT-B-32-DataComp.XL-s13B-b90K -t CVBenchCount` yields
```
********************** Evaluating CVBenchCount **********************
INFO:mteb.evaluation.MTEB:Loading dataset for CVBenchCount
INFO:mteb.abstasks.AbsTask:
Task: CVBenchCount, split: test, subset: default. Running...
/home/ubuntu/isaac/work/mteb/mteb/models/openclip_models.py:47: FutureWarning: `torch.cuda.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cuda', args...)` instead.
  with torch.no_grad(), torch.cuda.amp.autocast():
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  5.50it/s]
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 13/13 [00:00<00:00, 55.59it/s]
/home/ubuntu/isaac/work/mteb/mteb/models/openclip_models.py:76: FutureWarning: `torch.cuda.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cuda', args...)` instead.
  with torch.no_grad(), torch.cuda.amp.autocast():
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 13/13 [00:05<00:00,  2.32it/s]
788it [00:00, 2817.99it/s]
INFO:mteb.evaluation.MTEB:Evaluation for CVBenchCount on test took 9.98 seconds
INFO:mteb.evaluation.MTEB:Scores: {'default': {'accuracy': 0.23730964467005075, 'main_score': 0.23730964467005075}}
```

## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 