### PR TITLE
fix: add missing `e5` training datasets

### DIFF
--- a/mteb/models/e5_models.py
+++ b/mteb/models/e5_models.py
@@ -137,6 +137,10 @@ ME5_TRAINING_DATA = {
     "HotpotQAHardNegatives": ["train"],
     "HotpotQA-PL": ["train"],  # translation not trained on
     "HotpotQA-NL": ["train"],  # translation not trained on
+    "MIRACLRetrieval": ["train"],
+    "MIRACLRetrievalHardNegatives": ["train"],
+    "MIRACLReranking": ["train"],
+    "MrTidyRetrieval": ["train"],
 }
 
 e5_mult_small = ModelMeta(


### PR DESCRIPTION
We've missed `MIRACL` and `Mr.Tydi`
![image](https://github.com/user-attachments/assets/6fa8c86e-2ebe-4dc7-82ae-05bd041eebef)
https://arxiv.org/pdf/2402.05672

### Code Quality
<!-- Please do not delete this -->
- [X] **Code Formatted**: Format the code using `make lint` to maintain consistent style.

### Documentation
<!-- Please do not delete this -->
- [X] **Updated Documentation**: Add or update documentation to reflect the changes introduced in this PR.
