### PR TITLE
[mieb] Task filtering by modality supported by models

### DIFF
--- a/mteb/abstasks/TaskMetadata.py
+++ b/mteb/abstasks/TaskMetadata.py
@@ -15,6 +15,7 @@ from ..languages import (
     path_to_lang_codes,
     path_to_lang_scripts,
 )
+from ..modalities import MODALITIES
 
 TASK_SUBTYPE = Literal[
     "Article retrieval",
@@ -122,11 +123,6 @@ TASK_CATEGORY = Literal[
     "i2it",
     "t2it",
     "it2it",
-]
-
-MODALITIES = Literal[
-    "text",
-    "image",
 ]
 
 ANNOTATOR_TYPE = Literal[

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -373,12 +373,10 @@ class MTEB:
             )
 
             # skip evaluation if the model does not support the task modalities.
-            task_modalities = sorted(
-                "".join([m for m in set(task.metadata.category) if m.isalpha()])
-            )
-            if sorted(meta.modalities) != task_modalities:
+            task_modalities = "".join(sorted(task.metadata.modalities))
+            if "".join(sorted(meta.modalities)) != task_modalities:
                 logger.info(
-                    f"{meta.name} only supports {meta.modalities}, but the task category is {task.metadata.category}."
+                    f"{meta.name} only supports {meta.modalities}, but the task modalities are {task.metadata.modalities}."
                 )
                 del self.tasks[0]  # empty memory
                 continue

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -373,9 +373,15 @@ class MTEB:
             )
 
             # skip evaluation if the model does not support the task modalities.
-            for modality in meta.modalities:
-                if modality not in task.metadata.category:
-                    logger.info(f"{meta.name} only supports {meta.modalities}, but the task category is {task.metadata.category}.")
+            task_modalities = sorted(
+                "".join([m for m in set(task.metadata.category) if m.isalpha()])
+            )
+            if sorted(meta.modalities) != task_modalities:
+                logger.info(
+                    f"{meta.name} only supports {meta.modalities}, but the task category is {task.metadata.category}."
+                )
+                del self.tasks[0]  # empty memory
+                continue
 
             # skip evaluation if results folder exists and overwrite_results is False
             if output_path:

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -372,6 +372,11 @@ class MTEB:
                 f"\n\n********************** Evaluating {task.metadata.name} **********************"
             )
 
+            # skip evaluation if the model does not support the task modalities.
+            for modality in meta.modalities:
+                if modality not in task.metadata.category:
+                    logger.info(f"{meta.name} only supports {meta.modalities}, but the task category is {task.metadata.category}.")
+
             # skip evaluation if results folder exists and overwrite_results is False
             if output_path:
                 save_path = output_path / f"{task.metadata.name}{task.save_suffix}.json"

--- a/mteb/modalities.py
+++ b/mteb/modalities.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from typing_extensions import Literal
+
+MODALITIES = Literal[
+    "text",
+    "image",
+]

--- a/mteb/model_meta.py
+++ b/mteb/model_meta.py
@@ -74,6 +74,8 @@ class ModelMeta(BaseModel):
             input such as "query: {document}" or "passage: {document}".
         zero_shot_benchmarks: A list of benchmarks on which the model has been evaluated in a zero-shot setting. By default we assume that all models
             are evaluated non-zero-shot unless specified otherwise.
+        modalities: A string representing the modalities the model supports. e.g. "t" means the model supports text-related tasks, "it" or "ti" means 
+            the model support text and image-related tasks. Default is "t".
     """
 
     name: str | None
@@ -94,6 +96,7 @@ class ModelMeta(BaseModel):
     similarity_fn_name: DISTANCE_METRICS | None = None
     use_instuctions: bool | None = None
     zero_shot_benchmarks: list[str] | None = None
+    modalities: str = "t"
 
     def to_dict(self):
         dict_repr = self.model_dump()

--- a/mteb/model_meta.py
+++ b/mteb/model_meta.py
@@ -10,6 +10,7 @@ from mteb.abstasks.TaskMetadata import STR_DATE, STR_URL
 from mteb.encoder_interface import Encoder
 
 from .languages import ISO_LANGUAGE_SCRIPT
+from .modalities import MODALITIES
 
 if TYPE_CHECKING:
     from .models.sentence_transformer_wrapper import SentenceTransformerWrapper
@@ -74,8 +75,7 @@ class ModelMeta(BaseModel):
             input such as "query: {document}" or "passage: {document}".
         zero_shot_benchmarks: A list of benchmarks on which the model has been evaluated in a zero-shot setting. By default we assume that all models
             are evaluated non-zero-shot unless specified otherwise.
-        modalities: A string representing the modalities the model supports. e.g. "t" means the model supports text-related tasks, "it" or "ti" means
-            the model support text and image-related tasks. Default is "t".
+        modalities: A list of strings representing the modalities the model supports. Default is ["text].
     """
 
     name: str | None
@@ -96,7 +96,7 @@ class ModelMeta(BaseModel):
     similarity_fn_name: DISTANCE_METRICS | None = None
     use_instuctions: bool | None = None
     zero_shot_benchmarks: list[str] | None = None
-    modalities: str = "t"
+    modalities: list[MODALITIES] = ["text"]
 
     def to_dict(self):
         dict_repr = self.model_dump()

--- a/mteb/model_meta.py
+++ b/mteb/model_meta.py
@@ -74,7 +74,7 @@ class ModelMeta(BaseModel):
             input such as "query: {document}" or "passage: {document}".
         zero_shot_benchmarks: A list of benchmarks on which the model has been evaluated in a zero-shot setting. By default we assume that all models
             are evaluated non-zero-shot unless specified otherwise.
-        modalities: A string representing the modalities the model supports. e.g. "t" means the model supports text-related tasks, "it" or "ti" means 
+        modalities: A string representing the modalities the model supports. e.g. "t" means the model supports text-related tasks, "it" or "ti" means
             the model support text and image-related tasks. Default is "t".
     """
 

--- a/mteb/models/align_models.py
+++ b/mteb/models/align_models.py
@@ -143,6 +143,7 @@ align_base = ModelMeta(
     open_source=True,
     revision="e96a37facc7b1f59090ece82293226b817afd6ba",
     release_date="2023-02-24",
+    modalities="it",
 )
 
 if __name__ == "__main__":

--- a/mteb/models/align_models.py
+++ b/mteb/models/align_models.py
@@ -143,7 +143,7 @@ align_base = ModelMeta(
     open_source=True,
     revision="e96a37facc7b1f59090ece82293226b817afd6ba",
     release_date="2023-02-24",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 if __name__ == "__main__":

--- a/mteb/models/blip2_models.py
+++ b/mteb/models/blip2_models.py
@@ -225,6 +225,7 @@ blip2_opt_2_7b = ModelMeta(
     open_source=True,
     revision="51572668da0eb669e01a189dc22abe6088589a24",
     release_date="2024-03-22",
+    modalities="it",
 )
 
 blip2_opt_6_7b_coco = ModelMeta(
@@ -237,6 +238,7 @@ blip2_opt_6_7b_coco = ModelMeta(
     open_source=True,
     revision="0d580de59320a25a4d2c386387bcef310d5f286e",
     release_date="2024-03-31",
+    modalities="it",
 )
 
 

--- a/mteb/models/blip2_models.py
+++ b/mteb/models/blip2_models.py
@@ -225,7 +225,7 @@ blip2_opt_2_7b = ModelMeta(
     open_source=True,
     revision="51572668da0eb669e01a189dc22abe6088589a24",
     release_date="2024-03-22",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 blip2_opt_6_7b_coco = ModelMeta(
@@ -238,7 +238,7 @@ blip2_opt_6_7b_coco = ModelMeta(
     open_source=True,
     revision="0d580de59320a25a4d2c386387bcef310d5f286e",
     release_date="2024-03-31",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 

--- a/mteb/models/blip_models.py
+++ b/mteb/models/blip_models.py
@@ -164,7 +164,7 @@ blip_image_captioning_large = ModelMeta(
     open_source=True,
     revision="2227ac38c9f16105cb0412e7cab4759978a8fd90",
     release_date="2023-12-07",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 blip_image_captioning_base = ModelMeta(
@@ -177,7 +177,7 @@ blip_image_captioning_base = ModelMeta(
     open_source=True,
     revision="89b09ea1789f7addf2f6d6f0dfc4ce10ab58ef84",
     release_date="2023-08-01",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 
@@ -191,7 +191,7 @@ blip_vqa_base = ModelMeta(
     open_source=True,
     revision="c7df8e7cd7aa2ee9af18f56e2b29e59a92651b64",
     release_date="2023-12-07",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 blip_vqa_capfilt_large = ModelMeta(
@@ -204,7 +204,7 @@ blip_vqa_capfilt_large = ModelMeta(
     open_source=True,
     revision="e53f95265aeab69013fabb5380500ab984adbbb4",
     release_date="2023-01-22",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 blip_itm_base_coco = ModelMeta(
@@ -217,7 +217,7 @@ blip_itm_base_coco = ModelMeta(
     open_source=True,
     revision="7eaa90c11850c0b17fc38c6a11e7d88bd6ac231f",
     release_date="2023-08-01",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 blip_itm_large_coco = ModelMeta(
@@ -230,7 +230,7 @@ blip_itm_large_coco = ModelMeta(
     open_source=True,
     revision="fef05cafc05298067cbbca00b125749394a77a6f",
     release_date="2023-08-01",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 blip_itm_base_flickr = ModelMeta(
@@ -243,7 +243,7 @@ blip_itm_base_flickr = ModelMeta(
     open_source=True,
     revision="1de29e660d91ae1786c1876212ea805a22eab251",
     release_date="2023-08-01",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 blip_itm_large_flickr = ModelMeta(
@@ -256,7 +256,7 @@ blip_itm_large_flickr = ModelMeta(
     open_source=True,
     revision="bda12e6506758f54261b5ab174b2c55a3ba143fb",
     release_date="2023-08-01",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 

--- a/mteb/models/blip_models.py
+++ b/mteb/models/blip_models.py
@@ -164,6 +164,7 @@ blip_image_captioning_large = ModelMeta(
     open_source=True,
     revision="2227ac38c9f16105cb0412e7cab4759978a8fd90",
     release_date="2023-12-07",
+    modalities="it",
 )
 
 blip_image_captioning_base = ModelMeta(
@@ -176,6 +177,7 @@ blip_image_captioning_base = ModelMeta(
     open_source=True,
     revision="89b09ea1789f7addf2f6d6f0dfc4ce10ab58ef84",
     release_date="2023-08-01",
+    modalities="it",
 )
 
 
@@ -189,6 +191,7 @@ blip_vqa_base = ModelMeta(
     open_source=True,
     revision="c7df8e7cd7aa2ee9af18f56e2b29e59a92651b64",
     release_date="2023-12-07",
+    modalities="it",
 )
 
 blip_vqa_capfilt_large = ModelMeta(
@@ -201,6 +204,7 @@ blip_vqa_capfilt_large = ModelMeta(
     open_source=True,
     revision="e53f95265aeab69013fabb5380500ab984adbbb4",
     release_date="2023-01-22",
+    modalities="it",
 )
 
 blip_itm_base_coco = ModelMeta(
@@ -213,6 +217,7 @@ blip_itm_base_coco = ModelMeta(
     open_source=True,
     revision="7eaa90c11850c0b17fc38c6a11e7d88bd6ac231f",
     release_date="2023-08-01",
+    modalities="it",
 )
 
 blip_itm_large_coco = ModelMeta(
@@ -225,6 +230,7 @@ blip_itm_large_coco = ModelMeta(
     open_source=True,
     revision="fef05cafc05298067cbbca00b125749394a77a6f",
     release_date="2023-08-01",
+    modalities="it",
 )
 
 blip_itm_base_flickr = ModelMeta(
@@ -237,6 +243,7 @@ blip_itm_base_flickr = ModelMeta(
     open_source=True,
     revision="1de29e660d91ae1786c1876212ea805a22eab251",
     release_date="2023-08-01",
+    modalities="it",
 )
 
 blip_itm_large_flickr = ModelMeta(
@@ -249,6 +256,7 @@ blip_itm_large_flickr = ModelMeta(
     open_source=True,
     revision="bda12e6506758f54261b5ab174b2c55a3ba143fb",
     release_date="2023-08-01",
+    modalities="it",
 )
 
 

--- a/mteb/models/clip_models.py
+++ b/mteb/models/clip_models.py
@@ -147,7 +147,7 @@ clip_vit_large_patch14 = ModelMeta(
     open_source=True,
     revision="32bd64288804d66eefd0ccbe215aa642df71cc41",
     release_date="2021-02-26",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 clip_vit_base_patch32 = ModelMeta(
@@ -160,7 +160,7 @@ clip_vit_base_patch32 = ModelMeta(
     open_source=True,
     revision="3d74acf9a28c67741b2f4f2ea7635f0aaf6f0268",
     release_date="2021-02-26",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 clip_vit_base_patch16 = ModelMeta(
@@ -173,7 +173,7 @@ clip_vit_base_patch16 = ModelMeta(
     open_source=True,
     revision="57c216476eefef5ab752ec549e440a49ae4ae5f3",
     release_date="2021-02-26",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 if __name__ == "__main__":

--- a/mteb/models/clip_models.py
+++ b/mteb/models/clip_models.py
@@ -147,6 +147,7 @@ clip_vit_large_patch14 = ModelMeta(
     open_source=True,
     revision="32bd64288804d66eefd0ccbe215aa642df71cc41",
     release_date="2021-02-26",
+    modalities="it",
 )
 
 clip_vit_base_patch32 = ModelMeta(
@@ -159,6 +160,7 @@ clip_vit_base_patch32 = ModelMeta(
     open_source=True,
     revision="3d74acf9a28c67741b2f4f2ea7635f0aaf6f0268",
     release_date="2021-02-26",
+    modalities="it",
 )
 
 clip_vit_base_patch16 = ModelMeta(
@@ -171,6 +173,7 @@ clip_vit_base_patch16 = ModelMeta(
     open_source=True,
     revision="57c216476eefef5ab752ec549e440a49ae4ae5f3",
     release_date="2021-02-26",
+    modalities="it",
 )
 
 if __name__ == "__main__":

--- a/mteb/models/cohere_v.py
+++ b/mteb/models/cohere_v.py
@@ -195,7 +195,7 @@ cohere_mult_3 = ModelMeta(
     license=None,
     similarity_fn_name="cosine",
     framework=[],
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 cohere_eng_3 = ModelMeta(
@@ -212,7 +212,7 @@ cohere_eng_3 = ModelMeta(
     license=None,
     similarity_fn_name="cosine",
     framework=[],
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 if __name__ == "__main__":

--- a/mteb/models/cohere_v.py
+++ b/mteb/models/cohere_v.py
@@ -195,6 +195,7 @@ cohere_mult_3 = ModelMeta(
     license=None,
     similarity_fn_name="cosine",
     framework=[],
+    modalities="it",
 )
 
 cohere_eng_3 = ModelMeta(
@@ -211,6 +212,7 @@ cohere_eng_3 = ModelMeta(
     license=None,
     similarity_fn_name="cosine",
     framework=[],
+    modalities="it",
 )
 
 if __name__ == "__main__":

--- a/mteb/models/dino_models.py
+++ b/mteb/models/dino_models.py
@@ -130,6 +130,7 @@ dinov2_small = ModelMeta(
     open_source=True,
     revision="ed25f3a31f01632728cabb09d1542f84ab7b0056",
     release_date="2023-07-18",
+    modalities="i",
 )
 
 dinov2_base = ModelMeta(
@@ -142,6 +143,7 @@ dinov2_base = ModelMeta(
     open_source=True,
     revision="f9e44c814b77203eaa57a6bdbbd535f21ede1415",
     release_date="2023-07-18",
+    modalities="i",
 )
 
 dinov2_large = ModelMeta(
@@ -154,6 +156,7 @@ dinov2_large = ModelMeta(
     open_source=True,
     revision="47b73eefe95e8d44ec3623f8890bd894b6ea2d6c",
     release_date="2023-07-18",
+    modalities="i",
 )
 
 dinov2_giant = ModelMeta(
@@ -166,6 +169,7 @@ dinov2_giant = ModelMeta(
     open_source=True,
     revision="611a9d42f2335e0f921f1e313ad3c1b7178d206d",
     release_date="2023-07-18",
+    modalities="i",
 )
 
 if __name__ == "__main__":

--- a/mteb/models/dino_models.py
+++ b/mteb/models/dino_models.py
@@ -130,7 +130,7 @@ dinov2_small = ModelMeta(
     open_source=True,
     revision="ed25f3a31f01632728cabb09d1542f84ab7b0056",
     release_date="2023-07-18",
-    modalities="i",
+    modalities=["image"],
 )
 
 dinov2_base = ModelMeta(
@@ -143,7 +143,7 @@ dinov2_base = ModelMeta(
     open_source=True,
     revision="f9e44c814b77203eaa57a6bdbbd535f21ede1415",
     release_date="2023-07-18",
-    modalities="i",
+    modalities=["image"],
 )
 
 dinov2_large = ModelMeta(
@@ -156,7 +156,7 @@ dinov2_large = ModelMeta(
     open_source=True,
     revision="47b73eefe95e8d44ec3623f8890bd894b6ea2d6c",
     release_date="2023-07-18",
-    modalities="i",
+    modalities=["image"],
 )
 
 dinov2_giant = ModelMeta(
@@ -169,7 +169,7 @@ dinov2_giant = ModelMeta(
     open_source=True,
     revision="611a9d42f2335e0f921f1e313ad3c1b7178d206d",
     release_date="2023-07-18",
-    modalities="i",
+    modalities=["image"],
 )
 
 if __name__ == "__main__":

--- a/mteb/models/e5_v.py
+++ b/mteb/models/e5_v.py
@@ -185,7 +185,7 @@ e5_v = ModelMeta(
     open_source=True,
     revision="0c1f22679417b3ae925d779442221c40cd1861ab",
     release_date="2024-07-17",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 if __name__ == "__main__":

--- a/mteb/models/e5_v.py
+++ b/mteb/models/e5_v.py
@@ -185,6 +185,7 @@ e5_v = ModelMeta(
     open_source=True,
     revision="0c1f22679417b3ae925d779442221c40cd1861ab",
     release_date="2024-07-17",
+    modalities="it",
 )
 
 if __name__ == "__main__":

--- a/mteb/models/evaclip_models.py
+++ b/mteb/models/evaclip_models.py
@@ -175,7 +175,7 @@ EVA02_CLIP_B_16 = ModelMeta(
     open_source=True,
     revision="11afd202f2ae80869d6cef18b1ec775e79bd8d12",
     release_date="2023-04-26",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 EVA02_CLIP_L_14 = ModelMeta(
@@ -188,7 +188,7 @@ EVA02_CLIP_L_14 = ModelMeta(
     open_source=True,
     revision="11afd202f2ae80869d6cef18b1ec775e79bd8d12",
     release_date="2023-04-26",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 EVA02_CLIP_bigE_14 = ModelMeta(
@@ -201,7 +201,7 @@ EVA02_CLIP_bigE_14 = ModelMeta(
     open_source=True,
     revision="11afd202f2ae80869d6cef18b1ec775e79bd8d12",
     release_date="2023-04-26",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 
@@ -215,5 +215,5 @@ EVA02_CLIP_bigE_14_plus = ModelMeta(
     open_source=True,
     revision="11afd202f2ae80869d6cef18b1ec775e79bd8d12",
     release_date="2023-04-26",
-    modalities="it",
+    modalities=["image", "text"],
 )

--- a/mteb/models/evaclip_models.py
+++ b/mteb/models/evaclip_models.py
@@ -175,6 +175,7 @@ EVA02_CLIP_B_16 = ModelMeta(
     open_source=True,
     revision="11afd202f2ae80869d6cef18b1ec775e79bd8d12",
     release_date="2023-04-26",
+    modalities="it",
 )
 
 EVA02_CLIP_L_14 = ModelMeta(
@@ -187,6 +188,7 @@ EVA02_CLIP_L_14 = ModelMeta(
     open_source=True,
     revision="11afd202f2ae80869d6cef18b1ec775e79bd8d12",
     release_date="2023-04-26",
+    modalities="it",
 )
 
 EVA02_CLIP_bigE_14 = ModelMeta(
@@ -199,6 +201,7 @@ EVA02_CLIP_bigE_14 = ModelMeta(
     open_source=True,
     revision="11afd202f2ae80869d6cef18b1ec775e79bd8d12",
     release_date="2023-04-26",
+    modalities="it",
 )
 
 
@@ -212,4 +215,5 @@ EVA02_CLIP_bigE_14_plus = ModelMeta(
     open_source=True,
     revision="11afd202f2ae80869d6cef18b1ec775e79bd8d12",
     release_date="2023-04-26",
+    modalities="it",
 )

--- a/mteb/models/jina_clip.py
+++ b/mteb/models/jina_clip.py
@@ -158,7 +158,7 @@ jina_clip_v1 = ModelMeta(
     open_source=True,
     revision="06150c7c382d7a4faedc7d5a0d8cdb59308968f4",
     release_date="2024-05-30",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 

--- a/mteb/models/jina_clip.py
+++ b/mteb/models/jina_clip.py
@@ -158,6 +158,7 @@ jina_clip_v1 = ModelMeta(
     open_source=True,
     revision="06150c7c382d7a4faedc7d5a0d8cdb59308968f4",
     release_date="2024-05-30",
+    modalities="it",
 )
 
 

--- a/mteb/models/moco_models.py
+++ b/mteb/models/moco_models.py
@@ -148,6 +148,7 @@ mocov3_vit_base = ModelMeta(
     open_source=True,
     revision="7d091cd70772c5c0ecf7f00b5f12ca609a99d69d",
     release_date="2024-06-03",
+    modalities="i",
 )
 
 mocov3_vit_large = ModelMeta(
@@ -160,4 +161,5 @@ mocov3_vit_large = ModelMeta(
     open_source=True,
     revision="7bf75358d616f39b9716148bf4e3425f3bd35b47",
     release_date="2024-06-03",
+    modalities="i",
 )

--- a/mteb/models/moco_models.py
+++ b/mteb/models/moco_models.py
@@ -148,7 +148,7 @@ mocov3_vit_base = ModelMeta(
     open_source=True,
     revision="7d091cd70772c5c0ecf7f00b5f12ca609a99d69d",
     release_date="2024-06-03",
-    modalities="i",
+    modalities=["image"],
 )
 
 mocov3_vit_large = ModelMeta(
@@ -161,5 +161,5 @@ mocov3_vit_large = ModelMeta(
     open_source=True,
     revision="7bf75358d616f39b9716148bf4e3425f3bd35b47",
     release_date="2024-06-03",
-    modalities="i",
+    modalities=["image"],
 )

--- a/mteb/models/moco_models.py
+++ b/mteb/models/moco_models.py
@@ -50,7 +50,14 @@ def mocov3_loader(**kwargs):
             )
 
         @staticmethod
-        def get_text_embeddings(texts: list[str], batch_size: int = 32):
+        def get_text_embeddings(
+            texts: list[str],
+            *,
+            task_name: str | None = None,
+            prompt_type: PromptType | None = None,
+            batch_size: int = 32,
+            **kwargs: Any,
+        ):
             raise ValueError("MOCO models only support image encoding.")
 
         def get_image_embeddings(

--- a/mteb/models/nomic_models_vision.py
+++ b/mteb/models/nomic_models_vision.py
@@ -171,6 +171,7 @@ nomic_embed_vision_v1_5 = ModelMeta(
     open_source=True,
     revision="af2246fffdab78d8458418480e4886a8e48b70a7",
     release_date="2024-06-08",
+    modalities="it",
 )
 
 if __name__ == "__main__":

--- a/mteb/models/nomic_models_vision.py
+++ b/mteb/models/nomic_models_vision.py
@@ -171,7 +171,7 @@ nomic_embed_vision_v1_5 = ModelMeta(
     open_source=True,
     revision="af2246fffdab78d8458418480e4886a8e48b70a7",
     release_date="2024-06-08",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 if __name__ == "__main__":

--- a/mteb/models/openclip_models.py
+++ b/mteb/models/openclip_models.py
@@ -160,7 +160,7 @@ CLIP_ViT_L_14_DataComp_XL_s13B_b90K = ModelMeta(
     open_source=True,
     revision="84c9828e63dc9a9351d1fe637c346d4c1c4db341",
     release_date="2023-04-26",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 CLIP_ViT_B_32_DataComp_XL_s13B_b90K = ModelMeta(
@@ -173,7 +173,7 @@ CLIP_ViT_B_32_DataComp_XL_s13B_b90K = ModelMeta(
     open_source=True,
     revision="f0e2ffa09cbadab3db6a261ec1ec56407ce42912",
     release_date="2023-04-26",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 CLIP_ViT_B_16_DataComp_XL_s13B_b90K = ModelMeta(
@@ -186,7 +186,7 @@ CLIP_ViT_B_16_DataComp_XL_s13B_b90K = ModelMeta(
     open_source=True,
     revision="d110532e8d4ff91c574ee60a342323f28468b287",
     release_date="2023-04-26",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 CLIP_ViT_bigG_14_laion2B_39B_b160k = ModelMeta(
@@ -199,7 +199,7 @@ CLIP_ViT_bigG_14_laion2B_39B_b160k = ModelMeta(
     open_source=True,
     revision="bc7788f151930d91b58474715fdce5524ad9a189",
     release_date="2023-01-23",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 CLIP_ViT_g_14_laion2B_s34B_b88K = ModelMeta(
@@ -212,7 +212,7 @@ CLIP_ViT_g_14_laion2B_s34B_b88K = ModelMeta(
     open_source=True,
     revision="15efd0f6ac0c40c0f9da7becca03c974d7012604",
     release_date="2023-03-06",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 CLIP_ViT_H_14_laion2B_s32B_b79K = ModelMeta(
@@ -225,7 +225,7 @@ CLIP_ViT_H_14_laion2B_s32B_b79K = ModelMeta(
     open_source=True,
     revision="de081ac0a0ca8dc9d1533eed1ae884bb8ae1404b",
     release_date="2022-09-15",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 CLIP_ViT_L_14_laion2B_s32B_b82K = ModelMeta(
@@ -238,7 +238,7 @@ CLIP_ViT_L_14_laion2B_s32B_b82K = ModelMeta(
     open_source=True,
     revision="1627032197142fbe2a7cfec626f4ced3ae60d07a",
     release_date="2022-09-15",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 CLIP_ViT_B_32_laion2B_s34B_b79K = ModelMeta(
@@ -251,5 +251,5 @@ CLIP_ViT_B_32_laion2B_s34B_b79K = ModelMeta(
     open_source=True,
     revision="08f73555f1b2fb7c82058aebbd492887a94968ef",
     release_date="2022-09-15",
-    modalities="it",
+    modalities=["image", "text"],
 )

--- a/mteb/models/openclip_models.py
+++ b/mteb/models/openclip_models.py
@@ -160,6 +160,7 @@ CLIP_ViT_L_14_DataComp_XL_s13B_b90K = ModelMeta(
     open_source=True,
     revision="84c9828e63dc9a9351d1fe637c346d4c1c4db341",
     release_date="2023-04-26",
+    modalities="it",
 )
 
 CLIP_ViT_B_32_DataComp_XL_s13B_b90K = ModelMeta(
@@ -172,6 +173,7 @@ CLIP_ViT_B_32_DataComp_XL_s13B_b90K = ModelMeta(
     open_source=True,
     revision="f0e2ffa09cbadab3db6a261ec1ec56407ce42912",
     release_date="2023-04-26",
+    modalities="it",
 )
 
 CLIP_ViT_B_16_DataComp_XL_s13B_b90K = ModelMeta(
@@ -184,6 +186,7 @@ CLIP_ViT_B_16_DataComp_XL_s13B_b90K = ModelMeta(
     open_source=True,
     revision="d110532e8d4ff91c574ee60a342323f28468b287",
     release_date="2023-04-26",
+    modalities="it",
 )
 
 CLIP_ViT_bigG_14_laion2B_39B_b160k = ModelMeta(
@@ -196,6 +199,7 @@ CLIP_ViT_bigG_14_laion2B_39B_b160k = ModelMeta(
     open_source=True,
     revision="bc7788f151930d91b58474715fdce5524ad9a189",
     release_date="2023-01-23",
+    modalities="it",
 )
 
 CLIP_ViT_g_14_laion2B_s34B_b88K = ModelMeta(
@@ -208,6 +212,7 @@ CLIP_ViT_g_14_laion2B_s34B_b88K = ModelMeta(
     open_source=True,
     revision="15efd0f6ac0c40c0f9da7becca03c974d7012604",
     release_date="2023-03-06",
+    modalities="it",
 )
 
 CLIP_ViT_H_14_laion2B_s32B_b79K = ModelMeta(
@@ -220,6 +225,7 @@ CLIP_ViT_H_14_laion2B_s32B_b79K = ModelMeta(
     open_source=True,
     revision="de081ac0a0ca8dc9d1533eed1ae884bb8ae1404b",
     release_date="2022-09-15",
+    modalities="it",
 )
 
 CLIP_ViT_L_14_laion2B_s32B_b82K = ModelMeta(
@@ -232,6 +238,7 @@ CLIP_ViT_L_14_laion2B_s32B_b82K = ModelMeta(
     open_source=True,
     revision="1627032197142fbe2a7cfec626f4ced3ae60d07a",
     release_date="2022-09-15",
+    modalities="it",
 )
 
 CLIP_ViT_B_32_laion2B_s34B_b79K = ModelMeta(
@@ -244,4 +251,5 @@ CLIP_ViT_B_32_laion2B_s34B_b79K = ModelMeta(
     open_source=True,
     revision="08f73555f1b2fb7c82058aebbd492887a94968ef",
     release_date="2022-09-15",
+    modalities="it",
 )

--- a/mteb/models/siglip_models.py
+++ b/mteb/models/siglip_models.py
@@ -165,7 +165,7 @@ siglip_so400m_patch14_224 = ModelMeta(
     open_source=True,
     revision="d04cf29fca7b6374f74d8bea1969314492266b5e",
     release_date="2024-01-08",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 siglip_so400m_patch14_384 = ModelMeta(
@@ -178,7 +178,7 @@ siglip_so400m_patch14_384 = ModelMeta(
     open_source=True,
     revision="9fdffc58afc957d1a03a25b10dba0329ab15c2a3",
     release_date="2024-01-08",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 siglip_so400m_patch16_256_i18n = ModelMeta(
@@ -191,7 +191,7 @@ siglip_so400m_patch16_256_i18n = ModelMeta(
     open_source=True,
     revision="365d321c0cfdea96bc28e3a29787a11a062681a1",
     release_date="2024-01-08",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 siglip_base_patch16_256_multilingual = ModelMeta(
@@ -204,7 +204,7 @@ siglip_base_patch16_256_multilingual = ModelMeta(
     open_source=True,
     revision="8952a4eafcde3cb7ab46b1dd629b33f8784ca9c6",
     release_date="2024-01-08",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 siglip_base_patch16_256 = ModelMeta(
@@ -217,7 +217,7 @@ siglip_base_patch16_256 = ModelMeta(
     open_source=True,
     revision="b078df89e446d623010d890864d4207fe6399f61",
     release_date="2024-01-08",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 siglip_base_patch16_512 = ModelMeta(
@@ -230,7 +230,7 @@ siglip_base_patch16_512 = ModelMeta(
     open_source=True,
     revision="753a949581523b60257d93e18391e8c27f72eb22",
     release_date="2024-01-08",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 siglip_base_patch16_384 = ModelMeta(
@@ -243,7 +243,7 @@ siglip_base_patch16_384 = ModelMeta(
     open_source=True,
     revision="41aec1c83b32e0a6fca20ad88ba058aa5b5ea394",
     release_date="2024-01-08",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 siglip_base_patch16_224 = ModelMeta(
@@ -256,7 +256,7 @@ siglip_base_patch16_224 = ModelMeta(
     open_source=True,
     revision="7fd15f0689c79d79e38b1c2e2e2370a7bf2761ed",
     release_date="2024-01-08",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 siglip_large_patch16_256 = ModelMeta(
@@ -269,7 +269,7 @@ siglip_large_patch16_256 = ModelMeta(
     open_source=True,
     revision="d0da9f876e7d66b4e250cd2450c3ba2ce735e447",
     release_date="2024-01-08",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 siglip_large_patch16_384 = ModelMeta(
@@ -282,7 +282,7 @@ siglip_large_patch16_384 = ModelMeta(
     open_source=True,
     revision="ce005573a40965dfd21fd937fbdeeebf2439fc35",
     release_date="2024-01-08",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 if __name__ == "__main__":

--- a/mteb/models/siglip_models.py
+++ b/mteb/models/siglip_models.py
@@ -165,6 +165,7 @@ siglip_so400m_patch14_224 = ModelMeta(
     open_source=True,
     revision="d04cf29fca7b6374f74d8bea1969314492266b5e",
     release_date="2024-01-08",
+    modalities="it",
 )
 
 siglip_so400m_patch14_384 = ModelMeta(
@@ -177,6 +178,7 @@ siglip_so400m_patch14_384 = ModelMeta(
     open_source=True,
     revision="9fdffc58afc957d1a03a25b10dba0329ab15c2a3",
     release_date="2024-01-08",
+    modalities="it",
 )
 
 siglip_so400m_patch16_256_i18n = ModelMeta(
@@ -189,6 +191,7 @@ siglip_so400m_patch16_256_i18n = ModelMeta(
     open_source=True,
     revision="365d321c0cfdea96bc28e3a29787a11a062681a1",
     release_date="2024-01-08",
+    modalities="it",
 )
 
 siglip_base_patch16_256_multilingual = ModelMeta(
@@ -201,6 +204,7 @@ siglip_base_patch16_256_multilingual = ModelMeta(
     open_source=True,
     revision="8952a4eafcde3cb7ab46b1dd629b33f8784ca9c6",
     release_date="2024-01-08",
+    modalities="it",
 )
 
 siglip_base_patch16_256 = ModelMeta(
@@ -213,6 +217,7 @@ siglip_base_patch16_256 = ModelMeta(
     open_source=True,
     revision="b078df89e446d623010d890864d4207fe6399f61",
     release_date="2024-01-08",
+    modalities="it",
 )
 
 siglip_base_patch16_512 = ModelMeta(
@@ -225,6 +230,7 @@ siglip_base_patch16_512 = ModelMeta(
     open_source=True,
     revision="753a949581523b60257d93e18391e8c27f72eb22",
     release_date="2024-01-08",
+    modalities="it",
 )
 
 siglip_base_patch16_384 = ModelMeta(
@@ -237,6 +243,7 @@ siglip_base_patch16_384 = ModelMeta(
     open_source=True,
     revision="41aec1c83b32e0a6fca20ad88ba058aa5b5ea394",
     release_date="2024-01-08",
+    modalities="it",
 )
 
 siglip_base_patch16_224 = ModelMeta(
@@ -249,6 +256,7 @@ siglip_base_patch16_224 = ModelMeta(
     open_source=True,
     revision="7fd15f0689c79d79e38b1c2e2e2370a7bf2761ed",
     release_date="2024-01-08",
+    modalities="it",
 )
 
 siglip_large_patch16_256 = ModelMeta(
@@ -261,6 +269,7 @@ siglip_large_patch16_256 = ModelMeta(
     open_source=True,
     revision="d0da9f876e7d66b4e250cd2450c3ba2ce735e447",
     release_date="2024-01-08",
+    modalities="it",
 )
 
 siglip_large_patch16_384 = ModelMeta(
@@ -273,6 +282,7 @@ siglip_large_patch16_384 = ModelMeta(
     open_source=True,
     revision="ce005573a40965dfd21fd937fbdeeebf2439fc35",
     release_date="2024-01-08",
+    modalities="it",
 )
 
 if __name__ == "__main__":

--- a/mteb/models/vista_models.py
+++ b/mteb/models/vista_models.py
@@ -230,6 +230,7 @@ visualized_bge_base = ModelMeta(
     open_source=True,
     revision="98db10b10d22620010d06f11733346e1c98c34aa",
     release_date="2024-06-06",
+    modalities="it",
 )
 
 visualized_bge_m3 = ModelMeta(
@@ -243,6 +244,7 @@ visualized_bge_m3 = ModelMeta(
     open_source=True,
     revision="98db10b10d22620010d06f11733346e1c98c34aa",
     release_date="2024-06-06",
+    modalities="it",
 )
 
 if __name__ == "__main__":

--- a/mteb/models/vista_models.py
+++ b/mteb/models/vista_models.py
@@ -230,7 +230,7 @@ visualized_bge_base = ModelMeta(
     open_source=True,
     revision="98db10b10d22620010d06f11733346e1c98c34aa",
     release_date="2024-06-06",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 visualized_bge_m3 = ModelMeta(
@@ -244,7 +244,7 @@ visualized_bge_m3 = ModelMeta(
     open_source=True,
     revision="98db10b10d22620010d06f11733346e1c98c34aa",
     release_date="2024-06-06",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 if __name__ == "__main__":

--- a/mteb/models/vlm2vec_models.py
+++ b/mteb/models/vlm2vec_models.py
@@ -372,7 +372,7 @@ vlm2vec_lora = ModelMeta(
     open_source=True,
     revision="7403b6327958071c1e33c822c7453adadccc7298",
     release_date="2024-10-08",
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 vlm2vec_full = ModelMeta(
@@ -385,5 +385,5 @@ vlm2vec_full = ModelMeta(
     open_source=True,
     revision="e9afa98002097ac2471827ba23ea1f2ddd229480",
     release_date="2024-10-08",
-    modalities="it",
+    modalities=["image", "text"],
 )

--- a/mteb/models/vlm2vec_models.py
+++ b/mteb/models/vlm2vec_models.py
@@ -372,6 +372,7 @@ vlm2vec_lora = ModelMeta(
     open_source=True,
     revision="7403b6327958071c1e33c822c7453adadccc7298",
     release_date="2024-10-08",
+    modalities="it",
 )
 
 vlm2vec_full = ModelMeta(
@@ -384,4 +385,5 @@ vlm2vec_full = ModelMeta(
     open_source=True,
     revision="e9afa98002097ac2471827ba23ea1f2ddd229480",
     release_date="2024-10-08",
+    modalities="it",
 )

--- a/mteb/models/voyage_v.py
+++ b/mteb/models/voyage_v.py
@@ -255,7 +255,7 @@ voyage_v = ModelMeta(
     license=None,
     similarity_fn_name="cosine",
     framework=[],
-    modalities="it",
+    modalities=["image", "text"],
 )
 
 if __name__ == "__main__":

--- a/mteb/models/voyage_v.py
+++ b/mteb/models/voyage_v.py
@@ -241,7 +241,7 @@ def voyage_v_loader(**kwargs):
     return VoyageMultiModalModelWrapper(**kwargs)
 
 
-cohere_mult_3 = ModelMeta(
+voyage_v = ModelMeta(
     loader=partial(voyage_v_loader, model_name="voyage-multimodal-3"),
     name="voyage-multimodal-3",
     languages=[],  # Unknown
@@ -255,8 +255,9 @@ cohere_mult_3 = ModelMeta(
     license=None,
     similarity_fn_name="cosine",
     framework=[],
+    modalities="it",
 )
 
 if __name__ == "__main__":
-    mdl = mteb.get_model(cohere_mult_3.name, cohere_mult_3.revision)
+    mdl = mteb.get_model(voyage_v.name, voyage_v.revision)
     emb = mdl.encode(["Hello, world!"])


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->
Fixes #1632 

- Added ModelMeta.modalities, which defaults to `["text"]` to be backwards compatible. VLMs will have `["image","text"]`.
- Added logic in `MTEB.run` for exact match between task and model modalities
- Added modality model meta to relevant models

Here is the new log, showing that moco only supports images.
```
## Evaluating 1 tasks:
Any2AnyRetrieval
    - VidoreSyntheticDocQAAIRetrieval, t2i


INFO:mteb.evaluation.MTEB:

********************** Evaluating VidoreSyntheticDocQAAIRetrieval **********************
INFO:mteb.evaluation.MTEB:nyu-visionx/moco-v3-vit-b only supports ['image'], but the task modalities are ['text', 'image'].
```

## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 

cc @Muennighoff @gowitheflow-1998 