### PR TITLE
Fix: Add missing benchmarks in benchmarks.py

### DIFF
--- a/mteb/benchmarks/benchmarks.py
+++ b/mteb/benchmarks/benchmarks.py
@@ -918,3 +918,40 @@ MTEB_EU = Benchmark(
     reference=None,
     citation=None,
 )
+
+LONG_EMBED = Benchmark(
+    name="LongEmbed",
+    tasks=get_tasks(
+        tasks=[
+            "LEMBNarrativeQARetrieval",
+            "LEMBNeedleRetrieval",
+            "LEMBPasskeyRetrieval",
+            "LEMBQMSumRetrieval",
+            "LEMBSummScreenFDRetrieval",
+            "LEMBWikimQARetrieval",
+        ],
+    ),
+    description="The main benchmark for evaluating long document retrieval.",
+    reference="https://arxiv.org/abs/2404.12096v2",
+    citation="""@article{zhu2024longembed,
+  title={LongEmbed: Extending Embedding Models for Long Context Retrieval},
+  author={Zhu, Dawei and Wang, Liang and Yang, Nan and Song, Yifan and Wu, Wenhao and Wei, Furu and Li, Sujian},
+  journal={arXiv preprint arXiv:2404.12096},
+  year={2024}
+}""",
+)
+
+BRIGHT = Benchmark(
+    name="BRIGHT",
+    tasks=get_tasks(
+        tasks=["BrightRetrieval"],
+    ),
+    description="A Realistic and Challenging Benchmark for Reasoning-Intensive Retrieval.",
+    reference="https://brightbenchmark.github.io/",
+    citation="""@article{su2024bright,
+  title={Bright: A realistic and challenging benchmark for reasoning-intensive retrieval},
+  author={Su, Hongjin and Yen, Howard and Xia, Mengzhou and Shi, Weijia and Muennighoff, Niklas and Wang, Han-yu and Liu, Haisu and Shi, Quan and Siegel, Zachary S and Tang, Michael and others},
+  journal={arXiv preprint arXiv:2407.12883},
+  year={2024}
+}""",
+)


### PR DESCRIPTION
@x-tabdeveloping the Bright retrieval will probably look a bit odd. Is there a way to split a task into multiple columns?

Fixes #1423


<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->


## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 
