### PR TITLE
fix: Register MicroLlama Text Embedding

### DIFF
--- a/mteb/models/sentence_transformers_models.py
+++ b/mteb/models/sentence_transformers_models.py
@@ -269,3 +269,22 @@ all_MiniLM_L12_v2 = ModelMeta(
     superseded_by=None,
     adapted_from=None,
 )
+
+microllama_text_embedding = ModelMeta(
+    name="keeeeenw/MicroLlama-text-embedding",
+    languages=["eng-Latn"],
+    open_weights=True,
+    revision="98f70f14cdf12d7ea217ed2fd4e808b0195f1e7e",
+    release_date="2024-11-10",
+    n_parameters=272_000_000,
+    memory_usage=None,
+    embed_dim=1024,
+    license="apache-2.0",
+    max_tokens=2048,
+    reference="https://huggingface.co/keeeeenw/MicroLlama-text-embedding",
+    similarity_fn_name="cosine",
+    framework=["Sentence Transformers", "PyTorch"],
+    use_instructions=False,
+    superseded_by=None,
+    adapted_from=None,
+)


### PR DESCRIPTION
### Adding a model checklist
<!-- 
When adding a model to the model registry
see also https://github.com/embeddings-benchmark/mteb/blob/main/docs/reproducible_workflow.md
-->

 - [X] I have filled out the ModelMeta object to the extent possible
 - [X] I have ensured that my model can be loaded using
   - [X] `mteb.get_model(model_name, revision)` and
   - [X] `mteb.get_model_meta(model_name, revision)`
 - [X] I have tested the implementation works on a representative set of tasks.

### Testing results
```
>>> import mteb
>>> mteb.get_model_meta("keeeeenw/MicroLlama-text-embedding", "98f70f14cdf12d7ea217ed2fd4e808b0195f1e7e")
ModelMeta(name='keeeeenw/MicroLlama-text-embedding', revision='98f70f14cdf12d7ea217ed2fd4e808b0195f1e7e', release_date='2024-11-10', languages=['eng-Latn'], loader=None, n_parameters=272000000, memory_usage=None, max_tokens=2048.0, embed_dim=1024, license='apache-2.0', open_weights=True, public_training_data=None, public_training_code=None, framework=['Sentence Transformers', 'PyTorch'], reference='https://huggingface.co/keeeeenw/MicroLlama-text-embedding', similarity_fn_name='cosine', use_instructions=False, training_datasets=None, adapted_from=None, superseded_by=None)
>>> tasks = mteb.get_tasks(tasks=["Banking77Classification"])
... evaluation = mteb.MTEB(tasks=tasks)
... 
>>> model = mteb.get_model("keeeeenw/MicroLlama-text-embedding", "98f70f14cdf12d7ea217ed2fd4e808b0195f1e7e")
Loader not specified for model keeeeenw/MicroLlama-text-embedding, loading using sentence transformers.
>>> evaluation.run(model)
```