### PR TITLE
[MIEB] Make multimodal models compatible to `task_name` and `prompt_type`

### DIFF
--- a/mteb/evaluation/evaluators/Image/Any2AnyRetrievalEvaluator.py
+++ b/mteb/evaluation/evaluators/Image/Any2AnyRetrievalEvaluator.py
@@ -310,7 +310,7 @@ class Any2AnyRetrievalEvaluator(Evaluator):
             queries,
             self.top_k,
             self.score_function,
-            task_name=self.task_name,  # type: ignore
+            task_name=self.task_name,
         )
 
     @staticmethod

--- a/mteb/evaluation/evaluators/Image/Any2AnyRetrievalEvaluator.py
+++ b/mteb/evaluation/evaluators/Image/Any2AnyRetrievalEvaluator.py
@@ -17,7 +17,7 @@ from PIL import Image
 from torch.utils.data import DataLoader
 from torchvision import transforms
 
-from mteb.encoder_interface import Encoder
+from mteb.encoder_interface import Encoder, PromptType
 
 from ..Evaluator import Evaluator
 from ..utils import (
@@ -36,7 +36,7 @@ os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 logger = logging.getLogger(__name__)
 
-transform = transforms.Compose([transforms.PILToTensor()])
+DEFAULT_TRANSFORM = transforms.Compose([transforms.PILToTensor()])
 
 
 class ImageDataset(torch.utils.data.Dataset):
@@ -57,7 +57,8 @@ class ImageDataset(torch.utils.data.Dataset):
             image = image
         if image.mode != "RGB":
             image = image.convert("RGB")
-        image = self.transform(image)
+        if self.transform is not None:
+            image = self.transform(image)
         return image
 
 
@@ -73,11 +74,13 @@ class Any2AnyDenseRetrievalExactSearch:
         encode_kwargs: dict[str, Any] = {},
         corpus_chunk_size: int = 20000,
         previous_results: str | None = None,
+        transform=DEFAULT_TRANSFORM,
         **kwargs: Any,
     ):
         # Model is class that provides get_text_embeddings() and get_image_embeddings()
         self.model = model
         self.encode_kwargs = encode_kwargs
+        self.transform = transform
 
         if "batch_size" not in encode_kwargs:
             encode_kwargs["batch_size"] = 128
@@ -104,6 +107,7 @@ class Any2AnyDenseRetrievalExactSearch:
         queries: Dataset,  # solve memoery issues
         top_k: int,
         score_function: str,
+        task_name: str,
         return_sorted: bool = False,
         **kwargs,
     ) -> dict[str, dict[str, float]]:
@@ -121,11 +125,14 @@ class Any2AnyDenseRetrievalExactSearch:
         if q_modality == "text":
             query_texts = queries["text"]
             query_embeddings = self.model.get_text_embeddings(
-                texts=query_texts, batch_size=self.encode_kwargs["batch_size"]
+                texts=query_texts,
+                task_name=task_name,
+                prompt_type=PromptType.query,
+                **self.encode_kwargs,
             )
         else:
             queries_dataset = ImageDataset(
-                queries, image_column_name="image", transform=transform
+                queries, image_column_name="image", transform=self.transform
             )
             query_image_dataloader = DataLoader(
                 queries_dataset,
@@ -137,14 +144,18 @@ class Any2AnyDenseRetrievalExactSearch:
             if q_modality == "image":
                 query_embeddings = self.model.get_image_embeddings(
                     images=query_image_dataloader,
-                    batch_size=self.encode_kwargs["batch_size"],
+                    task_name=task_name,
+                    prompt_type=PromptType.query,
+                    **self.encode_kwargs,
                 )
             elif q_modality == "image,text":
                 query_texts = queries["text"]
                 query_embeddings = self.model.get_fused_embeddings(
                     texts=query_texts,
                     images=query_image_dataloader,
-                    batch_size=self.encode_kwargs["batch_size"],
+                    task_name=task_name,
+                    prompt_type=PromptType.query,
+                    **self.encode_kwargs,
                 )
             else:
                 raise ValueError(f"Unsupported modality: {q_modality}")
@@ -171,11 +182,14 @@ class Any2AnyDenseRetrievalExactSearch:
             if corpus_modality == "text":
                 corpus_texts = chunk["text"]
                 sub_corpus_embeddings = self.model.get_text_embeddings(
-                    texts=corpus_texts, batch_size=self.encode_kwargs["batch_size"]
+                    texts=corpus_texts,
+                    task_name=task_name,
+                    prompt_type=PromptType.passage,
+                    **self.encode_kwargs,
                 )
             else:
                 corpus_dataset = ImageDataset(
-                    chunk, image_column_name="image", transform=transform
+                    chunk, image_column_name="image", transform=self.transform
                 )
                 corpus_image_dataloader = DataLoader(
                     corpus_dataset,
@@ -187,14 +201,18 @@ class Any2AnyDenseRetrievalExactSearch:
                 if corpus_modality == "image":
                     sub_corpus_embeddings = self.model.get_image_embeddings(
                         images=corpus_image_dataloader,
-                        batch_size=self.encode_kwargs["batch_size"],
+                        task_name=task_name,
+                        prompt_type=PromptType.passage,
+                        **self.encode_kwargs,
                     )
                 elif corpus_modality == "image,text":
                     corpus_texts = chunk["text"]
                     sub_corpus_embeddings = self.model.get_fused_embeddings(
                         texts=corpus_texts,
                         images=corpus_image_dataloader,
-                        batch_size=self.encode_kwargs["batch_size"],
+                        task_name=task_name,
+                        prompt_type=PromptType.passage,
+                        **self.encode_kwargs,
                     )
                 else:
                     raise ValueError(f"Unsupported modality: {corpus_modality}")
@@ -292,7 +310,7 @@ class Any2AnyRetrievalEvaluator(Evaluator):
             queries,
             self.top_k,
             self.score_function,
-            prompt_name=self.task_name,  # type: ignore
+            task_name=self.task_name,  # type: ignore
         )
 
     @staticmethod

--- a/mteb/evaluation/evaluators/Image/ZeroshotClassificationEvaluator.py
+++ b/mteb/evaluation/evaluators/Image/ZeroshotClassificationEvaluator.py
@@ -84,6 +84,6 @@ class ZeroshotClassificationEvaluator(Evaluator):
 
         logger.info("Evaluating...")
 
-        accuracy = metrics.accuracy_score(self.labels, predictions)
+        accuracy = metrics.accuracy_score(self.labels, predictions.tolist())
 
         return {"accuracy": accuracy}

--- a/mteb/models/align_models.py
+++ b/mteb/models/align_models.py
@@ -9,6 +9,7 @@ from torch.utils.data import DataLoader
 from tqdm import tqdm
 from transformers import AutoModel, AutoProcessor
 
+from mteb.encoder_interface import PromptType
 from mteb.model_meta import ModelMeta
 
 
@@ -24,7 +25,14 @@ class ALIGNModelWrapper:
         self.model = AutoModel.from_pretrained(model_name).to(self.device)
         self.processor = AutoProcessor.from_pretrained(model_name)
 
-    def get_text_embeddings(self, texts: list[str], batch_size: int = 32):
+    def get_text_embeddings(
+        self,
+        texts: list[str],
+        batch_size: int = 32,
+        task_name: str | None = None,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
+    ):
         all_text_embeddings = []
 
         with torch.no_grad():
@@ -41,7 +49,12 @@ class ALIGNModelWrapper:
         return all_text_embeddings
 
     def get_image_embeddings(
-        self, images: list[Image.Image] | DataLoader, batch_size: int = 32
+        self,
+        images: list[Image.Image] | DataLoader,
+        batch_size: int = 32,
+        task_name: str | None = None,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
     ):
         all_image_embeddings = []
         if isinstance(images, DataLoader):
@@ -88,6 +101,9 @@ class ALIGNModelWrapper:
         images: list[Image.Image] | DataLoader = None,
         fusion_mode="sum",
         batch_size: int = 32,
+        task_name: str | None = None,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
     ):
         if texts is None and images is None:
             raise ValueError("Either texts or images must be provided")

--- a/mteb/models/align_models.py
+++ b/mteb/models/align_models.py
@@ -52,9 +52,10 @@ class ALIGNModelWrapper:
     def get_image_embeddings(
         self,
         images: list[Image.Image] | DataLoader,
-        batch_size: int = 32,
+        *,
         task_name: str | None = None,
         prompt_type: PromptType | None = None,
+        batch_size: int = 32,
         **kwargs: Any,
     ):
         all_image_embeddings = []
@@ -100,10 +101,10 @@ class ALIGNModelWrapper:
         self,
         texts: list[str] = None,
         images: list[Image.Image] | DataLoader = None,
-        fusion_mode="sum",
-        batch_size: int = 32,
         task_name: str | None = None,
         prompt_type: PromptType | None = None,
+        batch_size: int = 32,
+        fusion_mode="sum",
         **kwargs: Any,
     ):
         if texts is None and images is None:

--- a/mteb/models/align_models.py
+++ b/mteb/models/align_models.py
@@ -28,9 +28,10 @@ class ALIGNModelWrapper:
     def get_text_embeddings(
         self,
         texts: list[str],
-        batch_size: int = 32,
+        *,
         task_name: str | None = None,
         prompt_type: PromptType | None = None,
+        batch_size: int = 32,
         **kwargs: Any,
     ):
         all_text_embeddings = []

--- a/mteb/models/blip2_models.py
+++ b/mteb/models/blip2_models.py
@@ -52,9 +52,10 @@ def blip2_loader(**kwargs):
         def get_text_embeddings(
             self,
             texts: list[str],
-            batch_size: int = 32,
+            *,
             task_name: str | None = None,
             prompt_type: PromptType | None = None,
+            batch_size: int = 32,
             **kwargs: Any,
         ):
             all_text_embeddings = []
@@ -79,9 +80,10 @@ def blip2_loader(**kwargs):
         def get_image_embeddings(
             self,
             images: list[Image.Image] | DataLoader,
-            batch_size: int = 32,
+            *,
             task_name: str | None = None,
             prompt_type: PromptType | None = None,
+            batch_size: int = 32,
             **kwargs: Any,
         ):
             all_image_embeddings = []
@@ -172,10 +174,10 @@ def blip2_loader(**kwargs):
             self,
             texts: list[str] = None,
             images: list[Image.Image] | DataLoader = None,
-            fusion_mode="sum",
-            batch_size: int = 32,
             task_name: str | None = None,
             prompt_type: PromptType | None = None,
+            batch_size: int = 32,
+            fusion_mode="sum",
             **kwargs: Any,
         ):
             # TODO: find out if BLIP has a prescribed way of fusing text and image embeddings

--- a/mteb/models/blip2_models.py
+++ b/mteb/models/blip2_models.py
@@ -9,6 +9,7 @@ from torch.utils.data import DataLoader
 from tqdm import tqdm
 from transformers import Blip2Processor
 
+from mteb.encoder_interface import PromptType
 from mteb.model_meta import ModelMeta
 
 
@@ -48,7 +49,14 @@ def blip2_loader(**kwargs):
                 text=texts, images=images, return_tensors="pt", padding=True
             )
 
-        def get_text_embeddings(self, texts: list[str], batch_size: int = 32):
+        def get_text_embeddings(
+            self,
+            texts: list[str],
+            batch_size: int = 32,
+            task_name: str | None = None,
+            prompt_type: PromptType | None = None,
+            **kwargs: Any,
+        ):
             all_text_embeddings = []
 
             with torch.no_grad():
@@ -69,7 +77,12 @@ def blip2_loader(**kwargs):
             return all_text_embeddings
 
         def get_image_embeddings(
-            self, images: list[Image.Image] | DataLoader, batch_size: int = 32
+            self,
+            images: list[Image.Image] | DataLoader,
+            batch_size: int = 32,
+            task_name: str | None = None,
+            prompt_type: PromptType | None = None,
+            **kwargs: Any,
         ):
             all_image_embeddings = []
 
@@ -161,6 +174,9 @@ def blip2_loader(**kwargs):
             images: list[Image.Image] | DataLoader = None,
             fusion_mode="sum",
             batch_size: int = 32,
+            task_name: str | None = None,
+            prompt_type: PromptType | None = None,
+            **kwargs: Any,
         ):
             # TODO: find out if BLIP has a prescribed way of fusing text and image embeddings
             if texts is None and images is None:

--- a/mteb/models/blip_models.py
+++ b/mteb/models/blip_models.py
@@ -10,6 +10,7 @@ from torch.utils.data import DataLoader
 from tqdm import tqdm
 from transformers import BlipForImageTextRetrieval, BlipProcessor
 
+from mteb.encoder_interface import PromptType
 from mteb.model_meta import ModelMeta
 
 
@@ -36,7 +37,14 @@ class BLIPModelWrapper:
             text=texts, images=images, return_tensors="pt", padding=True
         )
 
-    def get_text_embeddings(self, texts: list[str], batch_size: int = 32):
+    def get_text_embeddings(
+        self,
+        texts: list[str],
+        batch_size: int = 32,
+        task_name: str | None = None,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
+    ):
         all_text_embeddings = []
 
         with torch.no_grad():
@@ -58,7 +66,12 @@ class BLIPModelWrapper:
         return all_text_embeddings
 
     def get_image_embeddings(
-        self, images: list[Image.Image] | DataLoader, batch_size: int = 32
+        self,
+        images: list[Image.Image] | DataLoader,
+        batch_size: int = 32,
+        task_name: str | None = None,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
     ):
         all_image_embeddings = []
 
@@ -108,6 +121,9 @@ class BLIPModelWrapper:
         images: list[Image.Image] | DataLoader = None,
         fusion_mode="sum",
         batch_size: int = 32,
+        task_name: str | None = None,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
     ):
         if texts is None and images is None:
             raise ValueError("Either texts or images must be provided")

--- a/mteb/models/blip_models.py
+++ b/mteb/models/blip_models.py
@@ -40,9 +40,10 @@ class BLIPModelWrapper:
     def get_text_embeddings(
         self,
         texts: list[str],
-        batch_size: int = 32,
+        *,
         task_name: str | None = None,
         prompt_type: PromptType | None = None,
+        batch_size: int = 32,
         **kwargs: Any,
     ):
         all_text_embeddings = []
@@ -68,9 +69,10 @@ class BLIPModelWrapper:
     def get_image_embeddings(
         self,
         images: list[Image.Image] | DataLoader,
-        batch_size: int = 32,
+        *,
         task_name: str | None = None,
         prompt_type: PromptType | None = None,
+        batch_size: int = 32,
         **kwargs: Any,
     ):
         all_image_embeddings = []
@@ -119,10 +121,10 @@ class BLIPModelWrapper:
         self,
         texts: list[str] = None,
         images: list[Image.Image] | DataLoader = None,
-        fusion_mode="sum",
-        batch_size: int = 32,
         task_name: str | None = None,
         prompt_type: PromptType | None = None,
+        batch_size: int = 32,
+        fusion_mode="sum",
         **kwargs: Any,
     ):
         if texts is None and images is None:

--- a/mteb/models/clip_models.py
+++ b/mteb/models/clip_models.py
@@ -9,6 +9,7 @@ from torch.utils.data import DataLoader
 from tqdm import tqdm
 from transformers import AutoModel, AutoProcessor
 
+from mteb.encoder_interface import PromptType
 from mteb.model_meta import ModelMeta
 
 
@@ -33,7 +34,14 @@ class CLIPModelWrapper:
             text=texts, images=images, return_tensors="pt", padding=True
         )
 
-    def get_text_embeddings(self, texts: list[str], batch_size: int = 32):
+    def get_text_embeddings(
+        self,
+        texts: list[str],
+        batch_size: int = 32,
+        task_name: str | None = None,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
+    ):
         all_text_embeddings = []
 
         with torch.no_grad():
@@ -50,7 +58,12 @@ class CLIPModelWrapper:
         return all_text_embeddings
 
     def get_image_embeddings(
-        self, images: list[Image.Image] | DataLoader, batch_size: int = 32
+        self,
+        images: list[Image.Image] | DataLoader,
+        batch_size: int = 32,
+        task_name: str | None = None,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
     ):
         all_image_embeddings = []
 
@@ -92,6 +105,9 @@ class CLIPModelWrapper:
         images: list[Image.Image] | DataLoader = None,
         fusion_mode="sum",
         batch_size: int = 32,
+        task_name: str | None = None,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
     ):
         if texts is None and images is None:
             raise ValueError("Either texts or images must be provided")

--- a/mteb/models/clip_models.py
+++ b/mteb/models/clip_models.py
@@ -37,9 +37,10 @@ class CLIPModelWrapper:
     def get_text_embeddings(
         self,
         texts: list[str],
-        batch_size: int = 32,
+        *,
         task_name: str | None = None,
         prompt_type: PromptType | None = None,
+        batch_size: int = 32,
         **kwargs: Any,
     ):
         all_text_embeddings = []
@@ -60,9 +61,10 @@ class CLIPModelWrapper:
     def get_image_embeddings(
         self,
         images: list[Image.Image] | DataLoader,
-        batch_size: int = 32,
+        *,
         task_name: str | None = None,
         prompt_type: PromptType | None = None,
+        batch_size: int = 32,
         **kwargs: Any,
     ):
         all_image_embeddings = []
@@ -103,10 +105,10 @@ class CLIPModelWrapper:
         self,
         texts: list[str] = None,
         images: list[Image.Image] | DataLoader = None,
-        fusion_mode="sum",
-        batch_size: int = 32,
         task_name: str | None = None,
         prompt_type: PromptType | None = None,
+        batch_size: int = 32,
+        fusion_mode="sum",
         **kwargs: Any,
     ):
         if texts is None and images is None:

--- a/mteb/models/cohere_v.py
+++ b/mteb/models/cohere_v.py
@@ -14,6 +14,7 @@ from torchvision import transforms
 from tqdm import tqdm
 
 import mteb
+from mteb.encoder_interface import PromptType
 from mteb.model_meta import ModelMeta
 
 api_key = os.getenv("COHERE_API_KEY")
@@ -42,7 +43,14 @@ def cohere_v_loader(**kwargs):
             Remove or adjust this after Cohere API changes capacity.
             """
 
-        def get_text_embeddings(self, texts: list[str], batch_size: int = 32):
+        def get_text_embeddings(
+            self,
+            texts: list[str],
+            batch_size: int = 32,
+            task_name: str | None = None,
+            prompt_type: PromptType | None = None,
+            **kwargs: Any,
+        ):
             all_text_embeddings = []
 
             for i in tqdm(range(0, len(texts), batch_size)):
@@ -58,7 +66,12 @@ def cohere_v_loader(**kwargs):
             return all_text_embeddings
 
         def get_image_embeddings(
-            self, images: list[Image.Image] | DataLoader, batch_size: int = 32
+            self,
+            images: list[Image.Image] | DataLoader,
+            batch_size: int = 32,
+            task_name: str | None = None,
+            prompt_type: PromptType | None = None,
+            **kwargs: Any,
         ):
             all_image_embeddings = []
 
@@ -132,6 +145,9 @@ def cohere_v_loader(**kwargs):
             images: list[Image.Image] | DataLoader = None,
             fusion_mode="sum",
             batch_size: int = 32,
+            task_name: str | None = None,
+            prompt_type: PromptType | None = None,
+            **kwargs: Any,
         ):
             if texts is None and images is None:
                 raise ValueError("Either texts or images must be provided")

--- a/mteb/models/cohere_v.py
+++ b/mteb/models/cohere_v.py
@@ -46,9 +46,10 @@ def cohere_v_loader(**kwargs):
         def get_text_embeddings(
             self,
             texts: list[str],
-            batch_size: int = 32,
+            *,
             task_name: str | None = None,
             prompt_type: PromptType | None = None,
+            batch_size: int = 32,
             **kwargs: Any,
         ):
             all_text_embeddings = []
@@ -68,9 +69,10 @@ def cohere_v_loader(**kwargs):
         def get_image_embeddings(
             self,
             images: list[Image.Image] | DataLoader,
-            batch_size: int = 32,
+            *,
             task_name: str | None = None,
             prompt_type: PromptType | None = None,
+            batch_size: int = 32,
             **kwargs: Any,
         ):
             all_image_embeddings = []
@@ -143,10 +145,10 @@ def cohere_v_loader(**kwargs):
             self,
             texts: list[str] = None,
             images: list[Image.Image] | DataLoader = None,
-            fusion_mode="sum",
-            batch_size: int = 32,
             task_name: str | None = None,
             prompt_type: PromptType | None = None,
+            batch_size: int = 32,
+            fusion_mode="sum",
             **kwargs: Any,
         ):
             if texts is None and images is None:

--- a/mteb/models/dino_models.py
+++ b/mteb/models/dino_models.py
@@ -32,9 +32,10 @@ class DINOModelWrapper:
     @staticmethod
     def get_text_embeddings(
         texts: list[str],
-        batch_size: int = 32,
+        *,
         task_name: str | None = None,
         prompt_type: PromptType | None = None,
+        batch_size: int = 32,
         **kwargs: Any,
     ):
         raise ValueError("DINO models only support image encoding.")
@@ -42,10 +43,11 @@ class DINOModelWrapper:
     def get_image_embeddings(
         self,
         images: list[Image.Image] | DataLoader,
-        batch_size: int = 32,
-        pooling="cls",
+        *,
         task_name: str | None = None,
         prompt_type: PromptType | None = None,
+        batch_size: int = 32,
+        pooling="cls",
         **kwargs: Any,
     ):
         all_image_embeddings = []
@@ -95,10 +97,10 @@ class DINOModelWrapper:
         self,
         texts: list[str] = None,
         images: list[Image.Image] | DataLoader = None,
-        fusion_mode="sum",
-        batch_size: int = 32,
         task_name: str | None = None,
         prompt_type: PromptType | None = None,
+        batch_size: int = 32,
+        fusion_mode="sum",
         **kwargs: Any,
     ):
         if texts is None and images is None:

--- a/mteb/models/dino_models.py
+++ b/mteb/models/dino_models.py
@@ -9,6 +9,7 @@ from torch.utils.data import DataLoader
 from tqdm import tqdm
 from transformers import AutoImageProcessor, AutoModel
 
+from mteb.encoder_interface import PromptType
 from mteb.model_meta import ModelMeta
 
 
@@ -29,7 +30,13 @@ class DINOModelWrapper:
         self.processor = AutoImageProcessor.from_pretrained(model_name)
 
     @staticmethod
-    def get_text_embeddings(texts: list[str], batch_size: int = 32):
+    def get_text_embeddings(
+        texts: list[str],
+        batch_size: int = 32,
+        task_name: str | None = None,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
+    ):
         raise ValueError("DINO models only support image encoding.")
 
     def get_image_embeddings(
@@ -37,6 +44,9 @@ class DINOModelWrapper:
         images: list[Image.Image] | DataLoader,
         batch_size: int = 32,
         pooling="cls",
+        task_name: str | None = None,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
     ):
         all_image_embeddings = []
 
@@ -87,6 +97,9 @@ class DINOModelWrapper:
         images: list[Image.Image] | DataLoader = None,
         fusion_mode="sum",
         batch_size: int = 32,
+        task_name: str | None = None,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
     ):
         if texts is None and images is None:
             raise ValueError("images must be provided for DINO models")

--- a/mteb/models/e5_v.py
+++ b/mteb/models/e5_v.py
@@ -9,6 +9,7 @@ from torch.utils.data import DataLoader
 from tqdm import tqdm
 from transformers import LlavaNextForConditionalGeneration, LlavaNextProcessor
 
+from mteb.encoder_interface import PromptType
 from mteb.model_meta import ModelMeta
 
 
@@ -42,7 +43,14 @@ class E5VWrapper:
         else:
             self.composed_prompt = self.template.format(composed_prompt)
 
-    def get_text_embeddings(self, texts: list[str], batch_size: int = 8):
+    def get_text_embeddings(
+        self,
+        texts: list[str],
+        batch_size: int = 8,
+        task_name: str | None = None,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
+    ):
         all_text_embeddings = []
 
         with torch.no_grad():
@@ -60,7 +68,12 @@ class E5VWrapper:
         return torch.cat(all_text_embeddings, dim=0)
 
     def get_image_embeddings(
-        self, images: list[Image.Image] | DataLoader, batch_size: int = 8
+        self,
+        images: list[Image.Image] | DataLoader,
+        batch_size: int = 8,
+        task_name: str | None = None,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
     ):
         all_image_embeddings = []
 
@@ -106,6 +119,9 @@ class E5VWrapper:
         texts: list[str] = None,
         images: list[Image.Image] = None,
         batch_size: int = 8,
+        task_name: str | None = None,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
     ):
         if texts is None and images is None:
             raise ValueError("Either texts or images must be provided")

--- a/mteb/models/e5_v.py
+++ b/mteb/models/e5_v.py
@@ -46,9 +46,10 @@ class E5VWrapper:
     def get_text_embeddings(
         self,
         texts: list[str],
-        batch_size: int = 8,
+        *,
         task_name: str | None = None,
         prompt_type: PromptType | None = None,
+        batch_size: int = 8,
         **kwargs: Any,
     ):
         all_text_embeddings = []
@@ -70,9 +71,10 @@ class E5VWrapper:
     def get_image_embeddings(
         self,
         images: list[Image.Image] | DataLoader,
-        batch_size: int = 8,
+        *,
         task_name: str | None = None,
         prompt_type: PromptType | None = None,
+        batch_size: int = 8,
         **kwargs: Any,
     ):
         all_image_embeddings = []
@@ -118,9 +120,10 @@ class E5VWrapper:
         self,
         texts: list[str] = None,
         images: list[Image.Image] = None,
-        batch_size: int = 8,
+        *,
         task_name: str | None = None,
         prompt_type: PromptType | None = None,
+        batch_size: int = 8,
         **kwargs: Any,
     ):
         if texts is None and images is None:

--- a/mteb/models/evaclip_models.py
+++ b/mteb/models/evaclip_models.py
@@ -49,9 +49,9 @@ def evaclip_loader(**kwargs):
             self,
             sentences: list[str],
             *,
-            batch_size: int = 32,
             task_name: str | None = None,
             prompt_type: PromptType | None = None,
+            batch_size: int = 32,
             **kwargs: Any,
         ):
             return self.get_text_embeddings(texts=sentences, batch_size=batch_size)
@@ -59,9 +59,10 @@ def evaclip_loader(**kwargs):
         def get_text_embeddings(
             self,
             texts: list[str],
-            batch_size: int = 32,
+            *,
             task_name: str | None = None,
             prompt_type: PromptType | None = None,
+            batch_size: int = 32,
             **kwargs: Any,
         ):
             all_text_embeddings = []
@@ -79,9 +80,10 @@ def evaclip_loader(**kwargs):
         def get_image_embeddings(
             self,
             images: list[Image.Image] | DataLoader,
-            batch_size: int = 32,
+            *,
             task_name: str | None = None,
             prompt_type: PromptType | None = None,
+            batch_size: int = 32,
             **kwargs: Any,
         ):
             all_image_embeddings = []
@@ -127,10 +129,11 @@ def evaclip_loader(**kwargs):
             self,
             texts: list[str] = None,
             images: list[Image.Image] | DataLoader = None,
-            fusion_mode="sum",
-            batch_size: int = 32,
+            *,
             task_name: str | None = None,
             prompt_type: PromptType | None = None,
+            batch_size: int = 32,
+            fusion_mode="sum",
             **kwargs: Any,
         ):
             if texts is None and images is None:

--- a/mteb/models/evaclip_models.py
+++ b/mteb/models/evaclip_models.py
@@ -8,6 +8,7 @@ from PIL import Image
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
+from mteb.encoder_interface import PromptType
 from mteb.model_meta import ModelMeta
 
 
@@ -49,11 +50,20 @@ def evaclip_loader(**kwargs):
             sentences: list[str],
             *,
             batch_size: int = 32,
+            task_name: str | None = None,
+            prompt_type: PromptType | None = None,
             **kwargs: Any,
         ):
             return self.get_text_embeddings(texts=sentences, batch_size=batch_size)
 
-        def get_text_embeddings(self, texts: list[str], batch_size: int = 32):
+        def get_text_embeddings(
+            self,
+            texts: list[str],
+            batch_size: int = 32,
+            task_name: str | None = None,
+            prompt_type: PromptType | None = None,
+            **kwargs: Any,
+        ):
             all_text_embeddings = []
 
             with torch.no_grad(), torch.cuda.amp.autocast():
@@ -67,7 +77,12 @@ def evaclip_loader(**kwargs):
             return all_text_embeddings
 
         def get_image_embeddings(
-            self, images: list[Image.Image] | DataLoader, batch_size: int = 32
+            self,
+            images: list[Image.Image] | DataLoader,
+            batch_size: int = 32,
+            task_name: str | None = None,
+            prompt_type: PromptType | None = None,
+            **kwargs: Any,
         ):
             all_image_embeddings = []
             if isinstance(images, DataLoader):
@@ -114,6 +129,9 @@ def evaclip_loader(**kwargs):
             images: list[Image.Image] | DataLoader = None,
             fusion_mode="sum",
             batch_size: int = 32,
+            task_name: str | None = None,
+            prompt_type: PromptType | None = None,
+            **kwargs: Any,
         ):
             if texts is None and images is None:
                 raise ValueError("Either texts or images must be provided")

--- a/mteb/models/jina_clip.py
+++ b/mteb/models/jina_clip.py
@@ -9,6 +9,7 @@ from torch.utils.data import DataLoader
 from tqdm import tqdm
 from transformers import AutoModel
 
+from mteb.encoder_interface import PromptType
 from mteb.model_meta import ModelMeta
 
 
@@ -31,6 +32,9 @@ class JinaCLIPModelWrapper:
         batch_size: int = 32,
         convert_to_numpy=False,
         convert_to_tensor=True,
+        task_name: str | None = None,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
     ):
         all_text_embeddings = []
 
@@ -53,6 +57,9 @@ class JinaCLIPModelWrapper:
         batch_size: int = 32,
         convert_to_numpy=False,
         convert_to_tensor=True,
+        task_name: str | None = None,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
     ):
         all_image_embeddings = []
 
@@ -94,6 +101,9 @@ class JinaCLIPModelWrapper:
         images: list[Image.Image] = None,
         fusion_mode="sum",
         batch_size: int = 32,
+        task_name: str | None = None,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
     ):
         if texts is None and images is None:
             raise ValueError("Either texts or images must be provided")

--- a/mteb/models/jina_clip.py
+++ b/mteb/models/jina_clip.py
@@ -29,11 +29,12 @@ class JinaCLIPModelWrapper:
     def get_text_embeddings(
         self,
         texts: list[str],
+        *,
+        task_name: str | None = None,
+        prompt_type: PromptType | None = None,
         batch_size: int = 32,
         convert_to_numpy=False,
         convert_to_tensor=True,
-        task_name: str | None = None,
-        prompt_type: PromptType | None = None,
         **kwargs: Any,
     ):
         all_text_embeddings = []
@@ -54,11 +55,12 @@ class JinaCLIPModelWrapper:
     def get_image_embeddings(
         self,
         images: list[Image.Image] | DataLoader,
+        *,
+        task_name: str | None = None,
+        prompt_type: PromptType | None = None,
         batch_size: int = 32,
         convert_to_numpy=False,
         convert_to_tensor=True,
-        task_name: str | None = None,
-        prompt_type: PromptType | None = None,
         **kwargs: Any,
     ):
         all_image_embeddings = []
@@ -99,10 +101,11 @@ class JinaCLIPModelWrapper:
         self,
         texts: list[str] = None,
         images: list[Image.Image] = None,
-        fusion_mode="sum",
-        batch_size: int = 32,
+        *,
         task_name: str | None = None,
         prompt_type: PromptType | None = None,
+        batch_size: int = 32,
+        fusion_mode="sum",
         **kwargs: Any,
     ):
         if texts is None and images is None:

--- a/mteb/models/moco_models.py
+++ b/mteb/models/moco_models.py
@@ -8,6 +8,7 @@ from PIL import Image
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
+from mteb.encoder_interface import PromptType
 from mteb.model_meta import ModelMeta
 
 
@@ -56,6 +57,9 @@ def mocov3_loader(**kwargs):
             self,
             images: list[Image.Image] | DataLoader,
             batch_size: int = 32,
+            task_name: str | None = None,
+            prompt_type: PromptType | None = None,
+            **kwargs: Any,
         ):
             all_image_embeddings = []
 
@@ -99,6 +103,9 @@ def mocov3_loader(**kwargs):
             images: list[Image.Image] | DataLoader = None,
             fusion_mode="sum",
             batch_size: int = 32,
+            task_name: str | None = None,
+            prompt_type: PromptType | None = None,
+            **kwargs: Any,
         ):
             if texts is None and images is None:
                 raise ValueError("images must be provided for MOCO models")

--- a/mteb/models/moco_models.py
+++ b/mteb/models/moco_models.py
@@ -56,9 +56,10 @@ def mocov3_loader(**kwargs):
         def get_image_embeddings(
             self,
             images: list[Image.Image] | DataLoader,
-            batch_size: int = 32,
+            *,
             task_name: str | None = None,
             prompt_type: PromptType | None = None,
+            batch_size: int = 32,
             **kwargs: Any,
         ):
             all_image_embeddings = []
@@ -101,10 +102,11 @@ def mocov3_loader(**kwargs):
             self,
             texts: list[str] = None,
             images: list[Image.Image] | DataLoader = None,
-            fusion_mode="sum",
-            batch_size: int = 32,
+            *,
             task_name: str | None = None,
             prompt_type: PromptType | None = None,
+            batch_size: int = 32,
+            fusion_mode="sum",
             **kwargs: Any,
         ):
             if texts is None and images is None:

--- a/mteb/models/nomic_models_vision.py
+++ b/mteb/models/nomic_models_vision.py
@@ -10,6 +10,7 @@ from torch.utils.data import DataLoader
 from tqdm import tqdm
 from transformers import AutoImageProcessor, AutoModel, AutoTokenizer
 
+from mteb.encoder_interface import PromptType
 from mteb.model_meta import ModelMeta
 
 
@@ -45,7 +46,14 @@ class NomicVisionModelWrapper:
             text=texts, images=images, return_tensors="pt", padding=True
         )
 
-    def get_text_embeddings(self, texts: list[str], batch_size: int = 32):
+    def get_text_embeddings(
+        self,
+        texts: list[str],
+        batch_size: int = 32,
+        task_name: str | None = None,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
+    ):
         all_text_embeddings = []
 
         with torch.no_grad():
@@ -78,7 +86,12 @@ class NomicVisionModelWrapper:
         )
 
     def get_image_embeddings(
-        self, images: list[Image.Image] | DataLoader, batch_size: int = 32
+        self,
+        images: list[Image.Image] | DataLoader,
+        batch_size: int = 32,
+        task_name: str | None = None,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
     ):
         all_image_embeddings = []
 
@@ -115,6 +128,9 @@ class NomicVisionModelWrapper:
         images: list[Image.Image] | DataLoader = None,
         fusion_mode="sum",
         batch_size: int = 32,
+        task_name: str | None = None,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
     ):
         if texts is None and images is None:
             raise ValueError("Either texts or images must be provided")

--- a/mteb/models/nomic_models_vision.py
+++ b/mteb/models/nomic_models_vision.py
@@ -49,9 +49,10 @@ class NomicVisionModelWrapper:
     def get_text_embeddings(
         self,
         texts: list[str],
-        batch_size: int = 32,
+        *,
         task_name: str | None = None,
         prompt_type: PromptType | None = None,
+        batch_size: int = 32,
         **kwargs: Any,
     ):
         all_text_embeddings = []
@@ -88,9 +89,10 @@ class NomicVisionModelWrapper:
     def get_image_embeddings(
         self,
         images: list[Image.Image] | DataLoader,
-        batch_size: int = 32,
+        *,
         task_name: str | None = None,
         prompt_type: PromptType | None = None,
+        batch_size: int = 32,
         **kwargs: Any,
     ):
         all_image_embeddings = []
@@ -126,10 +128,11 @@ class NomicVisionModelWrapper:
         self,
         texts: list[str] = None,
         images: list[Image.Image] | DataLoader = None,
-        fusion_mode="sum",
-        batch_size: int = 32,
+        *,
         task_name: str | None = None,
         prompt_type: PromptType | None = None,
+        batch_size: int = 32,
+        fusion_mode="sum",
         **kwargs: Any,
     ):
         if texts is None and images is None:

--- a/mteb/models/openclip_models.py
+++ b/mteb/models/openclip_models.py
@@ -8,6 +8,7 @@ from PIL import Image
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
+from mteb.encoder_interface import PromptType
 from mteb.model_meta import ModelMeta
 
 
@@ -41,7 +42,14 @@ def openclip_loader(**kwargs):
         ):
             return self.get_text_embeddings(texts=sentences, batch_size=batch_size)
 
-        def get_text_embeddings(self, texts: list[str], batch_size: int = 32):
+        def get_text_embeddings(
+            self,
+            texts: list[str],
+            batch_size: int = 32,
+            task_name: str | None = None,
+            prompt_type: PromptType | None = None,
+            **kwargs: Any,
+        ):
             all_text_embeddings = []
 
             with torch.no_grad(), torch.cuda.amp.autocast():
@@ -55,7 +63,12 @@ def openclip_loader(**kwargs):
             return all_text_embeddings
 
         def get_image_embeddings(
-            self, images: list[Image.Image] | DataLoader, batch_size: int = 32
+            self,
+            images: list[Image.Image] | DataLoader,
+            batch_size: int = 32,
+            task_name: str | None = None,
+            prompt_type: PromptType | None = None,
+            **kwargs: Any,
         ):
             all_image_embeddings = []
             if isinstance(images, DataLoader):
@@ -102,6 +115,9 @@ def openclip_loader(**kwargs):
             images: list[Image.Image] | DataLoader = None,
             fusion_mode="sum",
             batch_size: int = 32,
+            task_name: str | None = None,
+            prompt_type: PromptType | None = None,
+            **kwargs: Any,
         ):
             if texts is None and images is None:
                 raise ValueError("Either texts or images must be provided")

--- a/mteb/models/openclip_models.py
+++ b/mteb/models/openclip_models.py
@@ -45,10 +45,10 @@ def openclip_loader(**kwargs):
         def get_text_embeddings(
             self,
             texts: list[str],
-            batch_size: int = 32,
+            *,
             task_name: str | None = None,
             prompt_type: PromptType | None = None,
-            **kwargs: Any,
+            batch_size: int = 32,
         ):
             all_text_embeddings = []
 
@@ -65,9 +65,10 @@ def openclip_loader(**kwargs):
         def get_image_embeddings(
             self,
             images: list[Image.Image] | DataLoader,
-            batch_size: int = 32,
+            *,
             task_name: str | None = None,
             prompt_type: PromptType | None = None,
+            batch_size: int = 32,
             **kwargs: Any,
         ):
             all_image_embeddings = []
@@ -113,10 +114,11 @@ def openclip_loader(**kwargs):
             self,
             texts: list[str] = None,
             images: list[Image.Image] | DataLoader = None,
-            fusion_mode="sum",
-            batch_size: int = 32,
+            *,
             task_name: str | None = None,
             prompt_type: PromptType | None = None,
+            batch_size: int = 32,
+            fusion_mode="sum",
             **kwargs: Any,
         ):
             if texts is None and images is None:

--- a/mteb/models/siglip_models.py
+++ b/mteb/models/siglip_models.py
@@ -9,6 +9,7 @@ from torch.utils.data import DataLoader
 from tqdm import tqdm
 from transformers import AutoModel, AutoProcessor
 
+from mteb.encoder_interface import PromptType
 from mteb.model_meta import ModelMeta
 
 
@@ -33,7 +34,14 @@ class SiglipModelWrapper:
             text=texts, images=images, return_tensors="pt", padding=True
         )
 
-    def get_text_embeddings(self, texts: list[str], batch_size: int = 32):
+    def get_text_embeddings(
+        self,
+        texts: list[str],
+        batch_size: int = 32,
+        task_name: str | None = None,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
+    ):
         all_text_embeddings = []
 
         with torch.no_grad():
@@ -53,7 +61,12 @@ class SiglipModelWrapper:
         return all_text_embeddings
 
     def get_image_embeddings(
-        self, images: list[Image.Image] | DataLoader, batch_size: int = 32
+        self,
+        images: list[Image.Image] | DataLoader,
+        batch_size: int = 32,
+        task_name: str | None = None,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
     ):
         all_image_embeddings = []
 
@@ -110,6 +123,9 @@ class SiglipModelWrapper:
         images: list[Image.Image] | DataLoader = None,
         fusion_mode="sum",
         batch_size: int = 32,
+        task_name: str | None = None,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
     ):
         if texts is None and images is None:
             raise ValueError("Either texts or images must be provided")

--- a/mteb/models/siglip_models.py
+++ b/mteb/models/siglip_models.py
@@ -37,9 +37,10 @@ class SiglipModelWrapper:
     def get_text_embeddings(
         self,
         texts: list[str],
-        batch_size: int = 32,
+        *,
         task_name: str | None = None,
         prompt_type: PromptType | None = None,
+        batch_size: int = 32,
         **kwargs: Any,
     ):
         all_text_embeddings = []
@@ -63,9 +64,10 @@ class SiglipModelWrapper:
     def get_image_embeddings(
         self,
         images: list[Image.Image] | DataLoader,
-        batch_size: int = 32,
+        *,
         task_name: str | None = None,
         prompt_type: PromptType | None = None,
+        batch_size: int = 32,
         **kwargs: Any,
     ):
         all_image_embeddings = []
@@ -121,10 +123,11 @@ class SiglipModelWrapper:
         self,
         texts: list[str] = None,
         images: list[Image.Image] | DataLoader = None,
-        fusion_mode="sum",
-        batch_size: int = 32,
+        *,
         task_name: str | None = None,
         prompt_type: PromptType | None = None,
+        batch_size: int = 32,
+        fusion_mode="sum",
         **kwargs: Any,
     ):
         if texts is None and images is None:

--- a/mteb/models/vista_models.py
+++ b/mteb/models/vista_models.py
@@ -134,9 +134,10 @@ def vista_loader(**kwargs):
         def get_text_embeddings(
             self,
             texts: list[str],
-            batch_size: int = 32,
+            *,
             task_name: str | None = None,
             prompt_type: PromptType | None = None,
+            batch_size: int = 32,
             **kwargs: Any,
         ):
             all_text_embeddings = []
@@ -150,9 +151,10 @@ def vista_loader(**kwargs):
         def get_image_embeddings(
             self,
             images: list[Image.Image] | DataLoader,
-            batch_size: int = 32,
+            *,
             task_name: str | None = None,
             prompt_type: PromptType | None = None,
+            batch_size: int = 32,
             **kwargs: Any,
         ):
             all_image_embeddings = []
@@ -174,9 +176,10 @@ def vista_loader(**kwargs):
             self,
             texts: list[str] = None,
             images: list[Image.Image] | DataLoader = None,
-            batch_size: int = 32,
+            *,
             task_name: str | None = None,
             prompt_type: PromptType | None = None,
+            batch_size: int = 32,
             **kwargs: Any,
         ):
             all_embeddings = []

--- a/mteb/models/vista_models.py
+++ b/mteb/models/vista_models.py
@@ -9,6 +9,7 @@ from torch.utils.data import DataLoader
 from torchvision import transforms
 from tqdm import tqdm
 
+from mteb.encoder_interface import PromptType
 from mteb.model_meta import ModelMeta
 
 tensor_to_image = transforms.Compose([transforms.ToPILImage()])
@@ -94,7 +95,15 @@ def vista_loader(**kwargs):
                 t_reps = torch.nn.functional.normalize(t_reps, dim=-1)
             return t_reps.contiguous()
 
-        def encode(self, images=None, texts=None, tensors=False):
+        def encode(
+            self,
+            images=None,
+            texts=None,
+            tensors=False,
+            task_name: str | None = None,
+            prompt_type: PromptType | None = None,
+            **kwargs: Any,
+        ):
             if images is not None:
                 if isinstance(images, list):
                     if not tensors:
@@ -122,7 +131,14 @@ def vista_loader(**kwargs):
                 else:
                     return None
 
-        def get_text_embeddings(self, texts: list[str], batch_size: int = 32):
+        def get_text_embeddings(
+            self,
+            texts: list[str],
+            batch_size: int = 32,
+            task_name: str | None = None,
+            prompt_type: PromptType | None = None,
+            **kwargs: Any,
+        ):
             all_text_embeddings = []
             for i in tqdm(range(0, len(texts), batch_size)):
                 batch_texts = texts[i : i + batch_size]
@@ -132,7 +148,12 @@ def vista_loader(**kwargs):
             return torch.cat(all_text_embeddings, dim=0)
 
         def get_image_embeddings(
-            self, images: list[Image.Image] | DataLoader, batch_size: int = 32
+            self,
+            images: list[Image.Image] | DataLoader,
+            batch_size: int = 32,
+            task_name: str | None = None,
+            prompt_type: PromptType | None = None,
+            **kwargs: Any,
         ):
             all_image_embeddings = []
 
@@ -154,6 +175,9 @@ def vista_loader(**kwargs):
             texts: list[str] = None,
             images: list[Image.Image] | DataLoader = None,
             batch_size: int = 32,
+            task_name: str | None = None,
+            prompt_type: PromptType | None = None,
+            **kwargs: Any,
         ):
             all_embeddings = []
 

--- a/mteb/models/vlm2vec_models.py
+++ b/mteb/models/vlm2vec_models.py
@@ -10,6 +10,7 @@ from torch.utils.data import DataLoader
 from tqdm import tqdm
 from transformers import AutoConfig, AutoModelForCausalLM, AutoProcessor
 
+from mteb.encoder_interface import PromptType
 from mteb.model_meta import ModelMeta
 
 logging.basicConfig(level=logging.WARNING)
@@ -82,8 +83,9 @@ class VLM2VecWrapper:
         self,
         sentences: list[str],
         *,
-        prompt_name: str = None,
-        **kwargs: Any,  # noqa
+        task_name: str | None = None,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
     ):
         return self.get_text_embeddings(texts=sentences)
 
@@ -109,7 +111,12 @@ class VLM2VecWrapper:
 
     # reference: https://github.com/TIGER-AI-Lab/VLM2Vec/blob/main/src/collator.py
     def get_image_embeddings(
-        self, images: list[Image.Image] | DataLoader, batch_size: int = 32
+        self,
+        images: list[Image.Image] | DataLoader,
+        batch_size: int = 32,
+        task_name: str | None = None,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
     ):
         text = "<|image_1|> Represent the given image."
         all_image_embeddings = []
@@ -191,7 +198,14 @@ class VLM2VecWrapper:
         all_image_embeddings = torch.cat(all_image_embeddings, dim=0)
         return all_image_embeddings
 
-    def get_text_embeddings(self, texts: list[str], batch_size: int = 32):
+    def get_text_embeddings(
+        self,
+        texts: list[str],
+        batch_size: int = 32,
+        task_name: str | None = None,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
+    ):
         all_text_embeddings = []
 
         with torch.no_grad():
@@ -241,6 +255,9 @@ class VLM2VecWrapper:
         images: list[Image.Image] | DataLoader = None,
         fusion_mode="sum",
         batch_size: int = 32,
+        task_name: str | None = None,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
     ):
         if texts is None and images is None:
             raise ValueError("Either texts or images must be provided")

--- a/mteb/models/vlm2vec_models.py
+++ b/mteb/models/vlm2vec_models.py
@@ -113,9 +113,10 @@ class VLM2VecWrapper:
     def get_image_embeddings(
         self,
         images: list[Image.Image] | DataLoader,
-        batch_size: int = 32,
+        *,
         task_name: str | None = None,
         prompt_type: PromptType | None = None,
+        batch_size: int = 32,
         **kwargs: Any,
     ):
         text = "<|image_1|> Represent the given image."
@@ -201,9 +202,10 @@ class VLM2VecWrapper:
     def get_text_embeddings(
         self,
         texts: list[str],
-        batch_size: int = 32,
+        *,
         task_name: str | None = None,
         prompt_type: PromptType | None = None,
+        batch_size: int = 32,
         **kwargs: Any,
     ):
         all_text_embeddings = []
@@ -253,10 +255,11 @@ class VLM2VecWrapper:
         self,
         texts: list[str] = None,
         images: list[Image.Image] | DataLoader = None,
-        fusion_mode="sum",
-        batch_size: int = 32,
+        *,
         task_name: str | None = None,
         prompt_type: PromptType | None = None,
+        batch_size: int = 32,
+        fusion_mode="sum",
         **kwargs: Any,
     ):
         if texts is None and images is None:

--- a/mteb/models/voyage_v.py
+++ b/mteb/models/voyage_v.py
@@ -11,6 +11,7 @@ from torchvision import transforms
 from tqdm import tqdm
 
 import mteb
+from mteb.encoder_interface import PromptType
 from mteb.model_meta import ModelMeta
 
 api_key = os.getenv("VOYAGE_API_KEY")
@@ -33,8 +34,20 @@ def voyage_v_loader(**kwargs):
             self.vo = voyageai.Client()
 
         def get_text_embeddings(
-            self, texts: list[str], batch_size: int = 32, input_type=None
+            self,
+            texts: list[str],
+            batch_size: int = 32,
+            input_type=None,
+            task_name: str | None = None,
+            prompt_type: PromptType | None = None,
+            **kwargs: Any,
         ):
+            if input_type is None and prompt_type is not None:
+                if prompt_type == PromptType.passage:
+                    input_type = "document"
+                elif prompt_type == PromptType.query:
+                    input_type = "query"
+
             all_text_embeddings = []
 
             for i in tqdm(range(0, len(texts), batch_size)):
@@ -53,7 +66,16 @@ def voyage_v_loader(**kwargs):
             images: list[Image.Image] | DataLoader,
             batch_size: int = 32,
             input_type=None,
+            task_name: str | None = None,
+            prompt_type: PromptType | None = None,
+            **kwargs: Any,
         ):
+            if input_type is None and prompt_type is not None:
+                if prompt_type == PromptType.passage:
+                    input_type = "document"
+                elif prompt_type == PromptType.query:
+                    input_type = "query"
+
             all_image_embeddings = []
 
             if isinstance(images, DataLoader):
@@ -95,9 +117,18 @@ def voyage_v_loader(**kwargs):
             images: list[Image.Image] | DataLoader = None,
             batch_size: int = 32,
             input_type=None,
+            task_name: str | None = None,
+            prompt_type: PromptType | None = None,
+            **kwargs: Any,
         ):
             if texts is None and images is None:
                 raise ValueError("Either texts or images must be provided")
+
+            if input_type is None and prompt_type is not None:
+                if prompt_type == PromptType.passage:
+                    input_type = "document"
+                elif prompt_type == PromptType.query:
+                    input_type = "query"
 
             text_embeddings = None
             image_embeddings = None

--- a/mteb/models/voyage_v.py
+++ b/mteb/models/voyage_v.py
@@ -36,10 +36,11 @@ def voyage_v_loader(**kwargs):
         def get_text_embeddings(
             self,
             texts: list[str],
-            batch_size: int = 32,
-            input_type=None,
+            *,
             task_name: str | None = None,
             prompt_type: PromptType | None = None,
+            batch_size: int = 32,
+            input_type=None,
             **kwargs: Any,
         ):
             if input_type is None and prompt_type is not None:
@@ -64,10 +65,11 @@ def voyage_v_loader(**kwargs):
         def get_image_embeddings(
             self,
             images: list[Image.Image] | DataLoader,
-            batch_size: int = 32,
-            input_type=None,
+            *,
             task_name: str | None = None,
             prompt_type: PromptType | None = None,
+            batch_size: int = 32,
+            input_type=None,
             **kwargs: Any,
         ):
             if input_type is None and prompt_type is not None:
@@ -115,10 +117,11 @@ def voyage_v_loader(**kwargs):
             self,
             texts: list[str] = None,
             images: list[Image.Image] | DataLoader = None,
-            batch_size: int = 32,
-            input_type=None,
+            *,
             task_name: str | None = None,
             prompt_type: PromptType | None = None,
+            batch_size: int = 32,
+            input_type=None,
             **kwargs: Any,
         ):
             if texts is None and images is None:


### PR DESCRIPTION
Fix https://github.com/embeddings-benchmark/mteb/issues/1523#issuecomment-2535897120

1. Make `get_xxx_embeddings` follow `encode`, accepting the follow arguments.
```
    task_name=task_name,
    prompt_type=PromptType.passage,
    **self.encode_kwargs,
```
2. `ImageDataset.transform` could be `None`, which could avoid unnecessary `Image -> Tensor -> Image` operations.
3. Pass `input_type` to `voyage_v` API by `prompt_type`


<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->


## Checklist
<!-- Please do not delete this -->

- [ ] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 

I failed 8 tests, but they may not be triggered by above changes.

```
FAILED tests/test_benchmark/test_benchmark_integration_with_datasets.py::test_benchmark_sentence_transformer[model0-task0] - TypeError: 'NoneType' object is not callable
FAILED tests/test_reproducible_workflow.py::test_reproducibility_workflow[8b3219a92973c328a8e22fadcfa821b5dc75636a-sentence-transformers/all-MiniLM-L6-v2-BornholmBitextMining] - TypeError: 'NoneType' object is not callable
FAILED tests/test_tasks/test_all_abstasks.py::test_dataset_availability - aiohttp.client_exceptions.ConnectionTimeoutError: Connection timeout to host https://huggingface.co/datasets/nguha/legalbench/tree/12ca3b695563788fead87a982ad1a0682844...
FAILED tests/test_tasks/test_mieb_datasets.py::test_benchmark_sentence_transformer[model0-task1] - ValueError: Input arrays use different devices: cpu, cpu
FAILED tests/test_cli.py::test_run_task[average_word_embeddings_komninos-BornholmBitextMining-21eec43590414cb8e3a6f654857abed0483ae36e] - TypeError: 'NoneType' object is not callable
FAILED tests/test_benchmark/test_benchmark_integration_with_datasets.py::test_benchmark_sentence_transformer[model0-FarsTail] - FileNotFoundError: Unable to find 'https://huggingface.co/datasets/azarijafari/FarsTail/resolve/7335288588f14e5a687d97fc979194c2abe6f4e7/data/Test-word.csv'
FAILED tests/test_benchmark/test_benchmark_integration_with_datasets.py::test_benchmark_sentence_transformer[model0-BrazilianToxicTweetsClassification] - TypeError: 'NoneType' object is not callable
FAILED tests/test_cli.py::test_run_task[intfloat/multilingual-e5-small-BornholmBitextMining-fd1525a9fd15316a2d503bf26ab031a61d056e98] - TypeError: 'NoneType' object is not callable
```