### PR TITLE
fix: remove model as a parameter for MulticlassClassification

### DIFF
--- a/mteb/abstasks/AbsTaskMultilabelClassification.py
+++ b/mteb/abstasks/AbsTaskMultilabelClassification.py
@@ -209,7 +209,6 @@ class AbsTaskMultilabelClassification(AbsTask):
 
         X_test = model.encode(
             test_text,
-            model=model,
             task_name=self.metadata.name,
             **encode_kwargs,
         )


### PR DESCRIPTION
## Checklist

- [X] Run tests locally to make sure nothing is broken using `make test`. 
- [X] Run the formatter to format the code using `make lint`. 

Closes https://github.com/embeddings-benchmark/mteb/issues/1654
