### PR TITLE
feat: reduce logging for load_results()

### DIFF
--- a/mteb/load_results/load_results.py
+++ b/mteb/load_results/load_results.py
@@ -163,7 +163,7 @@ def load_results(
                         r = r.validate_and_filter_scores(task=task)
                         filtered_results.append(r)
                     except Exception as e:
-                        logger.warning(
+                        logger.info(
                             f"Validation failed for {r.task_name} in {model_name} {revision}: {e}"
                         )
                 _results = filtered_results

--- a/mteb/load_results/task_results.py
+++ b/mteb/load_results/task_results.py
@@ -511,8 +511,15 @@ class TaskResult(BaseModel):
                 new_scores[split].append(_scores)
                 seen_subsets.add(_scores["hf_subset"])
             if seen_subsets != hf_subsets:
+                missing_subsets = hf_subsets - seen_subsets
+                if len(missing_subsets) > 2:
+                    subset1, subset2 = list(missing_subsets)[:2]
+                    missing_subsets_str = f"{{'{subset1}', '{subset2}', ...}}"
+                else:
+                    missing_subsets_str = str(missing_subsets)
+
                 logger.warning(
-                    f"{task.metadata.name}: Missing subsets {hf_subsets - seen_subsets} for split {split}"
+                    f"{task.metadata.name}: Missing subsets {missing_subsets_str} for split {split}"
                 )
             seen_splits.add(split)
         if seen_splits != set(splits):

--- a/mteb/tasks/Classification/eng/EmotionClassification.py
+++ b/mteb/tasks/Classification/eng/EmotionClassification.py
@@ -16,7 +16,7 @@ class EmotionClassification(AbsTaskClassification):
         type="Classification",
         category="s2s",
         modalities=["text"],
-        eval_splits=["validation", "test"],
+        eval_splits=["test"],
         eval_langs=["eng-Latn"],
         main_score="accuracy",
         date=(

--- a/mteb/tasks/PairClassification/eng/SprintDuplicateQuestionsPC.py
+++ b/mteb/tasks/PairClassification/eng/SprintDuplicateQuestionsPC.py
@@ -17,7 +17,7 @@ class SprintDuplicateQuestionsPC(AbsTaskPairClassification):
         type="PairClassification",
         category="s2s",
         modalities=["text"],
-        eval_splits=["validation", "test"],
+        eval_splits=["test"],
         eval_langs=["eng-Latn"],
         main_score="max_ap",
         date=(

--- a/mteb/tasks/Retrieval/eng/FiQA2018Retrieval.py
+++ b/mteb/tasks/Retrieval/eng/FiQA2018Retrieval.py
@@ -19,7 +19,7 @@ class FiQA2018(AbsTaskRetrieval):
         type="Retrieval",
         category="s2p",
         modalities=["text"],
-        eval_splits=["train", "dev", "test"],
+        eval_splits=["test"],
         eval_langs=["eng-Latn"],
         main_score="ndcg_at_10",
         date=None,

--- a/mteb/tasks/Retrieval/eng/MSMARCORetrieval.py
+++ b/mteb/tasks/Retrieval/eng/MSMARCORetrieval.py
@@ -19,7 +19,7 @@ class MSMARCO(AbsTaskRetrieval):
         type="Retrieval",
         category="s2p",
         modalities=["text"],
-        eval_splits=["train", "dev", "test"],
+        eval_splits=["dev"],
         eval_langs=["eng-Latn"],
         main_score="ndcg_at_10",
         date=None,

--- a/mteb/tasks/Retrieval/eng/QuoraRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/QuoraRetrieval.py
@@ -22,7 +22,7 @@ class QuoraRetrieval(AbsTaskRetrieval):
         type="Retrieval",
         category="s2s",
         modalities=["text"],
-        eval_splits=["dev", "test"],
+        eval_splits=["test"],
         eval_langs=["eng-Latn"],
         main_score="ndcg_at_10",
         date=None,

--- a/mteb/tasks/Retrieval/eng/SciFactRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/SciFactRetrieval.py
@@ -17,7 +17,7 @@ class SciFact(AbsTaskRetrieval):
         type="Retrieval",
         category="s2p",
         modalities=["text"],
-        eval_splits=["train", "test"],
+        eval_splits=["test"],
         eval_langs=["eng-Latn"],
         main_score="ndcg_at_10",
         date=None,


### PR DESCRIPTION
potentially related to #1724

- redacts missing subsets to avoid 100+ subsets printed to a max of 2 (see below)
- reduce to logging.info instead of logging.warning
- removed splits that are commonly never evaluated on and thus also the errors for them being missing

The second part removed quite a few warnings (4930 to 3865)

It also seems like these train splits were accidentally included in some of the MMTEB benchmark.
This will remove those splits from those benchmarks (which are all in beta, so I believe that is fine). We will have to recompute the tables for the paper though (which we should probably do anyway).

I also found what I believe to be an error: Scifact (train) was is included in MTEB(Medical). I have removed the "train" split (alspochecked other tasks in benchmark)

Here is a count of the current top errors (along with reason for not removing them):
```py
{
    "MassiveScenarioClassification: Missing splits {'validation'}": 238,  # included in e.g. mteb(fra)
    "MassiveIntentClassification: Missing splits {'validation'}": 237, # included in e.g. mteb(fra)
    "MassiveScenarioClassification: Missing subsets {'af', 'da', ...} for split test": 230,
    "AmazonReviewsClassification: Missing splits {'validation'}": 229, # included in e.g. mteb(deu)
    "MassiveIntentClassification: Missing subsets {'af', 'da', ...} for split test": 228,
    "STS22: Missing subsets {'fr-pl', 'de-en', ...} for split test": 223,
    "AmazonReviewsClassification: Missing subsets {'es', 'ja', ...} for split test": 196,
    "MTOPDomainClassification: Missing splits {'validation'}": 195, # included in mteb(fra)
    "MTOPIntentClassification: Missing splits {'validation'}": 194, # included in mteb(fra)
    "AmazonCounterfactualClassification: Missing splits {'validation'}": 189, # included in mteb(deu)
    "MTOPDomainClassification: Missing subsets {'es', 'th', ...} for split test": 165,
    "STS17: Missing subsets {'en-ar', 'es-es', ...} for split test": 164,
    "MTOPIntentClassification: Missing subsets {'es', 'th', ...} for split test": 164,
    "AmazonCounterfactualClassification: Missing subsets {'de', 'ja', ...} for split test": 148,
}
```

One could argue that we should just remove this logging as it might hide potentially more severe logging.

<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->


## Checklist
<!-- Please do not delete this -->

- [ ] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 
