### PR TITLE
other: add script for leaderboard compare

### DIFF
--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -5,7 +5,6 @@ import json
 import logging
 import tempfile
 import time
-from collections import defaultdict
 from pathlib import Path
 from urllib.parse import urlencode
 
@@ -17,7 +16,6 @@ import mteb
 from mteb.caching import json_cache
 from mteb.leaderboard.figures import performance_size_plot, radar_chart
 from mteb.leaderboard.table import scores_to_tables
-from mteb.models.overview import get_model_meta
 
 logger = logging.getLogger(__name__)
 
@@ -143,28 +141,28 @@ benchmark_select = gr.Dropdown(
 )
 lang_select = gr.Dropdown(
     all_results.languages,
-    value=list(sorted(default_results.languages)),
+    value=sorted(default_results.languages),
     multiselect=True,
     label="Language",
     info="Select languages to include.",
 )
 type_select = gr.Dropdown(
     all_results.task_types,
-    value=list(sorted(default_results.task_types)),
+    value=sorted(default_results.task_types),
     multiselect=True,
     label="Task Type",
     info="Select task types to include.",
 )
 domain_select = gr.Dropdown(
     all_results.domains,
-    value=list(sorted(default_results.domains)),
+    value=sorted(default_results.domains),
     multiselect=True,
     label="Domain",
     info="Select domains to include.",
 )
 task_select = gr.Dropdown(
     all_results.task_names,
-    value=list(sorted(default_results.task_names)),
+    value=sorted(default_results.task_names),
     allow_custom_value=True,
     multiselect=True,
     label="Task",
@@ -330,16 +328,16 @@ with gr.Blocks(fill_width=True, theme=gr.themes.Base(), head=head) as demo:
         benchmark = mteb.get_benchmark(benchmark_name)
         languages = [task.languages for task in benchmark.tasks if task.languages]
         languages = set(itertools.chain.from_iterable(languages))
-        languages = list(sorted(languages))
+        languages = sorted(languages)
         domains = [
             task.metadata.domains for task in benchmark.tasks if task.metadata.domains
         ]
         domains = set(itertools.chain.from_iterable(domains))
         types = {task.metadata.type for task in benchmark.tasks if task.metadata.type}
         languages, domains, types = (
-            list(sorted(languages)),
-            list(sorted(domains)),
-            list(sorted(types)),
+            sorted(languages),
+            sorted(domains),
+            sorted(types),
         )
         elapsed = time.time() - start_time
         benchmark_results = all_benchmark_results[benchmark_name]

--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -5,8 +5,8 @@ import json
 import logging
 import tempfile
 import time
-from pathlib import Path
 from collections import defaultdict
+from pathlib import Path
 from urllib.parse import urlencode
 
 import gradio as gr

--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -6,6 +6,7 @@ import logging
 import tempfile
 import time
 from pathlib import Path
+from collections import defaultdict
 from urllib.parse import urlencode
 
 import gradio as gr
@@ -16,6 +17,7 @@ import mteb
 from mteb.caching import json_cache
 from mteb.leaderboard.figures import performance_size_plot, radar_chart
 from mteb.leaderboard.table import scores_to_tables
+from mteb.models.overview import get_model_meta
 
 logger = logging.getLogger(__name__)
 
@@ -141,28 +143,28 @@ benchmark_select = gr.Dropdown(
 )
 lang_select = gr.Dropdown(
     all_results.languages,
-    value=sorted(default_results.languages),
+    value=list(sorted(default_results.languages)),
     multiselect=True,
     label="Language",
     info="Select languages to include.",
 )
 type_select = gr.Dropdown(
     all_results.task_types,
-    value=sorted(default_results.task_types),
+    value=list(sorted(default_results.task_types)),
     multiselect=True,
     label="Task Type",
     info="Select task types to include.",
 )
 domain_select = gr.Dropdown(
     all_results.domains,
-    value=sorted(default_results.domains),
+    value=list(sorted(default_results.domains)),
     multiselect=True,
     label="Domain",
     info="Select domains to include.",
 )
 task_select = gr.Dropdown(
     all_results.task_names,
-    value=sorted(default_results.task_names),
+    value=list(sorted(default_results.task_names)),
     allow_custom_value=True,
     multiselect=True,
     label="Task",
@@ -328,16 +330,16 @@ with gr.Blocks(fill_width=True, theme=gr.themes.Base(), head=head) as demo:
         benchmark = mteb.get_benchmark(benchmark_name)
         languages = [task.languages for task in benchmark.tasks if task.languages]
         languages = set(itertools.chain.from_iterable(languages))
-        languages = sorted(languages)
+        languages = list(sorted(languages))
         domains = [
             task.metadata.domains for task in benchmark.tasks if task.metadata.domains
         ]
         domains = set(itertools.chain.from_iterable(domains))
         types = {task.metadata.type for task in benchmark.tasks if task.metadata.type}
         languages, domains, types = (
-            sorted(languages),
-            sorted(domains),
-            sorted(types),
+            list(sorted(languages)),
+            list(sorted(domains)),
+            list(sorted(types)),
         )
         elapsed = time.time() - start_time
         benchmark_results = all_benchmark_results[benchmark_name]

--- a/mteb/load_results/task_results.py
+++ b/mteb/load_results/task_results.py
@@ -470,7 +470,9 @@ class TaskResult(BaseModel):
 
         return aggregation(values)
 
-    def get_score_fast(self, splits, languages):
+    def get_score_fast(
+        self, splits: str | None = None, languages: str | None = None
+    ) -> float:
         """Sped up version of get_score that will be used if no aggregation, script or getter needs to be specified."""
         if splits is None:
             splits = self.scores
@@ -479,7 +481,7 @@ class TaskResult(BaseModel):
         for split in splits:
             if split not in self.scores:
                 raise ValueError(f"Split missing from scores: {split}")
-                continue
+
             for scores in self.scores[split]:
                 langs = scores["languages"]
                 hf_subset = scores["hf_subset"]

--- a/mteb/load_results/task_results.py
+++ b/mteb/load_results/task_results.py
@@ -470,9 +470,7 @@ class TaskResult(BaseModel):
 
         return aggregation(values)
 
-    def get_score_fast(
-        self, splits: str | None, languages: str | None
-    ) -> float:
+    def get_score_fast(self, splits: str | None, languages: str | None) -> float:
         """Sped up version of get_score that will be used if no aggregation, script or getter needs to be specified."""
         if splits is None:
             splits = self.scores

--- a/mteb/load_results/task_results.py
+++ b/mteb/load_results/task_results.py
@@ -471,7 +471,7 @@ class TaskResult(BaseModel):
         return aggregation(values)
 
     def get_score_fast(
-        self, splits: str | None = None, languages: str | None = None
+        self, splits: str | None, languages: str | None
     ) -> float:
         """Sped up version of get_score that will be used if no aggregation, script or getter needs to be specified."""
         if splits is None:

--- a/scripts/compare_leaderboard_results.py
+++ b/scripts/compare_leaderboard_results.py
@@ -33,6 +33,7 @@ for model_name_to_search in models:
             task_name = task_res.task.metadata.name
             split = "test" if task_name != "MSMARCO" else "dev"
             scores = [score["main_score"] for score in task_res.scores[split]]
+            # this tmp solution, because some tasks have multiple results
             cur_model[task_name] = {"new": sum(scores) / len(scores)}
 
     for task_dir in data_tasks_path.iterdir():

--- a/scripts/compare_leaderboard_results.py
+++ b/scripts/compare_leaderboard_results.py
@@ -63,7 +63,12 @@ for model_name_to_search in models:
                                             "old"
                                         ] = value
 
-    results.append({"model": model_name_to_search, "results": cur_model})
+    sorted_cur_model = {
+        task.metadata.name: cur_model[task.metadata.name]
+        for task in MTEB_ENG_CLASSIC.tasks
+        if task.metadata.name in cur_model
+    }
+    results.append({"model": model_name_to_search, "results": sorted_cur_model})
 
 # Write results to JSONL file
 with open("results.jsonl", "w") as file:

--- a/scripts/compare_leaderboard_results.py
+++ b/scripts/compare_leaderboard_results.py
@@ -9,12 +9,12 @@ from mteb import MTEB_ENG_CLASSIC, load_results
 logging.basicConfig(level=logging.INFO)
 
 models = [
-    "intfloat/multilingual-e5-small",
-    "intfloat/multilingual-e5-base",
-    "intfloat/multilingual-e5-large",
+    "dunzhang/stella_en_1.5B_v5",
+    "dunzhang/stella_en_400M_v5",
     # Add other models here
 ]
 
+# in same folder as mteb repo
 # git clone https://github.com/embeddings-benchmark/leaderboard
 data_tasks_path = Path("../../leaderboard/boards_data/en/data_tasks/")
 
@@ -34,7 +34,7 @@ for model_name_to_search in models:
             split = "test" if task_name != "MSMARCO" else "dev"
             scores = [score["main_score"] for score in task_res.scores[split]]
             # this tmp solution, because some tasks have multiple results
-            cur_model[task_name] = {"new": sum(scores) / len(scores)}
+            cur_model[task_name] = {"new": round((sum(scores) / len(scores)) * 100, 2)}
 
     for task_dir in data_tasks_path.iterdir():
         if task_dir.is_dir():

--- a/scripts/compare_leaderboard_results.py
+++ b/scripts/compare_leaderboard_results.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from mteb import MTEB_ENG_CLASSIC, load_results
+
+logging.basicConfig(level=logging.INFO)
+
+models = [
+    "intfloat/multilingual-e5-small",
+    "intfloat/multilingual-e5-base",
+    "intfloat/multilingual-e5-large",
+    # Add other models here
+]
+
+# git clone https://github.com/embeddings-benchmark/leaderboard
+data_tasks_path = Path("../../leaderboard/boards_data/en/data_tasks/")
+
+results = []
+
+for model_name_to_search in models:
+    model_results = load_results(
+        models=[model_name_to_search],
+        tasks=MTEB_ENG_CLASSIC.tasks,
+        only_main_score=True,
+    )
+
+    cur_model = {}
+    for model_res in model_results:
+        for task_res in model_res.task_results:
+            task_name = task_res.task.metadata.name
+            split = "test" if task_name != "MSMARCO" else "dev"
+            scores = [score["main_score"] for score in task_res.scores[split]]
+            cur_model[task_name] = {"new": sum(scores) / len(scores)}
+
+    for task_dir in data_tasks_path.iterdir():
+        if task_dir.is_dir():
+            results_file_path = task_dir / "default.jsonl"
+            if results_file_path.exists():
+                with open(results_file_path) as file:
+                    for line in file:
+                        data = json.loads(line)
+                        model_name = data.get("Model", "")
+                        if model_name_to_search in model_name:
+                            for key, value in data.items():
+                                if key in [
+                                    "index",
+                                    "Rank",
+                                    "Model",
+                                    "Model Size (Million Parameters)",
+                                    "Memory Usage (GB, fp32)",
+                                    "Embedding Dimensions",
+                                    "Max Tokens",
+                                    "Average",
+                                ]:
+                                    continue
+                                for benchmark_task in MTEB_ENG_CLASSIC.tasks:
+                                    if benchmark_task.metadata.name in key:
+                                        cur_model[benchmark_task.metadata.name][
+                                            "old"
+                                        ] = value
+
+    results.append({"model": model_name_to_search, "results": cur_model})
+
+# Write results to JSONL file
+with open("results.jsonl", "w") as file:
+    for result in results:
+        file.write(json.dumps(result) + "\n")
+
+# Write results to Markdown file
+with open("results.md", "w") as file:
+    for result in results:
+        file.write(f"## Model: {result['model']}\n\n")
+        file.write("| Task Name | Old Leaderboard | New Leaderboard |\n")
+        file.write("|-----------|-----------------|-----------------|\n")
+        for task_name, scores in result["results"].items():
+            old_score = scores.get("old", "N/A")
+            new_score = scores.get("new", "N/A")
+            file.write(f"| {task_name} | {old_score} | {new_score} |\n")
+        file.write("\n")


### PR DESCRIPTION
## Checklist
<!-- Please do not delete this -->

- [X] Run tests locally to make sure nothing is broken using `make test`. 
- [X] Run the formatter to format the code using `make lint`. 


ref https://github.com/embeddings-benchmark/mteb/issues/1571#issuecomment-2583329317

Results of script: [results.json](https://github.com/user-attachments/files/18382085/results.json) (this is jsonl file, but github don't allow to upload it as jsonl, only as json)

## Model: intfloat/multilingual-e5-small

| Task Name | Old Leaderboard | New Leaderboard |
|-----------|-----------------|-----------------|
| AmazonCounterfactualClassification | 71.87 | 74.8 |
| AmazonPolarityClassification | 88.61 | 88.7 |
| AmazonReviewsClassification | 45.75 | 44.7 |
| ArguAna | 39.09 | 39.06 |
| ArxivClusteringP2P | 39.22 | 39.22 |
| ArxivClusteringS2S | 30.8 | 30.8 |
| AskUbuntuDupQuestions | 56.42 | 57.88 |
| BIOSSES | 82.46 | 82.26 |
| Banking77Classification | 70.44 | 79.42 |
| BiorxivClusteringP2P | 35.84 | 35.75 |
| BiorxivClusteringS2S | 27.35 | 27.05 |
| CQADupstackAndroidRetrieval | N/A | 44.91 |
| CQADupstackEnglishRetrieval | N/A | 41.62 |
| CQADupstackGamingRetrieval | N/A | 54.83 |
| CQADupstackGisRetrieval | N/A | 33.68 |
| CQADupstackMathematicaRetrieval | N/A | 24.3 |
| CQADupstackPhysicsRetrieval | N/A | 38.46 |
| CQADupstackProgrammersRetrieval | N/A | 35.85 |
| CQADupstackStatsRetrieval | N/A | 31.48 |
| CQADupstackTexRetrieval | N/A | 25.97 |
| CQADupstackUnixRetrieval | N/A | 35.35 |
| CQADupstackWebmastersRetrieval | N/A | 36.79 |
| CQADupstackWordpressRetrieval | N/A | 29.56 |
| ClimateFEVER | 22.55 | 22.55 |
| DBPedia | 37.76 | 37.76 |
| EmotionClassification | 42.86 | 42.45 |
| FEVER | 75.27 | 75.27 |
| FiQA2018 | 33.13 | 33.31 |
| HotpotQA | 65.09 | 65.09 |
| ImdbClassification | 79.57 | 80.82 |
| MTOPDomainClassification | 88.99 | 91.07 |
| MTOPIntentClassification | 56.69 | 71.08 |
| MassiveIntentClassification | 63.87 | 70.3 |
| MassiveScenarioClassification | 69.28 | 74.48 |
| MedrxivClusteringP2P | 30.72 | 30.9 |
| MedrxivClusteringS2S | 27.0 | 27.26 |
| MindSmallReranking | 29.96 | 30.28 |
| NFCorpus | 31.0 | 31.01 |
| NQ | 56.29 | 56.29 |
| QuoraRetrieval | 86.93 | 86.93 |
| RedditClustering | 59.49 | 39.13 |
| RedditClusteringP2P | 59.49 | 58.98 |
| SCIDOCS | 13.9 | 13.89 |
| SICK-R | 77.51 | 77.51 |
| STS12 | 76.56 | 76.56 |
| STS13 | 76.97 | 76.97 |
| STS14 | 75.52 | 75.52 |
| STS15 | 87.12 | 87.12 |
| STS16 | 83.63 | 83.63 |
| STS17 | 86.42 | 71.81 |
| STS22 | 61.25 | 65.69 |
| STSBenchmark | 84.11 | 84.01 |
| SciDocsRR | 78.26 | 78.13 |
| SciFact | 67.7 | 67.7 |
| SprintDuplicateQuestions | 92.42 | 92.18 |
| StackExchangeClustering | 31.87 | 53.52 |
| StackExchangeClusteringP2P | 31.87 | 32.07 |
| StackOverflowDupQuestions | 46.97 | 49.2 |
| SummEval | 30.04 | 29.98 |
| TRECCOVID | 72.57 | 72.57 |
| Touche2020 | 21.16 | 21.16 |
| ToxicConversationsClassification | 63.59 | 69.39 |
| TweetSentimentExtractionClassification | 62.79 | 62.62 |
| TwentyNewsgroupsClustering | 33.67 | 33.22 |
| TwitterSemEval2015 | 70.75 | 70.95 |
| TwitterURLCorpus | 85.03 | 84.83 |
| MSMARCO | 40.99 | 40.99 |

## Model: intfloat/multilingual-e5-base

| Task Name | Old Leaderboard | New Leaderboard |
|-----------|-----------------|-----------------|
| AmazonCounterfactualClassification | 77.36 | 79.31 |
| AmazonPolarityClassification | 91.76 | 90.64 |
| AmazonReviewsClassification | 47.54 | 44.55 |
| ArguAna | 44.21 | 44.23 |
| ArxivClusteringP2P | 43.35 | 40.28 |
| ArxivClusteringS2S | 36.0 | 35.42 |
| AskUbuntuDupQuestions | 59.28 | 58.23 |
| BIOSSES | 85.05 | 85.06 |
| Banking77Classification | 73.53 | 82.74 |
| BiorxivClusteringP2P | 37.55 | 35.04 |
| BiorxivClusteringS2S | 30.33 | 29.46 |
| CQADupstackAndroidRetrieval | N/A | 47.83 |
| CQADupstackEnglishRetrieval | N/A | 44.06 |
| CQADupstackGamingRetrieval | N/A | 59.2 |
| CQADupstackGisRetrieval | N/A | 34.93 |
| CQADupstackMathematicaRetrieval | N/A | 27.03 |
| CQADupstackPhysicsRetrieval | N/A | 41.58 |
| CQADupstackProgrammersRetrieval | N/A | 40.7 |
| CQADupstackStatsRetrieval | N/A | 32.59 |
| CQADupstackTexRetrieval | N/A | 27.31 |
| CQADupstackUnixRetrieval | N/A | 36.73 |
| CQADupstackWebmastersRetrieval | N/A | 39.21 |
| CQADupstackWordpressRetrieval | N/A | 31.11 |
| ClimateFEVER | 23.86 | 23.86 |
| DBPedia | 40.36 | 40.36 |
| EmotionClassification | 45.68 | 45.18 |
| FEVER | 79.44 | 79.44 |
| FiQA2018 | 38.15 | 38.17 |
| HotpotQA | 68.56 | 68.56 |
| ImdbClassification | 84.29 | 85.46 |
| MTOPDomainClassification | 90.9 | 93.13 |
| MTOPIntentClassification | 61.6 | 75.27 |
| MassiveIntentClassification | 65.71 | 72.11 |
| MassiveScenarioClassification | 71.57 | 77.08 |
| MedrxivClusteringP2P | 30.6 | 28.92 |
| MedrxivClusteringS2S | 28.73 | 28.43 |
| MindSmallReranking | 29.28 | 30.97 |
| NFCorpus | 32.49 | 32.46 |
| NQ | 60.02 | 60.02 |
| QuoraRetrieval | 87.65 | 87.65 |
| RedditClustering | 61.69 | 42.41 |
| RedditClusteringP2P | 61.69 | 55.17 |
| SCIDOCS | 17.17 | 17.16 |
| SICK-R | 78.51 | 78.51 |
| STS12 | 76.7 | 76.7 |
| STS13 | 78.02 | 78.03 |
| STS14 | 76.6 | 76.6 |
| STS15 | 88.16 | 88.16 |
| STS16 | 84.28 | 84.28 |
| STS17 | 87.84 | 77.57 |
| STS22 | 62.26 | 66.21 |
| STSBenchmark | 85.64 | 85.64 |
| SciDocsRR | 81.81 | 80.74 |
| SciFact | 69.39 | 69.35 |
| SprintDuplicateQuestions | 93.02 | 93.01 |
| StackExchangeClustering | 33.51 | 55.27 |
| StackExchangeClusteringP2P | 33.51 | 30.46 |
| StackOverflowDupQuestions | 49.75 | 49.41 |
| SummEval | 30.23 | 30.11 |
| TRECCOVID | 69.5 | 69.76 |
| Touche2020 | 21.5 | 21.35 |
| ToxicConversationsClassification | 64.33 | 69.78 |
| TweetSentimentExtractionClassification | 62.8 | 61.28 |
| TwentyNewsgroupsClustering | 35.55 | 35.97 |
| TwitterSemEval2015 | 72.21 | 72.21 |
| TwitterURLCorpus | 85.48 | 85.48 |
| MSMARCO | 42.27 | 42.27 |

## Model: intfloat/multilingual-e5-large

| Task Name | Old Leaderboard | New Leaderboard |
|-----------|-----------------|-----------------|
| AmazonCounterfactualClassification | 78.67 | 79.74 |
| AmazonPolarityClassification | 93.26 | 93.49 |
| AmazonReviewsClassification | 49.2 | 47.56 |
| ArguAna | 54.36 | 54.38 |
| ArxivClusteringP2P | 44.31 | 44.31 |
| ArxivClusteringS2S | 38.43 | 38.43 |
| AskUbuntuDupQuestions | 59.24 | 60.28 |
| BIOSSES | 82.49 | 82.51 |
| Banking77Classification | 75.88 | 84.73 |
| BiorxivClusteringP2P | 35.5 | 35.34 |
| BiorxivClusteringS2S | 33.3 | 33.5 |
| CQADupstackAndroidRetrieval | N/A | 49.04 |
| CQADupstackEnglishRetrieval | N/A | 45.81 |
| CQADupstackGamingRetrieval | N/A | 58.7 |
| CQADupstackGisRetrieval | N/A | 36.95 |
| CQADupstackMathematicaRetrieval | N/A | 28.18 |
| CQADupstackPhysicsRetrieval | N/A | 43.66 |
| CQADupstackProgrammersRetrieval | N/A | 41.6 |
| CQADupstackStatsRetrieval | N/A | 32.38 |
| CQADupstackTexRetrieval | N/A | 28.36 |
| CQADupstackUnixRetrieval | N/A | 39.88 |
| CQADupstackWebmastersRetrieval | N/A | 39.88 |
| CQADupstackWordpressRetrieval | N/A | 31.64 |
| ClimateFEVER | 25.73 | 25.73 |
| DBPedia | 41.29 | 41.29 |
| EmotionClassification | 47.58 | 46.5 |
| FEVER | 82.81 | 82.81 |
| FiQA2018 | 43.81 | 43.8 |
| HotpotQA | 71.23 | 71.23 |
| ImdbClassification | 90.23 | 90.23 |
| MTOPDomainClassification | 91.81 | 93.67 |
| MTOPIntentClassification | 64.29 | 77.9 |
| MassiveIntentClassification | 68.51 | 73.76 |
| MassiveScenarioClassification | 73.04 | 77.51 |
| MedrxivClusteringP2P | 31.7 | 31.48 |
| MedrxivClusteringS2S | 29.76 | 29.71 |
| MindSmallReranking | 30.24 | 31.42 |
| NFCorpus | 33.95 | 33.98 |
| NQ | 64.06 | 64.06 |
| QuoraRetrieval | 88.18 | 88.18 |
| RedditClustering | 63.0 | 46.54 |
| RedditClusteringP2P | 63.0 | 63.22 |
| SCIDOCS | 17.45 | 17.47 |
| SICK-R | 80.23 | 80.23 |
| STS12 | 80.02 | 80.02 |
| STS13 | 81.55 | 81.55 |
| STS14 | 77.72 | 77.72 |
| STS15 | 89.31 | 89.31 |
| STS16 | 85.79 | 85.78 |
| STS17 | 88.12 | 82.09 |
| STS22 | 63.66 | 64.74 |
| STSBenchmark | 87.29 | 87.29 |
| SciDocsRR | 84.22 | 82.04 |
| SciFact | 70.42 | 70.2 |
| SprintDuplicateQuestions | 93.14 | 93.18 |
| StackExchangeClustering | 32.9 | 57.53 |
| StackExchangeClusteringP2P | 32.9 | 32.69 |
| StackOverflowDupQuestions | 50.14 | 49.72 |
| SummEval | 29.64 | 29.69 |
| TRECCOVID | 71.21 | 71.15 |
| Touche2020 | 23.13 | 23.39 |
| ToxicConversationsClassification | 66.01 | 71.32 |
| TweetSentimentExtractionClassification | 62.8 | 61.98 |
| TwentyNewsgroupsClustering | 39.4 | 38.91 |
| TwitterSemEval2015 | 75.28 | 75.48 |
| TwitterURLCorpus | 85.83 | 85.89 |
| MSMARCO | 43.7 | 43.7 |

