### PR TITLE
fix: nomic prompts

### DIFF
--- a/mteb/models/nomic_models.py
+++ b/mteb/models/nomic_models.py
@@ -155,7 +155,7 @@ nomic_embed_v1_ablated = ModelMeta(
 )
 
 
-nomic_embed_v1_ablated = ModelMeta(
+nomic_embed_v1_unsupervised = ModelMeta(
     loader=partial(  # type: ignore
         NomicWrapper,
         trust_remote_code=True,

--- a/mteb/models/nomic_models.py
+++ b/mteb/models/nomic_models.py
@@ -53,6 +53,10 @@ class NomicWrapper(SentenceTransformerWrapper):
         normalize = task.metadata.type not in (
             "Classification",
             "MultilabelClassification",
+            "PairClassification",
+            "Reranking",
+            "STS",
+            "Summarization",
         )
         emb = self.model.encode(
             sentences,

--- a/mteb/models/nomic_models.py
+++ b/mteb/models/nomic_models.py
@@ -28,9 +28,11 @@ class NomicWrapper(Wrapper):
         **kwargs: Any,
     ):
         self.model_name = model_name
-        self.model = SentenceTransformer(model_name, revision=revision, **kwargs)
         self.model_prompts = (
             self.validate_task_to_prompt_name(model_prompts) if model_prompts else None
+        )
+        self.model = SentenceTransformer(
+            model_name, revision=revision, prompts=model_prompts, **kwargs
         )
 
     def to(self, device: torch.device) -> None:

--- a/mteb/models/nomic_models.py
+++ b/mteb/models/nomic_models.py
@@ -45,15 +45,15 @@ class NomicWrapper(Wrapper):
         batch_size: int = 32,
         **kwargs: Any,
     ) -> np.ndarray:
-        input_type = self.get_prompt_name(self.model_prompts, task_name, prompt_type)
-
         # default to search_document if input_type and prompt_name are not provided
-        if input_type is None:
-            input_type = "search_document"
+        prompt_name = (
+            self.get_prompt_name(self.model_prompts, task_name, prompt_type)
+            or PromptType.passage.value
+        )
 
-        sentences = [f"{input_type}: {sentence}" for sentence in sentences]
-
-        emb = self.model.encode(sentences, batch_size=batch_size, **kwargs)
+        emb = self.model.encode(
+            sentences, prompt_name=prompt_name, batch_size=batch_size, **kwargs
+        )
         # v1.5 has a non-trainable layer norm to unit normalize the embeddings for binary quantization
         # the outputs are similar to if we just normalized but keeping the same for consistency
         if self.model_name == "nomic-ai/nomic-embed-text-v1.5":

--- a/mteb/models/nomic_models.py
+++ b/mteb/models/nomic_models.py
@@ -52,7 +52,11 @@ class NomicWrapper(SentenceTransformerWrapper):
         # https://github.com/nomic-ai/contrastors/blob/5f7b461e5a13b5636692d1c9f1141b27232fe966/src/contrastors/eval/mteb_eval/eval_mteb.py#L172
         normalize = task.metadata.type != "Classification"
         emb = self.model.encode(
-            sentences, prompt_name=prompt_name, batch_size=batch_size, normalize_embeddings=normalize, **kwargs
+            sentences,
+            prompt_name=prompt_name,
+            batch_size=batch_size,
+            normalize_embeddings=normalize,
+            **kwargs,
         )
         # v1.5 has a non-trainable layer norm to unit normalize the embeddings for binary quantization
         # the outputs are similar to if we just normalized but keeping the same for consistency


### PR DESCRIPTION
## Checklist
<!-- Please do not delete this -->

- [X] Run tests locally to make sure nothing is broken using `make test`. 
- [X] Run the formatter to format the code using `make lint`. 

Currently, prompt names are added at the beginning of sentences, but this isn't always correct. For example, instead of `classification: `, it might incorrectly be `MultilabelClassification: `, or `passage: ` instead of `search_document: `.