### PR TITLE
fix: Add back task filtering by modalities

### DIFF
--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -497,11 +497,14 @@ class MTEB:
                 del self.tasks[0]  # empty memory
                 continue
 
-            # skip evaluation if the model does not support the task modalities.
-            task_modalities = "".join(sorted(task.metadata.modalities))
-            if "".join(sorted(meta.modalities)) != task_modalities:
+            # NOTE: skip evaluation if the model does not support all of the task's modalities.
+            # If the model covers more than the task's modalities, evaluation will still be run.
+            sorted_task_modalities = sorted(task.metadata.modalities)
+            if meta.modalities is not None and any(
+                m not in meta.modalities for m in sorted_task_modalities
+            ):
                 logger.info(
-                    f"{meta.name} only supports {meta.modalities}, but the task modalities are {task.metadata.modalities}."
+                    f"{meta.name} only supports {meta.modalities}, but the task modalities are {sorted_task_modalities}."
                 )
                 del self.tasks[0]  # empty memory
                 continue

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -497,6 +497,15 @@ class MTEB:
                 del self.tasks[0]  # empty memory
                 continue
 
+            # skip evaluation if the model does not support the task modalities.
+            task_modalities = "".join(sorted(task.metadata.modalities))
+            if "".join(sorted(meta.modalities)) != task_modalities:
+                logger.info(
+                    f"{meta.name} only supports {meta.modalities}, but the task modalities are {task.metadata.modalities}."
+                )
+                del self.tasks[0]  # empty memory
+                continue
+
             task_eval_splits = (
                 eval_splits if eval_splits is not None else task.eval_splits
             )

--- a/tests/test_benchmark/mock_models.py
+++ b/tests/test_benchmark/mock_models.py
@@ -44,6 +44,28 @@ class MockTorchbf16Encoder(SentenceTransformer):
 
 
 class MockCLIPEncoder:
+    mteb_model_meta = ModelMeta(
+        name="MockCLIPModel",
+        languages=["eng_Latn"],
+        revision="3d74acf9a28c67741b2f4f2ea7635f0aaf6f0268",
+        release_date="2021-02-06",
+        modalities=["image", "text"],
+        n_parameters=86_600_000,
+        memory_usage_mb=330,
+        max_tokens=None,
+        embed_dim=768,
+        license=None,
+        open_weights=True,
+        public_training_code=None,
+        public_training_data=None,
+        framework=["PyTorch"],
+        reference="https://huggingface.co/openai/clip-vit-base-patch32",
+        similarity_fn_name=None,
+        use_instructions=False,
+        training_datasets=None,
+    )
+    model_card_data = mteb_model_meta
+
     def __init__(self):
         pass
 

--- a/tests/test_benchmark/mock_models.py
+++ b/tests/test_benchmark/mock_models.py
@@ -15,6 +15,7 @@ from torch.utils.data import DataLoader
 import mteb
 from mteb import SentenceTransformerWrapper
 from mteb.encoder_interface import PromptType
+from mteb.model_meta import ModelMeta
 from tests.test_benchmark.task_grid import MOCK_TASK_TEST_GRID
 
 
@@ -64,6 +65,45 @@ class MockCLIPEncoder:
 
     def calculate_probs(self, text_embeddings, image_embeddings):
         return torch.randn(image_embeddings.shape[0], text_embeddings.shape[0])
+
+
+class MockMocoEncoder:
+    mteb_model_meta = ModelMeta(
+        name="MockMocoModel",
+        languages=["eng_Latn"],
+        revision="7d091cd70772c5c0ecf7f00b5f12ca609a99d69d",
+        release_date="2024-01-01",
+        modalities=["image"],
+        n_parameters=86_600_000,
+        memory_usage_mb=330,
+        max_tokens=None,
+        embed_dim=768,
+        license=None,
+        open_weights=True,
+        public_training_code=None,
+        public_training_data=None,
+        framework=["PyTorch"],
+        reference="https://github.com/facebookresearch/moco-v3",
+        similarity_fn_name=None,
+        use_instructions=False,
+        training_datasets=None,
+    )
+    model_card_data = mteb_model_meta
+
+    def __init__(self):
+        pass
+
+    def get_text_embeddings(self, texts, **kwargs):
+        pass
+
+    def get_image_embeddings(self, images, **kwargs):
+        pass
+
+    def get_fused_embeddings(self, texts, images, **kwargs):
+        pass
+
+    def calculate_probs(self, text_embeddings, image_embeddings):
+        pass
 
 
 class MockSentenceTransformer(SentenceTransformer):

--- a/tests/test_benchmark/test_benchmark.py
+++ b/tests/test_benchmark/test_benchmark.py
@@ -17,6 +17,7 @@ from mteb.create_meta import generate_readme
 from mteb.evaluation.MTEB import logger
 
 from .mock_models import (
+    MockCLIPEncoder,
     MockMocoEncoder,
     MockNumpyEncoder,
     MockSentenceTransformer,
@@ -25,6 +26,7 @@ from .mock_models import (
     MockTorchEncoder,
 )
 from .mock_tasks import (
+    MockImageClusteringTask,
     MockImageTextPairClassificationTask,
     MockInstructionRetrival,
     MockMultilingualInstructionRetrival,
@@ -357,4 +359,16 @@ def test_task_modality_filtering(mock_logger, task):
     )
     mock_logger.assert_called_with(
         f"MockMocoModel only supports ['image'], but the task modalities are [{task_modalities}]."
+    )
+
+
+@pytest.mark.parametrize("task", [MockImageClusteringTask()])
+def test_task_modality_filtering_model_modalities_more_than_task_modalities(task):
+    eval = mteb.MTEB(tasks=[task])
+
+    # Run the evaluation
+    eval.run(
+        model=MockCLIPEncoder(),
+        output_folder="tests/results",
+        overwrite_results=True,
     )

--- a/tests/test_benchmark/test_benchmark.py
+++ b/tests/test_benchmark/test_benchmark.py
@@ -14,6 +14,7 @@ from sentence_transformers import SentenceTransformer
 import mteb
 import mteb.overview
 from mteb.create_meta import generate_readme
+from mteb.evaluation.MTEB import logger
 
 from .mock_models import (
     MockMocoEncoder,
@@ -339,22 +340,21 @@ def test_model_query_passage_prompts_task_type(
 @pytest.mark.parametrize(
     "task", [MockImageTextPairClassificationTask(), MockRetrievalTask()]
 )
-@patch("mteb.evaluation.MTEB.logger")
+@patch.object(logger, "info")
 def test_task_modality_filtering(mock_logger, task):
     eval = mteb.MTEB(tasks=[task])
 
     # Run the evaluation
-    with patch.object(mock_logger, "info") as mock_info:
-        eval.run(
-            model=MockMocoEncoder(),
-            output_folder="tests/results",
-            overwrite_results=True,
-        )
+    eval.run(
+        model=MockMocoEncoder(),
+        output_folder="tests/results",
+        overwrite_results=True,
+    )
 
     # Check that the task was skipped and the correct log message was generated
     task_modalities = ", ".join(
         f"'{modality}'" for modality in sorted(task.metadata.modalities)
     )
-    mock_info.assert_called_with(
+    mock_logger.assert_called_with(
         f"MockMocoModel only supports ['image'], but the task modalities are [{task_modalities}]."
     )


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->
Fixes #2075 
- Added back task filtering by modalities. 
- Added unit test to cover cases of running models with different modalities as tasks
 
When running `mteb run -m average_word_embeddings_komninos -t MNIST`, we now get (instead of an exception / error):

```
## Evaluating 1 tasks:
────────────────────────────────────────────────────────────────────────────── Selected tasks  ───────────────────────────────────────────────────────────────────────────────
ImageClassification
    - MNIST, i2i


INFO:mteb.evaluation.MTEB:

********************** Evaluating MNIST **********************
INFO:mteb.evaluation.MTEB:average_word_embeddings_komninos only supports ['text'], but the task modalities are ['image'].
```

### Code Quality
<!-- Please do not delete this -->
- [x] **Code Formatted**: Format the code using `make lint` to maintain consistent style.

### Documentation
<!-- Please do not delete this -->
- [x] **Updated Documentation**: Add or update documentation to reflect the changes introduced in this PR.

### Testing
<!-- Please do not delete this -->
- [x] **New Tests Added**: Write tests to cover new functionality. Validate with `make test-with-coverage`.
- [x] **Tests Passed**: Run tests locally using `make test` or `make test-with-coverage` to ensure no existing functionality is broken.
