### PR TITLE
fix(bm25s): search implementation

### DIFF
--- a/mteb/evaluation/evaluators/RetrievalEvaluator.py
+++ b/mteb/evaluation/evaluators/RetrievalEvaluator.py
@@ -477,10 +477,10 @@ class RetrievalEvaluator(Evaluator):
         if self.is_cross_encoder:
             return self.retriever.search_cross_encoder(corpus, queries, self.top_k)
         elif (
-            hasattr(self.retriever.model, "mteb_model_meta")
-            and self.retriever.model.mteb_model_meta.name == "bm25s"
+            hasattr(self.retriever.model.model, "mteb_model_meta")
+            and self.retriever.model.model.mteb_model_meta.name == "bm25s"
         ):
-            return self.retriever.model.search(
+            return self.retriever.model.model.search(
                 corpus,
                 queries,
                 self.top_k,

--- a/mteb/models/bm25.py
+++ b/mteb/models/bm25.py
@@ -58,7 +58,17 @@ def bm25_loader(**kwargs):
         ) -> dict[str, dict[str, float]]:
             logger.info("Encoding Corpus...")
             corpus_ids = list(corpus.keys())
-            corpus_with_ids = [{"doc_id": cid, **corpus[cid]} for cid in corpus_ids]
+            corpus_with_ids = [
+                {
+                    "doc_id": cid,
+                    **(
+                        {"text": corpus[cid]}
+                        if isinstance(corpus[cid], str)
+                        else corpus[cid]
+                    ),
+                }
+                for cid in corpus_ids
+            ]
 
             corpus_texts = [
                 "\n".join([doc.get("title", ""), doc["text"]])


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->

The `bm25s` implementation for retrieval tasks does not currently work with the latest versions of MTEB. This PR introduces two fixes to restore its functionality:

- Update the argument check in `RetrievalEvaluator` from `self.retriever.model` to `self.retriever.model.model`.
- Adjust the `search` method to account for the fact that `corpus[cid]` may now be a dictionary, removing the need to always wrap it as `{"text": corpus[cid]}`.

These changes were already applied in the results presented in https://github.com/embeddings-benchmark/results/pull/55 to verify that they worked properly. They will not impact older results.

## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 