### PR TITLE
fix: align readme with current mteb

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ model_name = "average_word_embeddings_komninos"
 # model_name = "sentence-transformers/all-MiniLM-L6-v2"
 
 model = SentenceTransformer(model_name)
+# or directly from mteb:
+model = mteb.get_model(model_name)
 tasks = mteb.get_tasks(tasks=["Banking77Classification"])
 evaluation = mteb.MTEB(tasks=tasks)
 results = evaluation.run(model, output_folder=f"results/{model_name}")
@@ -220,9 +222,13 @@ Note that the public leaderboard uses the test splits for all datasets except MS
 Models should implement the following interface, implementing an `encode` function taking as inputs a list of sentences, and returning a list of embeddings (embeddings can be `np.array`, `torch.tensor`, etc.). For inspiration, you can look at the [mteb/mtebscripts repo](https://github.com/embeddings-benchmark/mtebscripts) used for running diverse models via SLURM scripts for the paper.
 
 ```python
+import mteb
 from mteb.encoder_interface import PromptType
+from mteb.models.wrapper import Wrapper
+import numpy as np
 
-class CustomModel:
+
+class CustomModel(Wrapper):
     def encode(
         self,
         sentences: list[str],
@@ -244,7 +250,7 @@ class CustomModel:
         pass
 
 model = CustomModel()
-tasks = mteb.get_task("Banking77Classification")
+tasks = mteb.get_tasks(tasks=["Banking77Classification"])
 evaluation = MTEB(tasks=tasks)
 evaluation.run(model)
 ```

--- a/README.md
+++ b/README.md
@@ -46,12 +46,8 @@ from sentence_transformers import SentenceTransformer
 
 # Define the sentence-transformers model name
 model_name = "average_word_embeddings_komninos"
-# or directly from huggingface:
-# model_name = "sentence-transformers/all-MiniLM-L6-v2"
 
-model = SentenceTransformer(model_name)
-# or directly from mteb:
-model = mteb.get_model(model_name)
+model = mteb.get_model(model_name) # if the model is not implemented in MTEB it will be eq. to SentenceTransformer(model_name)
 tasks = mteb.get_tasks(tasks=["Banking77Classification"])
 evaluation = mteb.MTEB(tasks=tasks)
 results = evaluation.run(model, output_folder=f"results/{model_name}")
@@ -224,11 +220,10 @@ Models should implement the following interface, implementing an `encode` functi
 ```python
 import mteb
 from mteb.encoder_interface import PromptType
-from mteb.models.wrapper import Wrapper
 import numpy as np
 
 
-class CustomModel(Wrapper):
+class CustomModel:
     def encode(
         self,
         sentences: list[str],

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -13,7 +13,7 @@ from time import time
 from typing import Any
 
 import datasets
-from sentence_transformers import SentenceTransformer
+from sentence_transformers import CrossEncoder, SentenceTransformer
 
 from mteb.encoder_interface import Encoder
 from mteb.model_meta import ModelMeta
@@ -23,7 +23,6 @@ from ..abstasks import *
 from ..abstasks import AbsTask
 from ..load_results.task_results import TaskResult
 from ..models.sentence_transformer_wrapper import SentenceTransformerWrapper
-from ..models.wrapper import Wrapper
 from ..tasks import *
 from . import LangMapping
 
@@ -363,7 +362,7 @@ class MTEB:
 
         meta = self.create_model_meta(model)
         output_path = self.create_output_folder(meta, output_folder)
-        if not isinstance(model, Wrapper):
+        if isinstance(model, (SentenceTransformer, CrossEncoder)):
             model = SentenceTransformerWrapper(model)
 
         if output_path:

--- a/tests/test_benchmark/mock_models.py
+++ b/tests/test_benchmark/mock_models.py
@@ -33,7 +33,7 @@ class MockTorchEncoder(mteb.Encoder):
         return torch.randn(len(sentences), 10).numpy()
 
 
-class MockTorchbf16Encoder(mteb.Encoder):
+class MockTorchbf16Encoder(SentenceTransformer):
     def __init__(self):
         pass
 


### PR DESCRIPTION
## Checklist

- [X] Run tests locally to make sure nothing is broken using `make test`. 
- [X] Run the formatter to format the code using `make lint`. 

The current README is a bit misleading and causing issues for newcomers. See #1490 and #1491 for reference.