### PR TITLE
fix: Add the_ugly_duckling.txt for speedtask to Python wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ exclude = ["tests", "results"]
 
 [tool.setuptools.package-data]
 "*" = ["*.json"]
+"mteb.abstasks" = ["the_ugly_duckling.txt"]
 
 [tool.ruff]
 


### PR DESCRIPTION
This PR adds the file `the_ugly_duckling.txt` to the Python wheel. Currently when installing mteb with `pip install mteb` and then running a SpeedTask you get the error below. This PR fixes that.

```
  File ".../venv/lib/python3.12/site-packages/mteb/abstasks/AbsTaskSpeedTask.py", line 35, in load_data
    with file_path.open("r") as f:
         ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/pathlib.py", line 1013, in open
    return io.open(self, mode, buffering, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '.../venv/lib/python3.12/site-packages/mteb/abstasks/the_ugly_duckling.txt'
```
