### PR TITLE
Leaderboard 2.0: added performance x n_parameters plot + more benchmark info

### DIFF
--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -42,10 +42,10 @@ def update_description(
     n_task_types = len(task_types)
     n_tasks = len(benchmark.tasks)
     n_domains = len(domains)
-    description += f" - Number of languages: {n_languages}\n"
-    description += f" - Number of datasets: {n_tasks}\n"
-    description += f" - Number of task types: {n_task_types}\n"
-    description += f" - Number of domains : {n_domains}\n"
+    description += f" - **Number of languages**: {n_languages}\n"
+    description += f" - **Number of datasets**: {n_tasks}\n"
+    description += f" - **Number of task types**: {n_task_types}\n"
+    description += f" - **Number of domains**: {n_domains}\n"
     if str(benchmark.reference) != "None":
         description += f"\n[Click for More Info]({benchmark.reference})"
 

--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -207,18 +207,20 @@ with gr.Blocks(fill_width=True, theme=gr.themes.Base(), head=head) as demo:
                         )
     scores = gr.State(default_scores)
     with gr.Row():
-        description = gr.Markdown(
-            update_description,
-            inputs=[benchmark_select, lang_select, type_select, domain_select],
-        )
-        plot = gr.Plot(performance_size_plot, inputs=[summary_table])
+        with gr.Column():
+            description = gr.Markdown(
+                update_description,
+                inputs=[benchmark_select, lang_select, type_select, domain_select],
+            )
+            citation = gr.Markdown(update_citation, inputs=[benchmark_select])
+        with gr.Column():
+            plot = gr.Plot(performance_size_plot, inputs=[summary_table])
     with gr.Tab("Summary"):
         summary_table.render()
     with gr.Tab("Performance per task"):
         per_task_table.render()
     with gr.Tab("Task information"):
         task_info_table = gr.DataFrame(update_task_info, inputs=[task_select])
-    citation = gr.Markdown(update_citation, inputs=[benchmark_select])
 
     @gr.on(inputs=[scores, searchbar], outputs=[summary_table, per_task_table])
     def update_tables(scores, search_query: str):

--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -9,6 +9,7 @@ from gradio_rangeslider import RangeSlider
 
 import mteb
 from mteb.caching import json_cache
+from mteb.leaderboard.figures import performance_size_plot
 from mteb.leaderboard.table import scores_to_tables
 
 
@@ -194,7 +195,9 @@ with gr.Blocks(fill_width=True, theme=gr.themes.Base(), head=head) as demo:
                             interactive=True,
                         )
     scores = gr.State(default_scores)
-    description = gr.Markdown(update_description, inputs=[benchmark_select])
+    with gr.Row():
+        description = gr.Markdown(update_description, inputs=[benchmark_select])
+        plot = gr.Plot(performance_size_plot, inputs=[summary_table])
     with gr.Tab("Summary"):
         summary_table.render()
     with gr.Tab("Performance per task"):

--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -33,11 +33,22 @@ def update_citation(benchmark_name: str) -> str:
     return citation
 
 
-def update_description(benchmark_name: str) -> str:
+def update_description(
+    benchmark_name: str, languages: list[str], task_types: list[str], domains: list[str]
+) -> str:
     benchmark = mteb.get_benchmark(benchmark_name)
     description = f"## {benchmark.name}\n{benchmark.description}\n"
+    n_languages = len(languages)
+    n_task_types = len(task_types)
+    n_tasks = len(benchmark.tasks)
+    n_domains = len(domains)
+    description += f" - Number of languages: {n_languages}\n"
+    description += f" - Number of datasets: {n_tasks}\n"
+    description += f" - Number of task types: {n_task_types}\n"
+    description += f" - Number of domains : {n_domains}\n"
     if str(benchmark.reference) != "None":
         description += f"\n[Click for More Info]({benchmark.reference})"
+
     return description
 
 
@@ -196,7 +207,10 @@ with gr.Blocks(fill_width=True, theme=gr.themes.Base(), head=head) as demo:
                         )
     scores = gr.State(default_scores)
     with gr.Row():
-        description = gr.Markdown(update_description, inputs=[benchmark_select])
+        description = gr.Markdown(
+            update_description,
+            inputs=[benchmark_select, lang_select, type_select, domain_select],
+        )
         plot = gr.Plot(performance_size_plot, inputs=[summary_table])
     with gr.Tab("Summary"):
         summary_table.render()

--- a/mteb/leaderboard/figures.py
+++ b/mteb/leaderboard/figures.py
@@ -32,6 +32,7 @@ def performance_size_plot(df: pd.DataFrame) -> go.Figure:
     df["Embedding Dimensions"] = df["Embedding Dimensions"].map(int)
     df["Max Tokens"] = df["Max Tokens"].map(int)
     df["Log(Tokens)"] = np.log10(df["Max Tokens"])
+    min_score, max_score = df["Mean (Task)"].min(), df["Mean (Task)"].max()
     fig = px.scatter(
         df,
         x="Number of Parameters",
@@ -43,7 +44,7 @@ def performance_size_plot(df: pd.DataFrame) -> go.Figure:
         color="Log(Tokens)",
         range_color=[2, 5],
         range_x=[8 * 1e6, 11 * 1e9],
-        range_y=[0, 80],
+        range_y=[min(0, min_score * 1.25), max_score * 1.25],
         hover_data={
             "Max Tokens": True,
             "Embedding Dimensions": True,

--- a/mteb/leaderboard/figures.py
+++ b/mteb/leaderboard/figures.py
@@ -44,6 +44,16 @@ def performance_size_plot(df: pd.DataFrame) -> go.Figure:
         range_color=[2, 5],
         range_x=[8 * 1e6, 11 * 1e9],
         range_y=[0, 80],
+        hover_data={
+            "Max Tokens": True,
+            "Embedding Dimensions": True,
+            "Number of Parameters": True,
+            "Mean (Task)": True,
+            "Rank (Borda)": True,
+            "Log(Tokens)": False,
+            "model_text": False,
+        },
+        hover_name="Model",
     )
     fig.update_layout(
         coloraxis_colorbar=dict(
@@ -55,7 +65,11 @@ def performance_size_plot(df: pd.DataFrame) -> go.Figure:
                 "10K",
                 "100K",
             ],
-        )
+        ),
+        hoverlabel=dict(
+            bgcolor="white",
+            font_size=16,
+        ),
     )
     fig.update_traces(
         textposition="top center",

--- a/mteb/leaderboard/figures.py
+++ b/mteb/leaderboard/figures.py
@@ -1,0 +1,65 @@
+import numpy as np
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+
+
+def parse_n_params(text: str) -> int:
+    if text.endswith("M"):
+        return float(text[:-1]) * 1e6
+    if text.endswith("B"):
+        return float(text[:-1]) * 1e9
+
+
+def parse_model_name(name: str) -> str:
+    name, _ = name.split("]")
+    return name[1:]
+
+
+models_to_annotate = [
+    "all-MiniLM-L6-v2",
+    "GritLM-7B",
+    "LaBSE",
+    "multilingual-e5-large-instruct",
+]
+
+
+def performance_size_plot(df: pd.DataFrame) -> go.Figure:
+    df = df.copy()
+    df["Number of Parameters"] = df["Number of Parameters"].map(parse_n_params)
+    df["Model"] = df["Model"].map(parse_model_name)
+    df["model_text"] = df["Model"].where(df["Model"].isin(models_to_annotate), "")
+    df["Embedding Dimensions"] = df["Embedding Dimensions"].map(int)
+    df["Max Tokens"] = df["Max Tokens"].map(int)
+    df["Log(Tokens)"] = np.log10(df["Max Tokens"])
+    fig = px.scatter(
+        df,
+        x="Number of Parameters",
+        y="Mean (Task)",
+        log_x=True,
+        template="plotly_white",
+        text="model_text",
+        size="Embedding Dimensions",
+        color="Log(Tokens)",
+        range_color=[2, 5],
+    )
+    fig.update_layout(
+        coloraxis_colorbar=dict(
+            title="Max Tokens",
+            tickvals=[2, 3, 4, 5],
+            ticktext=[
+                "100",
+                "1K",
+                "10K",
+                "100K",
+            ],
+        )
+    )
+    fig.update_traces(
+        textposition="top center",
+    )
+    # fig.update_traces(marker=dict(size=14))
+    fig.update_layout(
+        font=dict(size=16, color="black"),
+    )
+    return fig

--- a/mteb/leaderboard/figures.py
+++ b/mteb/leaderboard/figures.py
@@ -42,6 +42,8 @@ def performance_size_plot(df: pd.DataFrame) -> go.Figure:
         size="Embedding Dimensions",
         color="Log(Tokens)",
         range_color=[2, 5],
+        range_x=[8 * 1e6, 11 * 1e9],
+        range_y=[0, 80],
     )
     fig.update_layout(
         coloraxis_colorbar=dict(
@@ -58,8 +60,8 @@ def performance_size_plot(df: pd.DataFrame) -> go.Figure:
     fig.update_traces(
         textposition="top center",
     )
-    # fig.update_traces(marker=dict(size=14))
     fig.update_layout(
         font=dict(size=16, color="black"),
+        margin=dict(b=20, t=10, l=20, r=10),
     )
     return fig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dev = ["ruff==0.6.4", # locked so we don't get PRs which fail only due to a lint
 codecarbon = ["codecarbon"]
 speedtask = ["GPUtil>=1.4.0", "psutil>=5.9.8"]
 peft = ["peft>=0.11.0"]
-leaderboard = ["gradio>=4.44.0", "gradio_rangeslider>=0.0.6"]
+leaderboard = ["gradio>=5.5.0", "gradio_rangeslider>=0.0.8"]
 flagembedding = ["FlagEmbedding"]
 jina = ["einops>=0.8.0"]
 flash_attention = ["flash-attn>=2.6.3"]


### PR DESCRIPTION
I added an interactive performance vs.  number of parameters plot as the first thing people see when selecting a benchmark. #1396 
I also added some info on the benchmarks to the benchmark description as Niklas requested here: #1317 

Here's a screenshot:
![image](https://github.com/user-attachments/assets/f95d4d14-45b4-4af5-a426-923cc82d0114)

I also bumped the Gradio version, as I thought it might fix certain things, but I have two burning problems still, for which I opened respective issues in Gradio (https://github.com/gradio-app/gradio/issues/9938, https://github.com/gradio-app/gradio/issues/9937)