### PR TITLE
[MIEB] Fix `get_fused_emebddings`

### DIFF
--- a/mteb/models/align_models.py
+++ b/mteb/models/align_models.py
@@ -101,9 +101,6 @@ class ALIGNModelWrapper:
         self,
         texts: list[str] = None,
         images: list[Image.Image] | DataLoader = None,
-        task_name: str | None = None,
-        prompt_type: PromptType | None = None,
-        batch_size: int = 32,
         fusion_mode="sum",
         **kwargs: Any,
     ):
@@ -114,10 +111,10 @@ class ALIGNModelWrapper:
         image_embeddings = None
 
         if texts is not None:
-            text_embeddings = self.get_text_embeddings(texts, batch_size)
+            text_embeddings = self.get_text_embeddings(texts, **kwargs)
 
         if images is not None:
-            image_embeddings = self.get_image_embeddings(images, batch_size)
+            image_embeddings = self.get_image_embeddings(images, **kwargs)
 
         if text_embeddings is not None and image_embeddings is not None:
             if len(text_embeddings) != len(image_embeddings):

--- a/mteb/models/blip2_models.py
+++ b/mteb/models/blip2_models.py
@@ -174,9 +174,6 @@ def blip2_loader(**kwargs):
             self,
             texts: list[str] = None,
             images: list[Image.Image] | DataLoader = None,
-            task_name: str | None = None,
-            prompt_type: PromptType | None = None,
-            batch_size: int = 32,
             fusion_mode="sum",
             **kwargs: Any,
         ):
@@ -188,10 +185,10 @@ def blip2_loader(**kwargs):
             image_embeddings = None
 
             if texts is not None:
-                text_embeddings = self.get_text_embeddings(texts, batch_size)
+                text_embeddings = self.get_text_embeddings(texts, **kwargs)
 
             if images is not None:
-                image_embeddings = self.get_image_embeddings(images, batch_size)
+                image_embeddings = self.get_image_embeddings(images, **kwargs)
 
             if text_embeddings is not None and image_embeddings is not None:
                 if len(text_embeddings) != len(image_embeddings):
@@ -202,7 +199,7 @@ def blip2_loader(**kwargs):
                     fused_embeddings = text_embeddings + image_embeddings
                 elif fusion_mode == "multimodal":
                     fused_embeddings = self.get_multimodal_embeddings(
-                        texts, images, batch_size
+                        texts, images, kwargs.get("batch_size", 32)
                     )
                 else:
                     # to do: add other fusion mode

--- a/mteb/models/blip_models.py
+++ b/mteb/models/blip_models.py
@@ -121,9 +121,6 @@ class BLIPModelWrapper:
         self,
         texts: list[str] = None,
         images: list[Image.Image] | DataLoader = None,
-        task_name: str | None = None,
-        prompt_type: PromptType | None = None,
-        batch_size: int = 32,
         fusion_mode="sum",
         **kwargs: Any,
     ):
@@ -134,10 +131,10 @@ class BLIPModelWrapper:
         image_embeddings = None
 
         if texts is not None:
-            text_embeddings = self.get_text_embeddings(texts, batch_size)
+            text_embeddings = self.get_text_embeddings(texts, **kwargs)
 
         if images is not None:
-            image_embeddings = self.get_image_embeddings(images, batch_size)
+            image_embeddings = self.get_image_embeddings(images, **kwargs)
 
         if text_embeddings is not None and image_embeddings is not None:
             if len(text_embeddings) != len(image_embeddings):

--- a/mteb/models/clip_models.py
+++ b/mteb/models/clip_models.py
@@ -105,9 +105,6 @@ class CLIPModelWrapper:
         self,
         texts: list[str] = None,
         images: list[Image.Image] | DataLoader = None,
-        task_name: str | None = None,
-        prompt_type: PromptType | None = None,
-        batch_size: int = 32,
         fusion_mode="sum",
         **kwargs: Any,
     ):
@@ -118,10 +115,10 @@ class CLIPModelWrapper:
         image_embeddings = None
 
         if texts is not None:
-            text_embeddings = self.get_text_embeddings(texts, batch_size)
+            text_embeddings = self.get_text_embeddings(texts, **kwargs)
 
         if images is not None:
-            image_embeddings = self.get_image_embeddings(images, batch_size)
+            image_embeddings = self.get_image_embeddings(images, **kwargs)
 
         if text_embeddings is not None and image_embeddings is not None:
             if len(text_embeddings) != len(image_embeddings):

--- a/mteb/models/cohere_v.py
+++ b/mteb/models/cohere_v.py
@@ -145,9 +145,6 @@ def cohere_v_loader(**kwargs):
             self,
             texts: list[str] = None,
             images: list[Image.Image] | DataLoader = None,
-            task_name: str | None = None,
-            prompt_type: PromptType | None = None,
-            batch_size: int = 32,
             fusion_mode="sum",
             **kwargs: Any,
         ):
@@ -158,10 +155,10 @@ def cohere_v_loader(**kwargs):
             image_embeddings = None
 
             if texts is not None:
-                text_embeddings = self.get_text_embeddings(texts, batch_size)
+                text_embeddings = self.get_text_embeddings(texts, **kwargs)
 
             if images is not None:
-                image_embeddings = self.get_image_embeddings(images, batch_size)
+                image_embeddings = self.get_image_embeddings(images, **kwargs)
 
             if text_embeddings is not None and image_embeddings is not None:
                 if len(text_embeddings) != len(image_embeddings):

--- a/mteb/models/dino_models.py
+++ b/mteb/models/dino_models.py
@@ -97,9 +97,6 @@ class DINOModelWrapper:
         self,
         texts: list[str] = None,
         images: list[Image.Image] | DataLoader = None,
-        task_name: str | None = None,
-        prompt_type: PromptType | None = None,
-        batch_size: int = 32,
         fusion_mode="sum",
         **kwargs: Any,
     ):
@@ -110,10 +107,10 @@ class DINOModelWrapper:
         image_embeddings = None
 
         if texts is not None:
-            text_embeddings = self.get_text_embeddings(texts, batch_size)
+            text_embeddings = self.get_text_embeddings(texts, **kwargs)
 
         if images is not None:
-            image_embeddings = self.get_image_embeddings(images, batch_size)
+            image_embeddings = self.get_image_embeddings(images, **kwargs)
 
         if text_embeddings is not None and image_embeddings is not None:
             raise ValueError("DINO models only support image encoding.")

--- a/mteb/models/e5_v.py
+++ b/mteb/models/e5_v.py
@@ -120,9 +120,6 @@ class E5VWrapper:
         self,
         texts: list[str] = None,
         images: list[Image.Image] = None,
-        *,
-        task_name: str | None = None,
-        prompt_type: PromptType | None = None,
         batch_size: int = 8,
         **kwargs: Any,
     ):
@@ -130,6 +127,7 @@ class E5VWrapper:
             raise ValueError("Either texts or images must be provided")
 
         all_fused_embeddings = []
+        kwargs.update(batch_size=batch_size)
 
         if texts is not None and images is not None:
             with torch.no_grad():
@@ -168,10 +166,10 @@ class E5VWrapper:
                         all_fused_embeddings.append(outputs.cpu())
             return torch.cat(all_fused_embeddings, dim=0)
         elif texts is not None:
-            text_embeddings = self.get_text_embeddings(texts, batch_size)
+            text_embeddings = self.get_text_embeddings(texts, **kwargs)
             return text_embeddings
         elif images is not None:
-            image_embeddings = self.get_image_embeddings(images, batch_size)
+            image_embeddings = self.get_image_embeddings(images, **kwargs)
             return image_embeddings
 
 

--- a/mteb/models/evaclip_models.py
+++ b/mteb/models/evaclip_models.py
@@ -129,10 +129,6 @@ def evaclip_loader(**kwargs):
             self,
             texts: list[str] = None,
             images: list[Image.Image] | DataLoader = None,
-            *,
-            task_name: str | None = None,
-            prompt_type: PromptType | None = None,
-            batch_size: int = 32,
             fusion_mode="sum",
             **kwargs: Any,
         ):
@@ -143,10 +139,10 @@ def evaclip_loader(**kwargs):
             image_embeddings = None
 
             if texts is not None:
-                text_embeddings = self.get_text_embeddings(texts, batch_size)
+                text_embeddings = self.get_text_embeddings(texts, **kwargs)
 
             if images is not None:
-                image_embeddings = self.get_image_embeddings(images, batch_size)
+                image_embeddings = self.get_image_embeddings(images, **kwargs)
 
             if text_embeddings is not None and image_embeddings is not None:
                 if len(text_embeddings) != len(image_embeddings):

--- a/mteb/models/jina_clip.py
+++ b/mteb/models/jina_clip.py
@@ -101,10 +101,6 @@ class JinaCLIPModelWrapper:
         self,
         texts: list[str] = None,
         images: list[Image.Image] = None,
-        *,
-        task_name: str | None = None,
-        prompt_type: PromptType | None = None,
-        batch_size: int = 32,
         fusion_mode="sum",
         **kwargs: Any,
     ):
@@ -116,18 +112,12 @@ class JinaCLIPModelWrapper:
 
         if texts is not None:
             text_embeddings = self.get_text_embeddings(
-                texts,
-                batch_size=batch_size,
-                convert_to_numpy=False,
-                convert_to_tensor=True,
+                texts, convert_to_numpy=False, convert_to_tensor=True, **kwargs
             )
 
         if images is not None:
             image_embeddings = self.get_image_embeddings(
-                images,
-                batch_size=batch_size,
-                convert_to_numpy=False,
-                convert_to_tensor=True,
+                images, convert_to_numpy=False, convert_to_tensor=True, **kwargs
             )
 
         if text_embeddings is not None and image_embeddings is not None:

--- a/mteb/models/nomic_models_vision.py
+++ b/mteb/models/nomic_models_vision.py
@@ -128,10 +128,6 @@ class NomicVisionModelWrapper:
         self,
         texts: list[str] = None,
         images: list[Image.Image] | DataLoader = None,
-        *,
-        task_name: str | None = None,
-        prompt_type: PromptType | None = None,
-        batch_size: int = 32,
         fusion_mode="sum",
         **kwargs: Any,
     ):
@@ -142,10 +138,10 @@ class NomicVisionModelWrapper:
         image_embeddings = None
 
         if texts is not None:
-            text_embeddings = self.get_text_embeddings(texts, batch_size)
+            text_embeddings = self.get_text_embeddings(texts, **kwargs)
 
         if images is not None:
-            image_embeddings = self.get_image_embeddings(images, batch_size)
+            image_embeddings = self.get_image_embeddings(images, **kwargs)
 
         if text_embeddings is not None and image_embeddings is not None:
             if len(text_embeddings) != len(image_embeddings):

--- a/mteb/models/openclip_models.py
+++ b/mteb/models/openclip_models.py
@@ -114,10 +114,6 @@ def openclip_loader(**kwargs):
             self,
             texts: list[str] = None,
             images: list[Image.Image] | DataLoader = None,
-            *,
-            task_name: str | None = None,
-            prompt_type: PromptType | None = None,
-            batch_size: int = 32,
             fusion_mode="sum",
             **kwargs: Any,
         ):
@@ -128,10 +124,10 @@ def openclip_loader(**kwargs):
             image_embeddings = None
 
             if texts is not None:
-                text_embeddings = self.get_text_embeddings(texts, batch_size)
+                text_embeddings = self.get_text_embeddings(texts, **kwargs)
 
             if images is not None:
-                image_embeddings = self.get_image_embeddings(images, batch_size)
+                image_embeddings = self.get_image_embeddings(images, **kwargs)
 
             if text_embeddings is not None and image_embeddings is not None:
                 if len(text_embeddings) != len(image_embeddings):

--- a/mteb/models/siglip_models.py
+++ b/mteb/models/siglip_models.py
@@ -123,10 +123,6 @@ class SiglipModelWrapper:
         self,
         texts: list[str] = None,
         images: list[Image.Image] | DataLoader = None,
-        *,
-        task_name: str | None = None,
-        prompt_type: PromptType | None = None,
-        batch_size: int = 32,
         fusion_mode="sum",
         **kwargs: Any,
     ):
@@ -137,10 +133,10 @@ class SiglipModelWrapper:
         image_embeddings = None
 
         if texts is not None:
-            text_embeddings = self.get_text_embeddings(texts, batch_size)
+            text_embeddings = self.get_text_embeddings(texts, **kwargs)
 
         if images is not None:
-            image_embeddings = self.get_image_embeddings(images, batch_size)
+            image_embeddings = self.get_image_embeddings(images, **kwargs)
 
         if text_embeddings is not None and image_embeddings is not None:
             if len(text_embeddings) != len(image_embeddings):

--- a/mteb/models/vista_models.py
+++ b/mteb/models/vista_models.py
@@ -176,7 +176,6 @@ def vista_loader(**kwargs):
             self,
             texts: list[str] = None,
             images: list[Image.Image] | DataLoader = None,
-            *,
             task_name: str | None = None,
             prompt_type: PromptType | None = None,
             batch_size: int = 32,

--- a/mteb/models/vlm2vec_models.py
+++ b/mteb/models/vlm2vec_models.py
@@ -267,13 +267,14 @@ class VLM2VecWrapper:
 
         text_embeddings = None
         image_embeddings = None
+        kwargs.update(task_name=task_name, prompt_type=prompt_type, batch_size=batch_size)
 
         if texts is not None and images is None:
-            text_embeddings = self.get_text_embeddings(texts, batch_size)
+            text_embeddings = self.get_text_embeddings(texts, **kwargs)
             return text_embeddings
 
         if images is not None and texts is None:
-            image_embeddings = self.get_image_embeddings(images, batch_size)
+            image_embeddings = self.get_image_embeddings(images, **kwargs)
             return image_embeddings
 
         # text_embeddings is not None and image_embeddings is not None

--- a/mteb/models/vlm2vec_models.py
+++ b/mteb/models/vlm2vec_models.py
@@ -267,7 +267,9 @@ class VLM2VecWrapper:
 
         text_embeddings = None
         image_embeddings = None
-        kwargs.update(task_name=task_name, prompt_type=prompt_type, batch_size=batch_size)
+        kwargs.update(
+            task_name=task_name, prompt_type=prompt_type, batch_size=batch_size
+        )
 
         if texts is not None and images is None:
             text_embeddings = self.get_text_embeddings(texts, **kwargs)

--- a/mteb/models/voyage_v.py
+++ b/mteb/models/voyage_v.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import logging
 import os
 from functools import partial
 from typing import Any
 
-import logging
 import torch
 from PIL import Image
 from torch.utils.data import DataLoader
@@ -12,7 +12,6 @@ from torchvision import transforms
 from tqdm import tqdm
 
 import mteb
-from mteb.model_meta import ModelMeta
 from mteb.encoder_interface import PromptType
 from mteb.model_meta import ModelMeta
 
@@ -23,9 +22,7 @@ tensor_to_image = transforms.Compose([transforms.ToPILImage()])
 def downsample_image(
     image: Image.Image, max_pixels: int = 16000000, target_longest_side: int = 4000
 ) -> Image.Image:
-    """
-    if image pixel > max_pixels, downsample it to target_longest_side while keeping the width height ratio.
-    """
+    """If image pixel > max_pixels, downsample it to target_longest_side while keeping the width height ratio."""
     width, height = image.size
     pixels = width * height
 


### PR DESCRIPTION
In PR https://github.com/embeddings-benchmark/mteb/pull/1583 , I only changed the arguments of `get_fused_emebddings`, but forgot to update the internal implementation logic accordingly, which caused runtime errors. (Sorry)

Now, they are fixed.

I will run `i`, `t`, and `it` encodings for each model to check.

## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 

---

Checking progress:
| code |  i2t - Flickr30kI2TRetrieval | it2t - LLaVAIT2TRetrieval PR https://github.com/embeddings-benchmark/mteb/pull/1611 | note |
|-----|-----|-----|----|
| align_models.py | ✓ | ✓ |
| blip2_models.py |  |  | `salesforce-lavis` is conflict with `sentence_transformers>=3.0`|
| blip_models.py | ✓ | ✓ |
| clip_models.py | ✓ | ✓ |
| cohere_v.py | | | I don't have a key |
| dino_models.py| | | DINO models only support image encoding. |
| e5_v.py | ✓ | ✓ |
| evaclip_models.py | | | Code error when init model |
| jina_clip.py | ✓ | ✓ |
| nomic_models_vision.py | ✓ | ✓ |
| openclip_models.py | ✓ | ✓ |
| siglip_models.py | ✓ | ✓ |
| vista_models.py | | | Code error when init model | 
| vlm2vec_models.py | ✓ | ✓ |
| voyage_v | | | I don't have a key |
