### PR TITLE
fix: pinned datasets to <3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "datasets>=2.19.0",
+    "datasets>=2.19.0,<3.0.0",
     "numpy>=1.0.0,<3.0.0",
     "requests>=2.26.0",
     "scikit_learn>=1.0.2",


### PR DESCRIPTION
This PR pins `datasets` version to be less than 3.0.0 to avoid `datasets.tasks` errors.

This solves #1465 

## Checklist

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 