### PR TITLE
fix: loading pre 1.11.0

### DIFF
--- a/mteb/load_results/task_results.py
+++ b/mteb/load_results/task_results.py
@@ -291,9 +291,12 @@ class TaskResult(BaseModel):
                 )
 
         pre_1_11_load = (
-            "mteb_version" in data
-            and data["mteb_version"] is not None
-            and Version(data["mteb_version"]) < Version("1.11.0")
+            (
+                "mteb_version" in data
+                and data["mteb_version"] is not None
+                and Version(data["mteb_version"]) < Version("1.11.0")
+            )
+            or "mteb_version" not in data
         )  # assume it is before 1.11.0 if the version is not present
         try:
             obj = cls.model_validate(data)

--- a/mteb/load_results/task_results.py
+++ b/mteb/load_results/task_results.py
@@ -298,6 +298,7 @@ class TaskResult(BaseModel):
             )
             or "mteb_version" not in data
         )  # assume it is before 1.11.0 if the version is not present
+
         try:
             obj = cls.model_validate(data)
         except Exception as e:


### PR DESCRIPTION
Currently can't load results without version, e. g. `{"test": {"en": {"accuracy": 0.7285810356}}, "mteb_dataset_name": "MassiveIntentClassification"}`


## Checklist
<!-- Please do not delete this -->

- [X] Run tests locally to make sure nothing is broken using `make test`. 
- [X] Run the formatter to format the code using `make lint`. 