### PR TITLE
feat: enable codecarbon by default

### DIFF
--- a/mteb/cli.py
+++ b/mteb/cli.py
@@ -265,8 +265,8 @@ def add_run_parser(subparsers) -> None:
     parser.add_argument(
         "--co2_tracker",
         type=bool,
-        default=False,
-        help="Enable CO₂ tracker, disabled by default",
+        default=True,
+        help="Enable CO₂ tracker, enabled by default",
     )
     parser.add_argument(
         "--eval_splits",

--- a/mteb/cli.py
+++ b/mteb/cli.py
@@ -142,12 +142,14 @@ def run(args: argparse.Namespace) -> None:
         args.save_predictions if hasattr(args, "save_predictions") else False
     )
 
+    enable_co2_tracker = not args.disable_co2_tracker
+
     eval.run(
         model,
         verbosity=args.verbosity,
         output_folder=args.output_folder,
         eval_splits=args.eval_splits,
-        co2_tracker=args.disable_co2_tracker,
+        co2_tracker=enable_co2_tracker,
         overwrite_results=args.overwrite,
         encode_kwargs=encode_kwargs,
         save_predictions=save_predictions,
@@ -264,7 +266,7 @@ def add_run_parser(subparsers) -> None:
     )
     parser.add_argument(
         "--disable_co2_tracker",
-        type=bool,
+        action="store_true",
         default=False,
         help="Disable CO₂ tracker, enabled by default",
     )

--- a/mteb/cli.py
+++ b/mteb/cli.py
@@ -147,7 +147,7 @@ def run(args: argparse.Namespace) -> None:
         verbosity=args.verbosity,
         output_folder=args.output_folder,
         eval_splits=args.eval_splits,
-        co2_tracker=args.co2_tracker,
+        co2_tracker=args.disable_co2_tracker,
         overwrite_results=args.overwrite,
         encode_kwargs=encode_kwargs,
         save_predictions=save_predictions,
@@ -263,10 +263,10 @@ def add_run_parser(subparsers) -> None:
         "-v", "--verbosity", type=int, default=2, help="Verbosity level"
     )
     parser.add_argument(
-        "--co2_tracker",
+        "--disable_co2_tracker",
         type=bool,
-        default=True,
-        help="Enable CO₂ tracker, enabled by default",
+        default=False,
+        help="Disable CO₂ tracker, enabled by default",
     )
     parser.add_argument(
         "--eval_splits",

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -414,7 +414,7 @@ class MTEB:
                 for split in task_eval_splits:
                     if co2_tracker:
                         with EmissionsTracker(
-                            save_to_file=False, save_to_api=False, logging_logger=logger
+                            save_to_file=False, save_to_api=False, logging_logger=logger, allow_multiple_runs=True,
                         ) as tracker:
                             results, tick, tock = self._run_eval(
                                 task,

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -413,7 +413,9 @@ class MTEB:
                 kg_co2_emissions: int | None = 0 if co2_tracker else None
                 for split in task_eval_splits:
                     if co2_tracker:
-                        logger.warning("Evaluating multiple MTEB runs simultaniously will produce incorrect CO₂ results")
+                        logger.warning(
+                            "Evaluating multiple MTEB runs simultaniously will produce incorrect CO₂ results"
+                        )
                         with EmissionsTracker(
                             save_to_file=False,
                             save_to_api=False,

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -13,8 +13,8 @@ from time import time
 from typing import Any
 
 import datasets
-from sentence_transformers import SentenceTransformer
 from codecarbon import EmissionsTracker
+from sentence_transformers import SentenceTransformer
 
 from mteb.encoder_interface import Encoder
 from mteb.model_meta import ModelMeta

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -414,7 +414,10 @@ class MTEB:
                 for split in task_eval_splits:
                     if co2_tracker:
                         with EmissionsTracker(
-                            save_to_file=False, save_to_api=False, logging_logger=logger, allow_multiple_runs=True,
+                            save_to_file=False,
+                            save_to_api=False,
+                            logging_logger=logger,
+                            allow_multiple_runs=True,
                         ) as tracker:
                             results, tick, tock = self._run_eval(
                                 task,

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -413,6 +413,7 @@ class MTEB:
                 kg_co2_emissions: int | None = 0 if co2_tracker else None
                 for split in task_eval_splits:
                     if co2_tracker:
+                        logger.warning("Evaluating multiple MTEB runs simultaniously will produce incorrect CO₂ results")
                         with EmissionsTracker(
                             save_to_file=False,
                             save_to_api=False,

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import datasets
 from sentence_transformers import SentenceTransformer
+from codecarbon import EmissionsTracker
 
 from mteb.encoder_interface import Encoder
 from mteb.model_meta import ModelMeta
@@ -316,7 +317,7 @@ class MTEB:
         eval_splits=None,
         overwrite_results: bool = False,
         raise_error: bool = True,
-        co2_tracker: bool = False,
+        co2_tracker: bool = True,
         encode_kwargs: dict[str, Any] = {},
         **kwargs,
     ) -> list[TaskResult]:
@@ -412,13 +413,6 @@ class MTEB:
                 kg_co2_emissions: int | None = 0 if co2_tracker else None
                 for split in task_eval_splits:
                     if co2_tracker:
-                        try:
-                            from codecarbon import EmissionsTracker
-                        except ImportError:
-                            raise ImportError(
-                                "To use the CO2 emissions tracker, please install codecarbon using 'pip install codecarbon'"
-                            )
-
                         with EmissionsTracker(
                             save_to_file=False, save_to_api=False, logging_logger=logger
                         ) as tracker:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "typing_extensions>=0.0.0",
     "eval_type_backport>=0.0.0",
     "polars>=0.20.22",
+    "codecarbon>=2.0.0",
 ]
 
 
@@ -54,7 +55,6 @@ mteb = "mteb.cli:main"
 [project.optional-dependencies]
 dev = ["ruff==0.6.4", # locked so we don't get PRs which fail only due to a lint update
 "pytest", "pytest-xdist", "pytest-coverage"]
-codecarbon = ["codecarbon"]
 speedtask = ["GPUtil>=1.4.0", "psutil>=5.9.8"]
 peft = ["peft>=0.11.0"]
 leaderboard = ["gradio>=4.44.0", "gradio_rangeslider>=0.0.6"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,7 +62,7 @@ def test_run_task(
         task_types=None,
         languages=None,
         batch_size=None,
-        co2_tracker=None,
+        disable_co2_tracker=None,
         overwrite=True,
         eval_splits=None,
         benchmarks=None,


### PR DESCRIPTION
This PR enables code carbon by default. Closes https://github.com/embeddings-benchmark/mteb/issues/1427

## Checklist
<!-- Please do not delete this -->

- [X] Run tests locally to make sure nothing is broken using `make test`. 
- [X] Run the formatter to format the code using `make lint`. 