### PR TITLE
Adding a banner to the new MMTEB leaderboard

### DIFF
--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -234,6 +234,13 @@ head = """
 """
 
 with gr.Blocks(fill_width=True, theme=gr.themes.Base(), head=head) as demo:
+
+    gr.Markdown("""
+    ## MMTEB: Massive Multilingual Text Embedding Benchmark
+
+    The MMTEB leaderboard compares text embedding models on 1000+ languages. Check out the [paper](https://openreview.net/pdf?id=zl3pfz4VCV) for details on datasets, languages and tasks. And you can contribute! 🤗 To add a model, please refer to the documentation in the [GitHub repository](https://github.com/embeddings-benchmark/mteb/path/to/doc) ✨
+    """)
+
     with gr.Row():
         with gr.Column(scale=5):
             gr.Markdown(

--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -237,7 +237,7 @@ with gr.Blocks(fill_width=True, theme=gr.themes.Base(), head=head) as demo:
     gr.Markdown("""
     ## MMTEB: Massive Multilingual Text Embedding Benchmark
 
-    The MMTEB leaderboard compares text embedding models on 1000+ languages. Check out the [paper](https://openreview.net/pdf?id=zl3pfz4VCV) for details on datasets, languages and tasks. And you can contribute! 🤗 To add a model, please refer to the documentation in the [GitHub repository](https://github.com/embeddings-benchmark/mteb/path/to/doc) ✨
+    The MMTEB leaderboard compares text embedding models on 1000+ languages. Check out the [paper](https://openreview.net/pdf?id=zl3pfz4VCV) for details on datasets, languages and tasks. And you can contribute! 🤗 To add a model, please refer to the documentation in the [GitHub repository](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_model.md) ✨
     """)
 
     with gr.Row():

--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -237,7 +237,7 @@ with gr.Blocks(fill_width=True, theme=gr.themes.Base(), head=head) as demo:
     gr.Markdown("""
     ## MMTEB: Massive Multilingual Text Embedding Benchmark
 
-    The MMTEB leaderboard compares text embedding models on 1000+ languages. Check out the [paper](https://openreview.net/pdf?id=zl3pfz4VCV) for details on datasets, languages and tasks. And you can contribute! 🤗 To add a model, please refer to the documentation in the [GitHub repository](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_model.md) ✨
+    The MMTEB leaderboard compares text embedding models on 1000+ languages. Check out the [paper](https://openreview.net/pdf?id=zl3pfz4VCV) for details on datasets, languages and tasks. And you can contribute! 🤗 To add a model, please refer to the documentation in the [GitHub repository](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_model.md). Also check out [MTEB Arena](https://huggingface.co/spaces/mteb/arena) ⚔️
     """)
 
     with gr.Row():

--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -234,7 +234,6 @@ head = """
 """
 
 with gr.Blocks(fill_width=True, theme=gr.themes.Base(), head=head) as demo:
-
     gr.Markdown("""
     ## MMTEB: Massive Multilingual Text Embedding Benchmark
 


### PR DESCRIPTION
### Code Quality
- [x] **Code Formatted**: Format the code using `make lint` to maintain consistent style.

### Documentation
- [x] Adding a banner to the new leaderboard
 
TODO:
- [x] ~~Put arxiv url? (right now the paper link points to open review)~~
- [x] Check documentation url (track updates on https://github.com/embeddings-benchmark/mteb/issues/1868)

### Testing

This is what it currently looks like (banner above titles Benchmarks and Model Selection):

<img width="1373" alt="image" src="https://github.com/user-attachments/assets/2a3ee837-2b6f-4c79-a7c1-2d2d6b664e70" />