### PR TITLE
Add 2 new Static Sentence Transformer models

### DIFF
--- a/mteb/models/sentence_transformers_models.py
+++ b/mteb/models/sentence_transformers_models.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from functools import partial
+
 from mteb.model_meta import ModelMeta
+from mteb.models.sentence_transformer_wrapper import SentenceTransformerWrapper
 
 paraphrase_langs = [
     "ara_Arab",
@@ -260,6 +263,160 @@ all_mpnet_base_v2 = ModelMeta(
     training_datasets=sent_trf_training_dataset,
     public_training_code=None,
     public_training_data=None,
+)
+
+static_multi_datasets = {
+    # wikititles
+    # taboeba
+    # talks
+    # europarl
+    # global_voices
+    # muse
+    # wikimatrix
+    # opensubtitles
+    "StackExchangeClustering.v2": [],
+    "StackExchangeClusteringP2P.v2": [],
+    # quora
+    "QuoraRetrieval": [],
+    "NanoQuoraRetrieval": [],
+    "Quora-NL": [],  # translation not trained on
+    # wikianswers_duplicates
+    # all_nli - the "triplet" subset
+    # simple_wiki
+    # altlex
+    # flickr30k_captions
+    # coco_captions
+    # nli_for_simcse
+    # negation
+}
+static_multi_languages = [
+    "eng_Latn",
+    "ara_Arab",
+    "bul_Cyrl",
+    "cat_Latn",
+    "ces_Latn",
+    "dan_Latn",
+    "deu_Latn",
+    "ell_Grek",
+    "spa_Latn",
+    "est_Latn",
+    "fas_Arab",
+    "fin_Latn",
+    "fra_Latn",
+    "glg_Latn",
+    "guj_Gujr",
+    "heb_Hebr",
+    "hin_Deva",
+    "hun_Latn",
+    "hye_Armn",
+    "ind_Latn",
+    "ita_Latn",
+    "jpn_Jpan",
+    "kat_Geor",
+    "kor_Hang",
+    "kur_Latn",
+    "lit_Latn",
+    "lav_Latn",
+    "mkd_Cyrl",
+    "mon_Cyrl",
+    "mar_Deva",
+    "mal_Mlym",
+    "mya_Mymr",
+    "nob_Latn",
+    "nld_Latn",
+    "pol_Latn",
+    "por_Latn",
+    "ron_Latn",
+    "rus_Cyrl",
+    "slk_Latn",
+    "slv_Latn",
+    "sqi_Latn",
+    "srp_Cyrl",
+    "swe_Latn",
+    "tha_Thai",
+    "tur_Latn",
+    "ukr_Cyrl",
+    "urd_Arab",
+    "vie_Latn",
+    "zho_Hans",
+]
+
+static_similarity_mrl_multilingual_v1 = ModelMeta(
+    name="sentence-transformers/static-similarity-mrl-multilingual-v1",
+    loader=partial(
+        SentenceTransformerWrapper,
+        model="sentence-transformers/static-similarity-mrl-multilingual-v1",
+        revision="7264ea07c5365a11d7e6d87dbb6195889a13054f",
+        device="cpu",  # CPU is just as quick, if not quicker
+    ),
+    languages=static_multi_languages,
+    open_weights=True,
+    revision="7264ea07c5365a11d7e6d87dbb6195889a13054f",
+    release_date="2025-01-15",
+    n_parameters=108_420_096,
+    memory_usage_mb=413,
+    embed_dim=1024,
+    license="apache-2.0",
+    max_tokens=None,
+    reference="https://huggingface.co/sentence-transformers/static-similarity-mrl-multilingual-v1",
+    similarity_fn_name="cosine",
+    framework=["Sentence Transformers", "PyTorch"],
+    use_instructions=False,
+    superseded_by=None,
+    adapted_from=None,
+    training_datasets=static_multi_datasets,
+    public_training_code="https://huggingface.co/blog/static-embeddings",
+    public_training_data="https://huggingface.co/collections/sentence-transformers/embedding-model-datasets-6644d7a3673a511914aa7552",
+)
+
+static_eng_datasets = {
+    "MSMARCO": ["train"],
+    "MSMARCOHardNegatives": ["train"],
+    "NanoMSMARCORetrieval": ["train"],
+    "MSMARCO-PL": ["train"],  # translation not trained on
+    "mMARCO-NL": ["train"],  # translation not trained on
+    # gooaq
+    # s2orc
+    # squad
+    # all-nli (multi-nli, snli)
+    # paq
+    # trivia-qa
+    # msmarco-10m
+    # swim_ir
+    # pubmedqa
+    "MIRACLRetrieval": ["train"],
+    "MIRACLRetrievalHardNegatives": ["train"],
+    "MIRACLReranking": ["train"],
+    "MultiLongDocRetrieval": ["train"],
+    "MrTidyRetrieval": ["train"],
+}
+
+static_retrieval_mrl_en_v1 = ModelMeta(
+    name="sentence-transformers/static-retrieval-mrl-en-v1",
+    loader=partial(
+        SentenceTransformerWrapper,
+        model="sentence-transformers/static-retrieval-mrl-en-v1",
+        revision="f60985c706f192d45d218078e49e5a8b6f15283a",
+        device="cpu",  # CPU is extremely quick already
+    ),
+    languages=["eng-Latn"],
+    open_weights=True,
+    revision="f60985c706f192d45d218078e49e5a8b6f15283a",
+    release_date="2025-01-15",
+    n_parameters=31_254_528,
+    memory_usage_mb=119,
+    embed_dim=1024,
+    license="apache-2.0",
+    max_tokens=None,
+    reference="https://huggingface.co/sentence-transformers/static-retrieval-mrl-en-v1",
+    similarity_fn_name="cosine",
+    framework=["Sentence Transformers", "PyTorch"],
+    use_instructions=False,
+    superseded_by=None,
+    adapted_from=None,
+    training_datasets=static_eng_datasets,
+    public_training_code="https://huggingface.co/blog/static-embeddings",
+    public_training_data="https://huggingface.co/collections/sentence-transformers/embedding-model-datasets-6644d7a3673a511914aa7552",
 )
 
 microllama_text_embedding = ModelMeta(

--- a/mteb/models/sentence_transformers_models.py
+++ b/mteb/models/sentence_transformers_models.py
@@ -267,7 +267,7 @@ all_mpnet_base_v2 = ModelMeta(
 
 static_multi_datasets = {
     # wikititles
-    # taboeba
+    "TatoebaBitextMining": [],
     # talks
     # europarl
     # global_voices


### PR DESCRIPTION
Fixes #2109 

This adds ModelMeta's for:
* https://huggingface.co/sentence-transformers/static-retrieval-mrl-en-v1
* https://huggingface.co/sentence-transformers/static-similarity-mrl-multilingual-v1

I'm running evaluations for these for https://github.com/embeddings-benchmark/results now.

### Code Quality
<!-- Please do not delete this -->
- [x] **Code Formatted**: Format the code using `make lint` to maintain consistent style.

### Documentation
<!-- Please do not delete this -->
- [ ] **Updated Documentation**: Add or update documentation to reflect the changes introduced in this PR.

### Testing
<!-- Please do not delete this -->
- [ ] **New Tests Added**: Write tests to cover new functionality. Validate with `make test-with-coverage`.
- [ ] **Tests Passed**: Run tests locally using `make test` or `make test-with-coverage` to ensure no existing functionality is broken.


### Adding a model checklist
<!-- 
When adding a model to the model registry
see also https://github.com/embeddings-benchmark/mteb/blob/main/docs/reproducible_workflow.md
-->

 - [x] I have filled out the ModelMeta object to the extent possible
 - [x] I have ensured that my model can be loaded using
   - [x] `mteb.get_model(model_name, revision)` and
   - [x] `mteb.get_model_meta(model_name, revision)`
 - [x] I have tested the implementation works on a representative set of tasks.

---

- Tom Aarsen