### PR TITLE
feat: Evaluate missing splits

### DIFF
--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -355,9 +355,9 @@ class MTEB:
         if existing_kg_co2_emissions and new_kg_co2_emissions:
             merged_kg_co2_emissions = existing_kg_co2_emissions + new_kg_co2_emissions
         merged_results = TaskResult(
-            dataset_revision=existing_results.dataset_revision,
-            task_name=existing_results.task_name,
-            mteb_version=existing_results.mteb_version,
+            dataset_revision=new_results.dataset_revision,
+            task_name=new_results.task_name,
+            mteb_version=new_results.mteb_version,
             scores=merged_scores,
             evaluation_time=existing_results.evaluation_time
             + new_results.evaluation_time,

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -350,7 +350,7 @@ class MTEB:
             scores=merged_scores,
             evaluation_time=existing_results.evaluation_time
             + new_results.evaluation_time,
-            kg_co2_emissions=existing_results.kg_co2_emissions,
+            kg_co2_emissions=existing_results.kg_co2_emissions + new_results.kg_co2_emissions,
         )
 
         return merged_results
@@ -437,7 +437,6 @@ class MTEB:
         )  # save them in case we re-use the object (e.g. for reranking)
 
         # To evaluate missing splits, we keep track of the task name and the corresponding splits.
-        # TODO: track languages too.
         self.last_evaluated_splits = {}
 
         while len(self.tasks) > 0:

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -5,7 +5,7 @@ import logging
 import os
 import traceback
 from collections.abc import Iterable
-from copy import copy
+from copy import copy, deepcopy
 from datetime import datetime
 from itertools import chain
 from pathlib import Path
@@ -15,6 +15,7 @@ from typing import Any
 import datasets
 from sentence_transformers import SentenceTransformer
 
+from mteb.abstasks.AbsTask import ScoresDict
 from mteb.encoder_interface import Encoder
 from mteb.model_meta import ModelMeta
 from mteb.models import model_meta_from_sentence_transformers
@@ -84,6 +85,8 @@ class MTEB:
 
         self._version = version
         self.err_logs_path = err_logs_path
+
+        self.last_evaluated_splits = {}
 
         self.select_tasks(**kwargs)
 
@@ -308,6 +311,59 @@ class MTEB:
         tock = time()
         return results, tick, tock
 
+    @staticmethod
+    def _get_missing_splits(
+        existing_results: TaskResult | None, task_eval_splits: list[str], task: AbsTask
+    ) -> list[str]:
+        if existing_results is None:
+            return task_eval_splits
+
+        missing_splits = []
+        for split in task_eval_splits:
+            if split not in existing_results.scores:
+                missing_splits.append(split)
+            elif not existing_results.scores[
+                split
+            ]:  # Check if the split has any scores
+                missing_splits.append(split)
+
+        return missing_splits
+
+    @staticmethod
+    def _merge_results(
+        existing_results: TaskResult, new_results: TaskResult
+    ) -> TaskResult:
+        merged_scores = existing_results.scores.copy()
+
+        for split, scores in new_results.scores.items():
+            if split in merged_scores:
+                merged_scores[split] = MTEB._merge_split_scores(
+                    merged_scores[split], scores
+                )
+            else:
+                merged_scores[split] = scores
+
+        merged_results = TaskResult(
+            dataset_revision=existing_results.dataset_revision,
+            task_name=existing_results.task_name,
+            mteb_version=existing_results.mteb_version,
+            scores=merged_scores,
+            evaluation_time=existing_results.evaluation_time
+            + new_results.evaluation_time,
+            kg_co2_emissions=existing_results.kg_co2_emissions,
+        )
+
+        return merged_results
+
+    @staticmethod
+    def _merge_split_scores(
+        existing_scores: list[ScoresDict], new_scores: list[ScoresDict]
+    ) -> list[ScoresDict]:
+        merged = {score["hf_subset"]: score for score in existing_scores}
+        for score in new_scores:
+            merged[score["hf_subset"]] = score
+        return list(merged.values())
+
     def run(
         self,
         model: SentenceTransformer | Encoder,
@@ -379,15 +435,16 @@ class MTEB:
         original_tasks = (
             self.tasks.copy()
         )  # save them in case we re-use the object (e.g. for reranking)
+        self.last_evaluated_splits = {}
         while len(self.tasks) > 0:
             task = self.tasks[0]
             logger.info(
                 f"\n\n********************** Evaluating {task.metadata.name} **********************"
             )
 
-            # skip evaluation if results folder exists and overwrite_results is False
             if output_path:
                 save_path = output_path / f"{task.metadata.name}{task.save_suffix}.json"
+                existing_results = None
                 if save_path.exists() and not overwrite_results:
                     logger.info(
                         f"{task.metadata.name} results already exists. Loading results from disk. Set overwrite_results=True to overwrite."
@@ -396,13 +453,29 @@ class MTEB:
                     evaluation_results.append(mteb_results)
                     del self.tasks[0]  # empty memory
                     continue
-            try:
+
                 task_eval_splits = (
                     eval_splits if eval_splits is not None else task.eval_splits
                 )
+                missing_splits = self._get_missing_splits(
+                    existing_results, task_eval_splits, task
+                )
 
-                # load data
-                logger.info(f"Loading dataset for {task.metadata_dict['name']}")
+                if not missing_splits and existing_results:
+                    logger.info(
+                        f"{task.metadata.name} results already exist. Loading results from disk."
+                    )
+                    evaluation_results.append(existing_results)
+                    self.last_evaluated_splits[task.metadata.name] = []  # Add this line
+                    del self.tasks[0]
+                    continue
+
+                if missing_splits:
+                    logger.info(
+                        f"Running evaluation for missing splits: {missing_splits}"
+                    )
+
+            try:
                 task.check_if_dataset_is_superseeded()
                 task.load_data(eval_splits=task_eval_splits, **kwargs)
 
@@ -410,7 +483,8 @@ class MTEB:
                 task_results = {}
                 evaluation_time = 0
                 kg_co2_emissions: int | None = 0 if co2_tracker else None
-                for split in task_eval_splits:
+
+                for split in missing_splits:
                     if co2_tracker:
                         try:
                             from codecarbon import EmissionsTracker
@@ -453,21 +527,22 @@ class MTEB:
                     if verbosity >= 1:
                         logger.info(f"Scores: {results}")
 
-                mteb_task_result = TaskResult.from_task_results(
+                new_results = TaskResult.from_task_results(
                     task,
                     task_results,
                     evaluation_time=evaluation_time,
                     kg_co2_emissions=kg_co2_emissions,
                 )
 
-                # save results
-                if output_path:
-                    with open(save_path, "w") as f_out:
-                        json.dump(
-                            mteb_task_result.to_dict(), f_out, indent=2, sort_keys=True
-                        )
+                if existing_results:
+                    merged_results = self._merge_results(existing_results, new_results)
+                else:
+                    merged_results = new_results
 
-                evaluation_results.append(mteb_task_result)
+                if output_path:
+                    merged_results.to_disk(save_path)
+
+                evaluation_results.append(merged_results)
 
             except Exception as e:
                 logger.error(
@@ -486,7 +561,6 @@ class MTEB:
             # empty memory
             del self.tasks[0]
 
-        # restore original tasks
         self.tasks = original_tasks
         return evaluation_results
 
@@ -537,3 +611,11 @@ class MTEB:
 
         with save_path.open("w") as f:
             json.dump(model_meta.to_dict(), f)
+
+    def get_last_evaluated_splits(self):
+        """Returns a dictionary of tasks and their evaluated splits from the most recent run.
+        Tasks with empty lists indicate that results already existed and no splits were evaluated.
+        """
+        return deepcopy(
+            {task: list(splits) for task, splits in self.last_evaluated_splits.items()}
+        )

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -350,7 +350,8 @@ class MTEB:
             scores=merged_scores,
             evaluation_time=existing_results.evaluation_time
             + new_results.evaluation_time,
-            kg_co2_emissions=existing_results.kg_co2_emissions + new_results.kg_co2_emissions,
+            kg_co2_emissions=existing_results.kg_co2_emissions
+            + new_results.kg_co2_emissions,
         )
 
         return merged_results

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -343,6 +343,17 @@ class MTEB:
             else:
                 merged_scores[split] = scores
 
+        existing_kg_co2_emissions = (
+            existing_results.kg_co2_emissions
+            if existing_results.kg_co2_emissions
+            else 0
+        )
+        new_kg_co2_emissions = (
+            new_results.kg_co2_emissions if new_results.kg_co2_emissions else 0
+        )
+        merged_kg_co2_emissions = None
+        if existing_kg_co2_emissions and new_kg_co2_emissions:
+            merged_kg_co2_emissions = existing_kg_co2_emissions + new_kg_co2_emissions
         merged_results = TaskResult(
             dataset_revision=existing_results.dataset_revision,
             task_name=existing_results.task_name,
@@ -350,8 +361,7 @@ class MTEB:
             scores=merged_scores,
             evaluation_time=existing_results.evaluation_time
             + new_results.evaluation_time,
-            kg_co2_emissions=existing_results.kg_co2_emissions
-            + new_results.kg_co2_emissions,
+            kg_co2_emissions=merged_kg_co2_emissions,
         )
 
         return merged_results

--- a/tests/test_benchmark/mock_tasks.py
+++ b/tests/test_benchmark/mock_tasks.py
@@ -1291,12 +1291,16 @@ class MockRetrievalTask(AbsTaskRetrieval):
         type="Retrieval",
         name="MockRetrievalTask",
         main_score="ndcg_at_10",
-        **general_args,  # type: ignore
+        **dict(general_args | {"eval_splits": ["val", "test"]}),  # type: ignore
     )
 
     def load_data(self, **kwargs):
         self.queries = {
             "test": {
+                "q1": "This is a test sentence",
+                "q2": "This is another test sentence",
+            },
+            "val": {
                 "q1": "This is a test sentence",
                 "q2": "This is another test sentence",
             }
@@ -1305,11 +1309,19 @@ class MockRetrievalTask(AbsTaskRetrieval):
             "test": {
                 "d1": "This is a positive sentence",
                 "d2": "This is another positive sentence",
+            },
+            "val": {
+                "d1": "This is a positive sentence",
+                "d2": "This is another positive sentence",
             }
         }
 
         self.relevant_docs = {
             "test": {
+                "q1": {"d1": 1, "d2": 0},
+                "q2": {"d1": 0, "d2": 1},
+            },
+            "val": {
                 "q1": {"d1": 1, "d2": 0},
                 "q2": {"d1": 0, "d2": 1},
             },

--- a/tests/test_benchmark/mock_tasks.py
+++ b/tests/test_benchmark/mock_tasks.py
@@ -1284,7 +1284,25 @@ class MockRetrievalTask(AbsTaskRetrieval):
             "average_relevant_docs_per_query": 2.0,
             "max_relevant_docs_per_query": 2,
             "unique_relevant_docs": 2,
-        }
+        },
+        "val": {
+            "number_of_characters": 112,
+            "num_samples": 4,
+            "num_queries": 2,
+            "num_documents": 2,
+            "min_document_length": 23,
+            "average_document_length": 26.0,
+            "max_document_length": 29,
+            "unique_documents": 2,
+            "min_query_length": 27,
+            "average_query_length": 30.0,
+            "max_query_length": 33,
+            "unique_queries": 2,
+            "min_relevant_docs_per_query": 2,
+            "average_relevant_docs_per_query": 2.0,
+            "max_relevant_docs_per_query": 2,
+            "unique_relevant_docs": 2,
+        },
     }
 
     metadata = TaskMetadata(
@@ -1303,7 +1321,7 @@ class MockRetrievalTask(AbsTaskRetrieval):
             "val": {
                 "q1": "This is a test sentence",
                 "q2": "This is another test sentence",
-            }
+            },
         }
         self.corpus = {
             "test": {
@@ -1313,7 +1331,7 @@ class MockRetrievalTask(AbsTaskRetrieval):
             "val": {
                 "d1": "This is a positive sentence",
                 "d2": "This is another positive sentence",
-            }
+            },
         }
 
         self.relevant_docs = {

--- a/tests/test_evaluation/test_split_evaluation.py
+++ b/tests/test_evaluation/test_split_evaluation.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
 import pytest
+
+from mteb import MTEB
 from tests.test_benchmark.mock_models import (
     MockSentenceTransformer,
 )
-
 from tests.test_benchmark.mock_tasks import (
     MockRetrievalTask,
 )
-
-from mteb import MTEB
 
 
 @pytest.fixture
@@ -30,56 +29,63 @@ def test_all_splits_evaluated(model, tasks, tmp_path):
         output_folder=str(tmp_path / "all_splits_evaluated"),
         verbosity=2,
     )
-    print(results)
+
     assert "MockRetrievalTask" == results[0].task_name
-    scores = results[0].scores
-    assert set(scores.keys()) == {"val", "test"}
-    assert len(scores.keys()) == 2
+    last_evaluated_splits = evaluation.get_last_evaluated_splits()
+    assert set(last_evaluated_splits["MockRetrievalTask"]) == {"val", "test"}
+    assert len(last_evaluated_splits["MockRetrievalTask"]) == 2
 
 
 def test_one_missing_split(model, tasks, tmp_path):
     evaluation = MTEB(tasks=tasks)
-    results1 = evaluation.run(
+    results = evaluation.run(
         model,
         eval_splits=["val"],
         output_folder=str(tmp_path / "testcase2"),
         verbosity=2,
     )
 
-    evaluation_2 = MTEB(tasks=tasks)
-    results2 = evaluation_2.run(
+    assert "MockRetrievalTask" == results[0].task_name
+    last_evaluated_splits = evaluation.get_last_evaluated_splits()
+    assert set(last_evaluated_splits["MockRetrievalTask"]) == {"val"}
+    assert len(last_evaluated_splits["MockRetrievalTask"]) == 1
+
+    results2 = evaluation.run(
         model,
         eval_splits=["val", "test"],
         output_folder=str(tmp_path / "testcase2"),
         verbosity=2,
+        overwrite_results=True,
     )
 
-    last_evaluated_splits = evaluation_2.get_last_evaluated_splits()
-
-    print(last_evaluated_splits)
-    assert "MockRetrievalTask" in last_evaluated_splits
-    assert set(last_evaluated_splits["NFCorpus"]) == {"test"}
-    assert len(last_evaluated_splits["NFCorpus"]) == 1
+    assert "MockRetrievalTask" == results2[0].task_name
+    last_evaluated_splits = evaluation.get_last_evaluated_splits()
+    assert set(last_evaluated_splits["MockRetrievalTask"]) == {"test"}
+    assert len(last_evaluated_splits["MockRetrievalTask"]) == 1
 
 
 def test_no_missing_splits(model, tasks, tmp_path):
-    evaluation_1 = MTEB(tasks=tasks)
-    results = evaluation_1.run(
+    evaluation = MTEB(tasks=tasks)
+    _ = evaluation.run(
         model,
         eval_splits=["val", "test"],
         output_folder=str(tmp_path / "testcase3"),
         verbosity=2,
     )
 
-    evaluation_2 = MTEB(tasks=tasks)
-    results2 = evaluation_2.run(
+    last_evaluated_splits = evaluation.get_last_evaluated_splits()
+    assert "MockRetrievalTask" in last_evaluated_splits
+    assert len(last_evaluated_splits["MockRetrievalTask"]) == 2
+
+    evaluation = MTEB(tasks=tasks)
+    _ = evaluation.run(
         model,
         eval_splits=["val", "test"],
         output_folder=str(tmp_path / "testcase3"),
         verbosity=2,
+        overwrite_results=True,
     )
 
-    last_evaluated_splits = evaluation_2.get_last_evaluated_splits()
-
-    assert "NFCorpus" in last_evaluated_splits
-    assert len(last_evaluated_splits["NFCorpus"]) == 0
+    last_evaluated_splits = evaluation.get_last_evaluated_splits()
+    assert "MockRetrievalTask" in last_evaluated_splits
+    assert len(last_evaluated_splits["MockRetrievalTask"]) == 0

--- a/tests/test_evaluation/test_split_evaluation.py
+++ b/tests/test_evaluation/test_split_evaluation.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import pytest
+from sentence_transformers import SentenceTransformer
+
+import mteb
+from mteb import MTEB
+
+
+@pytest.fixture
+def model():
+    return SentenceTransformer("all-MiniLM-L6-v2")
+
+
+@pytest.fixture
+def nfcorpus_tasks():
+    return mteb.get_tasks(tasks=["NFCorpus"], languages=["eng"])
+
+
+@pytest.mark.skip(reason="WIP")
+def test_all_splits_evaluated(model, nfcorpus_tasks, tmp_path):
+    evaluation = MTEB(tasks=nfcorpus_tasks)
+    evaluation.run(
+        model,
+        eval_splits=["train", "test"],
+        save_predictions=True,
+        output_folder=str(tmp_path / "testcase1"),
+        verbosity=2,
+    )
+    last_evaluated_splits = evaluation.get_last_evaluated_splits()
+    print(last_evaluated_splits)
+    assert "NFCorpus" in last_evaluated_splits
+    assert set(last_evaluated_splits["NFCorpus"]) == {"train", "test"}
+    assert len(last_evaluated_splits["NFCorpus"]) == 2
+
+
+@pytest.mark.skip(reason="WIP")
+def test_one_missing_split(model, nfcorpus_tasks, tmp_path):
+    evaluation = MTEB(tasks=nfcorpus_tasks)
+    evaluation.run(
+        model,
+        eval_splits=["train"],
+        save_predictions=True,
+        output_folder=str(tmp_path / "testcase2"),
+        verbosity=2,
+    )
+
+    # Get model and tasks again
+    model = SentenceTransformer("all-MiniLM-L6-v2")
+    nfcorpus_tasks = mteb.get_tasks(tasks=["NFCorpus"], languages=["eng"])
+
+    evaluation_2 = MTEB(tasks=nfcorpus_tasks)
+    evaluation_2.run(
+        model,
+        eval_splits=["train", "test"],
+        save_predictions=True,
+        output_folder=str(tmp_path / "testcase2"),
+        verbosity=2,
+    )
+
+    last_evaluated_splits = evaluation_2.get_last_evaluated_splits()
+
+    print(last_evaluated_splits)
+    assert "NFCorpus" in last_evaluated_splits
+    assert set(last_evaluated_splits["NFCorpus"]) == {"test"}
+    assert len(last_evaluated_splits["NFCorpus"]) == 1
+
+
+@pytest.mark.skip(reason="WIP")
+def test_no_missing_splits(model, nfcorpus_tasks, tmp_path):
+    evaluation_1 = MTEB(tasks=nfcorpus_tasks)
+    evaluation_1.run(
+        model,
+        eval_splits=["train", "test"],
+        save_predictions=True,
+        output_folder=str(tmp_path / "testcase3"),
+        verbosity=2,
+    )
+
+    evaluation_2 = MTEB(tasks=nfcorpus_tasks)
+    evaluation_2.run(
+        model,
+        eval_splits=["train", "test"],
+        save_predictions=True,
+        output_folder=str(tmp_path / "testcase3"),
+        verbosity=2,
+    )
+
+    last_evaluated_splits = evaluation_2.get_last_evaluated_splits()
+
+    assert "NFCorpus" in last_evaluated_splits
+    assert len(last_evaluated_splits["NFCorpus"]) == 0


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->
Fixes #1260 

- Based on https://github.com/embeddings-benchmark/mteb/pull/1268 and addresses most of the comments
- Once run, the returned result will contain the missing splits as well as the already run splits
- Requires `overwrite=True` to work
- Changed tests to use the same MTEB object instead of a new one

Example Usage
```python
from mteb import MTEB, get_tasks, get_model

tasks = get_tasks(tasks=["Banking77Classification"])
model = get_model("sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2")

# Runs only one split
evaluation = MTEB(tasks=tasks)
results = evaluation.run(
    model,
    eval_splits=["val"],
    output_folder=str(tmp_path / "testcase2"),
    verbosity=2,
)

# Will run the missing split and return results of both splits.
results2 = evaluation.run(
    model,
    eval_splits=["val", "test"],
    output_folder=str(tmp_path / "testcase2"),
    verbosity=2,
    overwrite_results=True,
)
```

## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 
