### PR TITLE
fix: Add BRIGHT (long)

### DIFF
--- a/mteb/benchmarks/benchmarks.py
+++ b/mteb/benchmarks/benchmarks.py
@@ -1060,9 +1060,7 @@ LONG_EMBED = Benchmark(
 
 BRIGHT = Benchmark(
     name="BRIGHT",
-    tasks=get_tasks(
-        tasks=["BrightRetrieval"],
-    ),
+    tasks=get_tasks(tasks=["BrightRetrieval"], eval_splits=["standard"]),
     description="""BRIGHT: A Realistic and Challenging Benchmark for Reasoning-Intensive Retrieval.
     BRIGHT is the first text retrieval
     benchmark that requires intensive reasoning to retrieve relevant documents with
@@ -1082,7 +1080,7 @@ BRIGHT = Benchmark(
 
 BRIGHT_LONG = Benchmark(
     name="BRIGHT (long)",
-    tasks=MTEBTasks((get_task("BrightRetrieval", eval_splits=["long"]),)),
+    tasks=get_tasks(tasks=["BrightRetrieval"], eval_splits=["long"]),
     description="""BRIGHT: A Realistic and Challenging Benchmark for Reasoning-Intensive Retrieval.
 BRIGHT is the first text retrieval
 benchmark that requires intensive reasoning to retrieve relevant documents with

--- a/mteb/benchmarks/benchmarks.py
+++ b/mteb/benchmarks/benchmarks.py
@@ -1080,17 +1080,17 @@ BRIGHT = Benchmark(
 )
 
 
-BRIGHT = Benchmark(
+BRIGHT_LONG = Benchmark(
     name="BRIGHT (long)",
     tasks=MTEBTasks((get_task("BrightRetrieval", eval_splits=["long"]),)),
     description="""BRIGHT: A Realistic and Challenging Benchmark for Reasoning-Intensive Retrieval.
-    BRIGHT is the first text retrieval
-    benchmark that requires intensive reasoning to retrieve relevant documents with
-    a dataset consisting of 1,384 real-world queries spanning diverse domains, such as
-    economics, psychology, mathematics, and coding. These queries are drawn from
-    naturally occurring and carefully curated human data.
+BRIGHT is the first text retrieval
+benchmark that requires intensive reasoning to retrieve relevant documents with
+a dataset consisting of 1,384 real-world queries spanning diverse domains, such as
+economics, psychology, mathematics, and coding. These queries are drawn from
+naturally occurring and carefully curated human data.
 
-    This is the long version of the benchmark, which only filter longer documents.
+This is the long version of the benchmark, which only filter longer documents.
     """,
     reference="https://brightbenchmark.github.io/",
     citation="""@article{su2024bright,

--- a/mteb/benchmarks/benchmarks.py
+++ b/mteb/benchmarks/benchmarks.py
@@ -1079,6 +1079,28 @@ BRIGHT = Benchmark(
 }""",
 )
 
+
+BRIGHT = Benchmark(
+    name="BRIGHT (long)",
+    tasks=MTEBTasks((get_task("BrightRetrieval", eval_splits=["long"]),)),
+    description="""BRIGHT: A Realistic and Challenging Benchmark for Reasoning-Intensive Retrieval.
+    BRIGHT is the first text retrieval
+    benchmark that requires intensive reasoning to retrieve relevant documents with
+    a dataset consisting of 1,384 real-world queries spanning diverse domains, such as
+    economics, psychology, mathematics, and coding. These queries are drawn from
+    naturally occurring and carefully curated human data.
+
+    This is the long version of the benchmark, which only filter longer documents.
+    """,
+    reference="https://brightbenchmark.github.io/",
+    citation="""@article{su2024bright,
+  title={Bright: A realistic and challenging benchmark for reasoning-intensive retrieval},
+  author={Su, Hongjin and Yen, Howard and Xia, Mengzhou and Shi, Weijia and Muennighoff, Niklas and Wang, Han-yu and Liu, Haisu and Shi, Quan and Siegel, Zachary S and Tang, Michael and others},
+  journal={arXiv preprint arXiv:2407.12883},
+  year={2024}
+}""",
+)
+
 CODE_RAG = Benchmark(
     name="CodeRAG",
     tasks=get_tasks(

--- a/mteb/load_results/task_results.py
+++ b/mteb/load_results/task_results.py
@@ -525,7 +525,7 @@ class TaskResult(BaseModel):
         if task is None:
             task = get_task(self.task_name)
 
-        splits = task.metadata.eval_splits
+        splits = task.eval_splits
         hf_subsets = task.hf_subsets
         hf_subsets = set(hf_subsets)
 

--- a/mteb/tasks/Retrieval/eng/BrightRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/BrightRetrieval.py
@@ -50,7 +50,6 @@ class BrightRetrieval(MultilingualTask, AbsTaskRetrieval):
         domains=["Non-fiction", "Written"],
         task_subtypes=["Article retrieval"],
         license="cc-by-4.0",
-        socioeconomic_status="low",
         annotations_creators="derived",
         dialect=[],
         sample_creation="found",

--- a/tests/test_load_results/test_task_results.py
+++ b/tests/test_load_results/test_task_results.py
@@ -34,7 +34,6 @@ class DummyTask(AbsTask):
         annotations_creators="derived",
         dialect=[],
         bibtex_citation="",
-        descriptive_stats={},
         modalities=["text"],
         sample_creation="created",
     )
@@ -48,11 +47,11 @@ class DummyTask(AbsTask):
     def _calculate_metrics_from_split(
         self, split: str, hf_subset: str | None = None, compute_overall=False
     ) -> dict[str, float]:
-        pass
+        return {}
 
 
-def test_mteb_results():
-    """Test TaskResult class (this is the same as the example in the docstring)"""
+@pytest.fixture()
+def task_result():
     scores = {
         "train": {
             "en-de": {
@@ -66,13 +65,19 @@ def test_mteb_results():
 
     evaluation_time = 100
 
-    mteb_results = TaskResult.from_task_results(
+    return TaskResult.from_task_results(
         task=DummyTask(), scores=scores, evaluation_time=evaluation_time
     )
 
-    assert mteb_results.get_score() == 0.55
-    assert mteb_results.get_score(languages=["eng"]) == 0.55
-    assert mteb_results.get_score(languages=["fra"]) == 0.6
+
+def test_task_results_get_score(task_result: TaskResult):
+    """Test TaskResult class (this is the same as the example in the docstring)"""
+    assert task_result.get_score() == 0.55
+    assert task_result.get_score(languages=["eng"]) == 0.55
+    assert task_result.get_score(languages=["fra"]) == 0.6
+
+
+def test_task_results_to_dict(task_result: TaskResult):
     dict_repr = {
         "dataset_revision": "1.0",
         "task_name": "dummy_task",
@@ -94,7 +99,52 @@ def test_mteb_results():
             ]
         },
     }
-    assert mteb_results.to_dict() == dict_repr
+    assert task_result.to_dict() == dict_repr
+
+
+def test_task_results_validate_and_filter():
+    scores = {
+        "train": {
+            "en-de": {
+                "main_score": 0.5,
+            },
+            "en-fr": {
+                "main_score": 0.6,
+            },
+        },
+        "test": {
+            "en-de": {
+                "main_score": 0.3,
+            },
+            "en-fr": {
+                "main_score": 0.4,
+            },
+        },
+    }
+
+    evaluation_time = 100
+
+    res = TaskResult.from_task_results(
+        task=DummyTask(), scores=scores, evaluation_time=evaluation_time
+    )
+
+    task = DummyTask()
+    task._eval_splits = ["train", "test"]
+    res1 = res.validate_and_filter_scores(task=task)
+
+    assert res1.scores.keys() == {"train", "test"}
+    assert res1.get_score() == (0.5 + 0.6 + 0.3 + 0.4) / 4
+
+    task._eval_splits = ["test"]
+    res2 = res.validate_and_filter_scores(task=task)
+    assert res2.scores.keys() == {"test"}
+    assert res2.get_score() == (0.3 + 0.4) / 2  # only test scores
+
+    task.hf_subsets = ["en-de"]
+    task._eval_splits = ["train", "test"]
+    res3 = res.validate_and_filter_scores(task=task)
+    assert res3.scores.keys() == {"train", "test"}
+    assert res3.get_score() == (0.5 + 0.3) / 2  # only en-de scores
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
fixed #1978 

- Fixed bug in validate_and_filter()
  - Added tests for this
- Added bright (long)
  - problem: bright (long) uses recall@1 as its main score. Not sure how to resolve that? (added issue #2046)
- Fixed bright to only use standard split

@x-tabdeveloping seems like the filtering does not check for splits, this seems a bit worrying to me:

Results from BRIGHT (long):
<img width="316" alt="Screenshot 2025-02-12 at 12 33 57" src="https://github.com/user-attachments/assets/78511a5c-889a-45bc-9067-fdc751b0b2c5" />

Results from BRIGHT:
<img width="295" alt="Screenshot 2025-02-12 at 12 38 01" src="https://github.com/user-attachments/assets/71e004a3-c6bd-4049-b83e-eb5b86919f37" />

---

Did a bit of a debugging process. It I have now fixed it in `validate_and_filter()`.

You can see the diff here:

```py
import mteb

task = mteb.get_task("BrightRetrieval")
res = mteb.load_results(tasks=[task])
res_filtered = res.filter_models().join_revisions()
[m for m in res_filtered.model_results if m.model_name == "GritLM/GritLM-7B"][
    0
].task_results[0].get_score()
# 0.310709 # expected


bench: mteb.Benchmark = mteb.get_benchmark("BRIGHT")
bright_results = bench.load_results(res)

[m for m in bright_results.model_results if m.model_name == "GritLM/GritLM-7B"][
    0
].task_results[0].get_score()
# before: 0.310709 # both splits
# after: 0.20627749999999997 # only standard split

bench_long: mteb.Benchmark = mteb.get_benchmark("BRIGHT (long)")
bright_long_results = bench.load_results(res)

[m for m in bright_long_results.model_results if m.model_name == "GritLM/GritLM-7B"][
    0
].task_results[0].get_score()
# before fix: 0.310709 # problem here
# after fix: 0.46735625 # intended 


model_res = [m for m in res.model_results if m.model_name == "GritLM/GritLM-7B"][0]
bright_task_res = model_res.task_results[0]

bright_task_res.get_score()
# 0.310709 # expected

model_res = [m for m in res.model_results if m.model_name == "GritLM/GritLM-7B"][0]
bright_task_res = model_res.task_results[0]

bright_task_res.get_score()
# 0.310709 # expected

bright_task_res.get_score(splits = ["long"])
# 0.46735625 # match score on results not on legacy leaderboard
# using recall at 1 as leaderboard
bright_task_res.get_score(splits = ["long"], getter = lambda x: x["recall_at_1"])
# matches leaderboard

bright_task_res.get_score(splits = ["standard"])
# 0.20627749999999997 # match score on BRIGHT leaderboard


filtered_task = bright_task_res.validate_and_filter_scores(task=bench_long.tasks[0])

bench_long.tasks[0].eval_splits # ['long']
filtered_task.scores.keys() 
# before fix: dict_keys(['standard', 'long']) !?
# after fix: dict_keys(['long'])
filtered_task.get_score()

# after: 0.46735625
```

