### PR TITLE
Add gte-modernbert-base

### DIFF
--- a/mteb/models/gte_models.py
+++ b/mteb/models/gte_models.py
@@ -315,6 +315,6 @@ gte_modernbert_base = ModelMeta(
     framework=["Sentence Transformers", "PyTorch"],
     use_instructions=False,
     public_training_code=None,  # couldn't find
-    training_datasets=gte_multi_training_data
+    training_datasets=gte_multi_training_data, #English part of gte_multi_training_data
 )
 

--- a/mteb/models/gte_models.py
+++ b/mteb/models/gte_models.py
@@ -316,6 +316,6 @@ gte_modernbert_base = ModelMeta(
     use_instructions=False,
     public_training_code=None,  # couldn't find
     public_training_data=None,
-    training_datasets=gte_multi_training_data, #English part of gte_multi_training_data,
+    training_datasets=gte_multi_training_data,  #English part of gte_multi_training_data,
 )
 

--- a/mteb/models/gte_models.py
+++ b/mteb/models/gte_models.py
@@ -295,6 +295,18 @@ gte_multilingual_base = ModelMeta(
     training_datasets=gte_multi_training_data,
 )
 
+gte_modernbert_data = {
+    "NQ": ["train"],
+    "MSMARCO": ["train"],
+    "HotpotQA": ["train"],
+    "FEVER": ["train"],
+    # not in MTEB:
+    #   - TriviaQA
+    #   - SQuAD
+    #   - AllNLI
+}
+
+
 gte-modernbert-base = ModelMeta(
     loader=partial(  # type: ignore
         sentence_transformers_loader,
@@ -315,6 +327,6 @@ gte-modernbert-base = ModelMeta(
     framework=["Sentence Transformers", "PyTorch"],
     use_instructions=False,
     public_training_code=None,  # couldn't find
-    training_datasets=None
+    training_datasets=gte_modernbert_data
 )
 

--- a/mteb/models/gte_models.py
+++ b/mteb/models/gte_models.py
@@ -316,6 +316,6 @@ gte_modernbert_base = ModelMeta(
     use_instructions=False,
     public_training_code=None,  # couldn't find
     public_training_data=None,
-    training_datasets=gte_multi_training_data, #English part of gte_multi_training_data
+    training_datasets=gte_multi_training_data, #English part of gte_multi_training_data,
 )
 

--- a/mteb/models/gte_models.py
+++ b/mteb/models/gte_models.py
@@ -315,6 +315,6 @@ gte_modernbert_base = ModelMeta(
     framework=["Sentence Transformers", "PyTorch"],
     use_instructions=False,
     public_training_code=None,  # couldn't find
-    training_datasets=gte_modernbert_data
+    training_datasets=gte_multi_training_data
 )
 

--- a/mteb/models/gte_models.py
+++ b/mteb/models/gte_models.py
@@ -315,6 +315,7 @@ gte_modernbert_base = ModelMeta(
     framework=["Sentence Transformers", "PyTorch"],
     use_instructions=False,
     public_training_code=None,  # couldn't find
+    public_training_data=None,
     training_datasets=gte_multi_training_data, #English part of gte_multi_training_data
 )
 

--- a/mteb/models/gte_models.py
+++ b/mteb/models/gte_models.py
@@ -294,3 +294,27 @@ gte_multilingual_base = ModelMeta(
     public_training_code=None,  # couldn't find
     training_datasets=gte_multi_training_data,
 )
+
+gte-modernbert-base = ModelMeta(
+    loader=partial(  # type: ignore
+        sentence_transformers_loader,
+        model_name="Alibaba-NLP/gte-modernbert-base",
+        revision="7ca8b4ca700621b67618669f5378fe5f5820b8e4",
+    ),
+    name="Alibaba-NLP/gte-modernbert-base",
+    languages=["eng_Latn"],
+    open_weights=True,
+    revision="7ca8b4ca700621b67618669f5378fe5f5820b8e4",
+    release_date="2025-01-21",  # initial commit of hf model.
+    n_parameters=149 * 1e6,
+    embed_dim=768,
+    license="apache-2",
+    max_tokens=8192,
+    reference="https://huggingface.co/Alibaba-NLP/gte-modernbert-base",
+    similarity_fn_name="cosine",
+    framework=["Sentence Transformers", "PyTorch"],
+    use_instructions=False,
+    public_training_code=None,  # couldn't find
+    training_datasets=None
+)
+

--- a/mteb/models/gte_models.py
+++ b/mteb/models/gte_models.py
@@ -295,7 +295,7 @@ gte_multilingual_base = ModelMeta(
     training_datasets=gte_multi_training_data,
 )
 
-gte-modernbert-base = ModelMeta(
+gte_modernbert_base = ModelMeta(
     loader=partial(  # type: ignore
         sentence_transformers_loader,
         model_name="Alibaba-NLP/gte-modernbert-base",

--- a/mteb/models/gte_models.py
+++ b/mteb/models/gte_models.py
@@ -316,6 +316,5 @@ gte_modernbert_base = ModelMeta(
     use_instructions=False,
     public_training_code=None,  # couldn't find
     public_training_data=None,
-    training_datasets=gte_multi_training_data,  #English part of gte_multi_training_data,
+    training_datasets=gte_multi_training_data,  # English part of gte_multi_training_data,
 )
-

--- a/mteb/models/gte_models.py
+++ b/mteb/models/gte_models.py
@@ -295,18 +295,6 @@ gte_multilingual_base = ModelMeta(
     training_datasets=gte_multi_training_data,
 )
 
-gte_modernbert_data = {
-    "NQ": ["train"],
-    "MSMARCO": ["train"],
-    "HotpotQA": ["train"],
-    "FEVER": ["train"],
-    # not in MTEB:
-    #   - TriviaQA
-    #   - SQuAD
-    #   - AllNLI
-}
-
-
 gte-modernbert-base = ModelMeta(
     loader=partial(  # type: ignore
         sentence_transformers_loader,


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->


## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 


### Adding datasets checklist
<!-- see also https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md -->

**Reason for dataset addition**: ... <!-- Add reason for adding dataset here. E.g. it covers task/language/domain previously not covered -->

- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb -m {model_name} -t {task_name}` command.
  - [x] `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
  - [x] `intfloat/multilingual-e5-small`
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [x] If the dataset is too big (e.g. >2048 examples), considering using `self.stratified_subsampling() under dataset_transform()`
- [x] I have filled out the metadata object in the dataset file (find documentation on it [here](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md#2-creating-the-metadata-object)).
- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 


### Adding a model checklist
<!-- 
When adding a model to the model registry
see also https://github.com/embeddings-benchmark/mteb/blob/main/docs/reproducible_workflow.md
-->

 - [x] I have filled out the ModelMeta object to the extent possible
 - [x] I have ensured that my model can be loaded using
   - [x] `mteb.get_model(model_name, revision)` and
   - [x] `mteb.get_model_meta(model_name, revision)`
 - [x] I have tested the implementation works on a representative set of tasks.