### PR TITLE
fix: add logging for RetrievalEvaluator NaN values for similarity scores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,4 @@ tests/create_meta/model_card.md
 
 # removed results from mteb repo they are now available at: https://github.com/embeddings-benchmark/results
 results/
+uv.lock

--- a/mteb/evaluation/evaluators/RetrievalEvaluator.py
+++ b/mteb/evaluation/evaluators/RetrievalEvaluator.py
@@ -188,7 +188,12 @@ class DenseRetrievalExactSearch:
             cos_scores = self.score_functions[score_function](
                 query_embeddings, sub_corpus_embeddings
             )
-            cos_scores[torch.isnan(cos_scores)] = -1
+            is_nan = torch.isnan(cos_scores)
+            if is_nan.sum() > 0:
+                logger.warning(
+                    f"Found {is_nan.sum()} NaN values in the similarity scores. Replacing NaN values with -1."
+                )
+            cos_scores[is_nan] = -1
 
             # Get top-k values
             cos_scores_top_k_values, cos_scores_top_k_idx = torch.topk(


### PR DESCRIPTION
Fixes #1389

Ran through tests but couldn't find a case where it was actually used. It might be a thing we can simply remove.

<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->


## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 
