### PR TITLE
fix: Add warning for non-retrieval tasks when using bm25s

### DIFF
--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -463,6 +463,13 @@ class MTEB:
                 f"\n\n********************** Evaluating {task.metadata.name} **********************"
             )
 
+            if "bm25s" in meta.name and task.metadata.type != "Retrieval":
+                logger.warning(
+                    f"bm25s only supports Retrieval tasks, but the task type is {task.metadata.type}. Skipping task."
+                )
+                del self.tasks[0]  # empty memory
+                continue
+
             task_eval_splits = (
                 eval_splits if eval_splits is not None else task.eval_splits
             )

--- a/mteb/models/bm25.py
+++ b/mteb/models/bm25.py
@@ -17,7 +17,7 @@ def bm25_loader(**kwargs):
         import Stemmer
     except ImportError:
         raise ImportError(
-            "bm25s or Stemmer is not installed. Please install it with `pip install bm25s PyStemmer`."
+            "bm25s or Stemmer is not installed. Please install it with `pip install mteb[bm25s]`."
         )
 
     class BM25Search(DRESModel, Wrapper):

--- a/mteb/models/bm25.py
+++ b/mteb/models/bm25.py
@@ -17,7 +17,7 @@ def bm25_loader(**kwargs):
         import Stemmer
     except ImportError:
         raise ImportError(
-            "bm25s or Stemmer is not installed. Please install it with `pip install mteb[bm25s]`."
+            "bm25s or PyStemmer is not installed. Please install it with `pip install mteb[bm25s]`."
         )
 
     class BM25Search(DRESModel, Wrapper):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ flash_attention = ["flash-attn>=2.6.3"]
 openai = ["openai>=1.41.0", "tiktoken>=0.8.0"]
 model2vec = ["model2vec>=0.3.0"]
 pylate = ["pylate>=1.1.4"]
-bm25s = ["bm25s", "PyStemmer"]
+bm25s = ["bm25s>=0.2.6", "PyStemmer>=2.2.0.3"]
 
 
 [tool.coverage.report]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ flash_attention = ["flash-attn>=2.6.3"]
 openai = ["openai>=1.41.0", "tiktoken>=0.8.0"]
 model2vec = ["model2vec>=0.3.0"]
 pylate = ["pylate>=1.1.4"]
+bm25s = ["bm25s", "PyStemmer"]
 
 
 [tool.coverage.report]


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->
Fixes #1646 

As bm25s is only intended for retrieval tasks, we now skip evaluating on non-retrieval tasks.
- Add warning for non-retrieval tasks when bm25s is the selected model
- Clean up install in `pyproject.toml`

Running `mteb run -m bm25s -t indonli` now yields:
```
## Evaluating 1 tasks:
──────────────────────────────────────────────────────────────────────────── Selected tasks  ────────────────────────────────────────────────────────────────────────────
PairClassification
    - indonli, s2s


INFO:mteb.evaluation.MTEB:

********************** Evaluating indonli **********************
WARNING:mteb.evaluation.MTEB:bm25s only supports Retrieval tasks, but the task type is PairClassification. Skipping task.
```

## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 

CC @Muennighoff 
