### PR TITLE
add missing benchmark to benchmarks.py

### DIFF
--- a/mteb/benchmarks/benchmarks.py
+++ b/mteb/benchmarks/benchmarks.py
@@ -438,6 +438,39 @@ CoIR = Benchmark(
     }""",
 )
 
+RAR_b = Benchmark(
+    name="RAR-b",
+    tasks=get_tasks(
+        tasks=[
+            "ARCChallenge",
+            "AlphaNLI",
+            "HellaSwag",
+            "WinoGrande",
+            "PIQA",
+            "SIQA",
+            "Quail",
+            "SpartQA",
+            "TempReasonL1",
+            "TempReasonL2Pure",
+            "TempReasonL2Fact",
+            "TempReasonL2Context",
+            "TempReasonL3Pure",
+            "TempReasonL3Fact",
+            "TempReasonL3Context",
+            "RARbCode",
+            "RARbMath",
+        ]
+    ),
+    description="A benchmark to evaluate reasoning capabilities of retrievers.",
+    reference="https://arxiv.org/abs/2404.06347",
+    citation="""@article{xiao2024rar,
+      title={RAR-b: Reasoning as Retrieval Benchmark},
+      author={Xiao, Chenghao and Hudson, G Thomas and Al Moubayed, Noura},
+      journal={arXiv preprint arXiv:2404.06347},
+      year={2024}
+    }""",
+)
+
 MTEB_FRA = Benchmark(
     name="MTEB(fra)",
     tasks=get_tasks(


### PR DESCRIPTION
adding RAR-b that's currently missing in `benchmarks.py` and thus not appearing on leaderboard 2.0 (#1013).

## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 
