### PR TITLE
fix: Zero shot and aggregation on Leaderboard

### DIFF
--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -412,7 +412,7 @@ with gr.Blocks(fill_width=True, theme=gr.themes.Base(), head=head) as demo:
         compatibility,
         instructions,
         model_size,
-        zero_shot,
+        zero_shot_setting,
     ):
         lower, upper = model_size
         # Setting to None, when the user doesn't specify anything
@@ -432,12 +432,12 @@ with gr.Blocks(fill_width=True, theme=gr.themes.Base(), head=head) as demo:
         tasks = mteb.get_tasks(tasks=task_select)
         models_to_keep = set()
         for model_meta in model_metas:
-            is_zero_shot = model_meta.is_zero_shot_on(tasks)
-            if is_zero_shot is None:
-                if zero_shot == "hard":
+            is_model_zero_shot = model_meta.is_zero_shot_on(tasks)
+            if is_model_zero_shot is None:
+                if zero_shot_setting == "hard":
                     continue
-            if not zero_shot:
-                if zero_shot != "off":
+            elif not is_model_zero_shot:
+                if zero_shot_setting != "off":
                     continue
             models_to_keep.add(model_meta.name)
         return list(models_to_keep)
@@ -460,7 +460,7 @@ with gr.Blocks(fill_width=True, theme=gr.themes.Base(), head=head) as demo:
             compatibility,
             instructions,
             model_size,
-            zero_shot,
+            zero_shot_setting=zero_shot,
         )
         elapsed = time.time() - start_time
         logger.info(f"update_models callback: {elapsed}s")

--- a/mteb/leaderboard/table.py
+++ b/mteb/leaderboard/table.py
@@ -88,7 +88,7 @@ def get_means_per_types(per_task: pd.DataFrame):
                 dict(
                     model_name=model_name,
                     task_type=task_type,
-                    score=scores[tasks].mean(),
+                    score=scores[tasks].mean(skipna=False),
                 )
             )
     return pd.DataFrame.from_records(records)

--- a/mteb/load_results/benchmark_results.py
+++ b/mteb/load_results/benchmark_results.py
@@ -13,8 +13,7 @@ from packaging.version import InvalidVersion, Version
 from pydantic import BaseModel, ConfigDict
 
 from mteb.abstasks.AbsTask import AbsTask, ScoresDict
-from mteb.abstasks.TaskMetadata import (ISO_LANGUAGE_SCRIPT, TASK_DOMAIN,
-                                        TASK_TYPE)
+from mteb.abstasks.TaskMetadata import ISO_LANGUAGE_SCRIPT, TASK_DOMAIN, TASK_TYPE
 from mteb.languages import ISO_LANGUAGE
 from mteb.load_results.task_results import TaskResult
 from mteb.models.overview import get_model_metas


### PR DESCRIPTION
Added a number of minor fixes:
 - `join_revision` now prefers when revision is specified as opposed to `"no_revision_available"`
 - Fixed problems with zero-shot filtering #1807 
 - Fixed aggregation issues on a task type level #1809 