### PR TITLE
Add versioning to MTEB benchmarks

### DIFF
--- a/mteb/benchmarks/__init__.py
+++ b/mteb/benchmarks/__init__.py
@@ -12,4 +12,5 @@ __all__ = [
     "BENCHMARK_REGISTRY",
     "get_benchmark",
     "get_benchmarks",
+    "Benchmark",
 ]

--- a/mteb/benchmarks/__init__.py
+++ b/mteb/benchmarks/__init__.py
@@ -1,4 +1,15 @@
 from __future__ import annotations
 
+from mteb.benchmarks.benchmark import Benchmark
 from mteb.benchmarks.benchmarks import *
-from mteb.benchmarks.get_benchmark import *
+from mteb.benchmarks.get_benchmark import (
+    BENCHMARK_REGISTRY,
+    get_benchmark,
+    get_benchmarks,
+)
+
+__all__ = [
+    "BENCHMARK_REGISTRY",
+    "get_benchmark",
+    "get_benchmarks",
+]

--- a/mteb/benchmarks/benchmark.py
+++ b/mteb/benchmarks/benchmark.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Annotated
+
+from pydantic import AnyUrl, BeforeValidator, TypeAdapter
+
+from mteb.load_results.load_results import load_results
+
+if TYPE_CHECKING:
+    from mteb.abstasks.AbsTask import AbsTask
+    from mteb.load_results.benchmark_results import BenchmarkResults
+
+http_url_adapter = TypeAdapter(AnyUrl)
+UrlString = Annotated[
+    str, BeforeValidator(lambda value: str(http_url_adapter.validate_python(value)))
+]  # Allows the type to be a string, but ensures that the string is a URL
+
+
+@dataclass
+class Benchmark:
+    """A benchmark object intended to run a certain benchmark within MTEB.
+
+    Args:
+        name: The name of the benchmark
+        tasks: The tasks within the benchmark.
+        description: A description of the benchmark, should include its intended goal and potentially a description of its construction
+        reference: A link reference, to a source containing additional information typically to a paper, leaderboard or github.
+        citation: A bibtex citation
+        contacts: The people to contact in case of a problem in the benchmark, preferably a GitHub handle.
+
+    Example:
+        >>> Benchmark(
+        ...     name="MTEB(custom)",
+        ...     tasks=mteb.get_tasks(
+        ...         tasks=["AmazonCounterfactualClassification", "AmazonPolarityClassification"],
+        ...         languages=["eng"],
+        ...     ),
+        ...     description="A custom benchmark"
+        ... )
+    """
+
+    name: str
+    tasks: Sequence[AbsTask]
+    description: str | None = None
+    reference: UrlString | None = None
+    citation: str | None = None
+    contacts: list[str] | None = None
+
+    def __iter__(self):
+        return iter(self.tasks)
+
+    def __len__(self) -> int:
+        return len(self.tasks)
+
+    def __getitem__(self, index):
+        return self.tasks[index]
+
+    def load_results(
+        self, base_results: None | BenchmarkResults = None
+    ) -> BenchmarkResults:
+        if not hasattr(self, "results_cache"):
+            self.results_cache = {}
+        if base_results in self.results_cache:
+            return self.results_cache[base_results]
+        if base_results is None:
+            base_results = load_results()
+        results = base_results.select_tasks(self.tasks)
+        self.results_cache[base_results] = results
+        return results

--- a/mteb/benchmarks/benchmarks.py
+++ b/mteb/benchmarks/benchmarks.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
-from dataclasses import dataclass
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
 from pydantic import AnyUrl, BeforeValidator, TypeAdapter
 
-from mteb.abstasks.AbsTask import AbsTask
-from mteb.load_results.benchmark_results import BenchmarkResults
-from mteb.load_results.load_results import load_results
+from mteb.benchmarks.benchmark import Benchmark
 from mteb.overview import MTEBTasks, get_task, get_tasks
+
+if TYPE_CHECKING:
+    pass
 
 http_url_adapter = TypeAdapter(AnyUrl)
 UrlString = Annotated[
@@ -17,61 +16,8 @@ UrlString = Annotated[
 ]  # Allows the type to be a string, but ensures that the string is a URL
 
 
-@dataclass
-class Benchmark:
-    """A benchmark object intended to run a certain benchmark within MTEB.
-
-    Args:
-        name: The name of the benchmark
-        tasks: The tasks within the benchmark.
-        description: A description of the benchmark, should include its intended goal and potentially a description of its construction
-        reference: A link reference, to a source containing additional information typically to a paper, leaderboard or github.
-        citation: A bibtex citation
-        contacts: The people to contact in case of a problem in the benchmark, preferably a GitHub handle.
-
-    Example:
-        >>> Benchmark(
-        ...     name="MTEB(custom)",
-        ...     tasks=mteb.get_tasks(
-        ...         tasks=["AmazonCounterfactualClassification", "AmazonPolarityClassification"],
-        ...         languages=["eng"],
-        ...     ),
-        ...     description="A custom benchmark"
-        ... )
-    """
-
-    name: str
-    tasks: Sequence[AbsTask]
-    description: str | None = None
-    reference: UrlString | None = None
-    citation: str | None = None
-    contacts: list[str] | None = None
-
-    def __iter__(self):
-        return iter(self.tasks)
-
-    def __len__(self) -> int:
-        return len(self.tasks)
-
-    def __getitem__(self, index):
-        return self.tasks[index]
-
-    def load_results(
-        self, base_results: None | BenchmarkResults = None
-    ) -> BenchmarkResults:
-        if not hasattr(self, "results_cache"):
-            self.results_cache = {}
-        if base_results in self.results_cache:
-            return self.results_cache[base_results]
-        if base_results is None:
-            base_results = load_results()
-        results = base_results.select_tasks(self.tasks)
-        self.results_cache[base_results] = results
-        return results
-
-
 MTEB_EN = Benchmark(
-    name="MTEB(eng)",
+    name="MTEB(eng, v2)",
     tasks=MTEBTasks(
         get_tasks(
             tasks=[
@@ -140,7 +86,7 @@ The original MTEB leaderboard is available under the [MTEB(eng, classic)](https:
 )
 
 MTEB_ENG_CLASSIC = Benchmark(
-    name="MTEB(eng, classic)",
+    name="MTEB(eng, v1)",
     tasks=MTEBTasks(
         get_tasks(
             tasks=[
@@ -237,7 +183,7 @@ We recommend that you use [MTEB(eng)](https://huggingface.co/spaces/mteb/leaderb
 )
 
 MTEB_MAIN_RU = Benchmark(
-    name="MTEB(rus)",
+    name="MTEB(rus, v1)",
     tasks=get_tasks(
         languages=["rus"],
         tasks=[
@@ -288,7 +234,7 @@ MTEB_MAIN_RU = Benchmark(
 )
 
 MTEB_RETRIEVAL_WITH_INSTRUCTIONS = Benchmark(
-    name="MTEB(Retrieval w/Instructions)",
+    name="FollowIR",
     tasks=get_tasks(
         tasks=[
             "Robust04InstructionRetrieval",
@@ -309,7 +255,7 @@ MTEB_RETRIEVAL_WITH_INSTRUCTIONS = Benchmark(
 )
 
 MTEB_RETRIEVAL_LAW = Benchmark(
-    name="MTEB(law)",  # This benchmark is likely in the need of an update
+    name="MTEB(law, v1)",  # This benchmark is likely in the need of an update
     tasks=get_tasks(
         tasks=[
             "AILACasedocs",
@@ -328,7 +274,7 @@ MTEB_RETRIEVAL_LAW = Benchmark(
 )
 
 MTEB_RETRIEVAL_MEDICAL = Benchmark(
-    name="MTEB(Medical)",
+    name="MTEB(Medical, v1)",
     tasks=get_tasks(
         tasks=[
             "CUREv1",
@@ -379,7 +325,7 @@ MTEB_MINERS_BITEXT_MINING = Benchmark(
 )
 
 SEB = Benchmark(
-    name="MTEB(Scandinavian)",
+    name="MTEB(Scandinavian, v1)",
     tasks=get_tasks(
         tasks=[
             # Bitext
@@ -493,7 +439,7 @@ RAR_b = Benchmark(
 )
 
 MTEB_FRA = Benchmark(
-    name="MTEB(fra)",
+    name="MTEB(fra, v1)",
     tasks=MTEBTasks(
         get_tasks(
             languages=["fra"],
@@ -546,9 +492,8 @@ MTEB_FRA = Benchmark(
     contacts=["imenelydiaker"],
 )
 
-
 MTEB_DEU = Benchmark(
-    name="MTEB(deu)",
+    name="MTEB(deu, v1)",
     tasks=get_tasks(
         languages=["deu"],
         exclusive_language_filter=True,
@@ -594,9 +539,8 @@ MTEB_DEU = Benchmark(
     contacts=["slvnwhrl"],
 )
 
-
 MTEB_KOR = Benchmark(
-    name="MTEB(kor)",
+    name="MTEB(kor, v1)",
     tasks=get_tasks(
         languages=["kor"],
         tasks=[  # @KennethEnevoldsen: We could probably expand this to a more solid benchamrk, but for now I have left it as is.
@@ -617,9 +561,8 @@ MTEB_KOR = Benchmark(
     citation=None,
 )
 
-
 MTEB_POL = Benchmark(
-    name="MTEB(pol)",
+    name="MTEB(pol, v1)",
     tasks=MTEBTasks(
         get_tasks(
             languages=["pol"],
@@ -664,7 +607,7 @@ two novel clustering tasks.""",  # Rephrased from the abstract
 )
 
 MTEB_code = Benchmark(
-    name="MTEB(code)",
+    name="MTEB(code, v1)",
     tasks=get_tasks(
         tasks=[
             # Retrieval
@@ -702,9 +645,8 @@ MTEB_code = Benchmark(
     citation=None,
 )
 
-
 MTEB_multilingual = Benchmark(
-    name="MTEB(Multilingual)",
+    name="MTEB(Multilingual, v1)",
     tasks=get_tasks(
         tasks=[
             "BornholmBitextMining",
@@ -848,7 +790,7 @@ MTEB_multilingual = Benchmark(
 )
 
 MTEB_JPN = Benchmark(
-    name="MTEB(jpn)",
+    name="MTEB(jpn, v1)",
     tasks=get_tasks(
         languages=["jpn"],
         tasks=[
@@ -916,7 +858,7 @@ indic_languages = [
 ]
 
 MTEB_INDIC = Benchmark(
-    name="MTEB(Indic)",
+    name="MTEB(Indic, v1)",
     tasks=get_tasks(
         tasks=[
             # Bitext
@@ -1004,7 +946,7 @@ eu_languages = [
 ]
 
 MTEB_EU = Benchmark(
-    name="MTEB(Europe)",
+    name="MTEB(Europe, v1)",
     tasks=get_tasks(
         tasks=[
             "BornholmBitextMining",
@@ -1137,7 +1079,6 @@ BRIGHT = Benchmark(
 }""",
 )
 
-
 CODE_RAG = Benchmark(
     name="CodeRAG",
     tasks=get_tasks(
@@ -1160,7 +1101,6 @@ CODE_RAG = Benchmark(
       url={https://arxiv.org/abs/2406.14497}, 
     }""",
 )
-
 
 BEIR = Benchmark(
     name="BEIR",
@@ -1219,7 +1159,7 @@ NANOBEIR = Benchmark(
 )
 
 C_MTEB = Benchmark(
-    name="MTEB(Chinese)",
+    name="MTEB(cmn, v1)",
     tasks=MTEBTasks(
         get_tasks(
             tasks=[
@@ -1275,7 +1215,7 @@ C_MTEB = Benchmark(
 )
 
 FA_MTEB = Benchmark(
-    name="FaMTEB(fas, beta)",
+    name="MTEB(fas, beta)",
     tasks=get_tasks(
         languages=["fas"],
         tasks=[

--- a/tests/test_benchmark/test_benchmark.py
+++ b/tests/test_benchmark/test_benchmark.py
@@ -12,7 +12,6 @@ from sentence_transformers import SentenceTransformer
 
 import mteb
 import mteb.overview
-from mteb.benchmarks.benchmarks import Benchmark
 from mteb.create_meta import generate_readme
 
 from .mock_models import (
@@ -167,7 +166,7 @@ def test_encode_kwargs_passed_to_all_encodes(task_name: str | mteb.AbsTask):
 @pytest.mark.parametrize("model", [MockNumpyEncoder()])
 def test_run_using_benchmark(model: mteb.Encoder):
     """Test that a benchmark object can be run using the MTEB class."""
-    bench = Benchmark(
+    bench = mteb.Benchmark(
         name="test_bench", tasks=mteb.get_tasks(tasks=["STS12", "SummEval"])
     )
 
@@ -181,7 +180,9 @@ def test_run_using_benchmark(model: mteb.Encoder):
 def test_run_using_list_of_benchmark(model: mteb.Encoder):
     """Test that a list of benchmark objects can be run using the MTEB class."""
     bench = [
-        Benchmark(name="test_bench", tasks=mteb.get_tasks(tasks=["STS12", "SummEval"]))
+        mteb.Benchmark(
+            name="test_bench", tasks=mteb.get_tasks(tasks=["STS12", "SummEval"])
+        )
     ]
 
     eval = mteb.MTEB(tasks=bench)
@@ -196,7 +197,7 @@ def test_benchmark_names_must_be_unique():
     names = [
         inst.name
         for nam, inst in benchmark_module.__dict__.items()
-        if isinstance(inst, Benchmark)
+        if isinstance(inst, mteb.Benchmark)
     ]
     assert len(names) == len(set(names))
 


### PR DESCRIPTION
- Following suggestion made in #2001 I added version to MTEB benchmarks
- changed the name of the MTEB(Chinese) to MTEB(cmn, v1). Though we could go for MTEB(Chinese, v1) assuming it is a group (also covering chinese other than mandarin)
- change the name of FaMTEB(fas, beta) to MTEB(fas)
- did a minor formatting of imports due to a circular import error
- moved the Benchmark object out of the file with the benchmarks
  - this is still >1000 lines so we could split it up to "external_benchmarks", "monolingual_benchmarks", "domain_specific_benchmarks", "multilingual_benchmarks"

Fixes #2001


<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->


### Code Quality
<!-- Please do not delete this -->
- [x] **Code Formatted**: Format the code using `make lint` to maintain consistent style.

### Documentation
<!-- Please do not delete this -->
- [ ] ~~**Updated Documentation**: Add or update documentation to reflect the changes introduced in this PR.~~

### Testing
<!-- Please do not delete this -->
- [ ] **New Tests Added**: Write tests to cover new functionality. Validate with `make test-with-coverage`.
- [ ] **Tests Passed**: Run tests locally using `make test` or `make test-with-coverage` to ensure no existing functionality is broken.