### PR TITLE
fix: override existing results

### DIFF
--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -478,7 +478,8 @@ class MTEB:
 
                     if not overwrite_results:
                         logger.info(
-                            f"{task.metadata.name} results already exists. Loading results from disk. Set overwrite_results=True to overwrite."
+                            f"{task.metadata.name} results already exists. Loading results from disk."
+                            f" Set overwrite_results=True to overwrite or `--overwrite`."
                         )
                         evaluation_results.append(existing_results)
                         del self.tasks[0]  # empty memory
@@ -496,7 +497,7 @@ class MTEB:
             final_splits_to_run = []
             # We need to run any split that is fully missing or has missing subsets
             for sp, info in missing_evaluations.items():
-                if info["whole_split_missing"] or info["missing_subsets"]:
+                if info["whole_split_missing"] or info["missing_subsets"] or overwrite_results:
                     final_splits_to_run.append(sp)
 
             # If no splits need to be run and results exist, skip
@@ -527,8 +528,9 @@ class MTEB:
                     # Determine subsets to run for this split
                     # If the whole split is missing, run all required subsets
                     # If only some subsets are missing, run only those
-                    subsets_to_run = info["missing_subsets"]
-                    if info["whole_split_missing"] and task_subsets is None:
+                    subsets_to_run = info["missing_subsets"] if not overwrite_results else task_subsets
+
+                    if (info["whole_split_missing"] or overwrite_results) and task_subsets is None:
                         subsets_to_run = ["default"]
 
                     if co2_tracker:

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -501,7 +501,6 @@ class MTEB:
                             if info["whole_split_missing"] or info["missing_subsets"]:
                                 final_splits_to_run.append(sp)
 
-
                     if not overwrite_results and len(final_splits_to_run) == 0:
                         logger.info(
                             f"{task.metadata.name} results already exists. Loading results from disk."

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -495,10 +495,7 @@ class MTEB:
                     final_splits_to_run = []
                     # We need to run any split that is fully missing or has missing subsets
                     for sp, info in missing_evaluations.items():
-                        if (
-                                info["whole_split_missing"]
-                                or info["missing_subsets"]
-                        ):
+                        if info["whole_split_missing"] or info["missing_subsets"]:
                             final_splits_to_run.append(sp)
 
                     if overwrite_results:

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -491,15 +491,16 @@ class MTEB:
                         eval_subsets,
                     )
 
-                    # Determine final splits to run
-                    final_splits_to_run = []
-                    # We need to run any split that is fully missing or has missing subsets
-                    for sp, info in missing_evaluations.items():
-                        if info["whole_split_missing"] or info["missing_subsets"]:
-                            final_splits_to_run.append(sp)
-
                     if overwrite_results:
                         final_splits_to_run = task_eval_splits
+                    else:
+                        # Determine final splits to run
+                        final_splits_to_run = []
+                        # We need to run any split that is fully missing or has missing subsets
+                        for sp, info in missing_evaluations.items():
+                            if info["whole_split_missing"] or info["missing_subsets"]:
+                                final_splits_to_run.append(sp)
+
 
                     if not overwrite_results and len(final_splits_to_run) == 0:
                         logger.info(

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -497,7 +497,11 @@ class MTEB:
             final_splits_to_run = []
             # We need to run any split that is fully missing or has missing subsets
             for sp, info in missing_evaluations.items():
-                if info["whole_split_missing"] or info["missing_subsets"] or overwrite_results:
+                if (
+                    info["whole_split_missing"]
+                    or info["missing_subsets"]
+                    or overwrite_results
+                ):
                     final_splits_to_run.append(sp)
 
             # If no splits need to be run and results exist, skip
@@ -528,9 +532,15 @@ class MTEB:
                     # Determine subsets to run for this split
                     # If the whole split is missing, run all required subsets
                     # If only some subsets are missing, run only those
-                    subsets_to_run = info["missing_subsets"] if not overwrite_results else task_subsets
+                    subsets_to_run = (
+                        info["missing_subsets"]
+                        if not overwrite_results
+                        else task_subsets
+                    )
 
-                    if (info["whole_split_missing"] or overwrite_results) and task_subsets is None:
+                    if (
+                        info["whole_split_missing"] or overwrite_results
+                    ) and task_subsets is None:
                         subsets_to_run = ["default"]
 
                     if co2_tracker:

--- a/tests/test_evaluation/test_split_evaluation.py
+++ b/tests/test_evaluation/test_split_evaluation.py
@@ -326,7 +326,9 @@ def test_all_splits_evaluated_with_overwrite(model, tasks, tmp_path):
     assert results[0].scores.keys() == {"val", "test"}
 
 
-def test_all_splits_subsets_evaluated_with_overwrite(model, multilingual_tasks, tmp_path):
+def test_all_splits_subsets_evaluated_with_overwrite(
+    model, multilingual_tasks, tmp_path
+):
     evaluation = MTEB(tasks=multilingual_tasks)
     results = evaluation.run(
         model,
@@ -360,4 +362,3 @@ def test_all_splits_subsets_evaluated_with_overwrite(model, multilingual_tasks, 
     for split in ["test", "val"]:
         assert len(results2[0].scores[split]) == 2
         assert sorted(results2[0].languages) == ["eng", "fra"]
-

--- a/tests/test_evaluation/test_split_evaluation.py
+++ b/tests/test_evaluation/test_split_evaluation.py
@@ -308,22 +308,22 @@ def test_all_splits_evaluated_with_overwrite(model, tasks, tmp_path):
 
     assert "MockRetrievalTask" == results[0].task_name
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
-    assert set(last_evaluated_splits["MockRetrievalTask"]) == {"val"}
     assert len(last_evaluated_splits["MockRetrievalTask"]) == 1
+    assert set(last_evaluated_splits["MockRetrievalTask"]) == {"val"}
     assert results[0].scores.keys() == {"val"}
 
     results2 = evaluation.run(
         model,
-        eval_splits=["val"],
+        eval_splits=["val", "test"],
         output_folder=str(tmp_path / "all_splits_evaluated_with_overwrite"),
         verbosity=2,
         overwrite_results=True,
     )
     assert "MockRetrievalTask" == results2[0].task_name
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
-    assert set(last_evaluated_splits["MockRetrievalTask"]) == {"val"}
-    assert len(last_evaluated_splits["MockRetrievalTask"]) == 1
-    assert results2[0].scores.keys() == {"val"}
+    assert len(last_evaluated_splits["MockRetrievalTask"]) == 2
+    assert set(last_evaluated_splits["MockRetrievalTask"]) == {"val", "test"}
+    assert results2[0].scores.keys() == {"val", "test"}
 
 
 def test_all_splits_subsets_evaluated_with_overwrite(
@@ -352,7 +352,7 @@ def test_all_splits_subsets_evaluated_with_overwrite(
         eval_splits=["test"],
         output_folder=str(tmp_path / "all_splits_subsets_evaluated_with_overwrite"),
         verbosity=2,
-        eval_subsets=["fra"],
+        eval_subsets=["fra", "eng"],
         overwrite_results=True,
     )
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
@@ -360,5 +360,5 @@ def test_all_splits_subsets_evaluated_with_overwrite(
     assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 1
     assert results2[0].scores.keys() == {"test"}
     for split in ["test"]:
-        assert len(results2[0].scores[split]) == 1
-        assert sorted(results2[0].languages) == ["fra"]
+        assert len(results2[0].scores[split]) == 2
+        assert sorted(results2[0].languages) == ["eng", "fra"]

--- a/tests/test_evaluation/test_split_evaluation.py
+++ b/tests/test_evaluation/test_split_evaluation.py
@@ -301,29 +301,29 @@ def test_all_splits_evaluated_with_overwrite(model, tasks, tmp_path):
     evaluation = MTEB(tasks=tasks)
     results = evaluation.run(
         model,
-        eval_splits=["val", "test"],
-        output_folder=str(tmp_path / "all_splits_evaluated"),
+        eval_splits=["val"],
+        output_folder=str(tmp_path / "all_splits_evaluated_with_overwrite"),
         verbosity=2,
     )
 
     assert "MockRetrievalTask" == results[0].task_name
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
-    assert set(last_evaluated_splits["MockRetrievalTask"]) == {"val", "test"}
-    assert len(last_evaluated_splits["MockRetrievalTask"]) == 2
-    assert results[0].scores.keys() == {"val", "test"}
+    assert set(last_evaluated_splits["MockRetrievalTask"]) == {"val"}
+    assert len(last_evaluated_splits["MockRetrievalTask"]) == 1
+    assert results[0].scores.keys() == {"val"}
 
     results2 = evaluation.run(
         model,
-        eval_splits=["val", "test"],
-        output_folder=str(tmp_path / "all_splits_evaluated"),
+        eval_splits=["val"],
+        output_folder=str(tmp_path / "all_splits_evaluated_with_overwrite"),
         verbosity=2,
         overwrite_results=True,
     )
     assert "MockRetrievalTask" == results2[0].task_name
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
-    assert set(last_evaluated_splits["MockRetrievalTask"]) == {"val", "test"}
-    assert len(last_evaluated_splits["MockRetrievalTask"]) == 2
-    assert results[0].scores.keys() == {"val", "test"}
+    assert set(last_evaluated_splits["MockRetrievalTask"]) == {"val"}
+    assert len(last_evaluated_splits["MockRetrievalTask"]) == 1
+    assert results2[0].scores.keys() == {"val"}
 
 
 def test_all_splits_subsets_evaluated_with_overwrite(
@@ -332,33 +332,31 @@ def test_all_splits_subsets_evaluated_with_overwrite(
     evaluation = MTEB(tasks=multilingual_tasks)
     results = evaluation.run(
         model,
-        eval_splits=["test", "val"],
-        output_folder=str(tmp_path / "no_missing_lang_test"),
+        eval_splits=["test",],
+        output_folder=str(tmp_path / "all_splits_subsets_evaluated_with_overwrite"),
         verbosity=2,
-        eval_subsets=["eng", "fra"],
+        eval_subsets=["fra"],
     )
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
     assert "MockMultilingualRetrievalTask" in last_evaluated_splits
-    assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 2
-    assert results[0].scores.keys() == {"test", "val"}
-    for split in ["test", "val"]:
-        assert len(results[0].scores[split]) == 2
-        assert sorted(results[0].languages) == ["eng", "fra"]
+    assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 1
+    assert results[0].scores.keys() == {"test"}
+    for split in ["test"]:
+        assert len(results[0].scores[split]) == 1
+        assert sorted(results[0].languages) == ["fra"]
 
     results2 = evaluation.run(
         model,
-        eval_splits=["test", "val"],
-        output_folder=str(tmp_path / "no_missing_lang_test"),
+        eval_splits=["test"],
+        output_folder=str(tmp_path / "all_splits_subsets_evaluated_with_overwrite"),
         verbosity=2,
-        eval_subsets=["eng", "fra"],
+        eval_subsets=["fra"],
         overwrite_results=True,
     )
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
     assert "MockMultilingualRetrievalTask" in last_evaluated_splits
-    assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 2
-    assert results2[0].scores.keys() == {"test", "val"}
-    assert len(results2[0].scores["test"]) == 2
-    assert results[0].scores.keys() == {"test", "val"}
-    for split in ["test", "val"]:
-        assert len(results2[0].scores[split]) == 2
-        assert sorted(results2[0].languages) == ["eng", "fra"]
+    assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 1
+    assert results2[0].scores.keys() == {"test"}
+    for split in ["test"]:
+        assert len(results2[0].scores[split]) == 1
+        assert sorted(results2[0].languages) == ["fra"]

--- a/tests/test_evaluation/test_split_evaluation.py
+++ b/tests/test_evaluation/test_split_evaluation.py
@@ -63,7 +63,6 @@ def test_one_missing_split(model, tasks, tmp_path):
         eval_splits=["val", "test"],
         output_folder=str(tmp_path / "testcase2"),
         verbosity=2,
-        overwrite_results=True,
     )
 
     assert "MockRetrievalTask" == results2[0].task_name
@@ -93,12 +92,10 @@ def test_no_missing_splits(model, tasks, tmp_path):
         eval_splits=["val", "test"],
         output_folder=str(tmp_path / "testcase3"),
         verbosity=2,
-        overwrite_results=True,
     )
 
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
-    assert "MockRetrievalTask" in last_evaluated_splits
-    assert len(last_evaluated_splits["MockRetrievalTask"]) == 0
+    assert len(last_evaluated_splits) == 0
     assert results[0].scores.keys() == {"test", "val"}
 
 
@@ -144,7 +141,6 @@ def test_missing_language(model, multilingual_tasks, tmp_path):
         output_folder=str(tmp_path / "missing_lang_test"),
         verbosity=2,
         eval_subsets=["eng", "fra"],
-        overwrite_results=True,
     )
 
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
@@ -178,11 +174,9 @@ def test_no_missing_languages(model, multilingual_tasks, tmp_path):
         output_folder=str(tmp_path / "no_missing_lang_test"),
         verbosity=2,
         eval_subsets=["eng", "fra"],
-        overwrite_results=True,
     )
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
-    assert "MockMultilingualRetrievalTask" in last_evaluated_splits
-    assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 0
+    assert len(last_evaluated_splits) == 0
     assert results[0].scores.keys() == {"test"}
     assert len(results[0].scores["test"]) == 2
     assert sorted(results[0].languages) == ["eng", "fra"]
@@ -210,7 +204,6 @@ def test_partial_languages(model, multilingual_tasks, tmp_path):
         output_folder=str(tmp_path / "partial_lang_test"),
         verbosity=2,
         eval_subsets=["fra", "eng"],
-        overwrite_results=True,
     )
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
     assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 1
@@ -245,7 +238,6 @@ def test_multilingual_one_missing_split_no_missing_lang(
         output_folder=str(tmp_path / "partial_langs_partial_splits"),
         verbosity=2,
         eval_subsets=["eng", "fra"],
-        overwrite_results=True,
     )
 
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
@@ -280,7 +272,6 @@ def test_multilingual_one_missing_lang_in_one_split(
         output_folder=str(tmp_path / "one_lang_one_split"),
         verbosity=2,
         eval_subsets=["eng"],
-        overwrite_results=True,
     )
 
     last_evaluated_splits = evaluation.get_last_evaluated_splits()
@@ -296,7 +287,6 @@ def test_multilingual_one_missing_lang_in_one_split(
         output_folder=str(tmp_path / "one_lang_one_split"),
         verbosity=2,
         eval_subsets=["eng", "fra"],
-        overwrite_results=True,
     )
 
     last_evaluated_splits = evaluation.get_last_evaluated_splits()

--- a/tests/test_evaluation/test_split_evaluation.py
+++ b/tests/test_evaluation/test_split_evaluation.py
@@ -332,7 +332,9 @@ def test_all_splits_subsets_evaluated_with_overwrite(
     evaluation = MTEB(tasks=multilingual_tasks)
     results = evaluation.run(
         model,
-        eval_splits=["test",],
+        eval_splits=[
+            "test",
+        ],
         output_folder=str(tmp_path / "all_splits_subsets_evaluated_with_overwrite"),
         verbosity=2,
         eval_subsets=["fra"],


### PR DESCRIPTION
## Checklist
<!-- Please do not delete this -->

- [X] Run tests locally to make sure nothing is broken using `make test`. 
- [X] Run the formatter to format the code using `make lint`. 

Currently, if `overwrite` is passed with existing results, it won't overwrite them, and everything will be skipped.

This was the reason of https://github.com/embeddings-benchmark/mteb/pull/1584#issuecomment-2541310911