### PR TITLE
Adding sentence-transformer-xxl model to mteb

### DIFF
--- a/mteb/models/sentence_transformers_models.py
+++ b/mteb/models/sentence_transformers_models.py
@@ -295,6 +295,66 @@ microllama_text_embedding = ModelMeta(
     public_training_data=None,
 )
 
+sentence_t5_base = ModelMeta(
+    name="sentence-transformers/sentence-t5-base",
+    languages=["eng-Latn"],
+    open_weights=True,
+    revision="50c53e206f8b01c9621484a3c0aafce4e55efebf",
+    release_date="2022-02-09",
+    n_parameters=110_000_000,
+    memory_usage_mb=209,
+    embed_dim=768,
+    license="apache-2.0",
+    max_tokens=512,
+    reference="https://huggingface.co/sentence-transformers/sentence-t5-base",
+    similarity_fn_name="cosine",
+    framework=["Sentence Transformers", "PyTorch"],
+    use_instructions=False,
+    public_training_code=None,
+    public_training_data=None,
+    training_datasets={"SNLI": ["train"], "Community QA": ["train"]},
+)
+
+sentence_t5_large = ModelMeta(
+    name="sentence-transformers/sentence-t5-large",
+    languages=["eng-Latn"],
+    open_weights=True,
+    revision="1fc08ea477205aa54a3e5b13f0971ae16b86410a",
+    release_date="2022-02-09",
+    n_parameters=335_000_000,
+    memory_usage_mb=639,
+    embed_dim=768,
+    license="apache-2.0",
+    max_tokens=512,
+    reference="https://huggingface.co/sentence-transformers/sentence-t5-large",
+    similarity_fn_name="cosine",
+    framework=["Sentence Transformers", "PyTorch"],
+    use_instructions=False,
+    public_training_code=None,
+    public_training_data=None,
+    training_datasets={"SNLI": ["train"], "Community QA": ["train"]},
+)
+
+sentence_t5_xl = ModelMeta(
+    name="sentence-transformers/sentence-t5-xl",
+    languages=["eng-Latn"],
+    open_weights=True,
+    revision="2965d31b368fb14117688e0bde77cbd720e91f53",
+    release_date="2024-03-27",
+    n_parameters=3_000_000_000,
+    memory_usage_mb=2367,
+    embed_dim=768,
+    license="apache-2.0",
+    max_tokens=512,
+    reference="https://huggingface.co/sentence-transformers/sentence-t5-xl",
+    similarity_fn_name="cosine",
+    framework=["Sentence Transformers", "PyTorch"],
+    use_instructions=False,
+    public_training_code=None,
+    public_training_data=None,
+    training_datasets={"SNLI": ["train"], "Community QA": ["train"]},
+)
+
 sentence_t5_xxl = ModelMeta(
     name="sentence-transformers/sentence-t5-xxl",
     languages=["eng-Latn"],

--- a/mteb/models/sentence_transformers_models.py
+++ b/mteb/models/sentence_transformers_models.py
@@ -301,7 +301,7 @@ sentence_t5_xxl = ModelMeta(
     open_weights=True,
     revision="4d122282ba80e807e9e6eb8c358269e92796365d",
     release_date="2024-03-27",
-    n_parameters=11_000_000_000, 
+    n_parameters=11_000_000_000,
     memory_usage_mb=9279,
     embed_dim=768,
     license="apache-2.0",
@@ -310,10 +310,7 @@ sentence_t5_xxl = ModelMeta(
     similarity_fn_name="cosine",
     framework=["Sentence Transformers", "PyTorch"],
     use_instructions=False,
-    public_training_code="https://arxiv.org/abs/2108.08877",
+    public_training_code=None,
     public_training_data=None,
-    training_datasets={
-        "SNLI": ["train"],
-        "Community QA": ["train"]
-    } 
+    training_datasets={"SNLI": ["train"], "Community QA": ["train"]},
 )

--- a/mteb/models/sentence_transformers_models.py
+++ b/mteb/models/sentence_transformers_models.py
@@ -294,3 +294,23 @@ microllama_text_embedding = ModelMeta(
     public_training_code=None,
     public_training_data=None,
 )
+
+sentence_t5_xxl = ModelMeta(
+    name="sentence-transformers/sentence-t5-xxl",
+    languages=["eng-Latn"],
+    open_weights=True,
+    revision="4d122282ba80e807e9e6eb8c358269e92796365d",
+    release_date="2024-03-27",
+    n_parameters=11_000_000_000, 
+    memory_usage_mb=9279,
+    embed_dim=768,
+    license="apache-2.0",
+    max_tokens=512,
+    reference="https://huggingface.co/sentence-transformers/sentence-t5-xxl",
+    similarity_fn_name="cosine",
+    framework=["Sentence Transformers", "PyTorch"],
+    use_instructions=False,
+    public_training_code="https://arxiv.org/abs/2108.08877",
+    public_training_data=None,
+    training_datasets={"Mixed NLI": ["train"]},
+)

--- a/mteb/models/sentence_transformers_models.py
+++ b/mteb/models/sentence_transformers_models.py
@@ -312,5 +312,8 @@ sentence_t5_xxl = ModelMeta(
     use_instructions=False,
     public_training_code="https://arxiv.org/abs/2108.08877",
     public_training_data=None,
-    training_datasets={"Mixed NLI": ["train"]},
+    training_datasets={
+        "SNLI": ["train"],
+        "Community QA": ["train"]
+    } 
 )


### PR DESCRIPTION
This PR adds `sentence-transformer-xxl` model to mteb, as requested in #1998. We modify the `mteb/models/sentence_transformers_models.py` with the metadata of Sentence Transformer XXL.

Closes #1998

### Adding a model checklist
<!-- 
When adding a model to the model registry
see also https://github.com/embeddings-benchmark/mteb/blob/main/docs/reproducible_workflow.md
-->

 - [x] I have filled out the ModelMeta object to the extent possible
 - [x] I have ensured that my model can be loaded using
   - [x] `mteb.get_model(model_name, revision)` and
   - [x] `mteb.get_model_meta(model_name, revision)`
 - [x] I have tested the implementation works on a representative set of tasks.
 
 
 @Muennighoff @KennethEnevoldsen