### PR TITLE
fix: bucc

### DIFF
--- a/mteb/tasks/BitextMining/multilingual/BUCCBitextMining.py
+++ b/mteb/tasks/BitextMining/multilingual/BUCCBitextMining.py
@@ -57,24 +57,3 @@ class BUCCBitextMining(AbsTaskBitextMining, MultilingualTask):
     abstract = "This paper presents the BUCC 2017 shared task on parallel sentence extraction from comparable corpora. It recalls the design of the datasets, presents their final construction and statistics and the methods used to evaluate system results. 13 runs were submitted to the shared task by 4 teams, covering three of the four proposed language pairs: French-English (7 runs), German-English (3 runs), and Chinese-English (3 runs). The best F-scores as measured against the gold standard were 0.84 (German-English), 0.80 (French-English), and 0.43 (Chinese-English). Because of the design of the dataset, in which not all gold parallel sentence pairs are known, these are only minimum values. We examined manually a small sample of the false negative sentence pairs for the most precise French-English runs and estimated the number of parallel sentence pairs not yet in the provided gold standard. Adding them to the gold standard leads to revised estimates for the French-English F-scores of at most +1.5pt. This suggests that the BUCC 2017 datasets provide a reasonable approximate evaluation of the parallel sentence spotting task.",
 }""",
     )
-
-    def dataset_transform(self):
-        dataset = {}
-        for lang in self.dataset:
-            dataset[lang] = {}
-            for split in _SPLITS:
-                data = self.dataset[lang][split]
-                gold = data["gold"][0]
-                gold = [(i - 1, j - 1) for (i, j) in gold]
-
-                sentence1 = data["sentence1"][0]
-                sentence2 = data["sentence2"][0]
-                sentence1 = [sentence1[i] for (i, j) in gold]
-                print(lang, len(gold))
-                print(len(sentence1), len(sentence2))
-                dataset[lang][split] = {
-                    "sentence1": sentence1,
-                    "sentence2": sentence2,
-                    "gold": gold,
-                }
-        self.dataset = dataset


### PR DESCRIPTION
Closes: https://github.com/embeddings-benchmark/mteb/issues/1694


## Checklist
<!-- Please do not delete this -->

- [X] Run tests locally to make sure nothing is broken using `make test`. 
- [X] Run the formatter to format the code using `make lint`. 

| | Leaderboard | PR |
|-|-|-|
| de-en | 97.86 | 98.9579 |
| fr-en | 92.66 | 97.3538 |
| ru-en | 93.5 | 96.9278 |
| zh-en | 88.79 | 96.4016 |

I tried running it with pre-#1674 (`v1.25.15`), but it still gave an error because it's not a `datasets.Dataset`. When I cast it to `Dataset`, it gave an error due to columns having different sizes. I'm curious about the intuition behind the `gold` column, as other bitext datasets don't seem to use it.

https://github.com/embeddings-benchmark/mteb/blob/0753abaacb31989e00b8e00322254cce85903639/mteb/tasks/BitextMining/multilingual/BUCCBitextMining.py#L72
I think maybe second parameter of golden supposed to be as `sentence2`, but then never used?