### PR TITLE
fix: add check for key error in loader

### DIFF
--- a/mteb/models/sentence_transformer_wrapper.py
+++ b/mteb/models/sentence_transformer_wrapper.py
@@ -46,7 +46,7 @@ class SentenceTransformerWrapper(Wrapper):
         ):
             try:
                 model_prompts = self.validate_task_to_prompt_name(self.model.prompts)
-            except (ValueError, KeyError):
+            except KeyError:
                 model_prompts = None
                 logger.warning(
                     "Model prompts are not in the expected format. Ignoring them."

--- a/mteb/models/sentence_transformer_wrapper.py
+++ b/mteb/models/sentence_transformer_wrapper.py
@@ -46,8 +46,11 @@ class SentenceTransformerWrapper(Wrapper):
         ):
             try:
                 model_prompts = self.validate_task_to_prompt_name(self.model.prompts)
-            except ValueError:
+            except (ValueError, KeyError):
                 model_prompts = None
+                logger.warning(
+                    "Model prompts are not in the expected format. Ignoring them."
+                )
         elif model_prompts is not None and hasattr(self.model, "prompts"):
             logger.info(f"Model prompts will be overwritten with {model_prompts}")
             self.model.prompts = model_prompts

--- a/mteb/models/wrapper.py
+++ b/mteb/models/wrapper.py
@@ -76,15 +76,15 @@ class Wrapper:
             if "-" in task_name:
                 task_name, prompt_type = task_name.split("-")
                 if prompt_type not in prompt_types:
-                    raise ValueError(
-                        f"Prompt type {prompt_type} is not valid. Valid prompt types are {prompt_types}"
-                    )
+                    msg = f"Prompt type {prompt_type} is not valid. Valid prompt types are {prompt_types}"
+                    logger.warning(msg)
+                    raise KeyError(msg)
             if task_name not in task_types and task_name not in prompt_types:
                 task = mteb.get_task(task_name=task_name)
                 if not task:
-                    raise ValueError(
-                        f"Task name {task_name} is not valid. Valid task names are task types [{task_types}], prompt types [{prompt_types}] and task names"
-                    )
+                    msg = f"Task name {task_name} is not valid. Valid task names are task types [{task_types}], prompt types [{prompt_types}] and task names"
+                    logger.warning(msg)
+                    raise KeyError(msg)
         return task_to_prompt_name
 
     @staticmethod

--- a/tests/test_reproducible_workflow.py
+++ b/tests/test_reproducible_workflow.py
@@ -71,5 +71,5 @@ def test_validate_task_to_prompt_name_fail():
             {"task_name": "prompt_name", "task_name-query": "prompt_name"}
         )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(KeyError):
         Wrapper.validate_task_to_prompt_name({"task_name-task_name": "prompt_name"})


### PR DESCRIPTION
Incorrect task names would raise `KeyError`, but previously the check was only for `ValueError`.

Closes https://github.com/embeddings-benchmark/mteb/issues/1657
Closes https://github.com/embeddings-benchmark/mteb/issues/1659

## Checklist
<!-- Please do not delete this -->

- [X] Run tests locally to make sure nothing is broken using `make test`. 
- [X] Run the formatter to format the code using `make lint`. 
