### PR TITLE
fix: Cast all Model2Vec outputs as floats

### DIFF
--- a/mteb/models/model2vec_models.py
+++ b/mteb/models/model2vec_models.py
@@ -50,7 +50,7 @@ class Model2VecWrapper(Wrapper):
         Returns:
             The encoded sentences.
         """
-        return self.static_model.encode(sentences)
+        return self.static_model.encode(sentences).astype(np.float32)
 
 
 m2v_base_glove_subword = ModelMeta(


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->
Fixes #1662 

Fix applies to both `minishlab/potion-base-2M` and `minishlab/M2V_base_output` (and should also apply to all other model2vec models). Running `mteb run -t ClimateFEVERHardNegatives -m minishlab/potion-base-2M` should produce the following results:

<details>

```
INFO:mteb.abstasks.AbsTaskRetrieval:Time taken to retrieve: 11.89 seconds
INFO:mteb.evaluation.MTEB:Evaluation for ClimateFEVERHardNegatives on test took 13.14 seconds
INFO:mteb.evaluation.MTEB:Scores: {'default': {'ndcg_at_1': 0.092, 'ndcg_at_3': 0.07845, 'ndcg_at_5': 0.0882, 'ndcg_at_10': 0.11008, 'ndcg_at_20': 0.13069, 'ndcg_at_100': 0.16963, 'ndcg_at_1000': 0.21536, 'map_at_1': 0.04165, 'map_at_3': 0.05536, 'map_at_5': 0.0622, 'map_at_10': 0.07081, 'map_at_20': 0.07609, 'map_at_100': 0.08203, 'map_at_1000': 0.08395, 'recall_at_1': 0.04165, 'recall_at_3': 0.072, 'recall_at_5': 0.09553, 'recall_at_10': 0.14773, 'recall_at_20': 0.20837, 'recall_at_100': 0.361, 'recall_at_1000': 0.6293, 'precision_at_1': 0.092, 'precision_at_3': 0.059, 'precision_at_5': 0.0478, 'precision_at_10': 0.0371, 'precision_at_20': 0.0269, 'precision_at_100': 0.01006, 'precision_at_1000': 0.00185, 'mrr_at_1': 0.092, 'mrr_at_3': 0.12433333333333332, 'mrr_at_5': 0.13518333333333335, 'mrr_at_10': 0.14714404761904762, 'mrr_at_20': 0.15547535137720897, 'mrr_at_100': 0.1607343452204719, 'mrr_at_1000': 0.16174585372632433, 'nauc_ndcg_at_1_max': np.float64(0.23791136360985057), 'nauc_ndcg_at_1_std': np.float64(0.07001201572543486), 'nauc_ndcg_at_1_diff1': np.float64(0.1962996231961829), 'nauc_ndcg_at_3_max': np.float64(0.23386580216589842), 'nauc_ndcg_at_3_std': np.float64(0.09511753693268539), 'nauc_ndcg_at_3_diff1': np.float64(0.16928907443775548), 'nauc_ndcg_at_5_max': np.float64(0.22270304861665163), 'nauc_ndcg_at_5_std': np.float64(0.09533983372354055), 'nauc_ndcg_at_5_diff1': np.float64(0.15471993837826867), 'nauc_ndcg_at_10_max': np.float64(0.22279703165612744), 'nauc_ndcg_at_10_std': np.float64(0.10365931408535312), 'nauc_ndcg_at_10_diff1': np.float64(0.15213453711575714), 'nauc_ndcg_at_20_max': np.float64(0.24262054519421714), 'nauc_ndcg_at_20_std': np.float64(0.118997422812022), 'nauc_ndcg_at_20_diff1': np.float64(0.14644733415901848), 'nauc_ndcg_at_100_max': np.float64(0.28204188241497713), 'nauc_ndcg_at_100_std': np.float64(0.16951830992416214), 'nauc_ndcg_at_100_diff1': np.float64(0.12885219066644693), 'nauc_ndcg_at_1000_max': np.float64(0.30495758060990646), 'nauc_ndcg_at_1000_std': np.float64(0.1864941395172068), 'nauc_ndcg_at_1000_diff1': np.float64(0.12806174495359013), 'nauc_map_at_1_max': np.float64(0.25318718847882604), 'nauc_map_at_1_std': np.float64(0.02933429878525064), 'nauc_map_at_1_diff1': np.float64(0.21609502400369862), 'nauc_map_at_3_max': np.float64(0.22883104041519933), 'nauc_map_at_3_std': np.float64(0.06282792407374065), 'nauc_map_at_3_diff1': np.float64(0.17907765441444592), 'nauc_map_at_5_max': np.float64(0.2266501544052262), 'nauc_map_at_5_std': np.float64(0.07001251766256945), 'nauc_map_at_5_diff1': np.float64(0.1730143687020981), 'nauc_map_at_10_max': np.float64(0.2276341146368072), 'nauc_map_at_10_std': np.float64(0.07810425584601163), 'nauc_map_at_10_diff1': np.float64(0.171154313496342), 'nauc_map_at_20_max': np.float64(0.2336171332630307), 'nauc_map_at_20_std': np.float64(0.0848614537064426), 'nauc_map_at_20_diff1': np.float64(0.16699458161368885), 'nauc_map_at_100_max': np.float64(0.24530187507937531), 'nauc_map_at_100_std': np.float64(0.09917358058973565), 'nauc_map_at_100_diff1': np.float64(0.1619384768322022), 'nauc_map_at_1000_max': np.float64(0.24737752727470907), 'nauc_map_at_1000_std': np.float64(0.10140124170186456), 'nauc_map_at_1000_diff1': np.float64(0.161684796531017), 'nauc_recall_at_1_max': np.float64(0.25318718847882604), 'nauc_recall_at_1_std': np.float64(0.02933429878525064), 'nauc_recall_at_1_diff1': np.float64(0.21609502400369862), 'nauc_recall_at_3_max': np.float64(0.2118105446986354), 'nauc_recall_at_3_std': np.float64(0.10051301331982013), 'nauc_recall_at_3_diff1': np.float64(0.15809065324059313), 'nauc_recall_at_5_max': np.float64(0.1988042068742307), 'nauc_recall_at_5_std': np.float64(0.10534813435899039), 'nauc_recall_at_5_diff1': np.float64(0.133534978270615), 'nauc_recall_at_10_max': np.float64(0.18529476248401108), 'nauc_recall_at_10_std': np.float64(0.106081732931599), 'nauc_recall_at_10_diff1': np.float64(0.13195027990901714), 'nauc_recall_at_20_max': np.float64(0.21310493062131902), 'nauc_recall_at_20_std': np.float64(0.13094315727814934), 'nauc_recall_at_20_diff1': np.float64(0.110949988931591), 'nauc_recall_at_100_max': np.float64(0.2824028998069169), 'nauc_recall_at_100_std': np.float64(0.2388137566920226), 'nauc_recall_at_100_diff1': np.float64(0.06586080443305406), 'nauc_recall_at_1000_max': np.float64(0.33643053582847704), 'nauc_recall_at_1000_std': np.float64(0.28933395436329484), 'nauc_recall_at_1000_diff1': np.float64(0.05107341645981921), 'nauc_precision_at_1_max': np.float64(0.23791136360985057), 'nauc_precision_at_1_std': np.float64(0.07001201572543486), 'nauc_precision_at_1_diff1': np.float64(0.1962996231961829), 'nauc_precision_at_3_max': np.float64(0.23662584778022255), 'nauc_precision_at_3_std': np.float64(0.13740093623856497), 'nauc_precision_at_3_diff1': np.float64(0.13416399680138816), 'nauc_precision_at_5_max': np.float64(0.23066002891521195), 'nauc_precision_at_5_std': np.float64(0.15442676486650445), 'nauc_precision_at_5_diff1': np.float64(0.11032900338811458), 'nauc_precision_at_10_max': np.float64(0.24035479916348174), 'nauc_precision_at_10_std': np.float64(0.17339473489092058), 'nauc_precision_at_10_diff1': np.float64(0.10348512071926763), 'nauc_precision_at_20_max': np.float64(0.28656489425808485), 'nauc_precision_at_20_std': np.float64(0.19119208416816727), 'nauc_precision_at_20_diff1': np.float64(0.09575513180393366), 'nauc_precision_at_100_max': np.float64(0.3416874247059894), 'nauc_precision_at_100_std': np.float64(0.27171321982239344), 'nauc_precision_at_100_diff1': np.float64(0.04893149497496228), 'nauc_precision_at_1000_max': np.float64(0.34250950540973163), 'nauc_precision_at_1000_std': np.float64(0.26286633723590996), 'nauc_precision_at_1000_diff1': np.float64(0.023778489677771793), 'nauc_mrr_at_1_max': np.float64(0.23791136360985057), 'nauc_mrr_at_1_std': np.float64(0.07001201572543486), 'nauc_mrr_at_1_diff1': np.float64(0.1962996231961829), 'nauc_mrr_at_3_max': np.float64(0.2345435287680885), 'nauc_mrr_at_3_std': np.float64(0.10085334326783167), 'nauc_mrr_at_3_diff1': np.float64(0.16936747849495476), 'nauc_mrr_at_5_max': np.float64(0.22822128783430637), 'nauc_mrr_at_5_std': np.float64(0.10563467865050648), 'nauc_mrr_at_5_diff1': np.float64(0.15566201343555608), 'nauc_mrr_at_10_max': np.float64(0.22692702492606143), 'nauc_mrr_at_10_std': np.float64(0.10457760396055654), 'nauc_mrr_at_10_diff1': np.float64(0.1518695501601595), 'nauc_mrr_at_20_max': np.float64(0.23481914928610564), 'nauc_mrr_at_20_std': np.float64(0.10864157057735269), 'nauc_mrr_at_20_diff1': np.float64(0.15402750106720264), 'nauc_mrr_at_100_max': np.float64(0.2380672935093362), 'nauc_mrr_at_100_std': np.float64(0.11224217223605862), 'nauc_mrr_at_100_diff1': np.float64(0.15203485198879632), 'nauc_mrr_at_1000_max': np.float64(0.23813036240419883), 'nauc_mrr_at_1000_std': np.float64(0.11233066648441825), 'nauc_mrr_at_1000_diff1': np.float64(0.15222337232432112), 'main_score': 0.11008}}
```

</details>

## Cause
Error was due to dtype mismatch. Even though `encode_kwargs` has `convert_to_tensor=True`, Model2Vec's encode method does not take in kwargs and [only outputs np.ndarray](https://github.com/MinishLab/model2vec/blob/1588694cdaefed4cf7bba6175b5ed53a70c22829/model2vec/model.py#L251).

## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 

CC @Muennighoff 
