### PR TITLE
fix: Added radar chart displaying capabilities on task types

### DIFF
--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -9,7 +9,7 @@ from gradio_rangeslider import RangeSlider
 
 import mteb
 from mteb.caching import json_cache
-from mteb.leaderboard.figures import performance_size_plot
+from mteb.leaderboard.figures import performance_size_plot, radar_chart
 from mteb.leaderboard.table import scores_to_tables
 
 
@@ -218,10 +218,16 @@ with gr.Blocks(fill_width=True, theme=gr.themes.Base(), head=head) as demo:
             )
             citation = gr.Markdown(update_citation, inputs=[benchmark_select])
         with gr.Column():
-            plot = gr.Plot(performance_size_plot, inputs=[summary_table])
-            gr.Markdown(
-                "*We only display models that have been run on all tasks in the benchmark*"
-            )
+            with gr.Tab("Performance-Size Plot"):
+                plot = gr.Plot(performance_size_plot, inputs=[summary_table])
+                gr.Markdown(
+                    "*We only display models that have been run on all tasks in the benchmark*"
+                )
+            with gr.Tab("Top 5 Radar Chart"):
+                radar_plot = gr.Plot(radar_chart, inputs=[summary_table])
+                gr.Markdown(
+                    "*We only display models that have been run on all task types in the benchmark*"
+                )
     with gr.Tab("Summary"):
         summary_table.render()
     with gr.Tab("Performance per task"):

--- a/mteb/leaderboard/figures.py
+++ b/mteb/leaderboard/figures.py
@@ -111,6 +111,8 @@ task_types = [
     "STS",
     "Summarization",
     # "InstructionRetrieval",
+    # Not displayed, because the scores are negative,
+    # doesn't work well with the radar chart.
     "Speed",
 ]
 

--- a/mteb/leaderboard/figures.py
+++ b/mteb/leaderboard/figures.py
@@ -97,3 +97,90 @@ def performance_size_plot(df: pd.DataFrame) -> go.Figure:
         margin=dict(b=20, t=10, l=20, r=10),  # noqa
     )
     return fig
+
+
+TOP_N = 5
+task_types = [
+    "BitextMining",
+    "Classification",
+    "MultilabelClassification",
+    "Clustering",
+    "PairClassification",
+    "Reranking",
+    "Retrieval",
+    "STS",
+    "Summarization",
+    # "InstructionRetrieval",
+    "Speed",
+]
+
+line_colors = [
+    "#EE4266",
+    "#00a6ed",
+    "#ECA72C",
+    "#B42318",
+    "#3CBBB1",
+]
+fill_colors = [
+    "rgba(238,66,102,0.2)",
+    "rgba(0,166,237,0.2)",
+    "rgba(236,167,44,0.2)",
+    "rgba(180,35,24,0.2)",
+    "rgba(60,187,177,0.2)",
+]
+
+
+def radar_chart(df: pd.DataFrame) -> go.Figure:
+    df = df.copy()
+    df["Model"] = df["Model"].map(parse_model_name)
+    # Remove whitespace
+    task_type_columns = [
+        column for column in df.columns if "".join(column.split()) in task_types
+    ]
+    df = df[["Model", *task_type_columns]].set_index("Model")
+    df = df.replace("", np.nan)
+    df = df.dropna()
+    df = df.head(TOP_N)
+    df = df.iloc[::-1]
+    fig = go.Figure()
+    for i, (model_name, row) in enumerate(df.iterrows()):
+        fig.add_trace(
+            go.Scatterpolar(
+                name=model_name,
+                r=[row[task_type] for task_type in task_type_columns]
+                + [row[task_type_columns[0]]],
+                theta=task_type_columns + [task_type_columns[0]],
+                showlegend=True,
+                mode="lines",
+                line=dict(width=2, color=line_colors[i]),
+                fill="toself",
+                fillcolor=fill_colors[i],
+            )
+        )
+    fig.update_layout(
+        font=dict(size=16, color="black"),  # noqa
+        template="plotly_white",
+        polar=dict(
+            radialaxis=dict(
+                visible=True,
+                gridcolor="black",
+                linecolor="rgba(0,0,0,0)",
+                gridwidth=1,
+                showticklabels=False,
+                ticks="",
+            ),
+            angularaxis=dict(
+                gridcolor="black", gridwidth=1.5, linecolor="rgba(0,0,0,0)"
+            ),
+        ),
+        legend=dict(
+            orientation="h",
+            yanchor="bottom",
+            y=-0.6,
+            xanchor="left",
+            x=-0.05,
+            entrywidthmode="fraction",
+            entrywidth=1 / 5,
+        ),
+    )
+    return fig


### PR DESCRIPTION
I added a radar chart to a tab you can switch to from the other plot.
It only displays the top 5 models that have been run on all task types to avoid clutter.
I also decided not to display instruction retrieval, since it can be negative and it looks weird.
Here's how it looks:
![image](https://github.com/user-attachments/assets/ab1e8aed-61dc-4b00-85cc-3ed4d2d27552)
