### PR TITLE
Extend MIEB test coverage

### DIFF
--- a/tests/test_benchmark/task_grid.py
+++ b/tests/test_benchmark/task_grid.py
@@ -10,14 +10,15 @@ from mteb.tasks.Classification.multilingual.IndicSentimentClassification import 
 from mteb.tasks.Clustering.eng.TwentyNewsgroupsClustering import (
     TwentyNewsgroupsClusteringFast,
 )
+from mteb.tasks.Image.Any2AnyMultiChoice import ROxfordEasyI2IMultiChoice
+from mteb.tasks.Image.Any2AnyRetrieval import Flickr30kI2TRetrieval
+from mteb.tasks.Image.Any2TextMultipleChoice import CVBenchCount
 from mteb.tasks.Image.Clustering import TinyImageNet
 from mteb.tasks.Image.ImageClassification import OxfordPetsClassification
 from mteb.tasks.Image.ImageMultilabelClassification import VOC2007Classification
 from mteb.tasks.Image.ImageTextPairClassification import AROFlickrOrder
+from mteb.tasks.Image.VisualSTS import STS16VisualSTS
 from mteb.tasks.Image.ZeroshotClassification import RenderedSST2
-from mteb.tasks.Image.Any2AnyRetrieval import Flickr30kI2TRetrieval
-from mteb.tasks.Image.Any2AnyMultiChoice import ROxfordEasyI2IMultiChoice
-from mteb.tasks.Image.Any2TextMultipleChoice import CVBenchCount
 
 from .mock_tasks import (
     MockBitextMiningTask,
@@ -87,6 +88,7 @@ voc2007 = VOC2007Classification()
 flickr = Flickr30kI2TRetrieval()
 roxford_mc = ROxfordEasyI2IMultiChoice()
 cvbench_count = CVBenchCount()
+sts16 = STS16VisualSTS()
 
 ## method override to speed up tests
 tiny_imagenet.dataset_transform = dataset_transform.__get__(tiny_imagenet)
@@ -97,6 +99,7 @@ voc2007.dataset_transform = dataset_transform.__get__(voc2007)
 flickr.dataset_transform = dataset_transform.__get__(flickr)
 roxford_mc.dataset_transform = dataset_transform.__get__(roxford_mc)
 cvbench_count.dataset_transform = dataset_transform.__get__(cvbench_count)
+sts16.dataset_transform = dataset_transform.__get__(sts16)
 
 
 MIEB_TASK_TEST_GRID = [
@@ -105,9 +108,10 @@ MIEB_TASK_TEST_GRID = [
     renderedSST2,  # zero shot classification
     oxford_pets,  # image classification
     voc2007,  # multilabel classification
-    flickr, # I2T retrieval
-    roxford_mc, # Any2Any MultiChoice
-    cvbench_count, # Any2Any Text MultiChoice
+    flickr,  # I2T retrieval
+    roxford_mc,  # Any2Any MultiChoice
+    cvbench_count,  # Any2Any Text MultiChoice
+    sts16,  # visual sts
 ]
 
 MIEB_TASK_TEST_GRID_AS_STRING = [

--- a/tests/test_benchmark/task_grid.py
+++ b/tests/test_benchmark/task_grid.py
@@ -11,8 +11,13 @@ from mteb.tasks.Clustering.eng.TwentyNewsgroupsClustering import (
     TwentyNewsgroupsClusteringFast,
 )
 from mteb.tasks.Image.Clustering import TinyImageNet
-from mteb.tasks.Image.ImageTextPairClassification import Winoground
+from mteb.tasks.Image.ImageClassification import OxfordPetsClassification
+from mteb.tasks.Image.ImageMultilabelClassification import VOC2007Classification
+from mteb.tasks.Image.ImageTextPairClassification import AROFlickrOrder
 from mteb.tasks.Image.ZeroshotClassification import RenderedSST2
+from mteb.tasks.Image.Any2AnyRetrieval import Flickr30kI2TRetrieval
+from mteb.tasks.Image.Any2AnyMultiChoice import ROxfordEasyI2IMultiChoice
+from mteb.tasks.Image.Any2TextMultipleChoice import CVBenchCount
 
 from .mock_tasks import (
     MockBitextMiningTask,
@@ -76,23 +81,33 @@ def dataset_transform(self):
 
 tiny_imagenet = TinyImageNet()
 renderedSST2 = RenderedSST2()
-winoground = Winoground()
+aro = AROFlickrOrder()
+oxford_pets = OxfordPetsClassification()
+voc2007 = VOC2007Classification()
+flickr = Flickr30kI2TRetrieval()
+roxford_mc = ROxfordEasyI2IMultiChoice()
+cvbench_count = CVBenchCount()
 
 ## method override to speed up tests
 tiny_imagenet.dataset_transform = dataset_transform.__get__(tiny_imagenet)
 renderedSST2.dataset_transform = dataset_transform.__get__(renderedSST2)
-winoground.dataset_transform = dataset_transform.__get__(winoground)
+aro.dataset_transform = dataset_transform.__get__(aro)
+oxford_pets.dataset_transform = dataset_transform.__get__(oxford_pets)
+voc2007.dataset_transform = dataset_transform.__get__(voc2007)
+flickr.dataset_transform = dataset_transform.__get__(flickr)
+roxford_mc.dataset_transform = dataset_transform.__get__(roxford_mc)
+cvbench_count.dataset_transform = dataset_transform.__get__(cvbench_count)
 
 
 MIEB_TASK_TEST_GRID = [
     tiny_imagenet,  # image clustering
-    # winoground,  # pair classification. Gated
+    aro,  # pair classification
     renderedSST2,  # zero shot classification
-    # The following takes a long time. Consider creating a mock class.
-    # "CIRRIT2TRetrieval",  # it2i retrieval
-    # "MSCOCOI2TRetrieval",  # i2t retrieval
-    # "MSCOCOT2IRetrieval",  # t2i retrieval
-    # oxford_flowers,  # image classification
+    oxford_pets,  # image classification
+    voc2007,  # multilabel classification
+    flickr, # I2T retrieval
+    roxford_mc, # Any2Any MultiChoice
+    cvbench_count, # Any2Any Text MultiChoice
 ]
 
 MIEB_TASK_TEST_GRID_AS_STRING = [

--- a/tests/test_tasks/test_mieb_datasets.py
+++ b/tests/test_tasks/test_mieb_datasets.py
@@ -14,7 +14,7 @@ from ..test_benchmark.mock_models import MockCLIPEncoder
 from ..test_benchmark.task_grid import MIEB_TASK_TEST_GRID
 
 logging.basicConfig(level=logging.INFO)
- 
+
 
 @pytest.mark.parametrize("task", MIEB_TASK_TEST_GRID)
 @pytest.mark.parametrize("model", [MockCLIPEncoder()])

--- a/tests/test_tasks/test_mieb_datasets.py
+++ b/tests/test_tasks/test_mieb_datasets.py
@@ -14,7 +14,7 @@ from ..test_benchmark.mock_models import MockCLIPEncoder
 from ..test_benchmark.task_grid import MIEB_TASK_TEST_GRID
 
 logging.basicConfig(level=logging.INFO)
-
+ 
 
 @pytest.mark.parametrize("task", MIEB_TASK_TEST_GRID)
 @pytest.mark.parametrize("model", [MockCLIPEncoder()])


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->
Part of #1339. Extend the test coverage for `mteb/abstasks/Image` and `mteb/evaluation/evaluators/Image` from 30% to 69%.
```
pytest tests/test_tasks/test_mieb_datasets.py -n auto --durations=5 --cov-report=term-missing --cov-config=pyproject.toml --cov=mteb/abstasks/Image --cov=mteb/evaluation/evaluators/Image
```

<details>
<summary>Before</summary>

```
---------- coverage: platform linux, python 3.12.1-final-0 -----------
Name                                                                       Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------------------------------------
mteb/abstasks/Image/AbsTaskAny2AnyMultiChoice.py                             202    166    18%   36-63, 67-71, 80-109, 112-121, 124-138, 141-155, 158-186, 218-238, 248-276, 281-372, 375, 380, 383-413, 422-441, 451-462
mteb/abstasks/Image/AbsTaskAny2AnyRetrieval.py                               202    166    18%   35-62, 66-70, 79-108, 111-120, 123-137, 140-154, 157-185, 214-234, 244-272, 277-367, 370, 375, 378-408, 417-436, 446-457
mteb/abstasks/Image/AbsTaskAny2TextMultipleChoice.py                          27      9    67%   33, 38, 48-64
mteb/abstasks/Image/AbsTaskImageClassification.py                             78     50    36%   72, 77, 88-113, 124-186, 194-210
mteb/abstasks/Image/AbsTaskImageClustering.py                                 23      1    96%   38
mteb/abstasks/Image/AbsTaskImageMultilabelClassification.py                  101     68    33%   31-41, 81, 86, 97-122, 134-196, 200-210
mteb/abstasks/Image/AbsTaskImageTextPairClassification.py                     22      6    73%   34, 39, 49-58
mteb/abstasks/Image/AbsTaskVisualSTS.py                                       39     19    51%   43, 47, 52-66, 69, 74-84
mteb/abstasks/Image/AbsTaskZeroshotClassification.py                          25      1    96%   36
mteb/abstasks/Image/__init__.py                                                0      0   100%
mteb/evaluation/evaluators/Image/Any2AnyMultiChoiceEvaluator.py              223    181    19%   44-46, 49, 52-61, 65, 79-99, 111-240, 244-264, 277-287, 295-298, 321-413, 423-444, 452-467, 476-487
mteb/evaluation/evaluators/Image/Any2AnyRetrievalEvaluator.py                220    178    19%   44-46, 49, 52-62, 66, 81-102, 114-250, 254-274, 288-298, 305-308, 330-417, 427-448, 456-471, 480-491
mteb/evaluation/evaluators/Image/Any2TextMultipleChoiceEvaluator.py           50     34    32%   45-54, 61-99
mteb/evaluation/evaluators/Image/ClassificationEvaluator.py                  204    166    19%   29, 37-39, 42, 45-49, 53, 69-89, 92-138, 154-173, 176-234, 243-257, 266-278, 287-299, 315-334, 337-387
mteb/evaluation/evaluators/Image/ClusteringEvaluator.py                       38      2    95%   30-31
mteb/evaluation/evaluators/Image/ImageTextPairClassificationEvaluator.py      78     57    27%   25-28, 31, 34-52, 56, 83-90, 97-173
mteb/evaluation/evaluators/Image/VisualSTSEvaluator.py                        65     43    34%   28-30, 33, 36-40, 44, 56-64, 73-130
mteb/evaluation/evaluators/Image/ZeroshotClassificationEvaluator.py           47      7    85%   32-36, 40, 64
mteb/evaluation/evaluators/Image/__init__.py                                   0      0   100%
--------------------------------------------------------------------------------------------------------
TOTAL                                                                       1644   1154    30%

```

</details>
<details>
<summary>After</summary>

```
---------- coverage: platform linux, python 3.12.1-final-0 -----------
Name                                                                       Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------------------------------------
mteb/abstasks/Image/AbsTaskAny2AnyMultiChoice.py                             202     96    52%   48-61, 67-71, 81-84, 112-121, 132, 149, 166, 174, 219, 268, 289-291, 294-310, 342-370, 380, 383-413, 422-441, 451-462
mteb/abstasks/Image/AbsTaskAny2AnyRetrieval.py                               202     96    52%   47-60, 66-70, 80-83, 111-120, 131, 148, 165, 173, 215, 264, 285-287, 290-306, 337-365, 375, 378-408, 417-436, 446-457
mteb/abstasks/Image/AbsTaskAny2TextMultipleChoice.py                          27      2    93%   38, 50
mteb/abstasks/Image/AbsTaskImageClassification.py                             78      6    92%   77, 89, 102, 147, 157, 177
mteb/abstasks/Image/AbsTaskImageClustering.py                                 23      1    96%   38
mteb/abstasks/Image/AbsTaskImageMultilabelClassification.py                  101      6    94%   86, 98, 111, 170-174
mteb/abstasks/Image/AbsTaskImageTextPairClassification.py                     22      1    95%   39
mteb/abstasks/Image/AbsTaskVisualSTS.py                                       39      9    77%   74-84
mteb/abstasks/Image/AbsTaskZeroshotClassification.py                          25      1    96%   36
mteb/abstasks/Image/__init__.py                                                0      0   100%
mteb/evaluation/evaluators/Image/Any2AnyMultiChoiceEvaluator.py              223     59    74%   52-61, 65, 83, 99, 112, 123-124, 143-151, 173-174, 193-201, 234, 244-264, 296, 322-329, 365-366, 426-439, 476-487
mteb/evaluation/evaluators/Image/Any2AnyRetrievalEvaluator.py                220     62    72%   52-62, 66, 86, 102, 115, 126-127, 151-161, 191-218, 244, 254-274, 306, 331-338, 374-375, 430-443, 480-491
mteb/evaluation/evaluators/Image/Any2TextMultipleChoiceEvaluator.py           50      3    94%   47, 62, 75
mteb/evaluation/evaluators/Image/ClassificationEvaluator.py                  204    132    35%   29, 45-49, 53, 69-89, 92-138, 154-173, 176-234, 243-257, 266-278, 287-299, 319, 322, 370, 372, 382-383
mteb/evaluation/evaluators/Image/ClusteringEvaluator.py                       38      2    95%   30-31
mteb/evaluation/evaluators/Image/ImageTextPairClassificationEvaluator.py      78     13    83%   34-52, 56, 85, 98
mteb/evaluation/evaluators/Image/VisualSTSEvaluator.py                        65     12    82%   36-40, 44, 74, 114, 116-120, 123-124
mteb/evaluation/evaluators/Image/ZeroshotClassificationEvaluator.py           47      7    85%   32-36, 40, 64
mteb/evaluation/evaluators/Image/__init__.py                                   0      0   100%
--------------------------------------------------------------------------------------------------------
TOTAL                                                                       1644    508    69%

```

</details>

## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 

Cc @gowitheflow-1998 