### PR TITLE
ci: only return 1 model_name per file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,5 +41,5 @@ build-docs:
 model-load-test:
 	@echo "--- 🚀 Running model load test ---"
 	pip install ".[dev, speedtask, pylate,gritlm,xformers,model2vec]"
-	python scripts/extract_model_names.py $(BASE_BRANCH)
+	python scripts/extract_model_names.py $(BASE_BRANCH) --return_one_model_name_per_file
 	python tests/test_models/model_loading.py --model_name_file scripts/model_names.txt

--- a/mteb/models/sentence_transformers_models.py
+++ b/mteb/models/sentence_transformers_models.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from mteb.model_meta import ModelMeta
 
-# testing this PR
 paraphrase_langs = [
     "ara_Arab",
     "bul_Cyrl",

--- a/mteb/models/sentence_transformers_models.py
+++ b/mteb/models/sentence_transformers_models.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from mteb.model_meta import ModelMeta
 
+# testing this PR
 paraphrase_langs = [
     "ara_Arab",
     "bul_Cyrl",


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->
Fixes #1756 

A change to `mteb/models/sentence_transformers_models.py` only results in `sentence-transformers/all-MiniLM-L6-v2` written to `scripts/model_names.txt` now using the `make model-load-test` command. The scripts can still be used separately to run existing options.

## How this affects implementing new models
It shouldn't and it doesn't. When models are added from scratch, the PRs are to follow the [relevant docs](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_model.md) and PR checklist. We saw an influx of model meta because of the leaderboard backfill. Every change to a model file now will trigger a model load test that takes 1 model from each file. The rest (loading, running, getting results) does not change and will remain the same as before.

This CI workflow is mainly for validating any updates made to model wrappers. I'd see it as a sanity check, because we should expect model wrappers to be tested (run on datasets to confirm changes are correct) before merging.

## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 
