### PR TITLE
Added training data annotations to MXBAI

### DIFF
--- a/mteb/models/mxbai_models.py
+++ b/mteb/models/mxbai_models.py
@@ -29,7 +29,9 @@ mxbai_embed_large_v1 = ModelMeta(
     use_instructions=True,
     public_training_code=None,
     public_training_data=None,
-    training_datasets=None,
+    training_datasets={
+        "MSMARCO": ["train"],
+    },
 )
 
 mxbai_embed_2d_large_v1 = ModelMeta(
@@ -52,7 +54,9 @@ mxbai_embed_2d_large_v1 = ModelMeta(
     superseded_by=None,
     public_training_code=None,
     public_training_data=None,
-    training_datasets=None,
+    training_datasets={
+        "MSMARCO": ["train"],
+    },
 )
 
 
@@ -76,5 +80,7 @@ mxbai_embed_xsmall_v1 = ModelMeta(
     superseded_by=None,
     public_training_code=None,
     public_training_data=None,
-    training_datasets=None,
+    training_datasets={
+        "MSMARCO": ["train"],
+    },
 )


### PR DESCRIPTION
I received this email from the Mixedbread team:
> as mentioned in our blog post ([https://www.mixedbread.com/blog/mxbai-embed-large-v1#built-for-rag-and-real-world-use-cases:~:text=During%20the%20whole,related%20use%20cases](https://eur01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.mixedbread.com%2Fblog%2Fmxbai-embed-large-v1%23built-for-rag-and-real-world-use-cases%3A~%3Atext%3DDuring%2520the%2520whole%2Crelated%2520use%2520cases&data=05%7C02%7Cmartonkardos%40cas.au.dk%7C44d7acaec50143eb9b7f08dd57468d7e%7C61fd1d36fecb47cab7d7d0df0370a198%7C1%7C0%7C638762682729840700%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=EzK3ibYx%2BeTlYwRy9bVNXgRRDRuXjakTBDNYt1CixYk%3D&reserved=0).) We do not train on any data (except the MSMarco training split) of MTEB. We have a strong filtering process to ensure the OOD setting. That's true for all of our models. Keep up the good work and let me know if you have any questions.