### PR TITLE
fix: bm25s

### DIFF
--- a/mteb/evaluation/evaluators/RetrievalEvaluator.py
+++ b/mteb/evaluation/evaluators/RetrievalEvaluator.py
@@ -477,6 +477,7 @@ class RetrievalEvaluator(Evaluator):
                 corpus,
                 queries,
                 self.top_k,
+                score_function="bm25",
                 task_name=self.task_name,  # type: ignore
             )
         else:


### PR DESCRIPTION
fix: bm25s match `search()`

## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 


