### PR TITLE
Fixed result loading on leaderboard

### DIFF
--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -20,7 +20,9 @@ from mteb.models.overview import get_model_meta
 def load_results():
     results_cache_path = Path(__file__).parent.joinpath("__cached_results.json")
     if not results_cache_path.exists():
-        all_results = mteb.load_results()
+        all_results = (
+            mteb.load_results(only_main_score=True).join_revisions().filter_models()
+        )
         all_results.to_disk(results_cache_path)
         return all_results
     else:
@@ -110,7 +112,7 @@ def update_task_info(task_names: str) -> gr.DataFrame:
     return gr.DataFrame(df, datatype=["markdown"] + ["str"] * (len(df.columns) - 1))
 
 
-all_results = load_results().join_revisions().filter_models()
+all_results = load_results()
 
 # Model sizes in million parameters
 min_model_size, max_model_size = 0, 10_000

--- a/mteb/leaderboard/figures.py
+++ b/mteb/leaderboard/figures.py
@@ -22,8 +22,8 @@ def failsafe_plot(fun):
     def wrapper(*args, **kwargs):
         try:
             return fun(*args, **kwargs)
-        except Exception:
-            return text_plot("Couldn't produce plot.")
+        except Exception as e:
+            return text_plot(f"Couldn't produce plot. Reason: {e}")
 
     return wrapper
 
@@ -110,7 +110,9 @@ def performance_size_plot(df: pd.DataFrame) -> go.Figure:
     df["Max Tokens"] = df["Max Tokens"].map(parse_float)
     df["Log(Tokens)"] = np.log10(df["Max Tokens"])
     df["Mean (Task)"] = df["Mean (Task)"].map(parse_float)
-    df = df.dropna(subset=["Mean (Task)", "Number of Parameters"])
+    df = df.dropna(
+        subset=["Mean (Task)", "Number of Parameters", "Embedding Dimensions"]
+    )
     if not len(df.index):
         return go.Figure()
     min_score, max_score = df["Mean (Task)"].min(), df["Mean (Task)"].max()

--- a/mteb/load_results/load_results.py
+++ b/mteb/load_results/load_results.py
@@ -90,6 +90,7 @@ def load_results(
     tasks: Sequence[AbsTask] | Sequence[str] | None = None,
     validate_and_filter: bool = True,
     require_model_meta: bool = True,
+    only_main_score: bool = False,
 ) -> BenchmarkResults:
     """Loads the results from the latest version of the results repository. The results are cached locally in the MTEB_CACHE directory.
     This directory can be set using the MTEB_CACHE environment variable or defaults to "~/.cache/mteb".
@@ -103,6 +104,7 @@ def load_results(
             extract the model name and revision from the path.
         validate_and_filter: If True it will validate that the results object for the task contains the correct splits and filter out
             splits from the results object that are not default in the task metadata. Defaults to True.
+        only_main_score: If True, only the main score will be loaded.
     """
     repo_directory = download_of_results(results_repo, download_latest=download_latest)
     model_paths = [p for p in (repo_directory / "results").glob("*") if p.is_dir()]
@@ -146,7 +148,12 @@ def load_results(
             task_json_files = [
                 f for f in revision_path.glob("*.json") if "model_meta.json" != f.name
             ]
-            _results = [TaskResult.from_disk(f) for f in task_json_files]
+            _results = []
+            for f in task_json_files:
+                task_res = TaskResult.from_disk(f)
+                if only_main_score:
+                    task_res = task_res.only_main_score()
+                _results.append(task_res)
 
             # filter out tasks that are not in the tasks list
             if tasks is not None:

--- a/mteb/load_results/task_results.py
+++ b/mteb/load_results/task_results.py
@@ -291,10 +291,13 @@ class TaskResult(BaseModel):
                 )
 
         pre_1_11_load = (
-            "mteb_version" in data
-            and data["mteb_version"] is not None
-            and Version(data["mteb_version"]) < Version("1.11.0")
-        ) or "mteb_version" not in data  # assume it is before 1.11.0 if the version is not present
+            (
+                "mteb_version" in data
+                and data["mteb_version"] is not None
+                and Version(data["mteb_version"]) < Version("1.11.0")
+            )
+            or "mteb_version" not in data
+        )  # assume it is before 1.11.0 if the version is not present
 
         try:
             obj = cls.model_validate(data)


### PR DESCRIPTION
When using the leaderboard, only main scores get loaded thereby preventing OOM errors.