### PR TITLE
fix: External results are preferred when only they have the needed splits

### DIFF
--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -20,15 +20,15 @@ from mteb.leaderboard.table import scores_to_tables
 
 logger = logging.getLogger(__name__)
 
+ALL_MODELS = {meta.name for meta in mteb.get_model_metas()}
+
 
 def load_results():
     results_cache_path = Path(__file__).parent.joinpath("__cached_results.json")
     if not results_cache_path.exists():
-        all_results = (
-            mteb.load_results(only_main_score=True, require_model_meta=False)
-            .join_revisions()
-            .filter_models()
-        )
+        all_results = mteb.load_results(
+            only_main_score=True, require_model_meta=False, models=ALL_MODELS
+        ).filter_models()
         all_results.to_disk(results_cache_path)
         return all_results
     else:
@@ -168,7 +168,7 @@ all_results = load_results()
 
 benchmarks = mteb.get_benchmarks()
 all_benchmark_results = {
-    benchmark.name: benchmark.load_results(base_results=all_results)
+    benchmark.name: benchmark.load_results(base_results=all_results).join_revisions()
     for benchmark in benchmarks
 }
 default_benchmark = mteb.get_benchmark(DEFAULT_BENCHMARK_NAME)

--- a/mteb/load_results/benchmark_results.py
+++ b/mteb/load_results/benchmark_results.py
@@ -259,6 +259,8 @@ class BenchmarkResults(BaseModel):
                 return None
 
         def keep_best(group: pd.DataFrame) -> pd.DataFrame:
+            # Filtering out task_results where no scores are present
+            group = group[group["has_scores"]]
             is_main_revision = group["revision"] == group["main_revision"]
             # If the main revision is present we select that
             if is_main_revision.sum() > 0:
@@ -286,6 +288,7 @@ class BenchmarkResults(BaseModel):
                         task_name=task_result.task_name,
                         mteb_version=task_result.mteb_version,
                         task_result=task_result,
+                        has_scores=bool(task_result.scores),
                     )
                 )
         task_df = pd.DataFrame.from_records(records)


### PR DESCRIPTION
I have fixed the issue where we had the needed scores from the external results, and they would be overwritten by a newer revision missing some splits. 