### PR TITLE
fix: update max tokens for OpenAI

### DIFF
--- a/mteb/models/openai_models.py
+++ b/mteb/models/openai_models.py
@@ -25,7 +25,7 @@ class OpenAIWrapper(Wrapper):
         **kwargs,
     ) -> None:
         """Wrapper for OpenAIs embedding API.
-        To handle documents larger than 8192 tokens, we truncate the document to the specified sequence length.
+        To handle documents larger than 8191 tokens, we truncate the document to the specified sequence length.
         """
         requires_package(self, "openai", "Openai text embedding")
         from openai import OpenAI
@@ -124,7 +124,7 @@ text_embedding_3_small = ModelMeta(
         OpenAIWrapper,
         model_name="text-embedding-3-small",
         tokenizer_name="cl100k_base",
-        max_tokens=8192,
+        max_tokens=8191,
     ),
     max_tokens=8191,
     embed_dim=1536,
@@ -149,7 +149,7 @@ text_embedding_3_large = ModelMeta(
         OpenAIWrapper,
         model_name="text-embedding-3-large",
         tokenizer_name="cl100k_base",
-        max_tokens=8192,
+        max_tokens=8191,
     ),
     max_tokens=8191,
     embed_dim=3072,
@@ -172,7 +172,7 @@ text_embedding_ada_002 = ModelMeta(
         OpenAIWrapper,
         model_name="text-embedding-ada-002",
         tokenizer_name="cl100k_base",
-        max_tokens=8192,
+        max_tokens=8191,
     ),
     reference="https://openai.com/index/new-and-improved-embedding-model/",
     max_tokens=8191,


### PR DESCRIPTION
>  While running the benchmark again for all tasks, I ran into an error while evaluating a classification task. Digging deeper, I noticed something weird. OpenAI text embedding models generally have a context length of 8192 (if you go over that, the API throws an error). But it looks like the `text-embedding-ada-002` model actually has a context length of 8191. If you push it to 8192 tokens, the API doesn’t throw an error (probably to align with the `text-embedding-3-*` models), but the model sometimes returns null values instead. I think we should update `openai_models.py` to fix this. Here’s a script to reproduce the issue, change 8191 to 8192 and see the results.
> 
> ```python
> from openai import OpenAI
> import tiktoken
> import numpy as np
> 
> client = OpenAI()
> encoding = tiktoken.get_encoding("cl100k_base")
> 
> sn = 'Hello World' * 5000
> 
> print(f'Num tokens: {len(encoding.encode(sn))}')
> 
> truncated_sentence = encoding.encode(sn)[:8191]
> truncated_sentence = encoding.decode(truncated_sentence)
> 
> response = client.embeddings.create(
>     input=truncated_sentence,
>     model="text-embedding-ada-002",
>     encoding_format="float",
> )
> 
> em = np.array(response.data[0].embedding)
> print(f'Null values: {np.isnan(em.astype(np.float32)).sum()}')
> ```

_Originally posted by @HSILA in https://github.com/embeddings-benchmark/mteb/issues/1708#issuecomment-2578648026_
            
We had difference num of `max_tokens` in loader and model meta and that caused this problem

## Checklist
<!-- Please do not delete this -->

- [X] Run tests locally to make sure nothing is broken using `make test`. 
- [X] Run the formatter to format the code using `make lint`. 
