### PR TITLE
Fix: minicpmv2

### DIFF
--- a/mteb/models/misc_models.py
+++ b/mteb/models/misc_models.py
@@ -1555,14 +1555,13 @@ omarelshehy__arabic_english_sts_matryoshka = ModelMeta(
 )
 openbmb__MiniCPM_Embedding = ModelMeta(
     loader=partial(  # type: ignore
-        # reqieres flash attention, tiktoken, blobfile, protobuf
         sentence_transformers_loader,
         model_name="openbmb/MiniCPM-Embedding",
         revision="c0cb2de33fb366e17c30f9d53142ff11bc18e049",
         # https://huggingface.co/openbmb/MiniCPM-Embedding/blob/c0cb2de33fb366e17c30f9d53142ff11bc18e049/README.md?code=true#L405
         model_kwargs={
-            # "attn_implementation": "flash_attention_2",
-            "torch_dtype": torch.float16
+            "attn_implementation": "flash_attention_2",
+            "torch_dtype": torch.float16,
         },
         trust_remote_code=True,
     ),

--- a/mteb/models/misc_models.py
+++ b/mteb/models/misc_models.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from functools import partial
 
+import torch
+
 from mteb.model_meta import ModelMeta, sentence_transformers_loader
 
 Haon_Chen__speed_embedding_7b_instruct = ModelMeta(
@@ -1553,9 +1555,15 @@ omarelshehy__arabic_english_sts_matryoshka = ModelMeta(
 )
 openbmb__MiniCPM_Embedding = ModelMeta(
     loader=partial(  # type: ignore
+        # reqieres flash attention, tiktoken, blobfile, protobuf
         sentence_transformers_loader,
         model_name="openbmb/MiniCPM-Embedding",
         revision="c0cb2de33fb366e17c30f9d53142ff11bc18e049",
+        # https://huggingface.co/openbmb/MiniCPM-Embedding/blob/c0cb2de33fb366e17c30f9d53142ff11bc18e049/README.md?code=true#L405
+        model_kwargs={
+            # "attn_implementation": "flash_attention_2",
+            "torch_dtype": torch.float16
+        },
         trust_remote_code=True,
     ),
     name="openbmb/MiniCPM-Embedding",

--- a/mteb/models/misc_models.py
+++ b/mteb/models/misc_models.py
@@ -1560,7 +1560,7 @@ openbmb__MiniCPM_Embedding = ModelMeta(
         revision="c0cb2de33fb366e17c30f9d53142ff11bc18e049",
         # https://huggingface.co/openbmb/MiniCPM-Embedding/blob/c0cb2de33fb366e17c30f9d53142ff11bc18e049/README.md?code=true#L405
         model_kwargs={
-            "attn_implementation": "flash_attention_2",
+            # "attn_implementation": "flash_attention_2",
             "torch_dtype": torch.float16,
         },
         trust_remote_code=True,


### PR DESCRIPTION
I haven't checked the performance because it was only tested on CMTEB, which includes very large tasks. Additionally, they probably ran it with instructions, but this needs to be verified. Also commented out `flash_attention_2`, because I've tested model on kaggle and `flash_attention_2` is not supporting T4. 

Closes https://github.com/embeddings-benchmark/mteb/issues/1696


## Checklist
- [X] Run tests locally to make sure nothing is broken using `make test`. 
- [X] Run the formatter to format the code using `make lint`. 


### Adding a model checklist
 - [X] I have ensured that my model can be loaded using
   - [X] `mteb.get_model(model_name)`