### PR TITLE
fix: Task load data error for SICK-BR-STS and XStance

### DIFF
--- a/mteb/tasks/PairClassification/multilingual/XStance.py
+++ b/mteb/tasks/PairClassification/multilingual/XStance.py
@@ -100,8 +100,8 @@ class XStance(MultilingualTask, AbsTaskPairClassification):
             for split in self.metadata.eval_splits:
                 _dataset[lang][split] = [
                     {
-                        "sent1": self.dataset[lang][split]["sentence1"],
-                        "sent2": self.dataset[lang][split]["sentence2"],
+                        "sentence1": self.dataset[lang][split]["sentence1"],
+                        "sentence2": self.dataset[lang][split]["sentence2"],
                         "labels": self.dataset[lang][split]["labels"],
                     }
                 ]

--- a/mteb/tasks/PairClassification/multilingual/XStance.py
+++ b/mteb/tasks/PairClassification/multilingual/XStance.py
@@ -100,8 +100,8 @@ class XStance(MultilingualTask, AbsTaskPairClassification):
             for split in self.metadata.eval_splits:
                 _dataset[lang][split] = [
                     {
-                        "sent1": self.dataset[lang][split]["sent1"],
-                        "sent2": self.dataset[lang][split]["sent2"],
+                        "sent1": self.dataset[lang][split]["sentence1"],
+                        "sent2": self.dataset[lang][split]["sentence2"],
                         "labels": self.dataset[lang][split]["labels"],
                     }
                 ]

--- a/mteb/tasks/STS/por/SickBrSTS.py
+++ b/mteb/tasks/STS/por/SickBrSTS.py
@@ -60,14 +60,12 @@ class SickBrSTS(AbsTaskSTS):
         return metadata_dict
 
     def dataset_transform(self):
-        for split in self.dataset:
-            self.dataset.update(
-                {
-                    split: self.dataset[split].train_test_split(
-                        test_size=N_SAMPLES, seed=self.seed, label="entailment_label"
-                    )["test"]
-                }
-            )
+        self.dataset = self.stratified_subsampling(
+            self.dataset,
+            seed=42,
+            splits=self.metadata.eval_splits,
+            label="entailment_label",
+        )
 
         self.dataset = self.dataset.rename_columns(
             {


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->
Fixes #1407 . This code now runs without error.

```python
import mteb
task = mteb.get_task("SICK-BR-STS")  # or XStance
task.load_data()
```

## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 
