### PR TITLE
fix: update task metadata to allow for null

### DIFF
--- a/mteb/leaderboard/figures.py
+++ b/mteb/leaderboard/figures.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pandas as pd
 import plotly.express as px
@@ -68,7 +70,7 @@ def performance_size_plot(df: pd.DataFrame) -> go.Figure:
         hover_name="Model",
     )
     fig.update_layout(
-        coloraxis_colorbar=dict(
+        coloraxis_colorbar=dict(  # noqa
             title="Max Tokens",
             tickvals=[2, 3, 4, 5],
             ticktext=[
@@ -78,7 +80,7 @@ def performance_size_plot(df: pd.DataFrame) -> go.Figure:
                 "100K",
             ],
         ),
-        hoverlabel=dict(
+        hoverlabel=dict(  # noqa
             bgcolor="white",
             font_size=16,
         ),
@@ -87,7 +89,7 @@ def performance_size_plot(df: pd.DataFrame) -> go.Figure:
         textposition="top center",
     )
     fig.update_layout(
-        font=dict(size=16, color="black"),
-        margin=dict(b=20, t=10, l=20, r=10),
+        font=dict(size=16, color="black"),  # noqa
+        margin=dict(b=20, t=10, l=20, r=10),  # noqa
     )
     return fig

--- a/mteb/leaderboard/table.py
+++ b/mteb/leaderboard/table.py
@@ -88,7 +88,7 @@ def get_means_per_types(df: pd.DataFrame) -> pd.DataFrame:
                 [name_to_score.get(task_name, np.nan) for task_name in task_names]
             )
             records.append(
-                dict(
+                dict(  # noqa
                     model_name=model_name,
                     model_revision=model_revision,
                     task_type=task_type,

--- a/mteb/load_results/task_results.py
+++ b/mteb/load_results/task_results.py
@@ -156,9 +156,9 @@ class TaskResult(BaseModel):
 
     dataset_revision: str
     task_name: str
-    mteb_version: str
+    mteb_version: str | None
     scores: dict[Split, list[ScoresDict]]
-    evaluation_time: float
+    evaluation_time: float | None
     kg_co2_emissions: float | None = None
 
     @classmethod
@@ -289,6 +289,9 @@ class TaskResult(BaseModel):
                 raise ValueError(
                     f"Error loading TaskResult from disk. You can try to load historic data by setting `load_historic_data=True`. Error: {e}"
                 )
+
+        if data["mteb_version"] is None:
+            data.pop("mteb_version")
 
         pre_1_11_load = (
             (


### PR DESCRIPTION
See https://github.com/embeddings-benchmark/results/pull/43

Should allow us to use null for both version and evaluation time.

Should also be merged into v2.0.0

<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->


## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 

