### PR TITLE
fix: Leaderboard Speedup

### DIFF
--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -117,7 +117,7 @@ def update_task_info(task_names: str) -> gr.DataFrame:
     return gr.DataFrame(df, datatype=["markdown"] + ["str"] * (len(df.columns) - 1))
 
 
-print("Loading all benchmark results")
+logger.info("Loading all benchmark results")
 all_results = load_results()
 
 # Model sizes in million parameters
@@ -130,7 +130,7 @@ all_benchmark_results = {
 }
 default_benchmark = mteb.get_benchmark("MTEB(Multilingual, beta)")
 default_results = all_benchmark_results[default_benchmark.name]
-print("Benchmark results loaded")
+logger.info("Benchmark results loaded")
 
 default_scores = default_results.get_scores(format="long")
 summary_table, per_task_table = scores_to_tables(default_scores)

--- a/mteb/leaderboard/table.py
+++ b/mteb/leaderboard/table.py
@@ -158,6 +158,10 @@ def scores_to_tables(
     joint_table.insert(0, "mean", overall_mean)
     joint_table.insert(1, "mean_by_task_type", typed_mean)
     joint_table["borda_rank"] = get_borda_rank(per_task)
+    joint_table = joint_table.sort_values("borda_rank", ascending=True)
+    per_task["borda_rank"] = joint_table["borda_rank"]
+    per_task = per_task.sort_values("borda_rank", ascending=True)
+    per_task = per_task.drop(columns=["borda_rank"])
     joint_table = joint_table.reset_index()
     model_metas = joint_table["model_name"].map(failsafe_get_model_meta)
     joint_table = joint_table[model_metas.notna()]
@@ -181,8 +185,6 @@ def scores_to_tables(
     joint_table.insert(
         1, "Zero-shot", model_metas.map(lambda m: get_zero_shot_emoji(m, tasks))
     )
-    joint_table = joint_table.sort_values("borda_rank", ascending=True)
-    per_task = per_task.loc[joint_table.set_index("model_name").index]
     # Removing HF organization from model
     joint_table["model_name"] = joint_table["model_name"].map(
         lambda name: name.split("/")[-1]

--- a/mteb/load_results/benchmark_results.py
+++ b/mteb/load_results/benchmark_results.py
@@ -87,21 +87,35 @@ class ModelResult(BaseModel):
         splits: list[Split] | None = None,
         languages: list[ISO_LANGUAGE | ISO_LANGUAGE_SCRIPT] | None = None,
         scripts: list[ISO_LANGUAGE_SCRIPT] | None = None,
-        getter: Callable[[ScoresDict], Score] = lambda scores: scores["main_score"],
-        aggregation: Callable[[list[Score]], Any] = np.mean,
+        getter: Callable[[ScoresDict], Score] | None = None,
+        aggregation: Callable[[list[Score]], Any] | None = None,
         format: Literal["wide", "long"] = "wide",
     ) -> dict | list:
+        if (getter is not None) or (aggregation is not None) or (scripts is not None):
+            use_fast = False
+            getter = (
+                getter if getter is not None else lambda scores: scores["main_score"]
+            )
+            aggregation = aggregation if aggregation is not None else np.mean
+        else:
+            use_fast = True
         if format == "wide":
             scores = {}
             for res in self.task_results:
                 try:
-                    scores[res.task_name] = res.get_score(
-                        splits=splits,
-                        languages=languages,
-                        scripts=scripts,
-                        getter=getter,
-                        aggregation=aggregation,
-                    )
+                    if use_fast:
+                        scores[res.task_name] = res.get_score_fast(
+                            splits=splits,
+                            languages=languages,
+                        )
+                    else:
+                        scores[res.task_name] = res.get_score(
+                            splits=splits,
+                            languages=languages,
+                            aggregation=aggregation,
+                            getter=getter,
+                            scripts=scripts,
+                        )
                 except Exception as e:
                     warnings.warn(
                         f"Couldn't get scores for {res.task_name} due to {e}."
@@ -111,16 +125,23 @@ class ModelResult(BaseModel):
             entries = []
             for task_res in self.task_results:
                 try:
+                    if use_fast:
+                        score = task_res.get_score_fast(
+                            splits=splits, languages=languages
+                        )
+                    else:
+                        score = task_res.get_score(
+                            splits=splits,
+                            languages=languages,
+                            aggregation=aggregation,
+                            getter=getter,
+                            scripts=scripts,
+                        )
                     entry = dict(  # noqa
                         model_name=self.model_name,
                         model_revision=self.model_revision,
                         task_name=task_res.task_name,
-                        score=task_res.get_score(
-                            splits=splits,
-                            languages=languages,
-                            getter=getter,
-                            aggregation=aggregation,
-                        ),
+                        score=score,
                         mteb_version=task_res.mteb_version,
                         dataset_revision=task_res.dataset_revision,
                         evaluation_time=task_res.evaluation_time,
@@ -285,8 +306,8 @@ class BenchmarkResults(BaseModel):
         splits: list[Split] | None = None,
         languages: list[ISO_LANGUAGE | ISO_LANGUAGE_SCRIPT] | None = None,
         scripts: list[ISO_LANGUAGE_SCRIPT] | None = None,
-        getter: Callable[[ScoresDict], Score] = lambda scores: scores["main_score"],
-        aggregation: Callable[[list[Score]], Any] = np.mean,
+        getter: Callable[[ScoresDict], Score] = None,
+        aggregation: Callable[[list[Score]], Any] = None,
         format: Literal["wide", "long"] = "wide",
     ) -> list[dict]:
         entries = []

--- a/mteb/load_results/task_results.py
+++ b/mteb/load_results/task_results.py
@@ -470,6 +470,35 @@ class TaskResult(BaseModel):
 
             return aggregation(values)
 
+    def get_score_fast(self, splits, languages):
+        """Sped up version of get_score that will be used if no aggregation, script or getter needs to be specified."""
+        if splits is None:
+            splits = self.scores
+        val_sum = 0
+        n_val = 0
+        for split in splits:
+            if split not in self.scores:
+                raise ValueError(f"Split missing from scores: {split}")
+                continue
+            for scores in self.scores[split]:
+                langs = scores["languages"]
+                hf_subset = scores["hf_subset"]
+                main_score = scores.get("main_score", None)
+                if main_score is None:
+                    raise ValueError(f"Missing main score for subset: {hf_subset}")
+                if languages is None:
+                    val_sum += main_score
+                    n_val += 1
+                    continue
+                for lang in langs:
+                    if lang.split("-")[0] in languages:
+                        val_sum += main_score
+                        n_val += 1
+                        break
+        if n_val == 0:
+            raise ValueError("No splits had scores for the specified languages.")
+        return val_sum / n_val
+
     @classmethod
     def from_validated(cls, **data) -> TaskResult:
         return cls.model_construct(**data)
@@ -493,7 +522,7 @@ class TaskResult(BaseModel):
         new_res = TaskResult.from_validated(**new_res)
         return new_res
 
-    def validate_and_filter_scores(self, task: AbsTask | None = None) -> AbsTask:
+    def validate_and_filter_scores(self, task: AbsTask | None = None) -> TaskResult:
         """This ensures that the scores are correct for the given task, by removing any splits besides those specified in the task metadata.
         Additionally it also ensure that all of the splits required as well as the languages are present in the scores.
         Returns new TaskResult object.


### PR DESCRIPTION
Due to the huge increase in data, I needed to optimize the leaderboard again.

#### `get_scores_fast`
Since one of the main issues was the amount of time it would take to call `get_scores()` I wrote a faster, more limited version plus I made sure scores only get calculated when absolutely necessary. 
I made the function itself faster by avoiding memory allocations wherever possible. On a larger scale this corresponds to a roughly 2.5x speed increase to `get_scores`

#### Dependency graph and events
I also added smarter managing of user-induced and callback-induced state changes, thereby drastically reducing the number of unnecessary callbacks.

The difference is night and day, the leaderboard went from being barely usable to quite fast :zap: 