### PR TITLE
Fix HagridRetrieval load_dataset "trust_remote_code"

### DIFF
--- a/mteb/tasks/Retrieval/eng/HagridRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/HagridRetrieval.py
@@ -53,6 +53,9 @@ class HagridRetrieval(AbsTaskRetrieval):
             "miracl/hagrid",
             split=self.metadata.eval_splits[0],
             revision=self.metadata_dict["dataset"].get("revision", None),
+            trust_remote_code=self.metadata_dict["dataset"].get(
+                "trust_remote_code", False
+            ),
         )
         proc_data = self.preprocess_data(data)
 


### PR DESCRIPTION
Fix the following error when evaluating on HagridRetrieval:

```
ValueError: The repository for miracl/hagrid contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/miracl/hagrid.
Please pass the argument `trust_remote_code=True` to allow custom code to be run.
Do you wish to run the custom code? [y/N]
```

<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->


### Code Quality
<!-- Please do not delete this -->
- [x] **Code Formatted**: Format the code using `make lint` to maintain consistent style.

### Documentation
<!-- Please do not delete this -->
- [x] **Updated Documentation**: Add or update documentation to reflect the changes introduced in this PR.

### Testing
<!-- Please do not delete this -->
- [x] **New Tests Added**: Write tests to cover new functionality. Validate with `make test-with-coverage`.
- [x] **Tests Passed**: Run tests locally using `make test` or `make test-with-coverage` to ensure no existing functionality is broken.