### PR TITLE
fix: BEIR-NL metadata mistake

### DIFF
--- a/mteb/tasks/Retrieval/nld/SCIDOCSNLRetrieval.py
+++ b/mteb/tasks/Retrieval/nld/SCIDOCSNLRetrieval.py
@@ -21,7 +21,7 @@ class SCIDOCSNL(AbsTaskRetrieval):
         category="s2p",
         modalities=["text"],
         eval_splits=["test"],
-        eval_langs=["eng-Latn"],
+        eval_langs=["nld-Latn"],
         main_score="ndcg_at_10",
         date=("2020-05-01", "2020-05-01"),  # best guess: based on submission date
         domains=["Academic", "Written", "Non-fiction"],


### PR DESCRIPTION
The language mistake in [SCIDOCSNLRetrieval.py](https://github.com/nikolay-banar/mteb/edit/main/mteb/tasks/Retrieval/nld/SCIDOCSNLRetrieval.py) is fixed.