### PR TITLE
[MIEB] Add new multimodal retrieval tasks

### DIFF
--- a/mteb/tasks/Image/Any2AnyRetrieval/__init__.py
+++ b/mteb/tasks/Image/Any2AnyRetrieval/__init__.py
@@ -5,6 +5,7 @@ from .eng.BLINKIT2TRetrieval import *
 from .eng.CIRRIT2IRetrieval import *
 from .eng.CUB200I2IRetrieval import *
 from .eng.EDIST2ITRetrieval import *
+from .eng.EncyclopediaVQAIT2ITRetrieval import *
 from .eng.Fashion200kI2TRetrieval import *
 from .eng.Fashion200kT2IRetrieval import *
 from .eng.FashionIQIT2IRetrieval import *
@@ -18,14 +19,17 @@ from .eng.HatefulMemesT2IRetrieval import *
 from .eng.ImageCoDeT2IRetrieval import *
 from .eng.InfoSeekIT2ITRetrieval import *
 from .eng.InfoSeekIT2TRetrieval import *
+from .eng.LLaVAIT2TRetrieval import *
 from .eng.MemotionI2TRetrieval import *
 from .eng.MemotionT2IRetrieval import *
 from .eng.METI2IRetrieval import *
 from .eng.MSCOCOI2TRetrieval import *
 from .eng.MSCOCOT2IRetrieval import *
 from .eng.NIGHTSI2IRetrieval import *
+from .eng.OKVQAIT2TRetrieval import *
 from .eng.OVENIT2ITRetrieval import *
 from .eng.OVENIT2TRetrieval import *
+from .eng.ReMuQIT2TRetrieval import *
 from .eng.ROxfordI2IRetrieval import *
 from .eng.RP2kI2IRetrieval import *
 from .eng.RParisI2IRetrieval import *

--- a/mteb/tasks/Image/Any2AnyRetrieval/eng/EncyclopediaVQAIT2ITRetrieval.py
+++ b/mteb/tasks/Image/Any2AnyRetrieval/eng/EncyclopediaVQAIT2ITRetrieval.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from mteb.abstasks.Image.AbsTaskAny2AnyRetrieval import AbsTaskAny2AnyRetrieval
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+
+class EncyclopediaVQAIT2ITRetrieval(AbsTaskAny2AnyRetrieval):
+    metadata = TaskMetadata(
+        name="EncyclopediaVQAIT2ITRetrieval",
+        description="Retrieval Wiki passage and image and passage to answer query about an image.",
+        reference="https://github.com/google-research/google-research/tree/master/encyclopedic_vqa",
+        dataset={
+            "path": "izhx/UMRB-EncyclopediaVQA",
+            "revision": "d6eae4f06e260664eb3f276fd1bdb5d4d4c9f32b",
+        },
+        type="Any2AnyRetrieval",
+        category="it2it",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="recall_at_5",
+        date=("2023-01-01", "2023-07-20"),
+        domains=["Encyclopaedic"],
+        task_subtypes=["Image Text Retrieval"],
+        license="cc-by-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        modalities=["image", "text"],
+        sample_creation="created",
+        bibtex_citation="""@inproceedings{mensink2023encyclopedic,
+  title={Encyclopedic VQA: Visual questions about detailed properties of fine-grained categories},
+  author={Mensink, Thomas and Uijlings, Jasper and Castrejon, Lluis and Goel, Arushi and Cadar, Felipe and Zhou, Howard and Sha, Fei and Araujo, Andr{\'e} and Ferrari, Vittorio},
+  booktitle={Proceedings of the IEEE/CVF International Conference on Computer Vision},
+  pages={3113--3124},
+  year={2023}
+}""",
+        descriptive_stats={
+            "n_samples": {"test": 3743},
+            "avg_character_length": {
+                "test": {
+                    "average_document_length": 1294.368802424136,
+                    "average_query_length": 51.703713598717606,
+                    "num_documents": 68313,
+                    "num_queries": 3743,
+                    "average_relevant_docs_per_query": 1.3056371894202512,
+                }
+            },
+        },
+    )

--- a/mteb/tasks/Image/Any2AnyRetrieval/eng/EncyclopediaVQAIT2ITRetrieval.py
+++ b/mteb/tasks/Image/Any2AnyRetrieval/eng/EncyclopediaVQAIT2ITRetrieval.py
@@ -17,7 +17,7 @@ class EncyclopediaVQAIT2ITRetrieval(AbsTaskAny2AnyRetrieval):
         category="it2it",
         eval_splits=["test"],
         eval_langs=["eng-Latn"],
-        main_score="recall_at_5",
+        main_score="cv_recall_at_5",
         date=("2023-01-01", "2023-07-20"),
         domains=["Encyclopaedic"],
         task_subtypes=["Image Text Retrieval"],

--- a/mteb/tasks/Image/Any2AnyRetrieval/eng/LLaVAIT2TRetrieval.py
+++ b/mteb/tasks/Image/Any2AnyRetrieval/eng/LLaVAIT2TRetrieval.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from mteb.abstasks.Image.AbsTaskAny2AnyRetrieval import AbsTaskAny2AnyRetrieval
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+
+class LLaVAIT2TRetrieval(AbsTaskAny2AnyRetrieval):
+    metadata = TaskMetadata(
+        name="LLaVAIT2TRetrieval",
+        description="Retrieve responses to answer questions about images.",
+        reference="https://github.com/LinWeizheDragon/FLMR/blob/main/docs/Datasets.md",
+        dataset={
+            "path": "izhx/UMRB-LLaVA",
+            "revision": "2a5ed414aab388d8cdd244ba2cf8c8960df4d44d",
+        },
+        type="Any2AnyRetrieval",
+        category="it2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="recall_at_5",
+        date=("2024-07-06", "2024-02-26"),
+        domains=["Encyclopaedic"],
+        task_subtypes=["Image Text Retrieval"],
+        license="cc-by-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        modalities=["text", "image"],
+        sample_creation="found",
+        bibtex_citation="""@inproceedings{lin-etal-2024-preflmr,
+    title = "{P}re{FLMR}: Scaling Up Fine-Grained Late-Interaction Multi-modal Retrievers",
+    author = "Lin, Weizhe  and
+      Mei, Jingbiao  and
+      Chen, Jinghong  and
+      Byrne, Bill",
+    editor = "Ku, Lun-Wei  and
+      Martins, Andre  and
+      Srikumar, Vivek",
+    booktitle = "Proceedings of the 62nd Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)",
+    month = aug,
+    year = "2024",
+    address = "Bangkok, Thailand",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2024.acl-long.289",
+    doi = "10.18653/v1/2024.acl-long.289",
+    pages = "5294--5316",
+}""",
+        descriptive_stats={
+            "n_samples": {"test": 5120},
+            "avg_character_length": {
+                "test": {
+                    "average_document_length": 546.1925258591925,
+                    "average_query_length": 59.580859375,
+                    "num_documents": 5994,
+                    "num_queries": 5120,
+                    "average_relevant_docs_per_query": 1.0,
+                }
+            },
+        },
+    )

--- a/mteb/tasks/Image/Any2AnyRetrieval/eng/LLaVAIT2TRetrieval.py
+++ b/mteb/tasks/Image/Any2AnyRetrieval/eng/LLaVAIT2TRetrieval.py
@@ -17,7 +17,7 @@ class LLaVAIT2TRetrieval(AbsTaskAny2AnyRetrieval):
         category="it2t",
         eval_splits=["test"],
         eval_langs=["eng-Latn"],
-        main_score="recall_at_5",
+        main_score="cv_recall_at_5",
         date=("2024-07-06", "2024-02-26"),
         domains=["Encyclopaedic"],
         task_subtypes=["Image Text Retrieval"],

--- a/mteb/tasks/Image/Any2AnyRetrieval/eng/OKVQAIT2TRetrieval.py
+++ b/mteb/tasks/Image/Any2AnyRetrieval/eng/OKVQAIT2TRetrieval.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from mteb.abstasks.Image.AbsTaskAny2AnyRetrieval import AbsTaskAny2AnyRetrieval
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+
+class OKVQAIT2TRetrieval(AbsTaskAny2AnyRetrieval):
+    metadata = TaskMetadata(
+        name="OKVQAIT2TRetrieval",
+        description="Retrieval a Wiki passage to answer query about an image.",
+        reference="https://okvqa.allenai.org",
+        dataset={
+            "path": "izhx/UMRB-OKVQA",
+            "revision": "96a84a043f5465893670cf616f90e64086c0417a",
+        },
+        type="Any2AnyRetrieval",
+        category="it2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="recall_at_10",
+        date=("2019-01-01", "2020-07-29"),
+        domains=["Encyclopaedic"],
+        task_subtypes=["Image Text Retrieval"],
+        license="cc-by-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        modalities=["image", "text"],
+        sample_creation="created",
+        bibtex_citation="""@inproceedings{marino2019ok,
+  title={Ok-vqa: A visual question answering benchmark requiring external knowledge},
+  author={Marino, Kenneth and Rastegari, Mohammad and Farhadi, Ali and Mottaghi, Roozbeh},
+  booktitle={Proceedings of the IEEE/cvf conference on computer vision and pattern recognition},
+  pages={3195--3204},
+  year={2019}
+}""",
+        descriptive_stats={
+            "n_samples": {"test": 5046},
+            "avg_character_length": {
+                "test": {
+                    "average_document_length": 41.7072929052715,
+                    "average_query_length": 631.7119703796849,
+                    "num_documents": 114516,
+                    "num_queries": 5046,
+                    "average_relevant_docs_per_query": 7.426674593737614,
+                }
+            },
+        },
+    )

--- a/mteb/tasks/Image/Any2AnyRetrieval/eng/OKVQAIT2TRetrieval.py
+++ b/mteb/tasks/Image/Any2AnyRetrieval/eng/OKVQAIT2TRetrieval.py
@@ -17,7 +17,7 @@ class OKVQAIT2TRetrieval(AbsTaskAny2AnyRetrieval):
         category="it2t",
         eval_splits=["test"],
         eval_langs=["eng-Latn"],
-        main_score="recall_at_10",
+        main_score="cv_recall_at_10",
         date=("2019-01-01", "2020-07-29"),
         domains=["Encyclopaedic"],
         task_subtypes=["Image Text Retrieval"],

--- a/mteb/tasks/Image/Any2AnyRetrieval/eng/ReMuQIT2TRetrieval.py
+++ b/mteb/tasks/Image/Any2AnyRetrieval/eng/ReMuQIT2TRetrieval.py
@@ -17,7 +17,7 @@ class ReMuQIT2TRetrieval(AbsTaskAny2AnyRetrieval):
         category="it2t",
         eval_splits=["test"],
         eval_langs=["eng-Latn"],
-        main_score="recall_at_5",
+        main_score="cv_recall_at_5",
         date=("2023-05-15", "2023-07-09"),
         domains=["Encyclopaedic"],
         task_subtypes=["Image Text Retrieval"],

--- a/mteb/tasks/Image/Any2AnyRetrieval/eng/ReMuQIT2TRetrieval.py
+++ b/mteb/tasks/Image/Any2AnyRetrieval/eng/ReMuQIT2TRetrieval.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from mteb.abstasks.Image.AbsTaskAny2AnyRetrieval import AbsTaskAny2AnyRetrieval
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+
+class ReMuQIT2TRetrieval(AbsTaskAny2AnyRetrieval):
+    metadata = TaskMetadata(
+        name="ReMuQIT2TRetrieval",
+        description="Retrieval a Wiki passage to answer query about an image.",
+        reference="https://github.com/luomancs/ReMuQ",
+        dataset={
+            "path": "izhx/UMRB-ReMuQ",
+            "revision": "f0bd5955d2897bd1bed56546e88082d966c90a80",
+        },
+        type="Any2AnyRetrieval",
+        category="it2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="recall_at_5",
+        date=("2023-05-15", "2023-07-09"),
+        domains=["Encyclopaedic"],
+        task_subtypes=["Image Text Retrieval"],
+        license="cc0-1.0",
+        annotations_creators="derived",
+        dialect=[],
+        modalities=["image", "text"],
+        sample_creation="created",
+        bibtex_citation="""@inproceedings{luo-etal-2023-end,
+    title = "End-to-end Knowledge Retrieval with Multi-modal Queries",
+    author = "Luo, Man  and
+      Fang, Zhiyuan  and
+      Gokhale, Tejas  and
+      Yang, Yezhou  and
+      Baral, Chitta",
+    editor = "Rogers, Anna  and
+      Boyd-Graber, Jordan  and
+      Okazaki, Naoaki",
+    booktitle = "Proceedings of the 61st Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)",
+    month = jul,
+    year = "2023",
+    address = "Toronto, Canada",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2023.acl-long.478",
+    doi = "10.18653/v1/2023.acl-long.478",
+    pages = "8573--8589",
+}""",
+        descriptive_stats={
+            "n_samples": {"test": 3609},
+            "avg_character_length": {
+                "test": {
+                    "average_document_length": 208.18675158868538,
+                    "average_query_length": 73.85508451094486,
+                    "num_documents": 138794,
+                    "num_queries": 3609,
+                    "average_relevant_docs_per_query": 1.0,
+                }
+            },
+        },
+    )


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

https://github.com/embeddings-benchmark/mteb/issues/1523

<!-- add additional description, question etc. related to the new dataset -->

Image-text to text retrieval:
 - LLaVAIT2TRetrieval
 - OKVQAIT2TRetrieval
 - ReMuQIT2TRetrieval

Image-text to image-text retrieval:
 - EncyclopediaVQAIT2ITRetrieval

I'm runing tests by `mteb run -m {model_name} -t {task_name}`

|   cv_recall_at_5      | LLaVA IT2Tl | OKVQA IT2T  | ReMuQ IT2T | EncyclopediaVQA IT2IT |
|--------------------|-------------|--------------|-------------|-----------|
| nomic-ai/nomic-embed-vision-v1.5 |  73.809 |  12.228  |  93.655  |   41.287   |
| openai/clip-vit-base-patch16     |        38.594 |  4.419    |  66.528  |   16.589   |

### Adding datasets checklist
<!-- see also https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md -->

**Reason for dataset addition**: These datasets are used in recent studies (such as preFLMR) to evaluate multimodal embedding models, and could provide a meaningful complement to current cross-modal retrieval tasks.
 <!-- Add reason for adding dataset here. E.g. it covers task/language/domain previously not covered -->

- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
  - [x] `nomic-ai/nomic-embed-vision-v1.5`
  - [x] `openai/clip-vit-base-patch16`
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [ ] If the dataset is too big (e.g. >2048 examples), considering using `self.stratified_subsampling() under dataset_transform()`
- [x] I have filled out the metadata object in the dataset file (find documentation on it [here](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md#2-creating-the-metadata-object)).
- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 
