### PR TITLE
fix: Hotfixed public_training_data type annotation

### DIFF
--- a/mteb/model_meta.py
+++ b/mteb/model_meta.py
@@ -95,7 +95,7 @@ class ModelMeta(BaseModel):
     license: str | None
     open_weights: bool | None
     public_training_code: str | None
-    public_training_data: str | None
+    public_training_data: str | bool | None
     framework: list[FRAMEWORKS]
     reference: STR_URL | None = None
     similarity_fn_name: DISTANCE_METRICS | None


### PR DESCRIPTION
It was removed then readded with the incorrect type and now every test is failing. This should fix it, but we should also probably add some docs and be on the same page on what this property is actually for.