### PR TITLE
fix: Fix test for empty descriptive tasks 

### DIFF
--- a/tests/test_TaskMetadata.py
+++ b/tests/test_TaskMetadata.py
@@ -1088,10 +1088,8 @@ def test_empy_descriptive_stat_in_new_datasets():
         553 == len(exceptions)
     ), "The number of exceptions has changed. Please do not add new datasets to this list."
 
-    exceptions = []
-
     for task in get_tasks():
         if task.metadata.descriptive_stats is None:
             assert (
-                task.metadata.name not in exceptions
+                task.metadata.name in exceptions
             ), f"Dataset {task.metadata.name} should have descriptive stats"


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->


## Checklist
<!-- Please do not delete this -->

- [X] Run tests locally to make sure nothing is broken using `make test`. 
- [X] Run the formatter to format the code using `make lint`. 

It seems that when creating the test, I missed recreating the array in the test case, which caused the test to not work correctly. Fixes https://github.com/embeddings-benchmark/mteb/issues/1412