### PR TITLE
Feat: Evaluate missing languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,21 @@ Note that the public leaderboard uses the test splits for all datasets except MS
 
 </details>
 
+
+<details>
+  <summary> Selecting evaluation subset </summary>
+
+### Selecting evaluation subset
+You can evaluate only on `eng` subsets of all tasks by doing the following:
+
+```python
+evaluation.run(model, eval_subsets=["eng"])
+```
+
+Monolingual tasks have `default` subset, other tasks have subsets that are specific to the dataset.
+
+</details>
+
 <details>
   <summary>  Using a custom model </summary>
 

--- a/README.md
+++ b/README.md
@@ -214,10 +214,10 @@ Note that the public leaderboard uses the test splits for all datasets except MS
   <summary> Selecting evaluation subset </summary>
 
 ### Selecting evaluation subset
-You can evaluate only on `eng` subsets of all tasks by doing the following:
+You can evaluate only on selected subsets. For example, if you want to evaluate only the `subset_name_to_run` subset of all tasks, do the following:
 
 ```python
-evaluation.run(model, eval_subsets=["eng"])
+evaluation.run(model, eval_subsets=["subset_name_to_run"])
 ```
 
 Monolingual tasks have `default` subset, other tasks have subsets that are specific to the dataset.

--- a/mteb/abstasks/AbsTask.py
+++ b/mteb/abstasks/AbsTask.py
@@ -89,19 +89,20 @@ class AbsTask(ABC):
         self,
         model: Encoder,
         split: str = "test",
+        subsets_to_run: list[HFSubset] | None = None,
         *,
         encode_kwargs: dict[str, Any] = {},
         **kwargs: Any,
     ) -> dict[HFSubset, ScoresDict]:
         """Evaluates a Sentence Embedding Model on the task.
-        Returns a dict (that can be serialized to json).
 
         Args:
-            model: Sentence embedding method. Implements a encode(sentences) method, that encodes sentences and returns a numpy matrix with the
-                sentence embeddings
+            model: Sentence embedding method. Implements a encode(sentences) method.
             split: Which datasplit to be used.
-            encode_kwargs: Additional keyword arguments that are passed to the model's `encode` method.
+            subsets_to_run: List of HFSubsets to evaluate. If None, all subsets are evaluated.
+            encode_kwargs: Additional keyword arguments passed to the model's `encode` method.
             kwargs: Additional keyword arguments that are passed to the _evaluate_subset method.
+                    In particular, this may include `subsets_to_run`, a list of hf_subsets to evaluate.
         """
         if not self.data_loaded:
             self.load_data()
@@ -110,6 +111,9 @@ class AbsTask(ABC):
 
         scores = {}
         hf_subsets = list(self.dataset.keys()) if self.is_multilingual else ["default"]
+
+        if subsets_to_run is not None:
+            hf_subsets = [s for s in hf_subsets if s in subsets_to_run]
 
         for hf_subset in hf_subsets:
             logger.info(

--- a/mteb/abstasks/AbsTask.py
+++ b/mteb/abstasks/AbsTask.py
@@ -97,12 +97,12 @@ class AbsTask(ABC):
         """Evaluates a Sentence Embedding Model on the task.
 
         Args:
-            model: Sentence embedding method. Implements a encode(sentences) method.
+            model: Sentence embedding method. Implements a encode(sentences) method, that encodes sentences and returns a numpy matrix with the
+                sentence embeddings
             split: Which datasplit to be used.
             subsets_to_run: List of HFSubsets to evaluate. If None, all subsets are evaluated.
-            encode_kwargs: Additional keyword arguments passed to the model's `encode` method.
+            encode_kwargs: Additional keyword arguments that are passed to the model's `encode` method.
             kwargs: Additional keyword arguments that are passed to the _evaluate_subset method.
-                    In particular, this may include `subsets_to_run`, a list of hf_subsets to evaluate.
         """
         if not self.data_loaded:
             self.load_data()

--- a/mteb/abstasks/AbsTaskBitextMining.py
+++ b/mteb/abstasks/AbsTaskBitextMining.py
@@ -67,7 +67,8 @@ class AbsTaskBitextMining(AbsTask):
     def evaluate(
         self,
         model: Encoder,
-        split: str,
+        split: str = "test",
+        subsets_to_run: list[HFSubset] | None = None,
         *,
         encode_kwargs: dict[str, Any] = {},
         **kwargs,
@@ -76,6 +77,10 @@ class AbsTaskBitextMining(AbsTask):
             self.load_data()
 
         hf_subsets = list(self.dataset) if self.is_multilingual else ["default"]
+
+        # If subsets_to_run is specified, filter the hf_subsets accordingly
+        if subsets_to_run is not None:
+            hf_subsets = [s for s in hf_subsets if s in subsets_to_run]
 
         scores = {}
         if self.parallel_subsets:

--- a/mteb/abstasks/AbsTaskClassification.py
+++ b/mteb/abstasks/AbsTaskClassification.py
@@ -95,6 +95,7 @@ class AbsTaskClassification(AbsTask):
         model,
         eval_split: str = "test",
         train_split: str = "train",
+        subsets_to_run: list[HFSubset] | None = None,
         *,
         encode_kwargs: dict[str, Any] = {},
         **kwargs,
@@ -104,6 +105,8 @@ class AbsTaskClassification(AbsTask):
 
         scores = {}
         hf_subsets = list(self.dataset) if self.is_multilingual else ["default"]
+        if subsets_to_run is not None:
+            hf_subsets = [s for s in hf_subsets if s in subsets_to_run]
 
         for hf_subset in hf_subsets:
             logger.info(

--- a/mteb/abstasks/AbsTaskInstructionRetrieval.py
+++ b/mteb/abstasks/AbsTaskInstructionRetrieval.py
@@ -516,6 +516,7 @@ class AbsTaskInstructionRetrieval(AbsTask):
         self,
         model: Encoder,
         split: str = "test",
+        subsets_to_run: list[str] | None = None,
         *,
         encode_kwargs: dict[str, Any] = {},
         **kwargs,
@@ -528,7 +529,11 @@ class AbsTaskInstructionRetrieval(AbsTask):
         )
         scores = {}
         if self.is_multilingual:
-            for lang in self.hf_subsets:
+            hf_subsets = self.hf_subsets
+            if subsets_to_run is not None:
+                hf_subsets = [s for s in hf_subsets if s in subsets_to_run]
+
+            for lang in hf_subsets:
                 logger.info(f"Language: {lang}")
                 scores[lang] = self._evaluate_subset_lang(
                     retriever,

--- a/mteb/abstasks/AbsTaskMultilabelClassification.py
+++ b/mteb/abstasks/AbsTaskMultilabelClassification.py
@@ -121,6 +121,7 @@ class AbsTaskMultilabelClassification(AbsTask):
         model: Encoder,
         eval_split: str = "test",
         train_split: str = "train",
+        subsets_to_run: list[HFSubset] | None = None,
         *,
         encode_kwargs: dict[str, Any] = {},
         **kwargs: Any,
@@ -130,6 +131,9 @@ class AbsTaskMultilabelClassification(AbsTask):
 
         scores = {}
         hf_subsets = list(self.dataset) if self.is_multilingual else ["default"]
+        # If subsets_to_run is specified, filter the hf_subsets accordingly
+        if subsets_to_run is not None:
+            hf_subsets = [s for s in hf_subsets if s in subsets_to_run]
 
         for hf_subset in hf_subsets:
             logger.info(

--- a/mteb/abstasks/AbsTaskRetrieval.py
+++ b/mteb/abstasks/AbsTaskRetrieval.py
@@ -304,6 +304,7 @@ class AbsTaskRetrieval(AbsTask):
         self,
         model,
         split: str = "test",
+        subsets_to_run: list[HFSubset] | None = None,
         *,
         encode_kwargs: dict[str, Any] = {},
         **kwargs,
@@ -317,6 +318,8 @@ class AbsTaskRetrieval(AbsTask):
 
         scores = {}
         hf_subsets = list(self.hf_subsets) if self.is_multilingual else ["default"]
+        if subsets_to_run is not None:
+            hf_subsets = [s for s in hf_subsets if s in subsets_to_run]
 
         for hf_subset in hf_subsets:
             logger.info(f"Subset: {hf_subset}")

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -462,11 +462,8 @@ class MTEB:
             task_eval_splits = (
                 eval_splits if eval_splits is not None else task.eval_splits
             )
-            task_eval_langs = (
-                task.metadata.eval_langs
-                if isinstance(task.metadata.eval_langs, dict)
-                else None
-            )
+            task_eval_langs = task.metadata.hf_subsets_to_langscripts
+
             existing_results = None
             save_path = None
 
@@ -680,7 +677,7 @@ class MTEB:
     def _get_missing_evaluations(
         existing_results: TaskResult | None,
         task_eval_splits: list[str],
-        task_eval_langs: dict[str, list[str]] | None,
+        task_eval_langs: dict[str, list[str]],
         eval_langs: list[str] | None,
     ) -> dict[str, dict[str, Any]]:
         """Return a dictionary for each split, indicating if the whole split is missing and which subsets are missing."""
@@ -690,21 +687,17 @@ class MTEB:
         }
 
         # Determine subsets to consider if multilingual
-        if task_eval_langs is not None:
-            if eval_langs is None:
-                # If no eval_langs specified, consider all subsets
-                subsets_to_consider = list(task_eval_langs.keys())
-            else:
-                subsets_to_consider = []
-                for hf_subset, lang_list in task_eval_langs.items():
-                    # lang_list are like ["eng-Latn", "deu-Latn"]
-                    iso_langs = [l.split("-")[0] for l in lang_list]
-                    # If any requested language is present in this subset, consider it
-                    if any(run_lang in iso_langs for run_lang in eval_langs):
-                        subsets_to_consider.append(hf_subset)
+        if eval_langs is None:
+            # If no eval_langs specified, consider all subsets
+            subsets_to_consider = list(task_eval_langs.keys())
         else:
-            # Not multilingual, just one "default" subset
-            subsets_to_consider = ["default"]
+            subsets_to_consider = []
+            for hf_subset, lang_list in task_eval_langs.items():
+                # lang_list are like ["eng-Latn", "deu-Latn"]
+                iso_langs = [l.split("-")[0] for l in lang_list]
+                # If any requested language is present in this subset, consider it
+                if any(run_lang in iso_langs for run_lang in eval_langs):
+                    subsets_to_consider.append(hf_subset)
 
         # If no existing results, all splits and subsets are missing
         if existing_results is None:

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -539,8 +539,9 @@ class MTEB:
                         try:
                             from codecarbon import EmissionsTracker
                         except ImportError:
-                            raise ImportError("Install codecarbon to use co2_tracker.")
-
+                            raise ImportError(
+                                "To use the CO2 emissions tracker, please install codecarbon using 'pip install codecarbon'"
+                            )
                         with EmissionsTracker(
                             save_to_file=False, save_to_api=False, logging_logger=logger
                         ) as tracker:
@@ -553,7 +554,9 @@ class MTEB:
                                 **kwargs,
                             )
 
-                        kg_co2_emissions += tracker.final_emissions  # type: ignore
+                        kg_co2_emissions += (
+                            tracker.final_emissions
+                        )  # expressed as kilograms of CO₂-equivalents
                     else:
                         results, tick, tock = self._run_eval(
                             task,

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -523,14 +523,9 @@ class MTEB:
                     # Determine subsets to run for this split
                     # If the whole split is missing, run all required subsets
                     # If only some subsets are missing, run only those
-                    if info["whole_split_missing"]:
-                        if task_subsets is not None:
-                            subsets_to_run = info["missing_subsets"]
-                        else:
-                            subsets_to_run = ["default"]
-                    else:
-                        # partial subsets missing
-                        subsets_to_run = info["missing_subsets"]
+                    subsets_to_run = info["missing_subsets"]
+                    if info["whole_split_missing"] and task_subsets is None:
+                        subsets_to_run = ["default"]
 
                     if co2_tracker:
                         try:

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -379,7 +379,8 @@ class MTEB:
         model: SentenceTransformer | Encoder,
         verbosity: int = 1,
         output_folder: str | None = "results",
-        eval_splits=None,
+        eval_splits: list[str] | None =None,
+        eval_langs: list[str] | None = None,
         overwrite_results: bool = False,
         raise_error: bool = True,
         co2_tracker: bool = False,
@@ -398,6 +399,7 @@ class MTEB:
             output_folder: Folder where the results will be saved. Default to 'results'. Where it will save the results in the format:
                 `{output_folder}/{model_name}/{model_revision}/{task_name}.json`.
             eval_splits: List of splits to evaluate on. If None, the splits are taken from the task metadata.
+            eval_langs: List of langs to evaluate on. If None, the splits are taken from the task metadata.
             overwrite_results: Whether to overwrite existing results.
             raise_error: Whether to raise an error if an exception occurs during evaluation.
             co2_tracker: Whether to enable or disable CO2 emissions tracker using codecarbon.
@@ -469,61 +471,100 @@ class MTEB:
                         del self.tasks[0]  # empty memory
                         continue
 
-                task_eval_splits = (
-                    eval_splits if eval_splits is not None else task.eval_splits
-                )
-                missing_splits = self._get_missing_splits(
-                    existing_results, task_eval_splits
+                task_eval_splits = eval_splits if eval_splits is not None else task.eval_splits
+                # Check missing splits
+                missing_splits = self._get_missing_splits(existing_results, task_eval_splits)
+
+                # If the task is multilingual, we have a dictionary of subsets and their languages.
+                # If not multilingual, eval_langs is either a list, then hf_subsets = "default".
+                task_eval_langs = None
+                if isinstance(task.metadata.eval_langs, dict):
+                    task_eval_langs = task.metadata.eval_langs
+
+                # Check missing subsets for the selected languages if needed
+                missing_subsets_per_split = self._get_missing_subsets_for_langs(
+                    existing_results,
+                    task_eval_splits,
+                    task_eval_langs,
+                    eval_langs
                 )
 
-                if not missing_splits and existing_results:
+                # If no splits missing and subsets missing are also empty, skip
+                all_subsets_missing = any(len(subsets) > 0 for subsets in missing_subsets_per_split.values())
+
+                if not missing_splits and not all_subsets_missing and existing_results:
                     evaluation_results.append(existing_results)
-
-                    # no splits are evaluated.
                     self.last_evaluated_splits[task.metadata.name] = []
                     del self.tasks[0]
                     continue
 
-                if missing_splits:
-                    logger.info(
-                        f"Running evaluation for missing splits: {missing_splits}"
-                    )
+                # Determine final splits to run (those that are missing or have missing subsets)
+                # A split should be run if it's missing entirely or if it has missing subsets.
+                final_splits_to_run = []
+                for sp in task_eval_splits:
+                    if sp in missing_splits:
+                        final_splits_to_run.append(sp)
+                    else:
+                        # If split is not missing entirely, check subsets
+                        if sp in missing_subsets_per_split and len(missing_subsets_per_split[sp]) > 0:
+                            final_splits_to_run.append(sp)
+
+                if not final_splits_to_run:
+                    # no new splits or subsets to run
+                    if existing_results:
+                        evaluation_results.append(existing_results)
+                    else:
+                        # No results and no splits means no evaluation (empty?), just skip
+                        evaluation_results.append(TaskResult(
+                            dataset_revision=task.metadata_dict["dataset"].get("revision", None),
+                            task_name=task.metadata_dict["name"],
+                            mteb_version=None,
+                            scores={},
+                            evaluation_time=0.0,
+                            kg_co2_emissions=None
+                        ))
+                    self.last_evaluated_splits[task.metadata.name] = []
+                    del self.tasks[0]
+                    continue
 
             try:
                 task.check_if_dataset_is_superseded()
                 task.load_data(eval_splits=task_eval_splits, **kwargs)
 
-                # run evaluation
                 task_results = {}
                 evaluation_time = 0
                 kg_co2_emissions: int | None = 0 if co2_tracker else None
 
                 self.last_evaluated_splits[task.metadata.name] = []
 
-                for split in missing_splits:
+                for split in final_splits_to_run:
+                    # Run only missing subsets if partial results exist
+                    subsets_to_run = missing_subsets_per_split[split]
+                    # If subsets_to_run is empty and split in missing_splits,
+                    # it means no results at all for this split previously
+                    # so we run all subsets.
+                    if not subsets_to_run and (existing_results is None or split in missing_splits):
+                        # Run all subsets
+                        if task_eval_langs is not None:
+                            subsets_to_run = list(task_eval_langs.keys())
+                        else:
+                            # Non multilingual
+                            subsets_to_run = ["default"]
+
                     if co2_tracker:
                         try:
                             from codecarbon import EmissionsTracker
                         except ImportError:
-                            raise ImportError(
-                                "To use the CO2 emissions tracker, please install codecarbon using 'pip install codecarbon'"
-                            )
-
-                        with EmissionsTracker(
-                            save_to_file=False, save_to_api=False, logging_logger=logger
-                        ) as tracker:
-                            results, tick, tock = self._run_eval(
-                                task,
+                            raise ImportError("Install codecarbon to use co2_tracker.")
+                        with EmissionsTracker(save_to_file=False, save_to_api=False, logging_logger=logger):
+                            results, tick, tock = task.evaluate(
                                 model,
                                 split,
-                                output_folder,
                                 encode_kwargs=encode_kwargs,
-                                **kwargs,
+                                **kwargs
                             )
 
-                        kg_co2_emissions += (
-                            tracker.final_emissions
-                        )  # expressed as kilograms of CO₂-equivalents
+                        kg_co2_emissions += tracker.final_emissions  # type: ignore
                     else:
                         results, tick, tock = self._run_eval(
                             task,
@@ -534,17 +575,30 @@ class MTEB:
                             **kwargs,
                         )
 
-                    self.last_evaluated_splits[task.metadata.name].append(split)
+                    # Filter results to only keep subsets_to_run if partial run
+                    filtered_results = {}
+                    for hf_subset, score_dict in results.items():
+                        if hf_subset in subsets_to_run:
+                            filtered_results[hf_subset] = score_dict
 
+                    # If we ran all subsets and got all results
+                    # filtered_results could be empty if subsets_to_run was empty, means no action needed
+                    if not subsets_to_run:
+                        continue
+
+                    # replace with filtered results
+                    task_results[split] = filtered_results
                     logger.info(
                         f"Evaluation for {task.metadata_dict['name']} on {split} took {tock - tick:.2f} seconds"
                     )
                     evaluation_time += tock - tick
 
-                    task_results[split] = results
                     if verbosity >= 1:
-                        logger.info(f"Scores: {results}")
+                        logger.info(f"Scores: {filtered_results}")
 
+                    self.last_evaluated_splits[task.metadata.name].append(split)
+
+                # Create new TaskResult
                 new_results = TaskResult.from_task_results(
                     task,
                     task_results,
@@ -552,6 +606,9 @@ class MTEB:
                     kg_co2_emissions=kg_co2_emissions,
                 )
 
+                # Merge with existing if needed
+                if output_path and save_path.exists():
+                    existing_results = TaskResult.from_disk(save_path)
                 if existing_results:
                     merged_results = self._merge_results(existing_results, new_results)
                 else:
@@ -637,3 +694,56 @@ class MTEB:
         return deepcopy(
             {task: list(splits) for task, splits in self.last_evaluated_splits.items()}
         )
+
+
+    @staticmethod
+    def _get_missing_subsets_for_langs(
+            existing_results: TaskResult | None,
+            task_eval_splits: list[str],
+            task_eval_langs: dict[str, list[str]] | None,
+            langs_to_run: list[str] | None,
+    ) -> dict[str, list[str]]:
+        """Return which subsets (hf_subsets) are missing results for the given languages to run.
+
+        If langs_to_run is None, consider all subsets/languages.
+        If langs_to_run is provided, only consider those subsets that include at least one language from langs_to_run.
+        If no task_eval_langs is provided (non-multilingual task), returns an empty dict.
+
+        Returns:
+            A dictionary with keys as splits and values as a list of subsets (hf_subsets) that need to be run.
+        """
+
+        # If no multilingual info provided, no need to check subsets by languages
+        if task_eval_langs is None:
+            return {split: [] for split in task_eval_splits}
+
+        # Filter subsets by desired languages
+        # If langs_to_run is None, we run all subsets. Otherwise run only those containing at least one of langs_to_run.
+        if langs_to_run is not None:
+            subsets_to_consider = []
+            for hf_subset, lang_list in task_eval_langs.items():
+                # lang_list are strings like "eng-Latn"
+                # Extract just the iso codes (part before the dash)
+                iso_langs = [l.split("-")[0] for l in lang_list]
+                if any(run_lang in iso_langs for run_lang in langs_to_run):
+                    subsets_to_consider.append(hf_subset)
+        else:
+            subsets_to_consider = list(task_eval_langs.keys())
+
+        missing_subsets_per_split = {}
+        if existing_results is None:
+            # If no existing results, all subsets need to be run
+            missing_subsets_per_split = {split: subsets_to_consider for split in task_eval_splits}
+        else:
+            # Check existing results for missing subsets
+            missing_subsets_per_split = {}
+            for split in task_eval_splits:
+                # existing_results.scores[split] = list of ScoresDict for each subset
+                existing_subsets = []
+                if split in existing_results.scores:
+                    for score_dict in existing_results.scores[split]:
+                        existing_subsets.append(score_dict["hf_subset"])
+                # Determine which subsets are missing
+                missing_subsets = [s for s in subsets_to_consider if s not in existing_subsets]
+                missing_subsets_per_split[split] = missing_subsets
+        return missing_subsets_per_split

--- a/mteb/models/misc_models.py
+++ b/mteb/models/misc_models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from mteb.model_meta import ModelMeta
 
 Haon_Chen__speed_embedding_7b_instruct = ModelMeta(

--- a/tests/test_benchmark/mock_tasks.py
+++ b/tests/test_benchmark/mock_tasks.py
@@ -1349,6 +1349,62 @@ class MockRetrievalTask(AbsTaskRetrieval):
 
 class MockMultilingualRetrievalTask(AbsTaskRetrieval, MultilingualTask):
     expected_stats = {
+        "val": {
+            "number_of_characters": 224,
+            "num_samples": 8,
+            "num_queries": 4,
+            "num_documents": 4,
+            "min_document_length": 23,
+            "average_document_length": 26.0,
+            "max_document_length": 29,
+            "unique_documents": 4,
+            "min_query_length": 27,
+            "average_query_length": 30.0,
+            "max_query_length": 33,
+            "unique_queries": 4,
+            "min_relevant_docs_per_query": 2,
+            "average_relevant_docs_per_query": 2.0,
+            "max_relevant_docs_per_query": 2,
+            "unique_relevant_docs": 4,
+            "hf_subset_descriptive_stats": {
+                "eng": {
+                    "number_of_characters": 112,
+                    "num_samples": 4,
+                    "num_queries": 2,
+                    "num_documents": 2,
+                    "min_document_length": 23,
+                    "average_document_length": 26.0,
+                    "max_document_length": 29,
+                    "unique_documents": 2,
+                    "min_query_length": 27,
+                    "average_query_length": 30.0,
+                    "max_query_length": 33,
+                    "unique_queries": 2,
+                    "min_relevant_docs_per_query": 2,
+                    "average_relevant_docs_per_query": 2.0,
+                    "max_relevant_docs_per_query": 2,
+                    "unique_relevant_docs": 2,
+                },
+                "fra": {
+                    "number_of_characters": 112,
+                    "num_samples": 4,
+                    "num_queries": 2,
+                    "num_documents": 2,
+                    "min_document_length": 23,
+                    "average_document_length": 26.0,
+                    "max_document_length": 29,
+                    "unique_documents": 2,
+                    "min_query_length": 27,
+                    "average_query_length": 30.0,
+                    "max_query_length": 33,
+                    "unique_queries": 2,
+                    "min_relevant_docs_per_query": 2,
+                    "average_relevant_docs_per_query": 2.0,
+                    "max_relevant_docs_per_query": 2,
+                    "unique_relevant_docs": 2,
+                },
+            },
+        },
         "test": {
             "number_of_characters": 224,
             "num_samples": 8,
@@ -1404,14 +1460,14 @@ class MockMultilingualRetrievalTask(AbsTaskRetrieval, MultilingualTask):
                     "unique_relevant_docs": 2,
                 },
             },
-        }
+        },
     }
 
     metadata = TaskMetadata(
         type="Retrieval",
         name="MockMultilingualRetrievalTask",
         main_score="ndcg_at_10",
-        **general_args,  # type: ignore
+        **dict(general_args | {"eval_splits": ["val", "test"]}),  # type: ignore
     )
     metadata.eval_langs = multilingual_eval_langs
 

--- a/tests/test_benchmark/mock_tasks.py
+++ b/tests/test_benchmark/mock_tasks.py
@@ -1420,19 +1420,31 @@ class MockMultilingualRetrievalTask(AbsTaskRetrieval, MultilingualTask):
             "test": {
                 "q1": "This is a test sentence",
                 "q2": "This is another test sentence",
-            }
+            },
+            "val": {
+                "q1": "This is a test sentence",
+                "q2": "This is another test sentence",
+            },
         }
         self.queries = {"eng": queries, "fra": queries}
         corpus = {
             "test": {
                 "d1": "This is a positive sentence",
                 "d2": "This is another positive sentence",
-            }
+            },
+            "val": {
+                "d1": "This is a positive sentence",
+                "d2": "This is another positive sentence",
+            },
         }
         self.corpus = {"eng": corpus, "fra": corpus}
 
         relevant_docs = {
             "test": {
+                "q1": {"d1": 1, "d2": 0},
+                "q2": {"d1": 0, "d2": 1},
+            },
+            "val": {
                 "q1": {"d1": 1, "d2": 0},
                 "q2": {"d1": 0, "d2": 1},
             },

--- a/tests/test_evaluation/test_split_evaluation.py
+++ b/tests/test_evaluation/test_split_evaluation.py
@@ -7,7 +7,8 @@ from tests.test_benchmark.mock_models import (
     MockSentenceTransformer,
 )
 from tests.test_benchmark.mock_tasks import (
-    MockMultilingualRetrievalTask, MockRetrievalTask,
+    MockMultilingualRetrievalTask,
+    MockRetrievalTask,
 )
 
 
@@ -103,55 +104,45 @@ def test_all_languages_evaluated(model, multilingual_tasks, tmp_path):
         eval_splits=["test"],
         output_folder=str(tmp_path / "all_lang_evaluated"),
         verbosity=2,
-        eval_langs=None,  # means run all languages
+        eval_langs=None,
     )
     assert "MockMultilingualRetrievalTask" == results[0].task_name
-    # Since we ran all subsets, last_evaluated_splits should contain "test"
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
     assert "MockMultilingualRetrievalTask" in last_evaluated_splits
-    # Only one split 'test' but multiple languages were evaluated
     assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 1
     assert last_evaluated_splits["MockMultilingualRetrievalTask"] == ["test"]
 
 
 def test_missing_language(model, multilingual_tasks, tmp_path):
-    # First, run only English
     evaluation = MTEB(tasks=multilingual_tasks)
     results = evaluation.run(
         model,
         eval_splits=["test"],
         output_folder=str(tmp_path / "missing_lang_test"),
         verbosity=2,
-        eval_langs=["eng"],  # run only English language subsets
+        eval_langs=["eng"],
     )
 
     assert "MockMultilingualRetrievalTask" == results[0].task_name
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
-    # We evaluated 'test' split for 'eng'
     assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 1
     assert last_evaluated_splits["MockMultilingualRetrievalTask"] == ["test"]
 
-    results2 = evaluation.run(
+    _ = evaluation.run(
         model,
         eval_splits=["test"],
         output_folder=str(tmp_path / "missing_lang_test"),
         verbosity=2,
-        eval_langs=["eng", "fra"],  # now we include German
+        eval_langs=["eng", "fra"],
         overwrite_results=True,
     )
 
-    # Check that only missing subset (German) was run this time
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
-    # We should see that only the missing language (fra) was evaluated now
-    # Since we ran with overwrite_results and included eng (already done) + fra (new),
-    # only the new language subsets are run. This means "test" split again, but now
-    # effectively for the missing subset.
     assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 1
     assert last_evaluated_splits["MockMultilingualRetrievalTask"] == ["test"]
 
 
 def test_no_missing_languages(model, multilingual_tasks, tmp_path):
-    # Run on all languages once
     evaluation = MTEB(tasks=multilingual_tasks)
     _ = evaluation.run(
         model,
@@ -162,10 +153,8 @@ def test_no_missing_languages(model, multilingual_tasks, tmp_path):
     )
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
     assert "MockMultilingualRetrievalTask" in last_evaluated_splits
-    # One split fully evaluated
     assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 1
 
-    # Run again with the same languages and overwrite_results=True
     evaluation = MTEB(tasks=multilingual_tasks)
     _ = evaluation.run(
         model,
@@ -176,32 +165,23 @@ def test_no_missing_languages(model, multilingual_tasks, tmp_path):
         overwrite_results=True,
     )
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
-    # Since nothing is missing and we overwrite, we re-run everything,
-    # but since we already have the data and re-ran, no missing subsets after the run
-    # means last_evaluated_splits is empty this time.
     assert "MockMultilingualRetrievalTask" in last_evaluated_splits
-    # If no subsets were missing, it means we had to run again due to overwrite,
-    # after running again, no "new" subsets were missing, so no "new" splits get recorded.
     assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 0
 
 
 def test_partial_languages(model, multilingual_tasks, tmp_path):
-    # Run first only French
     evaluation = MTEB(tasks=multilingual_tasks)
     _ = evaluation.run(
         model,
         eval_splits=["test"],
         output_folder=str(tmp_path / "partial_lang_test"),
         verbosity=2,
-        eval_langs=["fra"],  # run only French first
+        eval_langs=["fra"],
     )
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
-    # Only French run now, so "test" is recorded
     assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 1
     assert last_evaluated_splits["MockMultilingualRetrievalTask"] == ["test"]
 
-    # Now run French and English
-    # French is done, so only English should run now
     _ = evaluation.run(
         model,
         eval_splits=["test"],
@@ -211,91 +191,73 @@ def test_partial_languages(model, multilingual_tasks, tmp_path):
         overwrite_results=True,
     )
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
-    # After this run, English was missing previously (since we only did French),
-    # Now we evaluate English. "test" again is recorded.
     assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 1
     assert last_evaluated_splits["MockMultilingualRetrievalTask"] == ["test"]
 
 
-def test_multilingual_multiple_splits_partial_langs_partial_splits(model, multilingual_tasks, tmp_path):
+def test_multilingual_multiple_splits_partial_langs_partial_splits(
+    model, multilingual_tasks, tmp_path
+):
     evaluation = MTEB(tasks=multilingual_tasks)
     _ = evaluation.run(
         model,
         eval_splits=["val"],
         output_folder=str(tmp_path / "partial_langs_partial_splits"),
         verbosity=2,
-        langs_to_run=["eng", "fra"],  # run only English and French
+        eval_langs=["eng", "fra"],
     )
 
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
-    # Only val split was run, with eng and fra
     assert set(last_evaluated_splits["MockMultilingualRetrievalTask"]) == {"val"}
 
-    # Now run 'val' and 'test' splits on all languages eng, deu, fra
-    # English and French on val are done, but we haven't done German on val,
-    # and none of the languages done on 'test' yet.
-    # So this should run German on 'val', and eng, deu, fra on 'test'
-    # because test is completely missing.
     _ = evaluation.run(
         model,
         eval_splits=["val", "test"],
         output_folder=str(tmp_path / "partial_langs_partial_splits"),
         verbosity=2,
-        langs_to_run=["eng", "fra"],
+        eval_langs=["eng", "fra"],
         overwrite_results=True,
     )
 
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
-    # This time:
-    # - For 'val' split: only German was missing. So 'val' will appear in last_evaluated_splits again.
-    # - For 'test' split: all languages (eng, deu, fra) were missing, so 'test' will also appear again.
-    assert set(last_evaluated_splits["MockMultilingualRetrievalTask"]) == {"val", "test"}
-
-
-def test_multilingual_multiple_splits_missing_only_one_language_in_one_split(model, multilingual_tasks, tmp_path):
-    # Run all languages on 'val' only
-    evaluation = MTEB(tasks=multilingual_tasks)
-    _ = evaluation.run(
-        model,
-        eval_splits=["val"],
-        output_folder=str(tmp_path / "one_lang_one_split"),
-        verbosity=2,
-        langs_to_run=["eng", "fra"],
-    )
-
-    last_evaluated_splits = evaluation.get_last_evaluated_splits()
-    # val split fully done for all languages
-    assert set(last_evaluated_splits["MockMultilingualRetrievalTask"]) == {"val"}
-
-    # Now run 'val' and 'test' but only English and German (no French)
-    # val is fully done for eng, deu, fra. So no missing subsets for val.
-    # test not run yet, so test for eng, deu will run now.
-    _ = evaluation.run(
-        model,
-        eval_splits=["val", "test"],
-        output_folder=str(tmp_path / "one_lang_one_split"),
-        verbosity=2,
-        langs_to_run=["eng"],
-        overwrite_results=True,
-    )
-
-    last_evaluated_splits = evaluation.get_last_evaluated_splits()
-    # Since val was already fully done for all languages, no new evaluation for val
-    # test was missing completely, but we only requested eng and deu now, so we run them
-    # last_evaluated_splits should show that test was run this time
     assert set(last_evaluated_splits["MockMultilingualRetrievalTask"]) == {"test"}
 
-    # Now run again 'test' for all languages, including French
-    # eng, deu done on test, fra missing on test
+
+def test_multilingual_multiple_splits_missing_only_one_language_in_one_split(
+    model, multilingual_tasks, tmp_path
+):
+    evaluation = MTEB(tasks=multilingual_tasks)
+    _ = evaluation.run(
+        model,
+        eval_splits=["val"],
+        output_folder=str(tmp_path / "one_lang_one_split"),
+        verbosity=2,
+        eval_langs=["eng", "fra"],
+    )
+
+    last_evaluated_splits = evaluation.get_last_evaluated_splits()
+    assert set(last_evaluated_splits["MockMultilingualRetrievalTask"]) == {"val"}
+
+    _ = evaluation.run(
+        model,
+        eval_splits=["val", "test"],
+        output_folder=str(tmp_path / "one_lang_one_split"),
+        verbosity=2,
+        eval_langs=["eng"],
+        overwrite_results=True,
+    )
+
+    last_evaluated_splits = evaluation.get_last_evaluated_splits()
+    assert set(last_evaluated_splits["MockMultilingualRetrievalTask"]) == {"test"}
+
     _ = evaluation.run(
         model,
         eval_splits=["test"],
         output_folder=str(tmp_path / "one_lang_one_split"),
         verbosity=2,
-        langs_to_run=["eng", "fra"],
+        eval_langs=["eng", "fra"],
         overwrite_results=True,
     )
 
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
-    # Now only French on test was missing previously, so we run it now.
     assert set(last_evaluated_splits["MockMultilingualRetrievalTask"]) == {"test"}

--- a/tests/test_evaluation/test_split_evaluation.py
+++ b/tests/test_evaluation/test_split_evaluation.py
@@ -40,6 +40,7 @@ def test_all_splits_evaluated(model, tasks, tmp_path):
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
     assert set(last_evaluated_splits["MockRetrievalTask"]) == {"val", "test"}
     assert len(last_evaluated_splits["MockRetrievalTask"]) == 2
+    assert results[0].scores.keys() == {"val", "test"}
 
 
 def test_one_missing_split(model, tasks, tmp_path):
@@ -55,6 +56,7 @@ def test_one_missing_split(model, tasks, tmp_path):
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
     assert set(last_evaluated_splits["MockRetrievalTask"]) == {"val"}
     assert len(last_evaluated_splits["MockRetrievalTask"]) == 1
+    assert results[0].scores.keys() == {"val"}
 
     results2 = evaluation.run(
         model,
@@ -68,11 +70,12 @@ def test_one_missing_split(model, tasks, tmp_path):
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
     assert set(last_evaluated_splits["MockRetrievalTask"]) == {"test"}
     assert len(last_evaluated_splits["MockRetrievalTask"]) == 1
+    assert results2[0].scores.keys() == {"test", "val"}
 
 
 def test_no_missing_splits(model, tasks, tmp_path):
     evaluation = MTEB(tasks=tasks)
-    _ = evaluation.run(
+    results = evaluation.run(
         model,
         eval_splits=["val", "test"],
         output_folder=str(tmp_path / "testcase3"),
@@ -82,9 +85,10 @@ def test_no_missing_splits(model, tasks, tmp_path):
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
     assert "MockRetrievalTask" in last_evaluated_splits
     assert len(last_evaluated_splits["MockRetrievalTask"]) == 2
+    assert results[0].scores.keys() == {"test", "val"}
 
     evaluation = MTEB(tasks=tasks)
-    _ = evaluation.run(
+    results = evaluation.run(
         model,
         eval_splits=["val", "test"],
         output_folder=str(tmp_path / "testcase3"),
@@ -95,6 +99,7 @@ def test_no_missing_splits(model, tasks, tmp_path):
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
     assert "MockRetrievalTask" in last_evaluated_splits
     assert len(last_evaluated_splits["MockRetrievalTask"]) == 0
+    assert results[0].scores.keys() == {"test", "val"}
 
 
 def test_all_languages_evaluated(model, multilingual_tasks, tmp_path):
@@ -111,6 +116,8 @@ def test_all_languages_evaluated(model, multilingual_tasks, tmp_path):
     assert "MockMultilingualRetrievalTask" in last_evaluated_splits
     assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 1
     assert last_evaluated_splits["MockMultilingualRetrievalTask"] == ["test"]
+    assert results[0].scores.keys() == {"test"}
+    assert len(results[0].scores["test"]) == 2
 
 
 def test_missing_language(model, multilingual_tasks, tmp_path):
@@ -127,8 +134,10 @@ def test_missing_language(model, multilingual_tasks, tmp_path):
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
     assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 1
     assert last_evaluated_splits["MockMultilingualRetrievalTask"] == ["test"]
+    assert results[0].scores.keys() == {"test"}
+    assert results[0].languages == ["eng"]
 
-    _ = evaluation.run(
+    results = evaluation.run(
         model,
         eval_splits=["test"],
         output_folder=str(tmp_path / "missing_lang_test"),
@@ -140,11 +149,14 @@ def test_missing_language(model, multilingual_tasks, tmp_path):
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
     assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 1
     assert last_evaluated_splits["MockMultilingualRetrievalTask"] == ["test"]
+    assert sorted(results[0].languages) == ["eng", "fra"]
+    assert results[0].scores.keys() == {"test"}
+    assert len(results[0].scores["test"]) == 2
 
 
 def test_no_missing_languages(model, multilingual_tasks, tmp_path):
     evaluation = MTEB(tasks=multilingual_tasks)
-    _ = evaluation.run(
+    results = evaluation.run(
         model,
         eval_splits=["test"],
         output_folder=str(tmp_path / "no_missing_lang_test"),
@@ -154,9 +166,12 @@ def test_no_missing_languages(model, multilingual_tasks, tmp_path):
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
     assert "MockMultilingualRetrievalTask" in last_evaluated_splits
     assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 1
+    assert results[0].scores.keys() == {"test"}
+    assert len(results[0].scores["test"]) == 2
+    assert sorted(results[0].languages) == ["eng", "fra"]
 
     evaluation = MTEB(tasks=multilingual_tasks)
-    _ = evaluation.run(
+    results = evaluation.run(
         model,
         eval_splits=["test"],
         output_folder=str(tmp_path / "no_missing_lang_test"),
@@ -167,11 +182,14 @@ def test_no_missing_languages(model, multilingual_tasks, tmp_path):
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
     assert "MockMultilingualRetrievalTask" in last_evaluated_splits
     assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 0
+    assert results[0].scores.keys() == {"test"}
+    assert len(results[0].scores["test"]) == 2
+    assert sorted(results[0].languages) == ["eng", "fra"]
 
 
 def test_partial_languages(model, multilingual_tasks, tmp_path):
     evaluation = MTEB(tasks=multilingual_tasks)
-    _ = evaluation.run(
+    results = evaluation.run(
         model,
         eval_splits=["test"],
         output_folder=str(tmp_path / "partial_lang_test"),
@@ -181,8 +199,10 @@ def test_partial_languages(model, multilingual_tasks, tmp_path):
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
     assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 1
     assert last_evaluated_splits["MockMultilingualRetrievalTask"] == ["test"]
+    assert results[0].languages == ["fra"]
+    assert results[0].scores.keys() == {"test"}
 
-    _ = evaluation.run(
+    results = evaluation.run(
         model,
         eval_splits=["test"],
         output_folder=str(tmp_path / "partial_lang_test"),
@@ -193,13 +213,16 @@ def test_partial_languages(model, multilingual_tasks, tmp_path):
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
     assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 1
     assert last_evaluated_splits["MockMultilingualRetrievalTask"] == ["test"]
+    assert sorted(results[0].languages) == ["eng", "fra"]
+    assert results[0].scores.keys() == {"test"}
+    assert len(results[0].scores["test"]) == 2
 
 
 def test_multilingual_multiple_splits_partial_langs_partial_splits(
     model, multilingual_tasks, tmp_path
 ):
     evaluation = MTEB(tasks=multilingual_tasks)
-    _ = evaluation.run(
+    results = evaluation.run(
         model,
         eval_splits=["val"],
         output_folder=str(tmp_path / "partial_langs_partial_splits"),
@@ -209,8 +232,11 @@ def test_multilingual_multiple_splits_partial_langs_partial_splits(
 
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
     assert set(last_evaluated_splits["MockMultilingualRetrievalTask"]) == {"val"}
+    assert sorted(results[0].languages) == ["eng", "fra"]
+    assert results[0].scores.keys() == {"val"}
+    assert len(results[0].scores["val"]) == 2
 
-    _ = evaluation.run(
+    results = evaluation.run(
         model,
         eval_splits=["val", "test"],
         output_folder=str(tmp_path / "partial_langs_partial_splits"),
@@ -221,13 +247,17 @@ def test_multilingual_multiple_splits_partial_langs_partial_splits(
 
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
     assert set(last_evaluated_splits["MockMultilingualRetrievalTask"]) == {"test"}
+    assert sorted(results[0].languages) == ["eng", "fra"]
+    assert results[0].scores.keys() == {"test", "val"}
+    assert len(results[0].scores["test"]) == 2
+    assert len(results[0].scores["val"]) == 2
 
 
 def test_multilingual_multiple_splits_missing_only_one_language_in_one_split(
     model, multilingual_tasks, tmp_path
 ):
     evaluation = MTEB(tasks=multilingual_tasks)
-    _ = evaluation.run(
+    results = evaluation.run(
         model,
         eval_splits=["val"],
         output_folder=str(tmp_path / "one_lang_one_split"),
@@ -237,8 +267,11 @@ def test_multilingual_multiple_splits_missing_only_one_language_in_one_split(
 
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
     assert set(last_evaluated_splits["MockMultilingualRetrievalTask"]) == {"val"}
+    assert sorted(results[0].languages) == ["eng", "fra"]
+    assert results[0].scores.keys() == {"val"}
+    assert len(results[0].scores["val"]) == 2
 
-    _ = evaluation.run(
+    results = evaluation.run(
         model,
         eval_splits=["val", "test"],
         output_folder=str(tmp_path / "one_lang_one_split"),
@@ -249,8 +282,12 @@ def test_multilingual_multiple_splits_missing_only_one_language_in_one_split(
 
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
     assert set(last_evaluated_splits["MockMultilingualRetrievalTask"]) == {"test"}
+    assert sorted(results[0].languages) == ["eng", "fra"]
+    assert results[0].scores.keys() == {"test", "val"}
+    assert len(results[0].scores["test"]) == 1
+    assert len(results[0].scores["val"]) == 2
 
-    _ = evaluation.run(
+    results = evaluation.run(
         model,
         eval_splits=["test"],
         output_folder=str(tmp_path / "one_lang_one_split"),
@@ -261,3 +298,7 @@ def test_multilingual_multiple_splits_missing_only_one_language_in_one_split(
 
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
     assert set(last_evaluated_splits["MockMultilingualRetrievalTask"]) == {"test"}
+    assert sorted(results[0].languages) == ["eng", "fra"]
+    # output merged result with previous results
+    assert results[0].scores.keys() == {"test", "val"}
+    assert len(results[0].scores["test"]) == 2

--- a/tests/test_evaluation/test_split_evaluation.py
+++ b/tests/test_evaluation/test_split_evaluation.py
@@ -109,7 +109,7 @@ def test_all_languages_evaluated(model, multilingual_tasks, tmp_path):
         eval_splits=["test"],
         output_folder=str(tmp_path / "all_lang_evaluated"),
         verbosity=2,
-        eval_langs=None,
+        eval_subsets=None,
     )
     assert "MockMultilingualRetrievalTask" == results[0].task_name
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
@@ -127,7 +127,7 @@ def test_missing_language(model, multilingual_tasks, tmp_path):
         eval_splits=["test"],
         output_folder=str(tmp_path / "missing_lang_test"),
         verbosity=2,
-        eval_langs=["eng"],
+        eval_subsets=["eng"],
     )
 
     assert "MockMultilingualRetrievalTask" == results[0].task_name
@@ -143,7 +143,7 @@ def test_missing_language(model, multilingual_tasks, tmp_path):
         eval_splits=["test"],
         output_folder=str(tmp_path / "missing_lang_test"),
         verbosity=2,
-        eval_langs=["eng", "fra"],
+        eval_subsets=["eng", "fra"],
         overwrite_results=True,
     )
 
@@ -162,7 +162,7 @@ def test_no_missing_languages(model, multilingual_tasks, tmp_path):
         eval_splits=["test"],
         output_folder=str(tmp_path / "no_missing_lang_test"),
         verbosity=2,
-        eval_langs=["eng", "fra"],
+        eval_subsets=["eng", "fra"],
     )
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
     assert "MockMultilingualRetrievalTask" in last_evaluated_splits
@@ -177,7 +177,7 @@ def test_no_missing_languages(model, multilingual_tasks, tmp_path):
         eval_splits=["test"],
         output_folder=str(tmp_path / "no_missing_lang_test"),
         verbosity=2,
-        eval_langs=["eng", "fra"],
+        eval_subsets=["eng", "fra"],
         overwrite_results=True,
     )
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
@@ -195,7 +195,7 @@ def test_partial_languages(model, multilingual_tasks, tmp_path):
         eval_splits=["test"],
         output_folder=str(tmp_path / "partial_lang_test"),
         verbosity=2,
-        eval_langs=["fra"],
+        eval_subsets=["fra"],
     )
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
     assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 1
@@ -209,7 +209,7 @@ def test_partial_languages(model, multilingual_tasks, tmp_path):
         eval_splits=["test"],
         output_folder=str(tmp_path / "partial_lang_test"),
         verbosity=2,
-        eval_langs=["fra", "eng"],
+        eval_subsets=["fra", "eng"],
         overwrite_results=True,
     )
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
@@ -229,7 +229,7 @@ def test_multilingual_one_missing_split_no_missing_lang(
         eval_splits=["val"],
         output_folder=str(tmp_path / "partial_langs_partial_splits"),
         verbosity=2,
-        eval_langs=["eng", "fra"],
+        eval_subsets=["eng", "fra"],
     )
 
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
@@ -244,7 +244,7 @@ def test_multilingual_one_missing_split_no_missing_lang(
         eval_splits=["val", "test"],
         output_folder=str(tmp_path / "partial_langs_partial_splits"),
         verbosity=2,
-        eval_langs=["eng", "fra"],
+        eval_subsets=["eng", "fra"],
         overwrite_results=True,
     )
 
@@ -265,7 +265,7 @@ def test_multilingual_one_missing_lang_in_one_split(
         eval_splits=["val"],
         output_folder=str(tmp_path / "one_lang_one_split"),
         verbosity=2,
-        eval_langs=["eng", "fra"],
+        eval_subsets=["eng", "fra"],
     )
 
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
@@ -279,7 +279,7 @@ def test_multilingual_one_missing_lang_in_one_split(
         eval_splits=["val", "test"],
         output_folder=str(tmp_path / "one_lang_one_split"),
         verbosity=2,
-        eval_langs=["eng"],
+        eval_subsets=["eng"],
         overwrite_results=True,
     )
 
@@ -295,7 +295,7 @@ def test_multilingual_one_missing_lang_in_one_split(
         eval_splits=["test"],
         output_folder=str(tmp_path / "one_lang_one_split"),
         verbosity=2,
-        eval_langs=["eng", "fra"],
+        eval_subsets=["eng", "fra"],
         overwrite_results=True,
     )
 

--- a/tests/test_evaluation/test_split_evaluation.py
+++ b/tests/test_evaluation/test_split_evaluation.py
@@ -7,7 +7,7 @@ from tests.test_benchmark.mock_models import (
     MockSentenceTransformer,
 )
 from tests.test_benchmark.mock_tasks import (
-    MockRetrievalTask,
+    MockMultilingualRetrievalTask, MockRetrievalTask,
 )
 
 
@@ -19,6 +19,11 @@ def model():
 @pytest.fixture
 def tasks():
     return [MockRetrievalTask()]
+
+
+@pytest.fixture
+def multilingual_tasks():
+    return [MockMultilingualRetrievalTask()]
 
 
 def test_all_splits_evaluated(model, tasks, tmp_path):
@@ -89,3 +94,208 @@ def test_no_missing_splits(model, tasks, tmp_path):
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
     assert "MockRetrievalTask" in last_evaluated_splits
     assert len(last_evaluated_splits["MockRetrievalTask"]) == 0
+
+
+def test_all_languages_evaluated(model, multilingual_tasks, tmp_path):
+    evaluation = MTEB(tasks=multilingual_tasks)
+    results = evaluation.run(
+        model,
+        eval_splits=["test"],
+        output_folder=str(tmp_path / "all_lang_evaluated"),
+        verbosity=2,
+        eval_langs=None,  # means run all languages
+    )
+    assert "MockMultilingualRetrievalTask" == results[0].task_name
+    # Since we ran all subsets, last_evaluated_splits should contain "test"
+    last_evaluated_splits = evaluation.get_last_evaluated_splits()
+    assert "MockMultilingualRetrievalTask" in last_evaluated_splits
+    # Only one split 'test' but multiple languages were evaluated
+    assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 1
+    assert last_evaluated_splits["MockMultilingualRetrievalTask"] == ["test"]
+
+
+def test_missing_language(model, multilingual_tasks, tmp_path):
+    # First, run only English
+    evaluation = MTEB(tasks=multilingual_tasks)
+    results = evaluation.run(
+        model,
+        eval_splits=["test"],
+        output_folder=str(tmp_path / "missing_lang_test"),
+        verbosity=2,
+        eval_langs=["eng"],  # run only English language subsets
+    )
+
+    assert "MockMultilingualRetrievalTask" == results[0].task_name
+    last_evaluated_splits = evaluation.get_last_evaluated_splits()
+    # We evaluated 'test' split for 'eng'
+    assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 1
+    assert last_evaluated_splits["MockMultilingualRetrievalTask"] == ["test"]
+
+    results2 = evaluation.run(
+        model,
+        eval_splits=["test"],
+        output_folder=str(tmp_path / "missing_lang_test"),
+        verbosity=2,
+        eval_langs=["eng", "fra"],  # now we include German
+        overwrite_results=True,
+    )
+
+    # Check that only missing subset (German) was run this time
+    last_evaluated_splits = evaluation.get_last_evaluated_splits()
+    # We should see that only the missing language (fra) was evaluated now
+    # Since we ran with overwrite_results and included eng (already done) + fra (new),
+    # only the new language subsets are run. This means "test" split again, but now
+    # effectively for the missing subset.
+    assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 1
+    assert last_evaluated_splits["MockMultilingualRetrievalTask"] == ["test"]
+
+
+def test_no_missing_languages(model, multilingual_tasks, tmp_path):
+    # Run on all languages once
+    evaluation = MTEB(tasks=multilingual_tasks)
+    _ = evaluation.run(
+        model,
+        eval_splits=["test"],
+        output_folder=str(tmp_path / "no_missing_lang_test"),
+        verbosity=2,
+        eval_langs=["eng", "fra"],
+    )
+    last_evaluated_splits = evaluation.get_last_evaluated_splits()
+    assert "MockMultilingualRetrievalTask" in last_evaluated_splits
+    # One split fully evaluated
+    assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 1
+
+    # Run again with the same languages and overwrite_results=True
+    evaluation = MTEB(tasks=multilingual_tasks)
+    _ = evaluation.run(
+        model,
+        eval_splits=["test"],
+        output_folder=str(tmp_path / "no_missing_lang_test"),
+        verbosity=2,
+        eval_langs=["eng", "fra"],
+        overwrite_results=True,
+    )
+    last_evaluated_splits = evaluation.get_last_evaluated_splits()
+    # Since nothing is missing and we overwrite, we re-run everything,
+    # but since we already have the data and re-ran, no missing subsets after the run
+    # means last_evaluated_splits is empty this time.
+    assert "MockMultilingualRetrievalTask" in last_evaluated_splits
+    # If no subsets were missing, it means we had to run again due to overwrite,
+    # after running again, no "new" subsets were missing, so no "new" splits get recorded.
+    assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 0
+
+
+def test_partial_languages(model, multilingual_tasks, tmp_path):
+    # Run first only French
+    evaluation = MTEB(tasks=multilingual_tasks)
+    _ = evaluation.run(
+        model,
+        eval_splits=["test"],
+        output_folder=str(tmp_path / "partial_lang_test"),
+        verbosity=2,
+        eval_langs=["fra"],  # run only French first
+    )
+    last_evaluated_splits = evaluation.get_last_evaluated_splits()
+    # Only French run now, so "test" is recorded
+    assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 1
+    assert last_evaluated_splits["MockMultilingualRetrievalTask"] == ["test"]
+
+    # Now run French and English
+    # French is done, so only English should run now
+    _ = evaluation.run(
+        model,
+        eval_splits=["test"],
+        output_folder=str(tmp_path / "partial_lang_test"),
+        verbosity=2,
+        eval_langs=["fra", "eng"],
+        overwrite_results=True,
+    )
+    last_evaluated_splits = evaluation.get_last_evaluated_splits()
+    # After this run, English was missing previously (since we only did French),
+    # Now we evaluate English. "test" again is recorded.
+    assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 1
+    assert last_evaluated_splits["MockMultilingualRetrievalTask"] == ["test"]
+
+
+def test_multilingual_multiple_splits_partial_langs_partial_splits(model, multilingual_tasks, tmp_path):
+    evaluation = MTEB(tasks=multilingual_tasks)
+    _ = evaluation.run(
+        model,
+        eval_splits=["val"],
+        output_folder=str(tmp_path / "partial_langs_partial_splits"),
+        verbosity=2,
+        langs_to_run=["eng", "fra"],  # run only English and French
+    )
+
+    last_evaluated_splits = evaluation.get_last_evaluated_splits()
+    # Only val split was run, with eng and fra
+    assert set(last_evaluated_splits["MockMultilingualRetrievalTask"]) == {"val"}
+
+    # Now run 'val' and 'test' splits on all languages eng, deu, fra
+    # English and French on val are done, but we haven't done German on val,
+    # and none of the languages done on 'test' yet.
+    # So this should run German on 'val', and eng, deu, fra on 'test'
+    # because test is completely missing.
+    _ = evaluation.run(
+        model,
+        eval_splits=["val", "test"],
+        output_folder=str(tmp_path / "partial_langs_partial_splits"),
+        verbosity=2,
+        langs_to_run=["eng", "fra"],
+        overwrite_results=True,
+    )
+
+    last_evaluated_splits = evaluation.get_last_evaluated_splits()
+    # This time:
+    # - For 'val' split: only German was missing. So 'val' will appear in last_evaluated_splits again.
+    # - For 'test' split: all languages (eng, deu, fra) were missing, so 'test' will also appear again.
+    assert set(last_evaluated_splits["MockMultilingualRetrievalTask"]) == {"val", "test"}
+
+
+def test_multilingual_multiple_splits_missing_only_one_language_in_one_split(model, multilingual_tasks, tmp_path):
+    # Run all languages on 'val' only
+    evaluation = MTEB(tasks=multilingual_tasks)
+    _ = evaluation.run(
+        model,
+        eval_splits=["val"],
+        output_folder=str(tmp_path / "one_lang_one_split"),
+        verbosity=2,
+        langs_to_run=["eng", "fra"],
+    )
+
+    last_evaluated_splits = evaluation.get_last_evaluated_splits()
+    # val split fully done for all languages
+    assert set(last_evaluated_splits["MockMultilingualRetrievalTask"]) == {"val"}
+
+    # Now run 'val' and 'test' but only English and German (no French)
+    # val is fully done for eng, deu, fra. So no missing subsets for val.
+    # test not run yet, so test for eng, deu will run now.
+    _ = evaluation.run(
+        model,
+        eval_splits=["val", "test"],
+        output_folder=str(tmp_path / "one_lang_one_split"),
+        verbosity=2,
+        langs_to_run=["eng"],
+        overwrite_results=True,
+    )
+
+    last_evaluated_splits = evaluation.get_last_evaluated_splits()
+    # Since val was already fully done for all languages, no new evaluation for val
+    # test was missing completely, but we only requested eng and deu now, so we run them
+    # last_evaluated_splits should show that test was run this time
+    assert set(last_evaluated_splits["MockMultilingualRetrievalTask"]) == {"test"}
+
+    # Now run again 'test' for all languages, including French
+    # eng, deu done on test, fra missing on test
+    _ = evaluation.run(
+        model,
+        eval_splits=["test"],
+        output_folder=str(tmp_path / "one_lang_one_split"),
+        verbosity=2,
+        langs_to_run=["eng", "fra"],
+        overwrite_results=True,
+    )
+
+    last_evaluated_splits = evaluation.get_last_evaluated_splits()
+    # Now only French on test was missing previously, so we run it now.
+    assert set(last_evaluated_splits["MockMultilingualRetrievalTask"]) == {"test"}

--- a/tests/test_evaluation/test_split_evaluation.py
+++ b/tests/test_evaluation/test_split_evaluation.py
@@ -132,6 +132,7 @@ def test_missing_language(model, multilingual_tasks, tmp_path):
 
     assert "MockMultilingualRetrievalTask" == results[0].task_name
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
+    assert "MockMultilingualRetrievalTask" in last_evaluated_splits
     assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 1
     assert last_evaluated_splits["MockMultilingualRetrievalTask"] == ["test"]
     assert results[0].scores.keys() == {"test"}
@@ -199,8 +200,9 @@ def test_partial_languages(model, multilingual_tasks, tmp_path):
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
     assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 1
     assert last_evaluated_splits["MockMultilingualRetrievalTask"] == ["test"]
-    assert results[0].languages == ["fra"]
     assert results[0].scores.keys() == {"test"}
+    assert len(results[0].scores["test"]) == 1
+    assert results[0].languages == ["fra"]
 
     results = evaluation.run(
         model,
@@ -213,12 +215,12 @@ def test_partial_languages(model, multilingual_tasks, tmp_path):
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
     assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 1
     assert last_evaluated_splits["MockMultilingualRetrievalTask"] == ["test"]
-    assert sorted(results[0].languages) == ["eng", "fra"]
     assert results[0].scores.keys() == {"test"}
     assert len(results[0].scores["test"]) == 2
+    assert sorted(results[0].languages) == ["eng", "fra"]
 
 
-def test_multilingual_multiple_splits_partial_langs_partial_splits(
+def test_multilingual_one_missing_split_no_missing_lang(
     model, multilingual_tasks, tmp_path
 ):
     evaluation = MTEB(tasks=multilingual_tasks)
@@ -231,6 +233,7 @@ def test_multilingual_multiple_splits_partial_langs_partial_splits(
     )
 
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
+    assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 1
     assert set(last_evaluated_splits["MockMultilingualRetrievalTask"]) == {"val"}
     assert sorted(results[0].languages) == ["eng", "fra"]
     assert results[0].scores.keys() == {"val"}
@@ -253,7 +256,7 @@ def test_multilingual_multiple_splits_partial_langs_partial_splits(
     assert len(results[0].scores["val"]) == 2
 
 
-def test_multilingual_multiple_splits_missing_only_one_language_in_one_split(
+def test_multilingual_one_missing_lang_in_one_split(
     model, multilingual_tasks, tmp_path
 ):
     evaluation = MTEB(tasks=multilingual_tasks)


### PR DESCRIPTION
## Checklist
- [X] Run tests locally to make sure nothing is broken using `make test`. 
- [X] Run the formatter to format the code using `make lint`. 

Continue ideas from https://github.com/embeddings-benchmark/mteb/pull/1525

If a missing split is present in the existing results, return its results without running the evaluation.