### PR TITLE
Update results_to_dataframe to use BenchmarkResults class

### DIFF
--- a/mteb/task_selection.py
+++ b/mteb/task_selection.py
@@ -10,7 +10,7 @@ from sklearn.metrics import mean_squared_error
 from sklearn.preprocessing import StandardScaler
 from tqdm import tqdm
 
-import mteb
+from mteb.load_results.benchmark_results import BenchmarkResults
 
 MODEL_NAME = str
 REVISION = str
@@ -35,7 +35,7 @@ def mse_with_zscore(x: list[float], y: list[float]) -> float:
 
 
 def results_to_dataframe(
-    mteb_results: dict[MODEL_NAME, dict[REVISION, list[mteb.MTEBResults]]],
+    mteb_results: BenchmarkResults,
     drop_na: bool = True,
     **kwargs: Any,
 ) -> pd.DataFrame:
@@ -47,17 +47,16 @@ def results_to_dataframe(
         **kwargs: Additional keyword arguments to be passed to the `get_score` method of the `MTEBResults` class.
     """
     data = []
-    for model_name, revisions in mteb_results.items():
-        for rev, tasks_results in revisions.items():
-            for task_result in tasks_results:
-                data.append(
-                    {
-                        "Model": model_name,
-                        "Revision": rev,
-                        "task": task_result.task_name,
-                        "main_score": task_result.get_score(**kwargs),
-                    }
-                )
+    for model_res in mteb_results:
+        for task_result in model_res.task_results:
+            data.append(
+                {
+                    "Model": model_res.model_name,
+                    "Revision": model_res.model_revision,
+                    "task": task_result.task_name,
+                    "main_score": task_result.get_score(**kwargs),
+                }
+            )
     df = pd.DataFrame(data)
 
     if drop_na:


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->
Changed the `results_to_dataframe` function to make the [example](https://github.com/embeddings-benchmark/mteb/blob/ef5a068c82e51b82f7c2233581ea3e2b597a6a8b/README.md?plain=1#L405-L422) from the documentation work.
Error before
```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[32], line 11
      7 models = [mteb.get_model_meta(name) for name in results_eval_mteb_df["full_name"].unique()]
      9 results = mteb.load_results(models=models, tasks=tasks)
---> 11 df = results_to_dataframe(results)

File ~/miniconda3/envs/llm_emb/lib/python3.12/site-packages/mteb/task_selection.py:50, in results_to_dataframe(mteb_results, drop_na, **kwargs)
     42 """Convert the results of the MTEB evaluation to a pandas DataFrame.
     43 
     44 Args:
   (...)
     47     **kwargs: Additional keyword arguments to be passed to the `get_score` method of the `MTEBResults` class.
     48 """
     49 data = []
---> 50 for model_name, revisions in mteb_results.items():
     51     for rev, tasks_results in revisions.items():
     52         for task_result in tasks_results:

File ~/miniconda3/envs/llm_emb/lib/python3.12/site-packages/pydantic/main.py:892, in BaseModel.__getattr__(self, item)
    889     return super().__getattribute__(item)  # Raises AttributeError if appropriate
    890 else:
    891     # this is the current error
--> 892     raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}')

AttributeError: 'BenchmarkResults' object has no attribute 'items'
```

<!-- add additional description, question etc. related to the new dataset -->


## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 
