### PR TITLE
fix: loading pre 11

### DIFF
--- a/mteb/load_results/task_results.py
+++ b/mteb/load_results/task_results.py
@@ -387,18 +387,16 @@ class TaskResult(BaseModel):
         main_score = task.metadata.main_score
         for split, split_score in scores.items():
             for hf_subset, hf_subset_scores in split_score.items():
-                if task.metadata.type in ("STS", "PairClassification", "Reranking"):
-                    for name, prev_name in [
-                        ("cosine", "cos_sim"),
-                        ("manhattan", "manhattan"),
-                        ("euclidean", "euclidean"),
-                        ("dot", "dot"),
-                        ("max", "max"),
-                        ("similarity", "similarity"),
-                    ]:
-                        prev_name_scores = hf_subset_scores.pop(
-                            prev_name, {"spearman": "NaN"}
-                        )
+                for name, prev_name in [
+                    ("cosine", "cos_sim"),
+                    ("manhattan", "manhattan"),
+                    ("euclidean", "euclidean"),
+                    ("dot", "dot"),
+                    ("max", "max"),
+                    ("similarity", "similarity"),
+                ]:
+                    prev_name_scores = hf_subset_scores.pop(prev_name, None)
+                    if prev_name_scores is not None:
                         for k, v in prev_name_scores.items():
                             hf_subset_scores[f"{name}_{k}"] = v
 

--- a/mteb/load_results/task_results.py
+++ b/mteb/load_results/task_results.py
@@ -387,11 +387,13 @@ class TaskResult(BaseModel):
         main_score = task.metadata.main_score
         for split, split_score in scores.items():
             for hf_subset, hf_subset_scores in split_score.items():
-                if task.metadata.type == "STS":
+                if task.metadata.type in ("STS", "PairClassification", "Reranking"):
                     for name, prev_name in [
                         ("cosine", "cos_sim"),
                         ("manhattan", "manhattan"),
                         ("euclidean", "euclidean"),
+                        ("dot", "dot"),
+                        ("max", "max"),
                     ]:
                         prev_name_scores = hf_subset_scores.pop(
                             prev_name, {"spearman": "NaN"}

--- a/mteb/load_results/task_results.py
+++ b/mteb/load_results/task_results.py
@@ -394,6 +394,7 @@ class TaskResult(BaseModel):
                         ("euclidean", "euclidean"),
                         ("dot", "dot"),
                         ("max", "max"),
+                        ("similarity", "similarity")
                     ]:
                         prev_name_scores = hf_subset_scores.pop(
                             prev_name, {"spearman": "NaN"}

--- a/mteb/load_results/task_results.py
+++ b/mteb/load_results/task_results.py
@@ -394,7 +394,7 @@ class TaskResult(BaseModel):
                         ("euclidean", "euclidean"),
                         ("dot", "dot"),
                         ("max", "max"),
-                        ("similarity", "similarity")
+                        ("similarity", "similarity"),
                     ]:
                         prev_name_scores = hf_subset_scores.pop(
                             prev_name, {"spearman": "NaN"}


### PR DESCRIPTION
ref https://github.com/embeddings-benchmark/mteb/issues/1797

Retrieval and PairClassification scores were loaded incorrect

## Checklist
<!-- Please do not delete this -->

- [X] Run tests locally to make sure nothing is broken using `make test`. 
- [X] Run the formatter to format the code using `make lint`. 

