### PR TITLE
fix: Fixed task_type aggregation on leaderboard

### DIFF
--- a/mteb/load_results/task_results.py
+++ b/mteb/load_results/task_results.py
@@ -468,7 +468,7 @@ class TaskResult(BaseModel):
                         values.append(getter(scores))
                         break
 
-            return aggregation(values)
+        return aggregation(values)
 
     def get_score_fast(self, splits, languages):
         """Sped up version of get_score that will be used if no aggregation, script or getter needs to be specified."""


### PR DESCRIPTION
We had an issue where sometimes the mean(task_type) column would come out to be something different than mean(task) when there was a single task type on a benchmark.
I have fixed this issue, as well as a problem with `get_score`.