### PR TITLE
fix: Use prompts instead of prompt names for voyage

### DIFF
--- a/mteb/models/voyage_models.py
+++ b/mteb/models/voyage_models.py
@@ -94,10 +94,7 @@ class VoyageWrapper(Wrapper):
         prompt_type: PromptType | None = None,
         **kwargs: Any,
     ) -> np.ndarray:
-        input_type = (
-            self.get_prompt_name(self.model_prompts, task_name, prompt_type)
-            or "document"
-        )
+        input_type = self.get_prompt(self.model_prompts, task_name, prompt_type) or "document"
         return self._batched_encode(sentences, batch_size, input_type)
 
     def _batched_encode(

--- a/mteb/models/voyage_models.py
+++ b/mteb/models/voyage_models.py
@@ -94,9 +94,7 @@ class VoyageWrapper(Wrapper):
         prompt_type: PromptType | None = None,
         **kwargs: Any,
     ) -> np.ndarray:
-        input_type = (
-            self.get_prompt(self.model_prompts, task_name, prompt_type) or "document"
-        )
+        input_type = self.model_prompts.get(prompt_type.value, "document")
         return self._batched_encode(sentences, batch_size, input_type)
 
     def _batched_encode(

--- a/mteb/models/voyage_models.py
+++ b/mteb/models/voyage_models.py
@@ -94,7 +94,9 @@ class VoyageWrapper(Wrapper):
         prompt_type: PromptType | None = None,
         **kwargs: Any,
     ) -> np.ndarray:
-        input_type = self.get_prompt(self.model_prompts, task_name, prompt_type) or "document"
+        input_type = (
+            self.get_prompt(self.model_prompts, task_name, prompt_type) or "document"
+        )
         return self._batched_encode(sentences, batch_size, input_type)
 
     def _batched_encode(

--- a/mteb/models/wrapper.py
+++ b/mteb/models/wrapper.py
@@ -15,7 +15,7 @@ class Wrapper:
     Also contains some utility functions for wrappers for working with prompts and instructions.
     """
 
-    instruction_template: str | Callable[[str], str] | None = None
+    instruction_template: str | Callable[[str, str], str] | None = None
 
     @staticmethod
     def get_prompt_name(
@@ -63,6 +63,15 @@ class Wrapper:
             "No combination of task name and prompt type was found in model prompts."
         )
         return None
+
+    def get_prompt(self, task_to_prompt: dict[str, str] | None, task_name: str, prompt_type: PromptType | None) -> str | None:
+        """Get the prompt to be used for encoding sentences."""
+        if task_to_prompt is None:
+            return None
+        prompt_name = self.get_prompt_name(task_to_prompt, task_name, prompt_type)
+        if prompt_name is None:
+            return None
+        return task_to_prompt[prompt_name]
 
     @staticmethod
     def validate_task_to_prompt_name(

--- a/mteb/models/wrapper.py
+++ b/mteb/models/wrapper.py
@@ -64,7 +64,12 @@ class Wrapper:
         )
         return None
 
-    def get_prompt(self, task_to_prompt: dict[str, str] | None, task_name: str, prompt_type: PromptType | None) -> str | None:
+    def get_prompt(
+        self,
+        task_to_prompt: dict[str, str] | None,
+        task_name: str,
+        prompt_type: PromptType | None,
+    ) -> str | None:
         """Get the prompt to be used for encoding sentences."""
         if task_to_prompt is None:
             return None

--- a/mteb/models/wrapper.py
+++ b/mteb/models/wrapper.py
@@ -64,20 +64,6 @@ class Wrapper:
         )
         return None
 
-    def get_prompt(
-        self,
-        task_to_prompt: dict[str, str] | None,
-        task_name: str,
-        prompt_type: PromptType | None,
-    ) -> str | None:
-        """Get the prompt to be used for encoding sentences."""
-        if task_to_prompt is None:
-            return None
-        prompt_name = self.get_prompt_name(task_to_prompt, task_name, prompt_type)
-        if prompt_name is None:
-            return None
-        return task_to_prompt[prompt_name]
-
     @staticmethod
     def validate_task_to_prompt_name(
         task_to_prompt_name: dict[str, str] | None,


### PR DESCRIPTION
## Checklist

- [X] Run tests locally to make sure nothing is broken using `make test`. 
- [X] Run the formatter to format the code using `make lint`. 

Closes https://github.com/embeddings-benchmark/mteb/issues/1652 
Closes https://github.com/embeddings-benchmark/mteb/issues/1649