### PR TITLE
fix: NanoBeir

### DIFF
--- a/mteb/tasks/Retrieval/eng/NanoArguAnaRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/NanoArguAnaRetrieval.py
@@ -80,8 +80,10 @@ class NanoArguAnaRetrieval(AbsTaskRetrieval):
 
         for split in self.relevant_docs:
             relevant_docs[split] = defaultdict(dict)
-            for query_id, corpus_id in zip(self.relevant_docs[split]["query-id"],
-                                           self.relevant_docs[split]["corpus-id"]):
+            for query_id, corpus_id in zip(
+                self.relevant_docs[split]["query-id"],
+                self.relevant_docs[split]["corpus-id"],
+            ):
                 relevant_docs[split][query_id][corpus_id] = 1
         self.relevant_docs = relevant_docs
 

--- a/mteb/tasks/Retrieval/eng/NanoArguAnaRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/NanoArguAnaRetrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections import defaultdict
+
 from datasets import load_dataset
 
 from mteb.abstasks.AbsTaskRetrieval import AbsTaskRetrieval
@@ -74,12 +76,13 @@ class NanoArguAnaRetrieval(AbsTaskRetrieval):
             for split in self.queries
         }
 
-        self.relevant_docs = {
-            split: {
-                sample["query-id"]: {sample["corpus-id"]: 1}
-                for sample in self.relevant_docs[split]
-            }
-            for split in self.relevant_docs
-        }
+        relevant_docs = {}
+
+        for split in self.relevant_docs:
+            relevant_docs[split] = defaultdict(dict)
+            for query_id, corpus_id in zip(self.relevant_docs[split]["query-id"],
+                                           self.relevant_docs[split]["corpus-id"]):
+                relevant_docs[split][query_id][corpus_id] = 1
+        self.relevant_docs = relevant_docs
 
         self.data_loaded = True

--- a/mteb/tasks/Retrieval/eng/NanoClimateFeverRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/NanoClimateFeverRetrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections import defaultdict
+
 from datasets import load_dataset
 
 from mteb.abstasks.AbsTaskRetrieval import AbsTaskRetrieval
@@ -74,12 +76,13 @@ class NanoClimateFeverRetrieval(AbsTaskRetrieval):
             for split in self.queries
         }
 
-        self.relevant_docs = {
-            split: {
-                sample["query-id"]: {sample["corpus-id"]: 1}
-                for sample in self.relevant_docs[split]
-            }
-            for split in self.relevant_docs
-        }
+        relevant_docs = {}
+
+        for split in self.relevant_docs:
+            relevant_docs[split] = defaultdict(dict)
+            for query_id, corpus_id in zip(self.relevant_docs[split]["query-id"],
+                                           self.relevant_docs[split]["corpus-id"]):
+                relevant_docs[split][query_id][corpus_id] = 1
+        self.relevant_docs = relevant_docs
 
         self.data_loaded = True

--- a/mteb/tasks/Retrieval/eng/NanoClimateFeverRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/NanoClimateFeverRetrieval.py
@@ -80,8 +80,10 @@ class NanoClimateFeverRetrieval(AbsTaskRetrieval):
 
         for split in self.relevant_docs:
             relevant_docs[split] = defaultdict(dict)
-            for query_id, corpus_id in zip(self.relevant_docs[split]["query-id"],
-                                           self.relevant_docs[split]["corpus-id"]):
+            for query_id, corpus_id in zip(
+                self.relevant_docs[split]["query-id"],
+                self.relevant_docs[split]["corpus-id"],
+            ):
                 relevant_docs[split][query_id][corpus_id] = 1
         self.relevant_docs = relevant_docs
 

--- a/mteb/tasks/Retrieval/eng/NanoDBPediaRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/NanoDBPediaRetrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections import defaultdict
+
 from datasets import load_dataset
 
 from mteb.abstasks.AbsTaskRetrieval import AbsTaskRetrieval
@@ -64,12 +66,13 @@ class NanoDBPediaRetrieval(AbsTaskRetrieval):
             for split in self.queries
         }
 
-        self.relevant_docs = {
-            split: {
-                sample["query-id"]: {sample["corpus-id"]: 1}
-                for sample in self.relevant_docs[split]
-            }
-            for split in self.relevant_docs
-        }
+        relevant_docs = {}
+
+        for split in self.relevant_docs:
+            relevant_docs[split] = defaultdict(dict)
+            for query_id, corpus_id in zip(self.relevant_docs[split]["query-id"],
+                                           self.relevant_docs[split]["corpus-id"]):
+                relevant_docs[split][query_id][corpus_id] = 1
+        self.relevant_docs = relevant_docs
 
         self.data_loaded = True

--- a/mteb/tasks/Retrieval/eng/NanoDBPediaRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/NanoDBPediaRetrieval.py
@@ -70,8 +70,10 @@ class NanoDBPediaRetrieval(AbsTaskRetrieval):
 
         for split in self.relevant_docs:
             relevant_docs[split] = defaultdict(dict)
-            for query_id, corpus_id in zip(self.relevant_docs[split]["query-id"],
-                                           self.relevant_docs[split]["corpus-id"]):
+            for query_id, corpus_id in zip(
+                self.relevant_docs[split]["query-id"],
+                self.relevant_docs[split]["corpus-id"],
+            ):
                 relevant_docs[split][query_id][corpus_id] = 1
         self.relevant_docs = relevant_docs
 

--- a/mteb/tasks/Retrieval/eng/NanoFEVERRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/NanoFEVERRetrieval.py
@@ -94,8 +94,10 @@ class NanoFEVERRetrieval(AbsTaskRetrieval):
 
         for split in self.relevant_docs:
             relevant_docs[split] = defaultdict(dict)
-            for query_id, corpus_id in zip(self.relevant_docs[split]["query-id"],
-                                           self.relevant_docs[split]["corpus-id"]):
+            for query_id, corpus_id in zip(
+                self.relevant_docs[split]["query-id"],
+                self.relevant_docs[split]["corpus-id"],
+            ):
                 relevant_docs[split][query_id][corpus_id] = 1
         self.relevant_docs = relevant_docs
 

--- a/mteb/tasks/Retrieval/eng/NanoFEVERRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/NanoFEVERRetrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections import defaultdict
+
 from datasets import load_dataset
 
 from mteb.abstasks.AbsTaskRetrieval import AbsTaskRetrieval
@@ -88,12 +90,13 @@ class NanoFEVERRetrieval(AbsTaskRetrieval):
             for split in self.queries
         }
 
-        self.relevant_docs = {
-            split: {
-                sample["query-id"]: {sample["corpus-id"]: 1}
-                for sample in self.relevant_docs[split]
-            }
-            for split in self.relevant_docs
-        }
+        relevant_docs = {}
+
+        for split in self.relevant_docs:
+            relevant_docs[split] = defaultdict(dict)
+            for query_id, corpus_id in zip(self.relevant_docs[split]["query-id"],
+                                           self.relevant_docs[split]["corpus-id"]):
+                relevant_docs[split][query_id][corpus_id] = 1
+        self.relevant_docs = relevant_docs
 
         self.data_loaded = True

--- a/mteb/tasks/Retrieval/eng/NanoFiQA2018Retrieval.py
+++ b/mteb/tasks/Retrieval/eng/NanoFiQA2018Retrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections import defaultdict
+
 from datasets import load_dataset
 
 from mteb.abstasks.AbsTaskRetrieval import AbsTaskRetrieval
@@ -74,12 +76,13 @@ url={https://openreview.net/forum?id=wCu6T5xFjeJ}
             for split in self.queries
         }
 
-        self.relevant_docs = {
-            split: {
-                sample["query-id"]: {sample["corpus-id"]: 1}
-                for sample in self.relevant_docs[split]
-            }
-            for split in self.relevant_docs
-        }
+        relevant_docs = {}
+
+        for split in self.relevant_docs:
+            relevant_docs[split] = defaultdict(dict)
+            for query_id, corpus_id in zip(self.relevant_docs[split]["query-id"],
+                                           self.relevant_docs[split]["corpus-id"]):
+                relevant_docs[split][query_id][corpus_id] = 1
+        self.relevant_docs = relevant_docs
 
         self.data_loaded = True

--- a/mteb/tasks/Retrieval/eng/NanoFiQA2018Retrieval.py
+++ b/mteb/tasks/Retrieval/eng/NanoFiQA2018Retrieval.py
@@ -80,8 +80,10 @@ url={https://openreview.net/forum?id=wCu6T5xFjeJ}
 
         for split in self.relevant_docs:
             relevant_docs[split] = defaultdict(dict)
-            for query_id, corpus_id in zip(self.relevant_docs[split]["query-id"],
-                                           self.relevant_docs[split]["corpus-id"]):
+            for query_id, corpus_id in zip(
+                self.relevant_docs[split]["query-id"],
+                self.relevant_docs[split]["corpus-id"],
+            ):
                 relevant_docs[split][query_id][corpus_id] = 1
         self.relevant_docs = relevant_docs
 

--- a/mteb/tasks/Retrieval/eng/NanoHotpotQARetrieval.py
+++ b/mteb/tasks/Retrieval/eng/NanoHotpotQARetrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections import defaultdict
+
 from datasets import load_dataset
 
 from mteb.abstasks.AbsTaskRetrieval import AbsTaskRetrieval
@@ -91,12 +93,13 @@ class NanoHotpotQARetrieval(AbsTaskRetrieval):
             for split in self.queries
         }
 
-        self.relevant_docs = {
-            split: {
-                sample["query-id"]: {sample["corpus-id"]: 1}
-                for sample in self.relevant_docs[split]
-            }
-            for split in self.relevant_docs
-        }
+        relevant_docs = {}
+
+        for split in self.relevant_docs:
+            relevant_docs[split] = defaultdict(dict)
+            for query_id, corpus_id in zip(self.relevant_docs[split]["query-id"],
+                                           self.relevant_docs[split]["corpus-id"]):
+                relevant_docs[split][query_id][corpus_id] = 1
+        self.relevant_docs = relevant_docs
 
         self.data_loaded = True

--- a/mteb/tasks/Retrieval/eng/NanoHotpotQARetrieval.py
+++ b/mteb/tasks/Retrieval/eng/NanoHotpotQARetrieval.py
@@ -97,8 +97,10 @@ class NanoHotpotQARetrieval(AbsTaskRetrieval):
 
         for split in self.relevant_docs:
             relevant_docs[split] = defaultdict(dict)
-            for query_id, corpus_id in zip(self.relevant_docs[split]["query-id"],
-                                           self.relevant_docs[split]["corpus-id"]):
+            for query_id, corpus_id in zip(
+                self.relevant_docs[split]["query-id"],
+                self.relevant_docs[split]["corpus-id"],
+            ):
                 relevant_docs[split][query_id][corpus_id] = 1
         self.relevant_docs = relevant_docs
 

--- a/mteb/tasks/Retrieval/eng/NanoMSMARCORetrieval.py
+++ b/mteb/tasks/Retrieval/eng/NanoMSMARCORetrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections import defaultdict
+
 from datasets import load_dataset
 
 from mteb.abstasks.AbsTaskRetrieval import AbsTaskRetrieval
@@ -86,12 +88,13 @@ class NanoMSMARCORetrieval(AbsTaskRetrieval):
             for split in self.queries
         }
 
-        self.relevant_docs = {
-            split: {
-                sample["query-id"]: {sample["corpus-id"]: 1}
-                for sample in self.relevant_docs[split]
-            }
-            for split in self.relevant_docs
-        }
+        relevant_docs = {}
+
+        for split in self.relevant_docs:
+            relevant_docs[split] = defaultdict(dict)
+            for query_id, corpus_id in zip(self.relevant_docs[split]["query-id"],
+                                           self.relevant_docs[split]["corpus-id"]):
+                relevant_docs[split][query_id][corpus_id] = 1
+        self.relevant_docs = relevant_docs
 
         self.data_loaded = True

--- a/mteb/tasks/Retrieval/eng/NanoMSMARCORetrieval.py
+++ b/mteb/tasks/Retrieval/eng/NanoMSMARCORetrieval.py
@@ -92,8 +92,10 @@ class NanoMSMARCORetrieval(AbsTaskRetrieval):
 
         for split in self.relevant_docs:
             relevant_docs[split] = defaultdict(dict)
-            for query_id, corpus_id in zip(self.relevant_docs[split]["query-id"],
-                                           self.relevant_docs[split]["corpus-id"]):
+            for query_id, corpus_id in zip(
+                self.relevant_docs[split]["query-id"],
+                self.relevant_docs[split]["corpus-id"],
+            ):
                 relevant_docs[split][query_id][corpus_id] = 1
         self.relevant_docs = relevant_docs
 

--- a/mteb/tasks/Retrieval/eng/NanoNFCorpusRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/NanoNFCorpusRetrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections import defaultdict
+
 from datasets import load_dataset
 
 from mteb.abstasks.AbsTaskRetrieval import AbsTaskRetrieval
@@ -76,12 +78,13 @@ class NanoNFCorpusRetrieval(AbsTaskRetrieval):
             for split in self.queries
         }
 
-        self.relevant_docs = {
-            split: {
-                sample["query-id"]: {sample["corpus-id"]: 1}
-                for sample in self.relevant_docs[split]
-            }
-            for split in self.relevant_docs
-        }
+        relevant_docs = {}
+
+        for split in self.relevant_docs:
+            relevant_docs[split] = defaultdict(dict)
+            for query_id, corpus_id in zip(self.relevant_docs[split]["query-id"],
+                                           self.relevant_docs[split]["corpus-id"]):
+                relevant_docs[split][query_id][corpus_id] = 1
+        self.relevant_docs = relevant_docs
 
         self.data_loaded = True

--- a/mteb/tasks/Retrieval/eng/NanoNFCorpusRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/NanoNFCorpusRetrieval.py
@@ -82,8 +82,10 @@ class NanoNFCorpusRetrieval(AbsTaskRetrieval):
 
         for split in self.relevant_docs:
             relevant_docs[split] = defaultdict(dict)
-            for query_id, corpus_id in zip(self.relevant_docs[split]["query-id"],
-                                           self.relevant_docs[split]["corpus-id"]):
+            for query_id, corpus_id in zip(
+                self.relevant_docs[split]["query-id"],
+                self.relevant_docs[split]["corpus-id"],
+            ):
                 relevant_docs[split][query_id][corpus_id] = 1
         self.relevant_docs = relevant_docs
 

--- a/mteb/tasks/Retrieval/eng/NanoNQRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/NanoNQRetrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections import defaultdict
+
 from datasets import load_dataset
 
 from mteb.abstasks.AbsTaskRetrieval import AbsTaskRetrieval
@@ -72,12 +74,12 @@ class NanoNQRetrieval(AbsTaskRetrieval):
             for split in self.queries
         }
 
-        self.relevant_docs = {
-            split: {
-                sample["query-id"]: {sample["corpus-id"]: 1}
-                for sample in self.relevant_docs[split]
-            }
-            for split in self.relevant_docs
-        }
+        relevant_docs = {}
+
+        for split in self.relevant_docs:
+            relevant_docs[split] = defaultdict(dict)
+            for query_id, corpus_id in zip(self.relevant_docs[split]["query-id"], self.relevant_docs[split]["corpus-id"]):
+                relevant_docs[split][query_id][corpus_id] = 1
+        self.relevant_docs = relevant_docs
 
         self.data_loaded = True

--- a/mteb/tasks/Retrieval/eng/NanoNQRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/NanoNQRetrieval.py
@@ -78,7 +78,10 @@ class NanoNQRetrieval(AbsTaskRetrieval):
 
         for split in self.relevant_docs:
             relevant_docs[split] = defaultdict(dict)
-            for query_id, corpus_id in zip(self.relevant_docs[split]["query-id"], self.relevant_docs[split]["corpus-id"]):
+            for query_id, corpus_id in zip(
+                self.relevant_docs[split]["query-id"],
+                self.relevant_docs[split]["corpus-id"],
+            ):
                 relevant_docs[split][query_id][corpus_id] = 1
         self.relevant_docs = relevant_docs
 

--- a/mteb/tasks/Retrieval/eng/NanoQuoraRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/NanoQuoraRetrieval.py
@@ -81,7 +81,10 @@ class NanoQuoraRetrieval(AbsTaskRetrieval):
 
         for split in self.relevant_docs:
             relevant_docs[split] = defaultdict(dict)
-            for query_id, corpus_id in zip(self.relevant_docs[split]["query-id"], self.relevant_docs[split]["corpus-id"]):
+            for query_id, corpus_id in zip(
+                self.relevant_docs[split]["query-id"],
+                self.relevant_docs[split]["corpus-id"],
+            ):
                 relevant_docs[split][query_id][corpus_id] = 1
         self.relevant_docs = relevant_docs
 

--- a/mteb/tasks/Retrieval/eng/NanoQuoraRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/NanoQuoraRetrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections import defaultdict
+
 from datasets import load_dataset
 
 from mteb.abstasks.AbsTaskRetrieval import AbsTaskRetrieval
@@ -75,12 +77,12 @@ class NanoQuoraRetrieval(AbsTaskRetrieval):
             for split in self.queries
         }
 
-        self.relevant_docs = {
-            split: {
-                sample["query-id"]: {sample["corpus-id"]: 1}
-                for sample in self.relevant_docs[split]
-            }
-            for split in self.relevant_docs
-        }
+        relevant_docs = {}
+
+        for split in self.relevant_docs:
+            relevant_docs[split] = defaultdict(dict)
+            for query_id, corpus_id in zip(self.relevant_docs[split]["query-id"], self.relevant_docs[split]["corpus-id"]):
+                relevant_docs[split][query_id][corpus_id] = 1
+        self.relevant_docs = relevant_docs
 
         self.data_loaded = True

--- a/mteb/tasks/Retrieval/eng/NanoSCIDOCSRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/NanoSCIDOCSRetrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections import defaultdict
+
 from datasets import load_dataset
 
 from mteb.abstasks.AbsTaskRetrieval import AbsTaskRetrieval
@@ -74,12 +76,13 @@ class NanoSCIDOCSRetrieval(AbsTaskRetrieval):
             for split in self.queries
         }
 
-        self.relevant_docs = {
-            split: {
-                sample["query-id"]: {sample["corpus-id"]: 1}
-                for sample in self.relevant_docs[split]
-            }
-            for split in self.relevant_docs
-        }
+        relevant_docs = {}
+
+        for split in self.relevant_docs:
+            relevant_docs[split] = defaultdict(dict)
+            for query_id, corpus_id in zip(self.relevant_docs[split]["query-id"],
+                                           self.relevant_docs[split]["corpus-id"]):
+                relevant_docs[split][query_id][corpus_id] = 1
+        self.relevant_docs = relevant_docs
 
         self.data_loaded = True

--- a/mteb/tasks/Retrieval/eng/NanoSCIDOCSRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/NanoSCIDOCSRetrieval.py
@@ -80,8 +80,10 @@ class NanoSCIDOCSRetrieval(AbsTaskRetrieval):
 
         for split in self.relevant_docs:
             relevant_docs[split] = defaultdict(dict)
-            for query_id, corpus_id in zip(self.relevant_docs[split]["query-id"],
-                                           self.relevant_docs[split]["corpus-id"]):
+            for query_id, corpus_id in zip(
+                self.relevant_docs[split]["query-id"],
+                self.relevant_docs[split]["corpus-id"],
+            ):
                 relevant_docs[split][query_id][corpus_id] = 1
         self.relevant_docs = relevant_docs
 

--- a/mteb/tasks/Retrieval/eng/NanoSciFactRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/NanoSciFactRetrieval.py
@@ -78,7 +78,10 @@ class NanoSciFactRetrieval(AbsTaskRetrieval):
 
         for split in self.relevant_docs:
             relevant_docs[split] = defaultdict(dict)
-            for query_id, corpus_id in zip(self.relevant_docs[split]["query-id"], self.relevant_docs[split]["corpus-id"]):
+            for query_id, corpus_id in zip(
+                self.relevant_docs[split]["query-id"],
+                self.relevant_docs[split]["corpus-id"],
+            ):
                 relevant_docs[split][query_id][corpus_id] = 1
         self.relevant_docs = relevant_docs
 

--- a/mteb/tasks/Retrieval/eng/NanoSciFactRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/NanoSciFactRetrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections import defaultdict
+
 from datasets import load_dataset
 
 from mteb.abstasks.AbsTaskRetrieval import AbsTaskRetrieval
@@ -72,12 +74,12 @@ class NanoSciFactRetrieval(AbsTaskRetrieval):
             for split in self.queries
         }
 
-        self.relevant_docs = {
-            split: {
-                sample["query-id"]: {sample["corpus-id"]: 1}
-                for sample in self.relevant_docs[split]
-            }
-            for split in self.relevant_docs
-        }
+        relevant_docs = {}
+
+        for split in self.relevant_docs:
+            relevant_docs[split] = defaultdict(dict)
+            for query_id, corpus_id in zip(self.relevant_docs[split]["query-id"], self.relevant_docs[split]["corpus-id"]):
+                relevant_docs[split][query_id][corpus_id] = 1
+        self.relevant_docs = relevant_docs
 
         self.data_loaded = True

--- a/mteb/tasks/Retrieval/eng/NanoTouche2020Retrieval.py
+++ b/mteb/tasks/Retrieval/eng/NanoTouche2020Retrieval.py
@@ -89,7 +89,10 @@ class NanoTouche2020Retrieval(AbsTaskRetrieval):
 
         for split in self.relevant_docs:
             relevant_docs[split] = defaultdict(dict)
-            for query_id, corpus_id in zip(self.relevant_docs[split]["query-id"], self.relevant_docs[split]["corpus-id"]):
+            for query_id, corpus_id in zip(
+                self.relevant_docs[split]["query-id"],
+                self.relevant_docs[split]["corpus-id"],
+            ):
                 relevant_docs[split][query_id][corpus_id] = 1
         self.relevant_docs = relevant_docs
 

--- a/mteb/tasks/Retrieval/eng/NanoTouche2020Retrieval.py
+++ b/mteb/tasks/Retrieval/eng/NanoTouche2020Retrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections import defaultdict
+
 from datasets import load_dataset
 
 from mteb.abstasks.AbsTaskRetrieval import AbsTaskRetrieval
@@ -83,12 +85,12 @@ class NanoTouche2020Retrieval(AbsTaskRetrieval):
             for split in self.queries
         }
 
-        self.relevant_docs = {
-            split: {
-                sample["query-id"]: {sample["corpus-id"]: 1}
-                for sample in self.relevant_docs[split]
-            }
-            for split in self.relevant_docs
-        }
+        relevant_docs = {}
+
+        for split in self.relevant_docs:
+            relevant_docs[split] = defaultdict(dict)
+            for query_id, corpus_id in zip(self.relevant_docs[split]["query-id"], self.relevant_docs[split]["corpus-id"]):
+                relevant_docs[split][query_id][corpus_id] = 1
+        self.relevant_docs = relevant_docs
 
         self.data_loaded = True


### PR DESCRIPTION
## Checklist
<!-- Please do not delete this -->

- [X] Run tests locally to make sure nothing is broken using `make test`. 
- [X] Run the formatter to format the code using `make lint`. 

In the previous implementation, each query could only have one relevant document, but in most datasets, queries can have multiple relevant documents.

Results https://github.com/embeddings-benchmark/mteb/issues/1627#issuecomment-2568373454, https://github.com/embeddings-benchmark/results/pull/84
Closes https://github.com/embeddings-benchmark/mteb/issues/1627

