### PR TITLE
feat(google_models): fix issues and add support for `text-embedding-005` and `text-multilingual-embedding-002`

### DIFF
--- a/mteb/models/google_models.py
+++ b/mteb/models/google_models.py
@@ -4,6 +4,7 @@ from functools import partial
 from typing import Any
 
 import numpy as np
+import tqdm
 
 from mteb.encoder_interface import Encoder, PromptType
 from mteb.model_meta import ModelMeta
@@ -27,7 +28,8 @@ class GoogleTextEmbeddingModel(Encoder, Wrapper):
     def _embed(
         self,
         texts: list[str],
-        google_task_type: str | None = None,
+        google_task_type: str,
+        show_progress_bar: bool,
         titles: list[str] | None = None,
         dimensionality: int | None = 768,
     ) -> list[list[float]]:
@@ -54,14 +56,28 @@ class GoogleTextEmbeddingModel(Encoder, Wrapper):
             inputs = [
                 TextEmbeddingInput(text, task_type=google_task_type) for text in texts
             ]
+
         kwargs = {"output_dimensionality": dimensionality} if dimensionality else {}
-        try:
-            embeddings = model.get_embeddings(inputs, **kwargs)
-        # Except the very rare google.api_core.exceptions.InternalServerError
-        except Exception as e:
-            print("Retrying once after error:", e)
-            embeddings = model.get_embeddings(inputs, **kwargs)
-        return np.asarray([embedding.values for embedding in embeddings])
+
+        max_batch_size = 16  ## Vertex API limits the number of instances per call to 250, but there is also a limit of tokens involved. Let's be conservative and set it to 16 by default. TODO: in a future PR, leverage the CountTokens API to get the optimum batch size for each request.
+        batches = [
+            inputs[i : i + max_batch_size]
+            for i in range(0, len(inputs), max_batch_size)
+        ]
+
+        all_embeddings = []
+
+        for batch in tqdm.tqdm(batches, leave=False, disable=not show_progress_bar):
+            try:
+                embeddings_batch = model.get_embeddings(batch, **kwargs)
+            # Except the very rare google.api_core.exceptions.InternalServerError
+            except Exception as e:
+                print("Retrying once after error:", e)
+                embeddings_batch = model.get_embeddings(batch, **kwargs)
+
+            all_embeddings.extend([embedding.values for embedding in embeddings_batch])
+
+        return np.asarray(all_embeddings)
 
     def encode(
         self,
@@ -70,17 +86,26 @@ class GoogleTextEmbeddingModel(Encoder, Wrapper):
         prompt_type: PromptType | None = None,
         **kwargs: Any,
     ) -> np.ndarray:
-        google_task_type = self.get_prompt_name(
-            self.model_prompts, task_name, prompt_type
+        prompt_name = self.get_prompt_name(self.model_prompts, task_name, prompt_type)
+        google_task_type = self.model_prompts.get(prompt_name)
+
+        show_progress_bar = (
+            False
+            if "show_progress_bar" not in kwargs
+            else kwargs.pop("show_progress_bar")
         )
-        return self._embed(sentences, google_task_type=google_task_type)
+
+        return self._embed(
+            sentences,
+            google_task_type=google_task_type,
+            show_progress_bar=show_progress_bar,
+        )
 
 
-name = "text-embedding-004"
 google_emb_004 = ModelMeta(
     loader=partial(
         GoogleTextEmbeddingModel,
-        model_name=name,
+        model_name="text-embedding-004",
         model_prompts={
             "Classification": "CLASSIFICATION",
             "MultilabelClassification": "CLASSIFICATION",
@@ -90,11 +115,11 @@ google_emb_004 = ModelMeta(
             PromptType.passage.value: "RETRIEVAL_DOCUMENT",
         },
     ),
-    name=name,
+    name="google/text-embedding-004",
     languages=["eng-Latn"],
     open_weights=False,
     revision="1",  # revision is intended for implementation
-    release_date=None,  # couldnt figure this out
+    release_date="2024-05-14",
     n_parameters=None,
     memory_usage=None,
     max_tokens=2048,

--- a/mteb/models/google_models.py
+++ b/mteb/models/google_models.py
@@ -33,6 +33,15 @@ MULTILINGUAL_EVALUATED_LANGUAGES = [
     "zho_Hans",
 ]
 
+MODEL_PROMPTS = {
+    "Classification": "CLASSIFICATION",
+    "MultilabelClassification": "CLASSIFICATION",
+    "Clustering": "CLUSTERING",
+    "STS": "SIMILARITY",
+    PromptType.query.value: "RETRIEVAL_QUERY",
+    PromptType.passage.value: "RETRIEVAL_DOCUMENT",
+}
+
 
 class GoogleTextEmbeddingModel(Encoder, Wrapper):
     def __init__(
@@ -50,8 +59,8 @@ class GoogleTextEmbeddingModel(Encoder, Wrapper):
     def _embed(
         self,
         texts: list[str],
-        google_task_type: str,
-        show_progress_bar: bool,
+        google_task_type: str | None = None,
+        show_progress_bar: bool = False,
         titles: list[str] | None = None,
         dimensionality: int | None = 768,
     ) -> list[list[float]]:
@@ -128,14 +137,7 @@ google_text_emb_004 = ModelMeta(
     loader=partial(
         GoogleTextEmbeddingModel,
         model_name="text-embedding-004",
-        model_prompts={
-            "Classification": "CLASSIFICATION",
-            "MultilabelClassification": "CLASSIFICATION",
-            "Clustering": "CLUSTERING",
-            "STS": "SIMILARITY",
-            PromptType.query.value: "RETRIEVAL_QUERY",
-            PromptType.passage.value: "RETRIEVAL_DOCUMENT",
-        },
+        model_prompts=MODEL_PROMPTS,
     ),
     name="google/text-embedding-004",
     languages=["eng-Latn"],
@@ -156,14 +158,7 @@ google_text_emb_005 = ModelMeta(
     loader=partial(
         GoogleTextEmbeddingModel,
         model_name="text-embedding-005",
-        model_prompts={
-            "Classification": "CLASSIFICATION",
-            "MultilabelClassification": "CLASSIFICATION",
-            "Clustering": "CLUSTERING",
-            "STS": "SIMILARITY",
-            PromptType.query.value: "RETRIEVAL_QUERY",
-            PromptType.passage.value: "RETRIEVAL_DOCUMENT",
-        },
+        model_prompts=MODEL_PROMPTS,
     ),
     name="google/text-embedding-005",
     languages=["eng-Latn"],
@@ -184,14 +179,7 @@ google_text_multilingual_emb_002 = ModelMeta(
     loader=partial(
         GoogleTextEmbeddingModel,
         model_name="text-multilingual-embedding-002",
-        model_prompts={
-            "Classification": "CLASSIFICATION",
-            "MultilabelClassification": "CLASSIFICATION",
-            "Clustering": "CLUSTERING",
-            "STS": "SIMILARITY",
-            PromptType.query.value: "RETRIEVAL_QUERY",
-            PromptType.passage.value: "RETRIEVAL_DOCUMENT",
-        },
+        model_prompts=MODEL_PROMPTS,
     ),
     name="google/text-multilingual-embedding-002",
     languages=MULTILINGUAL_EVALUATED_LANGUAGES,  # From the list of evaluated languages in https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/text-embeddings-api#supported_text_languages

--- a/mteb/models/google_models.py
+++ b/mteb/models/google_models.py
@@ -11,6 +11,28 @@ from mteb.model_meta import ModelMeta
 
 from .wrapper import Wrapper
 
+MULTILINGUAL_EVALUATED_LANGUAGES = [
+    "arb_Arab",
+    "ben_Beng",
+    "eng_Latn",
+    "spa_Latn",
+    "deu_Latn",
+    "pes_Arab",
+    "fin_Latn",
+    "fra_Latn",
+    "hin_Deva",
+    "ind_Latn",
+    "jpn_Jpan",
+    "kor_Hang",
+    "rus_Cyrl",
+    "swh_Latn",
+    "tel_Telu",
+    "tha_Thai",
+    "yor_Latn",
+    "zho_Hant",
+    "zho_Hans",
+]
+
 
 class GoogleTextEmbeddingModel(Encoder, Wrapper):
     def __init__(
@@ -102,7 +124,7 @@ class GoogleTextEmbeddingModel(Encoder, Wrapper):
         )
 
 
-google_emb_004 = ModelMeta(
+google_text_emb_004 = ModelMeta(
     loader=partial(
         GoogleTextEmbeddingModel,
         model_name="text-embedding-004",
@@ -117,6 +139,62 @@ google_emb_004 = ModelMeta(
     ),
     name="google/text-embedding-004",
     languages=["eng-Latn"],
+    open_weights=False,
+    revision="1",  # revision is intended for implementation
+    release_date="2024-05-14",
+    n_parameters=None,
+    memory_usage=None,
+    max_tokens=2048,
+    embed_dim=768,
+    license=None,
+    similarity_fn_name="cosine",  # assumed
+    framework=["API"],
+    use_instructions=True,
+)
+
+google_text_emb_005 = ModelMeta(
+    loader=partial(
+        GoogleTextEmbeddingModel,
+        model_name="text-embedding-005",
+        model_prompts={
+            "Classification": "CLASSIFICATION",
+            "MultilabelClassification": "CLASSIFICATION",
+            "Clustering": "CLUSTERING",
+            "STS": "SIMILARITY",
+            PromptType.query.value: "RETRIEVAL_QUERY",
+            PromptType.passage.value: "RETRIEVAL_DOCUMENT",
+        },
+    ),
+    name="google/text-embedding-005",
+    languages=["eng-Latn"],
+    open_weights=False,
+    revision="1",  # revision is intended for implementation
+    release_date="2024-11-18",
+    n_parameters=None,
+    memory_usage=None,
+    max_tokens=2048,
+    embed_dim=768,
+    license=None,
+    similarity_fn_name="cosine",  # assumed
+    framework=["API"],
+    use_instructions=True,
+)
+
+google_text_multilingual_emb_002 = ModelMeta(
+    loader=partial(
+        GoogleTextEmbeddingModel,
+        model_name="text-multilingual-embedding-002",
+        model_prompts={
+            "Classification": "CLASSIFICATION",
+            "MultilabelClassification": "CLASSIFICATION",
+            "Clustering": "CLUSTERING",
+            "STS": "SIMILARITY",
+            PromptType.query.value: "RETRIEVAL_QUERY",
+            PromptType.passage.value: "RETRIEVAL_DOCUMENT",
+        },
+    ),
+    name="google/text-multilingual-embedding-002",
+    languages=MULTILINGUAL_EVALUATED_LANGUAGES,  # From the list of evaluated languages in https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/text-embeddings-api#supported_text_languages
     open_weights=False,
     revision="1",  # revision is intended for implementation
     release_date="2024-05-14",

--- a/mteb/models/model2vec_models.py
+++ b/mteb/models/model2vec_models.py
@@ -7,7 +7,6 @@ from typing import Any
 
 import numpy as np
 
-from mteb.encoder_interface import PromptType
 from mteb.model_meta import ModelMeta
 
 from .wrapper import Wrapper
@@ -25,6 +24,7 @@ class Model2VecWrapper(Wrapper):
 
         Args:
             model_name: The Model2Vec model to load from HuggingFace Hub.
+            **kwargs: Additional arguments to pass to the wrapper.
         """
         try:
             from model2vec import StaticModel


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->

Hello! Small PR focused on `google_models.py` since we noticed that they were not working properly on the latest versions of MTEB.

This PR introduces a few fixes to make them work again, as well as two new models: `text-embedding-005` and `text-multilingual-embedding-002`.

Fixes #1480

## Changelist

- Use batching to circumvent Vertex AI limits on number of instances and input tokens
- Optionally use `tqdm` to show batching progress
- Load correct `google_task_type`, since we were wrongly passing the `prompt_name` before
- Add support for `text-embedding-005` and `text-multilingual-embedding-002` models
- Fix linting issue in `model2vec_models.py` raised by `make lint`


## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 

### Adding a model checklist
<!-- 
When adding a model to the model registry
see also https://github.com/embeddings-benchmark/mteb/blob/main/docs/reproducible_workflow.md
-->

 - [x] I have filled out the ModelMeta object to the extent possible
 - [x] I have ensured that my model can be loaded using
   - [x] `mteb.get_model(model_name, revision)` and
   - [x] `mteb.get_model_meta(model_name, revision)`
 - [x] I have tested the implementation works on a representative set of tasks. -> Results for `CUREv1` will be added to the results repo.