### PR TITLE
[mieb] fixing lrap computation for multi-label classification

### DIFF
--- a/mteb/abstasks/Image/AbsTaskImageMultilabelClassification.py
+++ b/mteb/abstasks/Image/AbsTaskImageMultilabelClassification.py
@@ -36,7 +36,13 @@ def evaluate_classifier(
     f1 = f1_score(y_test, y_pred, average="macro")
     scores["accuracy"] = accuracy
     scores["f1"] = f1
-    lrap = label_ranking_average_precision_score(y_test, y_pred)
+    all_probs = []
+    for estimator in classifier.estimators_:
+        probs = estimator.predict_proba(embeddings_test)[:, 1]
+        all_probs.append(probs)
+
+    y_score = np.stack(all_probs, axis=1)  # shape: (n_samples, n_labels)
+    lrap = label_ranking_average_precision_score(y_test, y_score)
     scores["lrap"] = lrap
     return scores
 

--- a/mteb/tasks/Image/ImageMultilabelClassification/eng/PascalVOC2007.py
+++ b/mteb/tasks/Image/ImageMultilabelClassification/eng/PascalVOC2007.py
@@ -21,7 +21,7 @@ class VOC2007Classification(AbsTaskImageMultilabelClassification):
         category="i2i",
         eval_splits=["test"],
         eval_langs=["eng-Latn"],
-        main_score="accuracy",
+        main_score="lrap",
         date=(
             "2005-01-01",
             "2014-01-01",


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->
Fixes https://github.com/embeddings-benchmark/mteb/issues/1792

Fixing the computation of the `lrap` metric for multi-label classification. `lrap` is supposed to [operate on continuous scores](https://scikit-learn.org/1.5/modules/generated/sklearn.metrics.label_ranking_average_precision_score.html), instead of predicted labels. This change largely smooths the large performance range in `lrap` across models brought by change in `samples_per_label`.

Was trying to fix the same for main but got a chain of failed tests (mainly because `main` is using `KNeighborsClassifier()` by itself - which I'm not sure would work in the expected way either; `mieb` is currently using `MultiOutputClassifer(estimator=LogisicRegression())`, which makes each label a separate binary classification problem).

## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 