### PR TITLE
fix: GermanDPR Dataset Causes Cross-Encoder Failure Due to Unexpected dict

### DIFF
--- a/mteb/tasks/Retrieval/deu/GermanDPRRetrieval.py
+++ b/mteb/tasks/Retrieval/deu/GermanDPRRetrieval.py
@@ -83,6 +83,7 @@ class GermanDPR(AbsTaskRetrieval):
             )
             corpus.update(neg_docs)
             relevant_docs[q_id] = {k: 1 for k in pos_docs}
+        corpus = {doc["id"]: doc.get("title", "") + " " + doc["text"] for doc in corpus}
         self.queries = {self._EVAL_SPLIT: queries}
         self.corpus = {self._EVAL_SPLIT: corpus}
         self.relevant_docs = {self._EVAL_SPLIT: relevant_docs}


### PR DESCRIPTION
Fixes #1609


<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->


## Checklist
<!-- Please do not delete this -->

- [ ] Run tests locally to make sure nothing is broken using `make test`. 
- [ ] Run the formatter to format the code using `make lint`. 

