### PR TITLE
fix: Fixed previous incorrect specification of splits for CMTEB ( MTEB(cmn, v1) )

### DIFF
--- a/mteb/benchmarks/benchmarks.py
+++ b/mteb/benchmarks/benchmarks.py
@@ -1215,14 +1215,14 @@ C_MTEB = Benchmark(
                 "JDReview",
             ],
         )
-        + get_tasks(tasks=["MultilingualSentiment"], eval_splits=["test"])
         + get_tasks(
             tasks=[
+                "MultilingualSentiment",
                 "ATEC",
                 "BQ",
                 "STSB",
             ],
-            eval_splits=["validation"],
+            eval_splits=["test"],
         )
     ),
     description="The Chinese Massive Text Embedding Benchmark (C-MTEB) is a comprehensive benchmark for Chinese text embeddings covering 6 tasks and 35 datasets.",


### PR DESCRIPTION
Fixes #2064
