### PR TITLE
fix: Proprietary models now get correctly shown in leaderboard

### DIFF
--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from pathlib import Path
 
 import gradio as gr
+import pandas as pd
 from gradio_rangeslider import RangeSlider
 
 import mteb
@@ -316,12 +317,13 @@ with gr.Blocks(fill_width=True, theme=gr.themes.Base(), head=head) as demo:
             domains=domains,
         )
         lower, upper = model_size
-        # Multiplying by millions
-        lower = lower * 1e6
-        upper = upper * 1e6
         # Setting to None, when the user doesn't specify anything
         if (lower == min_model_size) and (upper == max_model_size):
             lower, upper = None, None
+        else:
+            # Multiplying by millions
+            lower = lower * 1e6
+            upper = upper * 1e6
         benchmark_results = benchmark_results.filter_models(
             open_weights=availability,
             use_instructions=instructions,

--- a/mteb/leaderboard/table.py
+++ b/mteb/leaderboard/table.py
@@ -163,9 +163,13 @@ def scores_to_tables(
         lambda name: name.split("/")[-1]
     )
     # Adding markdown link to model names
-    joint_table["model_name"] = (
-        "[" + joint_table["model_name"] + "](" + joint_table.pop("model_link") + ")"
+    name_w_link = (
+        "[" + joint_table["model_name"] + "](" + joint_table["model_link"] + ")"
     )
+    joint_table["model_name"] = joint_table["model_name"].mask(
+        joint_table["model_link"].notna(), name_w_link
+    )
+    joint_table = joint_table.drop(columns=["model_link"])
     joint_table = joint_table.rename(
         columns={
             "model_name": "Model",

--- a/mteb/leaderboard/table.py
+++ b/mteb/leaderboard/table.py
@@ -32,7 +32,7 @@ def format_scores(score: float) -> float:
 
 def format_n_parameters(n_parameters) -> str:
     if (n_parameters is None) or (not int(n_parameters)):
-        return ""
+        return "Unknown"
     n_thousand = int(n_parameters // 1e3)
     if n_thousand < 1:
         return str(int(n_parameters))
@@ -46,9 +46,7 @@ def format_n_parameters(n_parameters) -> str:
 
 def split_on_capital(s: str) -> str:
     """Splits on capital letters and joins with spaces"""
-    if all(c.isupper() for c in s):
-        return s
-    return " ".join(re.findall("[A-Z][^A-Z]*", s))
+    return " ".join(re.findall(r"[A-Z]?[a-z]+|[A-Z]+(?=[A-Z]|$)", s))
 
 
 def get_column_widths(df: pd.DataFrame) -> list[str]:
@@ -59,9 +57,12 @@ def get_column_widths(df: pd.DataFrame) -> list[str]:
             value_lengths = [len(f"{value:.2f}") for value in df[column_name]]
         else:
             value_lengths = [len(str(value)) for value in df[column_name]]
-        max_length = max(max(column_word_lengths), max(value_lengths))
-        n_pixels = 25 + (max_length * 10)
-        widths.append(f"{n_pixels}px")
+        try:
+            max_length = max(max(column_word_lengths), max(value_lengths))
+            n_pixels = 35 + (max_length * 12.5)
+            widths.append(f"{n_pixels}px")
+        except Exception:
+            widths.append("50px")
     return widths
 
 
@@ -138,19 +139,20 @@ def scores_to_tables(
     joint_table.insert(1, "mean_by_task_type", typed_mean)
     joint_table["borda_rank"] = get_borda_rank(per_task)
     joint_table = joint_table.reset_index()
-    joint_table = joint_table.drop(columns=["model_revision"])
     model_metas = joint_table["model_name"].map(failsafe_get_model_meta)
     joint_table = joint_table[model_metas.notna()]
     joint_table["model_link"] = model_metas.map(lambda m: m.reference)
     joint_table.insert(
         1,
         "Max Tokens",
-        model_metas.map(lambda m: str(int(m.max_tokens)) if m.max_tokens else ""),
+        model_metas.map(
+            lambda m: str(int(m.max_tokens)) if m.max_tokens else "Unknown"
+        ),
     )
     joint_table.insert(
         1,
         "Embedding Dimensions",
-        model_metas.map(lambda m: str(int(m.embed_dim)) if m.embed_dim else ""),
+        model_metas.map(lambda m: str(int(m.embed_dim)) if m.embed_dim else "Unknown"),
     )
     joint_table.insert(
         1,
@@ -158,6 +160,10 @@ def scores_to_tables(
         model_metas.map(lambda m: format_n_parameters(m.n_parameters)),
     )
     joint_table = joint_table.sort_values("borda_rank", ascending=True)
+    per_task = per_task.loc[
+        joint_table.set_index(["model_name", "model_revision"]).index
+    ]
+    joint_table = joint_table.drop(columns=["model_revision"])
     # Removing HF organization from model
     joint_table["model_name"] = joint_table["model_name"].map(
         lambda name: name.split("/")[-1]
@@ -188,6 +194,7 @@ def scores_to_tables(
     )
     joint_table.insert(0, "Rank (Borda)", joint_table.pop("borda_rank"))
     column_widths = get_column_widths(joint_table)
+    task_column_widths = get_column_widths(per_task)
     # overriding for model name
     column_widths[1] = "250px"
     column_types = get_column_types(joint_table)
@@ -210,9 +217,12 @@ def scores_to_tables(
     return (
         gr.DataFrame(
             joint_table_style,
-            # column_widths=column_widths,
+            column_widths=column_widths,
             datatype=column_types,
-            # wrap=True,
+            interactive=False,
+            wrap=True,
         ),
-        gr.DataFrame(per_task_style),
+        gr.DataFrame(
+            per_task_style, column_widths=task_column_widths, interactive=False
+        ),
     )

--- a/mteb/models/openai_models.py
+++ b/mteb/models/openai_models.py
@@ -81,6 +81,7 @@ text_embedding_3_large = ModelMeta(
     max_tokens=8191,
     embed_dim=3072,
     open_weights=False,
+    reference="https://openai.com/index/new-embedding-models-and-api-updates/",
     framework=["API"],
     use_instructions=False,
     n_parameters=None,
@@ -92,6 +93,7 @@ text_embedding_ada_002 = ModelMeta(
     release_date="2022-12-15",
     languages=None,  # supported languages not specified
     loader=partial(OpenAIWrapper, model_name="text-embedding-ada-002"),
+    reference="https://openai.com/index/new-and-improved-embedding-model/",
     max_tokens=8191,
     embed_dim=1536,
     open_weights=False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dev = ["ruff==0.6.4", # locked so we don't get PRs which fail only due to a lint
 codecarbon = ["codecarbon"]
 speedtask = ["GPUtil>=1.4.0", "psutil>=5.9.8"]
 peft = ["peft>=0.11.0"]
-leaderboard = ["gradio>=5.5.0", "gradio_rangeslider>=0.0.8"]
+leaderboard = ["gradio>=5.7.1", "gradio_rangeslider>=0.0.8"]
 flagembedding = ["FlagEmbedding"]
 jina = ["einops>=0.8.0"]
 flash_attention = ["flash-attn>=2.6.3"]


### PR DESCRIPTION
Proprietary models were not correctly shown due to model size filtering being incorrectly implemented.
I also fixed column wrapping and formatting, the per task performance table is also correctly ordered.