### PR TITLE
fix: rollback BUCC revision

### DIFF
--- a/mteb/evaluation/evaluators/BitextMiningEvaluator.py
+++ b/mteb/evaluation/evaluators/BitextMiningEvaluator.py
@@ -44,9 +44,12 @@ class BitextMiningEvaluator(Evaluator):
 
     def compute_metrics(self, model: Encoder, encode_kwargs: dict[str, Any] = {}):
         pair_elements = {p for pair in self.pairs for p in pair}
-        subsets = [
-            col for col in self.sentences.features.keys() if col in pair_elements
-        ]
+        if isinstance(self.sentences, Dataset):
+            subsets = [
+                col for col in self.sentences.features.keys() if col in pair_elements
+            ]
+        else:
+            subsets = [col for col in pair_elements]
         n_subsets = len(subsets)
 
         embeddings = {}

--- a/mteb/evaluation/evaluators/BitextMiningEvaluator.py
+++ b/mteb/evaluation/evaluators/BitextMiningEvaluator.py
@@ -50,7 +50,7 @@ class BitextMiningEvaluator(Evaluator):
             ]
         else:
             # BUCC outputs a dict instead of a Dataset
-            subsets = [col for col in pair_elements]
+            subsets = list(pair_elements)
         n_subsets = len(subsets)
 
         embeddings = {}

--- a/mteb/evaluation/evaluators/BitextMiningEvaluator.py
+++ b/mteb/evaluation/evaluators/BitextMiningEvaluator.py
@@ -49,6 +49,7 @@ class BitextMiningEvaluator(Evaluator):
                 col for col in self.sentences.features.keys() if col in pair_elements
             ]
         else:
+            # BUCC outputs a dict instead of a Dataset
             subsets = [col for col in pair_elements]
         n_subsets = len(subsets)
 

--- a/mteb/tasks/BitextMining/multilingual/BUCCBitextMining.py
+++ b/mteb/tasks/BitextMining/multilingual/BUCCBitextMining.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from mteb import logging
+import logging
+
 from mteb.abstasks.AbsTaskBitextMining import AbsTaskBitextMining
 from mteb.abstasks.MultilingualTask import MultilingualTask
 from mteb.abstasks.TaskMetadata import TaskMetadata

--- a/mteb/tasks/BitextMining/multilingual/BUCCBitextMining.py
+++ b/mteb/tasks/BitextMining/multilingual/BUCCBitextMining.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from mteb import logging
 from mteb.abstasks.AbsTaskBitextMining import AbsTaskBitextMining
 from mteb.abstasks.MultilingualTask import MultilingualTask
 from mteb.abstasks.TaskMetadata import TaskMetadata
@@ -14,6 +15,8 @@ _LANGUAGES = {
 
 _SPLITS = ["test"]
 
+logger = logging.getLogger(__name__)
+
 
 class BUCCBitextMining(AbsTaskBitextMining, MultilingualTask):
     superseded_by = "BUCC.v2"
@@ -21,7 +24,8 @@ class BUCCBitextMining(AbsTaskBitextMining, MultilingualTask):
         name="BUCC",
         dataset={
             "path": "mteb/bucc-bitext-mining",
-            "revision": "1739dc11ffe9b7bfccd7f3d585aeb4c544fc6677",
+            "revision": "d51519689f32196a32af33b075a01d0e7c51e252",
+            "trust_remote_code": True,
         },
         description="BUCC bitext mining dataset",
         reference="https://comparable.limsi.fr/bucc2018/bucc2018-task.html",
@@ -70,8 +74,9 @@ class BUCCBitextMining(AbsTaskBitextMining, MultilingualTask):
                 sentence1 = data["sentence1"][0]
                 sentence2 = data["sentence2"][0]
                 sentence1 = [sentence1[i] for (i, j) in gold]
-                print(lang, len(gold))
-                print(len(sentence1), len(sentence2))
+                logger.info(f"Lang {lang} num gold {len(gold)}")
+                logger.info(f"Lang {lang} num sentence1 {len(sentence1)}")
+                logger.info(f"Lang {lang} num sentence2 {len(sentence2)}")
                 dataset[lang][split] = {
                     "sentence1": sentence1,
                     "sentence2": sentence2,


### PR DESCRIPTION
## Checklist
<!-- Please do not delete this -->

- [X] Run tests locally to make sure nothing is broken using `make test`. 
- [X] Run the formatter to format the code using `make lint`. 

Closing: https://github.com/embeddings-benchmark/mteb/issues/1694

Results for `sentence-transformers/LaBSE`, since I can't reproduce results for `intfloat/multilingual-e5-small`. Maybe they used for `query: ` as prefix here.

| | Leaderboard (BUCC) | PR (BUCC) | BUCC.v2 |
|-|-|-|-|
| de-en | 99.35 | 99.3633 | 99.4294 |
| fr-en | 98.72 | 98.716 | 98.9489 |
| ru-en | 97.78 | 97.7755 | 97.4614 |
| zh-en | 99.16 | 99.1575 | 99.2277 |