### PR TITLE
Adding gtr-t5 model to mteb

### DIFF
--- a/mteb/models/gtr_models.py
+++ b/mteb/models/gtr_models.py
@@ -1,12 +1,53 @@
 from mteb.model_meta import ModelMeta
 
+gtr_t5_large = ModelMeta(
+    name="sentence-transformers/gtr-t5-large",
+    languages=["eng-Latn"],  # in format eng-Latn
+    open_weights=True,
+    revision="a2c8ac47f998531948d4cbe32a0b577a7037a5e3",
+    release_date="2022-02-09",
+    n_parameters=335_000_000,
+    memory_usage_mb=None,
+    embed_dim=768,
+    license="apache-2.0",
+    max_tokens=512,
+    reference="https://huggingface.co/sentence-transformers/gtr-t5-large",
+    similarity_fn_name="cosine",
+    framework=["Sentence Transformers", "PyTorch"],
+    use_instructions=False,
+    public_training_code=None,
+    public_training_data=None,
+    training_datasets=None,
+)
+
+gtr_t5_xl = ModelMeta(
+    name="sentence-transformers/gtr-t5-xl",
+    languages=["eng-Latn"],  # in format eng-Latn
+    open_weights=True,
+    revision="23a8d667a1ad2578af181ce762867003c498d1bf",
+    release_date="2022-02-09",
+    n_parameters=1_240_000_000,
+    memory_usage_mb=None,
+    embed_dim=768,
+    license="apache-2.0",
+    max_tokens=512,
+    reference="https://huggingface.co/sentence-transformers/gtr-t5-xl",
+    similarity_fn_name="cosine",
+    framework=["Sentence Transformers", "PyTorch"],
+    use_instructions=False,
+    public_training_code=None,
+    public_training_data=None,
+    training_datasets=None,
+)
+
 gtr_t5_xxl = ModelMeta(
-    name="gtr-t5-xxl",
+    name="sentence-transformers/gtr-t5-xxl",
     languages=["eng-Latn"],  # in format eng-Latn
     open_weights=True,
     revision="73f2a9156a3dcc2194dfdb2bf201cd7d17e17884",
     release_date="2022-02-09",
     n_parameters=4_860_000_000,
+    memory_usage_mb=None,
     embed_dim=768,
     license="apache-2.0",
     max_tokens=512,
@@ -26,10 +67,11 @@ gtr_t5_base = ModelMeta(
     revision="7027e9594267928589816394bdd295273ddc0739",
     release_date="2022-02-09",
     n_parameters=110_000_000,
+    memory_usage_mb=None,
     embed_dim=768,
     license="apache-2.0",
     max_tokens=512,
-    reference="https://huggingface.co/sentence-transformers/gtr-t5-bases",
+    reference="https://huggingface.co/sentence-transformers/gtr-t5-base",
     similarity_fn_name="cosine",
     framework=["Sentence Transformers", "PyTorch"],
     use_instructions=False,

--- a/mteb/models/gtr_models.py
+++ b/mteb/models/gtr_models.py
@@ -1,0 +1,39 @@
+from mteb.model_meta import ModelMeta
+
+gtr_t5_xxl = ModelMeta(
+    name="gtr-t5-xxl",
+    languages=["eng-Latn"],  # in format eng-Latn
+    open_weights=True,
+    revision="73f2a9156a3dcc2194dfdb2bf201cd7d17e17884",
+    release_date="2022-02-09",
+    n_parameters=4_860_000_000,
+    embed_dim=768,
+    license="apache-2.0",
+    max_tokens=512,
+    reference="https://huggingface.co/sentence-transformers/gtr-t5-xxl",
+    similarity_fn_name="cosine",
+    framework=["Sentence Transformers", "PyTorch"],
+    use_instructions=False,
+    public_training_code=None,
+    public_training_data=None,
+    training_datasets=None,
+)
+
+gtr_t5_base = ModelMeta(
+    name="sentence-transformers/gtr-t5-base",
+    languages=["eng-Latn"],  # in format eng-Latn
+    open_weights=True,
+    revision="7027e9594267928589816394bdd295273ddc0739",
+    release_date="2022-02-09",
+    n_parameters=110_000_000,
+    embed_dim=768,
+    license="apache-2.0",
+    max_tokens=512,
+    reference="https://huggingface.co/sentence-transformers/gtr-t5-bases",
+    similarity_fn_name="cosine",
+    framework=["Sentence Transformers", "PyTorch"],
+    use_instructions=False,
+    public_training_code=None,
+    public_training_data=None,
+    training_datasets=None,
+)

--- a/mteb/models/overview.py
+++ b/mteb/models/overview.py
@@ -29,11 +29,11 @@ from mteb.models import (
     e5_models,
     e5_v,
     evaclip_models,
-    fa_models,
     gme_models,
     google_models,
     gritlm_models,
     gte_models,
+    gtr_models,
     ibm_granite_models,
     inf_models,
     jasper_models,
@@ -63,7 +63,6 @@ from mteb.models import (
     salesforce_models,
     sentence_transformers_models,
     siglip_models,
-    sonar_models,
     stella_models,
     text2vec_models,
     uae_models,
@@ -98,6 +97,7 @@ model_modules = [
     gritlm_models,
     gte_models,
     gme_models,
+    gtr_models,
     ibm_granite_models,
     inf_models,
     jasper_models,
@@ -131,11 +131,9 @@ model_modules = [
     vlm2vec_models,
     voyage_v,
     stella_models,
-    sonar_models,
     text2vec_models,
     uae_models,
     voyage_models,
-    fa_models,
 ]
 MODEL_REGISTRY = {}
 
@@ -154,18 +152,7 @@ def get_model_metas(
     use_instructions: bool | None = None,
     zero_shot_on: list[AbsTask] | None = None,
 ) -> list[ModelMeta]:
-    """Load all models' metadata that fit the specified criteria.
-
-    Args:
-        model_names: A list of model names to filter by. If None, all models are included.
-        languages: A list of languages to filter by. If None, all languages are included.
-        open_weights: Whether to filter by models with open weights. If None this filter is ignored.
-        frameworks: A list of frameworks to filter by. If None, all frameworks are included.
-        n_parameters_range: A tuple of lower and upper bounds of the number of parameters to filter by.
-            If (None, None), this filter is ignored.
-        use_instructions: Whether to filter by models that use instructions. If None, all models are included.
-        zero_shot_on: A list of tasks on which the model is zero-shot. If None this filter is ignored.
-    """
+    """Load all models' metadata that fit the specified criteria."""
     res = []
     model_names = set(model_names) if model_names is not None else None
     languages = set(languages) if languages is not None else None
@@ -186,16 +173,14 @@ def get_model_metas(
             model_meta.use_instructions != use_instructions
         ):
             continue
-
         lower, upper = n_parameters_range
         n_parameters = model_meta.n_parameters
-
         if upper is not None:
             if (n_parameters is None) or (n_parameters > upper):
                 continue
-            if lower is not None and n_parameters < lower:
+        if lower is not None:
+            if (n_parameters is None) or (n_parameters < lower):
                 continue
-
         if zero_shot_on is not None:
             if not model_meta.is_zero_shot_on(zero_shot_on):
                 continue
@@ -271,11 +256,10 @@ def model_meta_from_hf_hub(model_name: str) -> ModelMeta:
             # TODO: We need a mapping between conflicting language codes
             languages=None,
             license=card_data.get("license", None),
-            framework=frameworks,  # type: ignore
+            framework=frameworks,
             training_datasets=card_data.get("datasets", None),
             similarity_fn_name=None,
             n_parameters=None,
-            memory_usage_mb=None,
             max_tokens=None,
             embed_dim=None,
             open_weights=True,
@@ -291,7 +275,6 @@ def model_meta_from_hf_hub(model_name: str) -> ModelMeta:
             languages=None,
             release_date=None,
             n_parameters=None,
-            memory_usage_mb=None,
             max_tokens=None,
             embed_dim=None,
             license=None,
@@ -325,7 +308,6 @@ def model_meta_from_sentence_transformers(model: SentenceTransformer) -> ModelMe
             framework=["Sentence Transformers"],
             similarity_fn_name=model.similarity_fn_name,
             n_parameters=None,
-            memory_usage_mb=None,
             max_tokens=None,
             embed_dim=None,
             license=None,
@@ -345,7 +327,6 @@ def model_meta_from_sentence_transformers(model: SentenceTransformer) -> ModelMe
             languages=None,
             release_date=None,
             n_parameters=None,
-            memory_usage_mb=None,
             max_tokens=None,
             embed_dim=None,
             license=None,


### PR DESCRIPTION
This PR adds gtr-t5-base/large/xl/xxl models to mteb, as requested in https://github.com/embeddings-benchmark/mteb/issues/2000. 

Closes https://github.com/embeddings-benchmark/mteb/issues/2000

### Adding a model checklist
 - [x] I have filled out the ModelMeta object to the extent possible
 - [x] I have ensured that my model can be loaded using
   - [x] `mteb.get_model(model_name, revision)` and
   - [x] `mteb.get_model_meta(model_name, revision)`
 - [x] I have tested the implementation works on a representative set of tasks.