### PR TITLE
fix: Fix load external results with `None` mteb_version

### DIFF
--- a/mteb/load_results/task_results.py
+++ b/mteb/load_results/task_results.py
@@ -291,7 +291,8 @@ class TaskResult(BaseModel):
                 )
 
         pre_1_11_load = (
-            "mteb_version" in data and data["mteb_version"] is not None
+            "mteb_version" in data
+            and data["mteb_version"] is not None
             and Version(data["mteb_version"]) < Version("1.11.0")
         )  # assume it is before 1.11.0 if the version is not present
         try:
@@ -304,9 +305,11 @@ class TaskResult(BaseModel):
             )
             obj = cls._convert_from_before_v1_11_0(data)
 
-        pre_v_12_48 = "mteb_version" in data and data["mteb_version"] is not None and Version(
-            data["mteb_version"]
-        ) < Version("1.12.48")
+        pre_v_12_48 = (
+            "mteb_version" in data
+            and data["mteb_version"] is not None
+            and Version(data["mteb_version"]) < Version("1.12.48")
+        )
 
         if pre_v_12_48:
             cls._fix_pair_classification_scores(obj)

--- a/mteb/load_results/task_results.py
+++ b/mteb/load_results/task_results.py
@@ -290,15 +290,9 @@ class TaskResult(BaseModel):
                     f"Error loading TaskResult from disk. You can try to load historic data by setting `load_historic_data=True`. Error: {e}"
                 )
 
-        if ("mteb_version" in data) and (data["mteb_version"] is None):
-            data.pop("mteb_version")
-
         pre_1_11_load = (
-            (
-                "mteb_version" in data
-                and Version(data["mteb_version"]) < Version("1.11.0")
-            )
-            or "mteb_version" not in data
+            "mteb_version" in data and data["mteb_version"] is not None
+            and Version(data["mteb_version"]) < Version("1.11.0")
         )  # assume it is before 1.11.0 if the version is not present
         try:
             obj = cls.model_validate(data)
@@ -310,7 +304,7 @@ class TaskResult(BaseModel):
             )
             obj = cls._convert_from_before_v1_11_0(data)
 
-        pre_v_12_48 = "mteb_version" in data and Version(
+        pre_v_12_48 = "mteb_version" in data and data["mteb_version"] is not None and Version(
             data["mteb_version"]
         ) < Version("1.12.48")
 


### PR DESCRIPTION
## Checklist
<!-- Please do not delete this -->

- [X] Run tests locally to make sure nothing is broken using `make test`. 
- [X] Run the formatter to format the code using `make lint`. 

In the current implementation, `mteb_version` is dropped if it's set to `None`, but `TaskResult` expects `mteb_version` to be present in the dictionary