### PR TITLE
fix: [v2] _run_eval() for case: co2_tracker False & add test

### DIFF
--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -589,7 +589,6 @@ class MTEB:
                             task,
                             model,
                             split,
-                            output_folder,
                             subsets_to_run=subsets_to_run,
                             encode_kwargs=encode_kwargs,
                             **kwargs,

--- a/tests/test_benchmark/test_benchmark.py
+++ b/tests/test_benchmark/test_benchmark.py
@@ -67,6 +67,24 @@ def test_benchmark_encoders_on_task(task: str | AbsTask, model: mteb.Encoder):
     eval.run(model, output_folder="tests/results", overwrite_results=True)
 
 
+@pytest.mark.parametrize("task", [MockMultilingualRetrievalTask])
+@pytest.mark.parametrize(
+    "model",
+    [MockSentenceTransformer()],
+)
+def test_run_eval_without_co2_tracking(task: str | AbsTask, model: mteb.Encoder):
+    """Test that a task can be fetched and run without CO2 tracking"""
+    if isinstance(task, str):
+        tasks = mteb.get_tasks(tasks=[task])
+    else:
+        tasks = [task]
+
+    eval = mteb.MTEB(tasks=tasks)
+    eval.run(
+        model, output_folder="tests/results", overwrite_results=True, co2_tracker=False
+    )
+
+
 @pytest.mark.parametrize("task", MOCK_TASK_TEST_GRID[:1])
 @pytest.mark.parametrize("model", [MockNumpyEncoder()])
 def test_reload_results(task: str | AbsTask, model: mteb.Encoder, tmp_path: Path):


### PR DESCRIPTION
Fixes `_run_eval()` for `co2_tracker=False` and adds a corresponding test

## Checklist
- [x] Run tests locally to make sure nothing is broken using `make test`.  Not all -> https://github.com/embeddings-benchmark/mteb/issues/1766
- [x] Run the formatter to format the code using `make lint`. 
