### PR TITLE
fix: disable co2_tracker for API models

### DIFF
--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -436,6 +436,10 @@ class MTEB:
         if isinstance(model, (SentenceTransformer, CrossEncoder)):
             model = SentenceTransformerWrapper(model)
 
+        ## Disable co2_tracker for API models
+        if "API" in meta.framework:
+            co2_tracker = False
+
         if output_path:
             self._save_model_metadata(meta, output_path)
 


### PR DESCRIPTION
When `co2_tracker` is enabled, it is used for API-based models as well, which can be misleading. This PR introduces a simple check to determine if a model's meta defines `API` as its framework, and if so, disables `co2_tracker` for the evaluation run.

Currently, four model families use `API` as their framework: `cohere_models`, `google_models`, `openai_models` and `voyage_models`.

This PR relates to the conversation [here](https://github.com/embeddings-benchmark/results/pull/71#issuecomment-2542593617).

## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 