### PR TITLE
fix: allow to load no revision available

### DIFF
--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -24,7 +24,7 @@ def load_results():
     results_cache_path = Path(__file__).parent.joinpath("__cached_results.json")
     if not results_cache_path.exists():
         all_results = (
-            mteb.load_results(only_main_score=True).join_revisions().filter_models()
+            mteb.load_results(only_main_score=True, require_model_meta=False).join_revisions().filter_models()
         )
         all_results.to_disk(results_cache_path)
         return all_results

--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -24,7 +24,9 @@ def load_results():
     results_cache_path = Path(__file__).parent.joinpath("__cached_results.json")
     if not results_cache_path.exists():
         all_results = (
-            mteb.load_results(only_main_score=True, require_model_meta=False).join_revisions().filter_models()
+            mteb.load_results(only_main_score=True, require_model_meta=False)
+            .join_revisions()
+            .filter_models()
         )
         all_results.to_disk(results_cache_path)
         return all_results

--- a/mteb/load_results/load_results.py
+++ b/mteb/load_results/load_results.py
@@ -139,6 +139,7 @@ def load_results(
                 continue
             model_name, revision = model_name_and_revision
 
+            model_name = model_name.replace("__", "/")
             if models_to_keep is not None and model_name not in models_to_keep:
                 continue
             elif models_to_keep is not None and models_to_keep[model_name] is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dev = ["ruff==0.6.4", # locked so we don't get PRs which fail only due to a lint
 codecarbon = ["codecarbon"]
 speedtask = ["GPUtil>=1.4.0", "psutil>=5.9.8"]
 peft = ["peft>=0.11.0"]
-leaderboard = ["gradio>=5.7.1", "gradio_rangeslider>=0.0.8"]
+leaderboard = ["gradio>=5.7.1", "gradio_rangeslider>=0.0.8", "plotly>=5.24.0"]
 flagembedding = ["FlagEmbedding"]
 jina = ["einops>=0.8.0"]
 flash_attention = ["flash-attn>=2.6.3"]

--- a/scripts/compare_leaderboard_results.py
+++ b/scripts/compare_leaderboard_results.py
@@ -2,70 +2,81 @@ from __future__ import annotations
 
 import json
 import logging
+from collections import defaultdict
 from pathlib import Path
 
-from mteb import MTEB_ENG_CLASSIC, load_results
+from mteb import get_benchmark, load_results
 
 logging.basicConfig(level=logging.INFO)
 
 models = [
-    "dunzhang/stella_en_1.5B_v5",
-    "dunzhang/stella_en_400M_v5",
+    "intfloat/multilingual-e5-small",
     # Add other models here
 ]
+benchmark = get_benchmark("MTEB(Chinese)")
+
+results = []
 
 # in same folder as mteb repo
 # git clone https://github.com/embeddings-benchmark/leaderboard
-data_tasks_path = Path("../../leaderboard/boards_data/en/data_tasks/")
+# get path of current file
+base_path = Path(__file__).parent.parent.parent / "leaderboard" / "boards_data"
 
-results = []
 
 for model_name_to_search in models:
     model_results = load_results(
         models=[model_name_to_search],
-        tasks=MTEB_ENG_CLASSIC.tasks,
+        tasks=benchmark.tasks,
         only_main_score=True,
+        require_model_meta=False,
     )
 
-    cur_model = {}
+    cur_model = {
+        task.metadata.name: defaultdict(dict)
+        for task in benchmark.tasks
+    }
     for model_res in model_results:
         for task_res in model_res.task_results:
             task_name = task_res.task.metadata.name
-            split = "test" if task_name != "MSMARCO" else "dev"
-            scores = [score["main_score"] for score in task_res.scores[split]]
-            # this tmp solution, because some tasks have multiple results
-            cur_model[task_name] = {"new": round((sum(scores) / len(scores)) * 100, 2)}
 
-    for task_dir in data_tasks_path.iterdir():
-        if task_dir.is_dir():
-            results_file_path = task_dir / "default.jsonl"
-            if results_file_path.exists():
-                with open(results_file_path) as file:
-                    for line in file:
-                        data = json.loads(line)
-                        model_name = data.get("Model", "")
-                        if model_name_to_search in model_name:
-                            for key, value in data.items():
-                                if key in [
-                                    "index",
-                                    "Rank",
-                                    "Model",
-                                    "Model Size (Million Parameters)",
-                                    "Memory Usage (GB, fp32)",
-                                    "Embedding Dimensions",
-                                    "Max Tokens",
-                                    "Average",
-                                ]:
-                                    continue
-                                for benchmark_task in MTEB_ENG_CLASSIC.tasks:
-                                    if benchmark_task.metadata.name in key:
-                                        cur_model[benchmark_task.metadata.name][
-                                            "old"
-                                        ] = value
+            split = "test" if "test" in task_res.task.metadata.eval_splits else task_res.task.metadata.eval_splits[0]
+            if split in task_res.scores:
+                scores = [score["main_score"] for score in task_res.scores[split]]
+                cur_model[task_name]["new"] = round((sum(scores) / len(scores)) * 100, 2)
+
+    for lang_path in base_path.iterdir():
+        data_tasks_path = lang_path / "data_tasks"
+
+        for task_dir in data_tasks_path.iterdir():
+            if task_dir.is_dir():
+                results_file_path = task_dir / "default.jsonl"
+                if results_file_path.exists():
+                    with open(results_file_path) as file:
+                        for line in file:
+                            data = json.loads(line)
+                            model_name = data.get("Model", "")
+                            if model_name_to_search in model_name:
+                                for key, value in data.items():
+                                    if key in [
+                                        "index",
+                                        "Rank",
+                                        "Model",
+                                        "Model Size (Million Parameters)",
+                                        "Memory Usage (GB, fp32)",
+                                        "Embedding Dimensions",
+                                        "Max Tokens",
+                                        "Average",
+                                    ]:
+                                        continue
+                                    for benchmark_task in benchmark.tasks:
+                                        if benchmark_task.metadata.name in key:
+                                            cur_model[benchmark_task.metadata.name][
+                                                "old"
+                                            ] = value
 
     sorted_cur_model = {
         task.metadata.name: cur_model[task.metadata.name]
-        for task in MTEB_ENG_CLASSIC.tasks
+        for task in benchmark.tasks
         if task.metadata.name in cur_model
     }
     results.append({"model": model_name_to_search, "results": sorted_cur_model})

--- a/scripts/compare_leaderboard_results.py
+++ b/scripts/compare_leaderboard_results.py
@@ -31,18 +31,21 @@ for model_name_to_search in models:
         require_model_meta=False,
     )
 
-    cur_model = {
-        task.metadata.name: defaultdict(dict)
-        for task in benchmark.tasks
-    }
+    cur_model = {task.metadata.name: defaultdict(dict) for task in benchmark.tasks}
     for model_res in model_results:
         for task_res in model_res.task_results:
             task_name = task_res.task.metadata.name
 
-            split = "test" if "test" in task_res.task.metadata.eval_splits else task_res.task.metadata.eval_splits[0]
+            split = (
+                "test"
+                if "test" in task_res.task.metadata.eval_splits
+                else task_res.task.metadata.eval_splits[0]
+            )
             if split in task_res.scores:
                 scores = [score["main_score"] for score in task_res.scores[split]]
-                cur_model[task_name]["new"] = round((sum(scores) / len(scores)) * 100, 2)
+                cur_model[task_name]["new"] = round(
+                    (sum(scores) / len(scores)) * 100, 2
+                )
 
     for lang_path in base_path.iterdir():
         data_tasks_path = lang_path / "data_tasks"


### PR DESCRIPTION
Previously, results from `no_revision_available` were filtered out, because it tried to match `intfloat/multilingual-e5-small` and `intfloat__multilingual-e5-small` (dir name). Also updated script for leaderboard comparison. I tried to build a leaderboard, but I got OOM.

## Checklist
<!-- Please do not delete this -->

- [X] Run tests locally to make sure nothing is broken using `make test`. 
- [X] Run the formatter to format the code using `make lint`. 


## Model: intfloat/multilingual-e5-small

| Task Name | Old Leaderboard | New Leaderboard |
|-----------|-----------------|-----------------|
| T2Retrieval | 71.39 | 71.39 |
| MMarcoRetrieval | 73.17 | 73.17 |
| DuRetrieval | 81.35 | 81.35 |
| CovidRetrieval | 72.82 | 72.82 |
| CmedqaRetrieval | 24.38 | 24.38 |
| EcomRetrieval | 53.56 | 53.56 |
| MedicalRetrieval | 44.84 | 44.84 |
| VideoRetrieval | 58.09 | 58.09 |
| T2Reranking | 65.24 | 65.24 |
| MMarcoReranking | 24.33 | 24.33 |
| CMedQAv1-reranking | N/A | 63.44 |
| CMedQAv2-reranking | N/A | 62.41 |
| Ocnli | 60.77 | 58.69 |
| Cmnli | 72.12 | 65.35 |
| CLSClusteringS2S | 37.79 | 37.79 |
| CLSClusteringP2P | 39.14 | 39.14 |
| ThuNewsClusteringS2S | 48.93 | 48.93 |
| ThuNewsClusteringP2P | 55.18 | 55.18 |
| ATEC | 35.14 | 35.14 |
| BQ | 21.51 | 43.27 |
| LCQMC | 72.7 | 72.7 |
| PAWSX | 11.01 | 11.01 |
| STSB | 84.11 | 77.73 |
| AFQMC | 25.21 | 25.21 |
| QBQTC | 30.25 | 30.25 |
| TNews | 48.38 | 48.38 |
| IFlyTek | 47.35 | 47.35 |
| Waimai | 83.9 | 83.9 |
| OnlineShopping | 88.73 | 88.73 |
| MultilingualSentiment | 64.74 | 66.34 |
| JDReview | 79.34 | 79.34 |

results for `Cmnli` are different, because in old leaderboard models are compared by `max_ap`, but `main_score` for `Cmnli` is `max_accuracy`

https://github.com/embeddings-benchmark/results/blob/4f6a9fc42a2e67922d36ad3d41baf3aa9c969e6e/results/intfloat__multilingual-e5-small/no_revision_available/Cmnli.json#L43-L47