### PR TITLE
fix: Updated model annotations for GTE, e5, gritlm, and SFR models

### DIFF
--- a/mteb/models/arctic_models.py
+++ b/mteb/models/arctic_models.py
@@ -81,8 +81,44 @@ LANGUAGES_V2_0 = [
     "zho_Hans",
 ]
 
+arctic_v1_training_datasets = {
+    # source: https://arxiv.org/pdf/2405.05374
+    # splits not specified to assuming everything
+    # in MTEB
+    "NQ": ["test"],
+    "NQ-NL": ["test"],  # translated from NQ (not trained on)
+    "NQHardNegatives": ["test"],
+    "NQ-PL": ["test"],
+    "HotPotQA": ["test"],  # translated, not trained on
+    "HotPotQAHardNegatives": ["test"],
+    "HotPotQA-PL": ["test"],  # translated from hotpotQA (not trained on)
+    "HotpotQA-NL": ["test"],  # translated from hotpotQA (not trained on)
+    "FEVER": ["test"],
+    "FEVER-NL": ["test"],  # translated from FEVER (not trained on)
+    "FEVERHardNegatives": ["test"],
+    # not in MTEB
+    # trained on stack exchange (title-body)
+    # "stackexchange": [],
+    # potentially means that:
+    # "StackExchangeClusteringP2P": ["test"],
+    # "StackExchangeClusteringP2P.v2": ["test"],
+    # "StackExchangeClustering": ["test"],
+    # "StackExchangeClustering.v2": ["test"],
+    # not in MTEB
+    # "paq": [],
+    # "s2orc": [],
+    # "other": [],  # undisclosed including webdata
+}  # also use synthetic
+
+arctic_v2_training_datasets = {
+    **arctic_v1_training_datasets,
+    "MIRACLRetrieval": ["train"],
+    "MIRACLRetrievalHardNegatives": ["train"],
+    "MIRACLReranking": ["train"],
+}
+
 arctic_embed_xs = ModelMeta(
-    loader=partial(
+    loader=partial(  # type: ignore
         sentence_transformers_loader,
         model_name="Snowflake/snowflake-arctic-embed-xs",
         revision="742da4f66e1823b5b4dbe6c320a1375a1fd85f9e",
@@ -105,39 +141,12 @@ arctic_embed_xs = ModelMeta(
     superseded_by=None,
     public_training_code=None,
     public_training_data=None,
-    training_datasets={
-        # source: https://arxiv.org/pdf/2405.05374
-        # splits not specified to assuming everything
-        # in MTEB
-        "NQ": ["test"],
-        "NQ-NL": ["test"],  # translated from NQ (not trained on)
-        "NQHardNegatives": ["test"],
-        "NQ-PL": ["test"],
-        "HotPotQA": ["test"],  # translated, not trained on
-        "HotPotQAHardNegatives": ["test"],
-        "HotPotQA-PL": ["test"],  # translated from hotpotQA (not trained on)
-        "HotpotQA-NL": ["test"],  # translated from hotpotQA (not trained on)
-        "FEVER": ["test"],
-        "FEVER-NL": ["test"],  # translated from FEVER (not trained on)
-        "FEVERHardNegatives": ["test"],
-        # not in MTEB
-        # trained on stack exchange (title-body)
-        # "stackexchange": [],
-        # potentially means that:
-        # "StackExchangeClusteringP2P": ["test"],
-        # "StackExchangeClusteringP2P.v2": ["test"],
-        # "StackExchangeClustering": ["test"],
-        # "StackExchangeClustering.v2": ["test"],
-        # not in MTEB
-        # "paq": [],
-        # "s2orc": [],
-        # "other": [],  # undisclosed including webdata
-    },  # also use synthetic
+    training_datasets=arctic_v1_training_datasets,
 )
 
 
 arctic_embed_s = ModelMeta(
-    loader=partial(
+    loader=partial(  # type: ignore
         sentence_transformers_loader,
         model_name="Snowflake/snowflake-arctic-embed-s",
         revision="d3c1d2d433dd0fdc8e9ca01331a5f225639e798f",
@@ -160,38 +169,12 @@ arctic_embed_s = ModelMeta(
     superseded_by=None,
     public_training_code=None,
     public_training_data=None,  # couldn't find
-    training_datasets={
-        # source: https://arxiv.org/pdf/2405.05374
-        # splits not specified to assuming everything
-        # in MTEB
-        "NQ": ["test"],
-        "NQ-NL": ["test"],  # translated from NQ (not trained on)
-        "NQHardNegatives": ["test"],
-        "HotPotQA": ["test"],
-        "HotPotQAHardNegatives": ["test"],
-        "HotPotQA-PL": ["test"],  # translated from hotpotQA (not trained on)
-        "HotpotQA-NL": ["test"],  # translated from hotpotQA (not trained on)
-        "FEVER": ["test"],
-        "FEVER-NL": ["test"],  # translated from FEVER (not trained on)
-        "FEVERHardNegatives": ["test"],
-        # not in MTEB
-        # trained on stack exchange (title-body)
-        # "stackexchange": [],
-        # potentially means that:
-        # "StackExchangeClusteringP2P": ["test"],
-        # "StackExchangeClusteringP2P.v2": ["test"],
-        # "StackExchangeClustering": ["test"],
-        # "StackExchangeClustering.v2": ["test"],
-        # not in MTEB
-        # "paq": [],
-        # "s2orc": [],
-        # "other": [],  # undisclosed including webdata
-    },  # also use synthetic
+    training_datasets=arctic_v1_training_datasets,
 )
 
 
 arctic_embed_m = ModelMeta(
-    loader=partial(
+    loader=partial(  # type: ignore
         sentence_transformers_loader,
         model_name="Snowflake/snowflake-arctic-embed-m",
         revision="cc17beacbac32366782584c8752220405a0f3f40",
@@ -214,37 +197,11 @@ arctic_embed_m = ModelMeta(
     superseded_by="Snowflake/snowflake-arctic-embed-m-v1.5",
     public_training_code=None,
     public_training_data=None,  # couldn't find
-    training_datasets={
-        # source: https://arxiv.org/pdf/2405.05374
-        # splits not specified to assuming everything
-        # in MTEB
-        "NQ": ["test"],
-        "NQ-NL": ["test"],  # translated from NQ (not trained on)
-        "NQHardNegatives": ["test"],
-        "HotPotQA": ["test"],
-        "HotPotQAHardNegatives": ["test"],
-        "HotPotQA-PL": ["test"],  # translated from hotpotQA (not trained on)
-        "HotpotQA-NL": ["test"],  # translated from hotpotQA (not trained on)
-        "FEVER": ["test"],
-        "FEVER-NL": ["test"],  # translated from FEVER (not trained on)
-        "FEVERHardNegatives": ["test"],
-        # not in MTEB
-        # trained on stack exchange (title-body)
-        # "stackexchange": [],
-        # potentially means that:
-        # "StackExchangeClusteringP2P": ["test"],
-        # "StackExchangeClusteringP2P.v2": ["test"],
-        # "StackExchangeClustering": ["test"],
-        # "StackExchangeClustering.v2": ["test"],
-        # not in MTEB
-        # "paq": [],
-        # "s2orc": [],
-        # "other": [],  # undisclosed including webdata
-    },  # also use synthetic
+    training_datasets=arctic_v1_training_datasets,
 )
 
 arctic_embed_m_long = ModelMeta(
-    loader=partial(
+    loader=partial(  # type: ignore
         sentence_transformers_loader,
         model_name="Snowflake/snowflake-arctic-embed-m-long",
         revision="89d0f6ab196eead40b90cb6f9fefec01a908d2d1",
@@ -268,38 +225,11 @@ arctic_embed_m_long = ModelMeta(
     superseded_by="Snowflake/snowflake-arctic-embed-m-v2.0",
     public_training_code=None,
     public_training_data=None,  # couldn't find
-    training_datasets={
-        # source: https://arxiv.org/pdf/2405.05374
-        # splits not specified to assuming everything
-        # in MTEB
-        "NQ": ["test"],
-        "NQ-NL": ["test"],  # translated from NQ (not trained on)
-        "NQHardNegatives": ["test"],
-        "HotPotQA": ["test"],
-        "HotPotQAHardNegatives": ["test"],
-        "HotPotQA-PL": ["test"],  # translated from hotpotQA (not trained on)
-        "HotpotQA-NL": ["test"],  # translated from hotpotQA (not trained on)
-        "FEVER": ["test"],
-        "FEVER-NL": ["test"],  # translated from FEVER (not trained on)
-        "FEVERHardNegatives": ["test"],
-        # trained on stack exchange, unsure if sources match
-        # not in MTEB
-        # trained on stack exchange (title-body)
-        # "stackexchange": [],
-        # potentially means that:
-        # "StackExchangeClusteringP2P": ["test"],
-        # "StackExchangeClusteringP2P.v2": ["test"],
-        # "StackExchangeClustering": ["test"],
-        # "StackExchangeClustering.v2": ["test"],
-        # not in MTEB
-        # "paq": [],
-        # "s2orc": [],
-        # "other": [],  # undisclosed including webdata
-    },  # also use synthetic
+    training_datasets=arctic_v1_training_datasets,
 )
 
 arctic_embed_l = ModelMeta(
-    loader=partial(
+    loader=partial(  # type: ignore
         sentence_transformers_loader,
         model_name="Snowflake/snowflake-arctic-embed-l",
         revision="9a9e5834d2e89cdd8bb72b64111dde496e4fe78c",
@@ -322,37 +252,11 @@ arctic_embed_l = ModelMeta(
     superseded_by="Snowflake/snowflake-arctic-embed-l-v2.0",
     public_training_code=None,
     public_training_data=None,  # couldn't find
-    training_datasets={
-        # source: https://arxiv.org/pdf/2405.05374
-        # splits not specified to assuming everything
-        # in MTEB
-        "NQ": ["test"],
-        "NQ-NL": ["test"],  # translated from NQ (not trained on)
-        "NQHardNegatives": ["test"],
-        "HotPotQA": ["test"],
-        "HotPotQAHardNegatives": ["test"],
-        "HotPotQA-PL": ["test"],  # translated from hotpotQA (not trained on)
-        "HotpotQA-NL": ["test"],  # translated from hotpotQA (not trained on)
-        "FEVER": ["test"],
-        "FEVER-NL": ["test"],  # translated from FEVER (not trained on)
-        "FEVERHardNegatives": ["test"],
-        # not in MTEB
-        # trained on stack exchange (title-body)
-        # "stackexchange": [],
-        # potentially means that:
-        # "StackExchangeClusteringP2P": ["test"],
-        # "StackExchangeClusteringP2P.v2": ["test"],
-        # "StackExchangeClustering": ["test"],
-        # "StackExchangeClustering.v2": ["test"],
-        # not in MTEB
-        # "paq": [],
-        # "s2orc": [],
-        # "other": [],  # undisclosed including webdata
-    },  # also use synthetic
+    training_datasets=arctic_v1_training_datasets,
 )
 
 arctic_embed_m_v1_5 = ModelMeta(
-    loader=partial(
+    loader=partial(  # type: ignore
         sentence_transformers_loader,
         model_name="Snowflake/snowflake-arctic-embed-m-v1.5",
         revision="97eab2e17fcb7ccb8bb94d6e547898fa1a6a0f47",
@@ -378,11 +282,11 @@ arctic_embed_m_v1_5 = ModelMeta(
     superseded_by="Snowflake/snowflake-arctic-embed-m-v2.0",
     public_training_code=None,
     public_training_data=None,
-    training_datasets=None,
+    training_datasets=arctic_v1_training_datasets,
 )
 
 arctic_embed_m_v2_0 = ModelMeta(
-    loader=partial(
+    loader=partial(  # type: ignore
         sentence_transformers_loader,
         model_name="Snowflake/snowflake-arctic-embed-m-v2.0",
         revision="f2a7d59d80dfda5b1d14f096f3ce88bb6bf9ebdc",
@@ -406,34 +310,11 @@ arctic_embed_m_v2_0 = ModelMeta(
     superseded_by=None,
     public_training_code=None,
     public_training_data=None,  # couldn't find
-    training_datasets={
-        # source: https://arxiv.org/pdf/2405.05374
-        # splits not specified to assuming everything
-        # in MTEB
-        "NQ": ["test"],
-        "NQHardNegatives": ["test"],
-        "HotPotQA": ["test"],
-        "HotPotQAHardNegatives": ["test"],
-        "HotPotQA-PL": ["test"],  # translated from hotpotQA (not trained on)
-        "FEVER": ["test"],
-        "FEVERHardNegatives": ["test"],
-        # not in MTEB
-        # trained on stack exchange (title-body)
-        # "stackexchange": [],
-        # potentially means that:
-        # "StackExchangeClusteringP2P": ["test"],
-        # "StackExchangeClusteringP2P.v2": ["test"],
-        # "StackExchangeClustering": ["test"],
-        # "StackExchangeClustering.v2": ["test"],
-        # not in MTEB
-        # "paq": [],
-        # "s2orc": [],
-        # "other": [],  # undisclosed including webdata
-    },  # also use synthetic
+    training_datasets=arctic_v2_training_datasets,
 )
 
 arctic_embed_l_v2_0 = ModelMeta(
-    loader=partial(
+    loader=partial(  # type: ignore
         sentence_transformers_loader,
         model_name="Snowflake/snowflake-arctic-embed-l-v2.0",
         revision="edc2df7b6c25794b340229ca082e7c78782e6374",
@@ -456,28 +337,5 @@ arctic_embed_l_v2_0 = ModelMeta(
     superseded_by=None,
     public_training_code=None,
     public_training_data=None,  # couldn't find
-    training_datasets={
-        # source: https://arxiv.org/pdf/2405.05374
-        # splits not specified to assuming everything
-        # in MTEB
-        "NQ": ["test"],
-        "NQHardNegatives": ["test"],
-        "HotPotQA": ["test"],
-        "HotPotQAHardNegatives": ["test"],
-        "HotPotQA-PL": ["test"],  # translated from hotpotQA (not trained on)
-        "FEVER": ["test"],
-        "FEVERHardNegatives": ["test"],
-        # not in MTEB
-        # trained on stack exchange (title-body)
-        # "stackexchange": [],
-        # potentially means that:
-        # "StackExchangeClusteringP2P": ["test"],
-        # "StackExchangeClusteringP2P.v2": ["test"],
-        # "StackExchangeClustering": ["test"],
-        # "StackExchangeClustering.v2": ["test"],
-        # not in MTEB
-        # "paq": [],
-        # "s2orc": [],
-        # "other": [],  # undisclosed including webdata
-    },  # also use synthetic
+    training_datasets=arctic_v2_training_datasets,
 )

--- a/mteb/models/e5_instruct.py
+++ b/mteb/models/e5_instruct.py
@@ -25,6 +25,9 @@ E5_MISTRAL_TRAINING_DATA = {
     "HotpotQAHardNegatives": ["train"],
     "HotpotQA-PL": ["train"],  # translation not trained on
     "HotpotQA-NL": ["train"],  # translation not trained on
+    "MIRACLRetrieval": ["train"],
+    "MIRACLRetrievalHardNegatives": ["train"],
+    "MIRACLReranking": ["train"], # https://arxiv.org/pdf/2402.09906, section M
 }
 
 e5_instruct = ModelMeta(
@@ -163,6 +166,10 @@ zeta_alpha_ai__Zeta_Alpha_E5_Mistral = ModelMeta(
         "STS12": ["train"],
         "STS22": ["train"],
         "STSBenchmark": ["train"],
+            "MIRACLRetrieval": ["train"],
+    "MIRACLRetrievalHardNegatives": ["train"],
+    "MIRACLReranking": ["train"], # https://arxiv.org/pdf/2402.05672, table 2
+        
     },
     adapted_from="intfloat/e5-mistral-7b-instruct",
     superseded_by=None,

--- a/mteb/models/e5_instruct.py
+++ b/mteb/models/e5_instruct.py
@@ -27,7 +27,7 @@ E5_MISTRAL_TRAINING_DATA = {
     "HotpotQA-NL": ["train"],  # translation not trained on
     "MIRACLRetrieval": ["train"],
     "MIRACLRetrievalHardNegatives": ["train"],
-    "MIRACLReranking": ["train"], # https://arxiv.org/pdf/2402.09906, section M
+    "MIRACLReranking": ["train"],  # https://arxiv.org/pdf/2402.09906, section M
 }
 
 e5_instruct = ModelMeta(
@@ -166,10 +166,9 @@ zeta_alpha_ai__Zeta_Alpha_E5_Mistral = ModelMeta(
         "STS12": ["train"],
         "STS22": ["train"],
         "STSBenchmark": ["train"],
-            "MIRACLRetrieval": ["train"],
-    "MIRACLRetrievalHardNegatives": ["train"],
-    "MIRACLReranking": ["train"], # https://arxiv.org/pdf/2402.05672, table 2
-        
+        "MIRACLRetrieval": ["train"],
+        "MIRACLRetrievalHardNegatives": ["train"],
+        "MIRACLReranking": ["train"],  # https://arxiv.org/pdf/2402.05672, table 2
     },
     adapted_from="intfloat/e5-mistral-7b-instruct",
     superseded_by=None,

--- a/mteb/models/gte_models.py
+++ b/mteb/models/gte_models.py
@@ -276,9 +276,11 @@ gte_multi_training_data = {
     "HotpotQA-NL": ["train"],
     "FEVER": ["train"],
     "FEVER-NL": ["train"],
-    "MIRACLReranking": ["train"],
     "MrTidyRetrieval": ["train"],
     "MultiLongDocRetrieval": ["train"],
+    "MIRACLReranking": ["train"],
+    "MIRACLRetrieval": ["train"],
+    "MIRACLRetrievalHardNegatives": ["train"], # https://arxiv.org/pdf/2407.19669, Table 11
     # not in MTEB:
     #   - TriviaQA
     #   - SQuAD

--- a/mteb/models/gte_models.py
+++ b/mteb/models/gte_models.py
@@ -280,7 +280,9 @@ gte_multi_training_data = {
     "MultiLongDocRetrieval": ["train"],
     "MIRACLReranking": ["train"],
     "MIRACLRetrieval": ["train"],
-    "MIRACLRetrievalHardNegatives": ["train"], # https://arxiv.org/pdf/2407.19669, Table 11
+    "MIRACLRetrievalHardNegatives": [
+        "train"
+    ],  # https://arxiv.org/pdf/2407.19669, Table 11
     # not in MTEB:
     #   - TriviaQA
     #   - SQuAD

--- a/mteb/models/salesforce_models.py
+++ b/mteb/models/salesforce_models.py
@@ -30,6 +30,11 @@ SFR_TRAINING_DATA = {  # inherits from e5
     "HotpotQAHardNegatives": ["train"],
     "HotpotQA-PL": ["train"],  # translation not trained on
     "HotpotQA-NL": ["train"],  # translation not trained on
+    # source: https://github.com/embeddings-benchmark/leaderboard/issues/41
+    # qoute: In the realm of Semantic Textual Similarity (STS), it is trained on STS12, STS22, and STSBenchmark
+    "STS12": ["train"],
+    "STS22": ["train"],
+    "STSBenchmark": ["train"],
 }
 
 SFR_Embedding_2_R = ModelMeta(


### PR DESCRIPTION
Reported with references to paper + quotes.

<img width="633" alt="Screenshot 2025-02-19 at 12 02 31" src="https://github.com/user-attachments/assets/6a9352de-d746-4f04-b9bb-bfa402a76bfa" />
<img width="630" alt="Screenshot 2025-02-19 at 12 02 37" src="https://github.com/user-attachments/assets/f1358c4d-67a8-4ed0-aa50-e93a05811f32" />
