### PR TITLE
fix(publichealth-qa):  ignore rows with `None` values in `question` or `answer`

### DIFF
--- a/mteb/tasks/Retrieval/multilingual/PublicHealthQARetrieval.py
+++ b/mteb/tasks/Retrieval/multilingual/PublicHealthQARetrieval.py
@@ -43,6 +43,9 @@ def _load_publichealthqa_data(
         answer_ids = {answer: _id for _id, answer in enumerate(set(data["answer"]))}
 
         for row in data:
+            if row["question"] is None or row["answer"] is None:
+                # There are some questions and answers that are None in the original dataset, specifically in the Arabic subset.
+                continue
             question = row["question"]
             answer = row["answer"]
             query_id = f"Q{question_ids[question]}"


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->

[PublicHealthQA](https://huggingface.co/datasets/xhluca/publichealth-qa) has some rows with `None` values in `question` or `answer`, which raised an error while evaluating models on it. We noticed the issue when evaluating models in the `MTEB(Medical)` benchmark. This change was already applied in the results presented in https://github.com/embeddings-benchmark/results/pull/55.

## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 