### PR TITLE
fix: add version check e5-v in mieb

### DIFF
--- a/mteb/models/e5_v.py
+++ b/mteb/models/e5_v.py
@@ -14,8 +14,9 @@ from transformers import LlavaNextForConditionalGeneration, LlavaNextProcessor
 from mteb.encoder_interface import PromptType
 from mteb.model_meta import ModelMeta
 
-
-E5_V_TRANSFORMERS_VERSION = "4.44.2" # Issue 1647: Only works with transformers==4.44.2.
+E5_V_TRANSFORMERS_VERSION = (
+    "4.44.2"  # Issue 1647: Only works with transformers==4.44.2.
+)
 
 
 class E5VWrapper:
@@ -25,8 +26,12 @@ class E5VWrapper:
         composed_prompt=None,
         **kwargs: Any,
     ):
-        if version.parse(transformers.__version__) != version.parse(E5_V_TRANSFORMERS_VERSION):
-            raise ImportError(f"This wrapper only works with transformers=={E5_V_TRANSFORMERS_VERSION}")
+        if version.parse(transformers.__version__) != version.parse(
+            E5_V_TRANSFORMERS_VERSION
+        ):
+            raise ImportError(
+                f"This wrapper only works with transformers=={E5_V_TRANSFORMERS_VERSION}"
+            )
 
         self.model_name = model_name
         self.processor = LlavaNextProcessor.from_pretrained(model_name)

--- a/mteb/models/e5_v.py
+++ b/mteb/models/e5_v.py
@@ -15,6 +15,9 @@ from mteb.encoder_interface import PromptType
 from mteb.model_meta import ModelMeta
 
 
+E5_V_TRANSFORMERS_VERSION = "4.44.2" # Issue 1647: Only works with transformers==4.44.2.
+
+
 class E5VWrapper:
     def __init__(
         self,
@@ -22,9 +25,8 @@ class E5VWrapper:
         composed_prompt=None,
         **kwargs: Any,
     ):
-        # Issue 1647: Only works with transformers==4.44.2.
-        if version.parse(transformers.__version__) != version.parse("4.44.2"):
-            raise ImportError("This wrapper only works with transformers==4.44.2")
+        if version.parse(transformers.__version__) != version.parse(E5_V_TRANSFORMERS_VERSION):
+            raise ImportError(f"This wrapper only works with transformers=={E5_V_TRANSFORMERS_VERSION}")
 
         self.model_name = model_name
         self.processor = LlavaNextProcessor.from_pretrained(model_name)

--- a/mteb/models/e5_v.py
+++ b/mteb/models/e5_v.py
@@ -4,6 +4,8 @@ from functools import partial
 from typing import Any
 
 import torch
+import transformers
+from packaging import version
 from PIL import Image
 from torch.utils.data import DataLoader
 from tqdm import tqdm
@@ -20,6 +22,10 @@ class E5VWrapper:
         composed_prompt=None,
         **kwargs: Any,
     ):
+        # Issue 1647: Only works with transformers==4.44.2.
+        if version.parse(transformers.__version__) != version.parse("4.44.2"):
+            raise ImportError("This wrapper only works with transformers==4.44.2")
+
         self.model_name = model_name
         self.processor = LlavaNextProcessor.from_pretrained(model_name)
         if "device" in kwargs:


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->
Fixes #1647 

Running `python mteb/models/e5_v.py` now returns
```
ImportError: This wrapper only works with transformers==4.44.2
```

## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 
