### PR TITLE
[mieb] model task modalities matching logic

### DIFF
--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -374,7 +374,9 @@ class MTEB:
 
             # skip evaluation if the model does not support the task modalities.
             task_modalities = "".join(sorted(task.metadata.modalities))
-            if "".join(sorted(meta.modalities)) != task_modalities:
+            if ("".join(sorted(meta.modalities)) != task_modalities) and (
+                not set(task.metadata.modalities).issubset(set(meta.modalities))
+            ):
                 logger.warning(
                     f"{meta.name} only supports {meta.modalities}, but the task modalities are {task.metadata.modalities}. Skipping task."
                 )


### PR DESCRIPTION
In #1633, the skipping of image&text tasks for image-only models was added but image-only tasks are now being skipped for image-text models as well. Fixing this with a subset logic.

## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 