### PR TITLE
feat: Multilingual retrieval loader

### DIFF
--- a/mteb/abstasks/AbsTaskRetrieval.py
+++ b/mteb/abstasks/AbsTaskRetrieval.py
@@ -150,7 +150,8 @@ class AbsTaskRetrieval(AbsTask):
                 # Conversion from DataSet
                 queries = {query["id"]: query["text"] for query in queries}
                 corpus = {
-                    doc["id"]: doc.get("title", "") + " " + doc["text"] for doc in corpus
+                    doc["id"]: doc.get("title", "") + " " + doc["text"]
+                    for doc in corpus
                 }
                 self.corpus[split], self.queries[split], self.relevant_docs[split] = (
                     corpus,
@@ -162,7 +163,8 @@ class AbsTaskRetrieval(AbsTask):
                 if instructions:
                     self.instructions = {
                         split: {
-                            inst["query-id"]: inst["instruction"] for inst in instructions
+                            inst["query-id"]: inst["instruction"]
+                            for inst in instructions
                         }
                     }
                 if top_ranked:
@@ -171,7 +173,7 @@ class AbsTaskRetrieval(AbsTask):
                     }
         else:
             if not isinstance(self.metadata.eval_langs, dict):
-                raise ValueError(f"eval_langs must be a dict for multilingual tasks")
+                raise ValueError("eval_langs must be a dict for multilingual tasks")
             for lang in self.metadata.eval_langs:
                 self.corpus[lang], self.queries[lang], self.relevant_docs[lang] = (
                     {},
@@ -191,9 +193,14 @@ class AbsTaskRetrieval(AbsTask):
                     # Conversion from DataSet
                     queries = {query["id"]: query["text"] for query in queries}
                     corpus = {
-                        doc["id"]: doc.get("title", "") + " " + doc["text"] for doc in corpus
+                        doc["id"]: doc.get("title", "") + " " + doc["text"]
+                        for doc in corpus
                     }
-                    self.corpus[lang][split], self.queries[lang][split], self.relevant_docs[lang][split] = (
+                    (
+                        self.corpus[lang][split],
+                        self.queries[lang][split],
+                        self.relevant_docs[lang][split],
+                    ) = (
                         corpus,
                         queries,
                         qrels,
@@ -205,14 +212,17 @@ class AbsTaskRetrieval(AbsTask):
                             self.instructions = {}
                         self.instructions[lang] = {
                             split: {
-                                inst["query-id"]: inst["instruction"] for inst in instructions
+                                inst["query-id"]: inst["instruction"]
+                                for inst in instructions
                             }
                         }
                     if top_ranked:
                         if self.top_ranked is None:
                             self.top_ranked = {}
                         self.top_ranked = {
-                            split: {tr["query-id"]: tr["corpus-ids"] for tr in top_ranked}
+                            split: {
+                                tr["query-id"]: tr["corpus-ids"] for tr in top_ranked
+                            }
                         }
 
         self.data_loaded = True

--- a/mteb/abstasks/AbsTaskRetrieval.py
+++ b/mteb/abstasks/AbsTaskRetrieval.py
@@ -132,42 +132,88 @@ class AbsTaskRetrieval(AbsTask):
             return
         self.corpus, self.queries, self.relevant_docs = {}, {}, {}
         self.instructions, self.top_ranked = None, None
-        dataset_path = self.metadata_dict["dataset"]["path"]
+        dataset_path = self.metadata.dataset["path"]
         hf_repo_qrels = (
             dataset_path + "-qrels" if "clarin-knext" in dataset_path else None
         )
-        for split in kwargs.get("eval_splits", self.metadata_dict["eval_splits"]):
-            corpus, queries, qrels, instructions, top_ranked = HFDataLoader(
-                hf_repo=dataset_path,
-                hf_repo_qrels=hf_repo_qrels,
-                streaming=False,
-                keep_in_memory=False,
-                trust_remote_code=self.metadata_dict["dataset"].get(
-                    "trust_remote_code", False
-                ),
-            ).load(split=split)
-            # Conversion from DataSet
-            queries = {query["id"]: query["text"] for query in queries}
-            corpus = {
-                doc["id"]: doc.get("title", "") + " " + doc["text"] for doc in corpus
-            }
-            self.corpus[split], self.queries[split], self.relevant_docs[split] = (
-                corpus,
-                queries,
-                qrels,
-            )
+        if not self.is_multilingual:
+            for split in kwargs.get("eval_splits", self.metadata.eval_splits):
+                corpus, queries, qrels, instructions, top_ranked = HFDataLoader(
+                    hf_repo=dataset_path,
+                    hf_repo_qrels=hf_repo_qrels,
+                    streaming=False,
+                    keep_in_memory=False,
+                    trust_remote_code=self.metadata.dataset.get(
+                        "trust_remote_code", False
+                    ),
+                ).load(split=split)
+                # Conversion from DataSet
+                queries = {query["id"]: query["text"] for query in queries}
+                corpus = {
+                    doc["id"]: doc.get("title", "") + " " + doc["text"] for doc in corpus
+                }
+                self.corpus[split], self.queries[split], self.relevant_docs[split] = (
+                    corpus,
+                    queries,
+                    qrels,
+                )
 
-            # optional args
-            if instructions:
-                self.instructions = {
-                    split: {
-                        inst["query-id"]: inst["instruction"] for inst in instructions
+                # optional args
+                if instructions:
+                    self.instructions = {
+                        split: {
+                            inst["query-id"]: inst["instruction"] for inst in instructions
+                        }
                     }
-                }
-            if top_ranked:
-                self.top_ranked = {
-                    split: {tr["query-id"]: tr["corpus-ids"] for tr in top_ranked}
-                }
+                if top_ranked:
+                    self.top_ranked = {
+                        split: {tr["query-id"]: tr["corpus-ids"] for tr in top_ranked}
+                    }
+        else:
+            if not isinstance(self.metadata.eval_langs, dict):
+                raise ValueError(f"eval_langs must be a dict for multilingual tasks")
+            for lang in self.metadata.eval_langs:
+                self.corpus[lang], self.queries[lang], self.relevant_docs[lang] = (
+                    {},
+                    {},
+                    {},
+                )
+                for split in kwargs.get("eval_splits", self.metadata.eval_splits):
+                    corpus, queries, qrels, instructions, top_ranked = HFDataLoader(
+                        hf_repo=dataset_path,
+                        hf_repo_qrels=hf_repo_qrels,
+                        streaming=False,
+                        keep_in_memory=False,
+                        trust_remote_code=self.metadata.dataset.get(
+                            "trust_remote_code", False
+                        ),
+                    ).load(split=split, config=lang)
+                    # Conversion from DataSet
+                    queries = {query["id"]: query["text"] for query in queries}
+                    corpus = {
+                        doc["id"]: doc.get("title", "") + " " + doc["text"] for doc in corpus
+                    }
+                    self.corpus[lang][split], self.queries[lang][split], self.relevant_docs[lang][split] = (
+                        corpus,
+                        queries,
+                        qrels,
+                    )
+
+                    # optional args
+                    if instructions:
+                        if self.instructions is None:
+                            self.instructions = {}
+                        self.instructions[lang] = {
+                            split: {
+                                inst["query-id"]: inst["instruction"] for inst in instructions
+                            }
+                        }
+                    if top_ranked:
+                        if self.top_ranked is None:
+                            self.top_ranked = {}
+                        self.top_ranked = {
+                            split: {tr["query-id"]: tr["corpus-ids"] for tr in top_ranked}
+                        }
 
         self.data_loaded = True
 

--- a/mteb/abstasks/dataloaders.py
+++ b/mteb/abstasks/dataloaders.py
@@ -126,7 +126,9 @@ class HFDataLoader:
             logger.info("Loading Queries...")
             self._load_queries(config)
 
-        if any(c.endswith("top_ranked") for c in configs) in configs or (not self.hf_repo and self.top_ranked_file):
+        if any(c.endswith("top_ranked") for c in configs) in configs or (
+            not self.hf_repo and self.top_ranked_file
+        ):
             logger.info("Loading Top Ranked")
             self._load_top_ranked(config)
             logger.info(
@@ -135,7 +137,9 @@ class HFDataLoader:
         else:
             self.top_ranked = None
 
-        if any(c.endswith("instruction") for c in configs) or (not self.hf_repo and self.instructions_file):
+        if any(c.endswith("instruction") for c in configs) or (
+            not self.hf_repo and self.instructions_file
+        ):
             logger.info("Loading Instructions")
             self._load_instructions(config)
             logger.info(
@@ -299,7 +303,7 @@ class HFDataLoader:
         self.top_ranked = top_ranked_ds
 
     def _load_instructions(self, config: str | None = None):
-        config = f"instruction-{config}"if config is not None else"instruction"
+        config = f"instruction-{config}" if config is not None else "instruction"
         if self.hf_repo:
             instructions_ds = load_dataset(
                 self.hf_repo,


### PR DESCRIPTION
## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [X] Run the formatter to format the code using `make lint`. 

I've added a multilingual retrieval loader with the following structure:  

- `{config}-corpus`  
- `{config}-queries`  
...  

However, currently, there are no datasets that fit this structure. Previously, when I uploaded datasets, I used `corpus-config`, but more other datasets start with `config`. These datasets have variations that make them incompatible with this loader for direct use, so this is more for the future