### PR TITLE
fix: Smarter leaderboard caching with cachetools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dev = ["ruff==0.6.4", # locked so we don't get PRs which fail only due to a lint
 codecarbon = ["codecarbon"]
 speedtask = ["GPUtil>=1.4.0", "psutil>=5.9.8"]
 peft = ["peft>=0.11.0"]
-leaderboard = ["gradio>=5.7.1", "gradio_rangeslider>=0.0.8", "plotly>=5.24.0,<6.0.0"]
+leaderboard = ["gradio>=5.5.0,<6.0.0", "gradio_rangeslider>=0.0.8", "plotly>=5.24.0,<6.0.0"]
 flagembedding = ["FlagEmbedding"]
 jina = ["einops>=0.8.0"]
 flash_attention = ["flash-attn>=2.6.3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "eval_type_backport>=0.0.0",
     "polars>=0.20.22",
     "torchvision>0.0.0",
+    "cachetools>=5.2.0",
 ]
 
 


### PR DESCRIPTION
I've improved the leaderboard caching by preventing as many taxing calculations as humanly possible.
There's a slight performance improvement on my machine, but I'd imagine this makes a bigger difference in production.
Additionally, all callbacks are run with all benchmarks on startup, so that most things would already be in the cache when the leaderboard is running.

Unfortunately I have no way of completely preventing callbacks and communication with the server, so it's not as significant an improvement as previous ones.