### PR TITLE
Made result loading more permissive, changed eval splits for HotPotQA and DBPedia

### DIFF
--- a/mteb/load_results/task_results.py
+++ b/mteb/load_results/task_results.py
@@ -459,7 +459,7 @@ class TaskResult(BaseModel):
         values = []
         for split in splits:
             if split not in self.scores:
-                raise ValueError(f"Split {split} not found in scores")
+                logger.warning(f"Split {split} not found in scores")
 
             for scores in self.scores[split]:
                 eval_langs = scores["languages"]
@@ -511,12 +511,14 @@ class TaskResult(BaseModel):
                 new_scores[split].append(_scores)
                 seen_subsets.add(_scores["hf_subset"])
             if seen_subsets != hf_subsets:
-                raise ValueError(
-                    f"Missing subsets {hf_subsets - seen_subsets} for split {split}"
+                logger.warning(
+                    f"{task.metadata.name}: Missing subsets {hf_subsets - seen_subsets} for split {split}"
                 )
             seen_splits.add(split)
         if seen_splits != set(splits):
-            raise ValueError(f"Missing splits {set(splits) - seen_splits}")
+            logger.warning(
+                f"{task.metadata.name}: Missing splits {set(splits) - seen_splits}"
+            )
         new_res = {**self.to_dict(), "scores": new_scores}
         new_res = TaskResult.from_validated(**new_res)
         return new_res

--- a/mteb/load_results/task_results.py
+++ b/mteb/load_results/task_results.py
@@ -291,10 +291,13 @@ class TaskResult(BaseModel):
                 )
 
         pre_1_11_load = (
-            "mteb_version" in data
-            and data["mteb_version"] is not None
-            and Version(data["mteb_version"]) < Version("1.11.0")
-        ) or "mteb_version" not in data  # assume it is before 1.11.0 if the version is not present
+            (
+                "mteb_version" in data
+                and data["mteb_version"] is not None
+                and Version(data["mteb_version"]) < Version("1.11.0")
+            )
+            or "mteb_version" not in data
+        )  # assume it is before 1.11.0 if the version is not present
 
         try:
             obj = cls.model_validate(data)

--- a/mteb/load_results/task_results.py
+++ b/mteb/load_results/task_results.py
@@ -291,13 +291,10 @@ class TaskResult(BaseModel):
                 )
 
         pre_1_11_load = (
-            (
-                "mteb_version" in data
-                and data["mteb_version"] is not None
-                and Version(data["mteb_version"]) < Version("1.11.0")
-            )
-            or "mteb_version" not in data
-        )  # assume it is before 1.11.0 if the version is not present
+            "mteb_version" in data
+            and data["mteb_version"] is not None
+            and Version(data["mteb_version"]) < Version("1.11.0")
+        ) or "mteb_version" not in data  # assume it is before 1.11.0 if the version is not present
 
         try:
             obj = cls.model_validate(data)
@@ -459,7 +456,7 @@ class TaskResult(BaseModel):
         values = []
         for split in splits:
             if split not in self.scores:
-                logger.warning(f"Split {split} not found in scores")
+                raise ValueError(f"Split {split} not found in scores")
 
             for scores in self.scores[split]:
                 eval_langs = scores["languages"]

--- a/mteb/tasks/Retrieval/eng/DBPediaRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/DBPediaRetrieval.py
@@ -17,7 +17,7 @@ class DBPedia(AbsTaskRetrieval):
         type="Retrieval",
         category="s2p",
         modalities=["text"],
-        eval_splits=["dev", "test"],
+        eval_splits=["test"],
         eval_langs=["eng-Latn"],
         main_score="ndcg_at_10",
         date=("2017-01-01", "2017-01-01"),  # best guess: based on publication date

--- a/mteb/tasks/Retrieval/eng/HotpotQARetrieval.py
+++ b/mteb/tasks/Retrieval/eng/HotpotQARetrieval.py
@@ -20,7 +20,7 @@ class HotpotQA(AbsTaskRetrieval):
         type="Retrieval",
         category="s2p",
         modalities=["text"],
-        eval_splits=["train", "dev", "test"],
+        eval_splits=["test"],
         eval_langs=["eng-Latn"],
         main_score="ndcg_at_10",
         date=("2018-01-01", "2018-12-31"),  # best guess: based on publication date


### PR DESCRIPTION
Some results were missing from the leaderboard, since task result validation removed them, because some languages were missing from the results.
Validation only throws warnings now, I also removed some splits from `eval_splits` on two tasks, since all models were missing these splits from the results repo.