### PR TITLE
Remove overlapping legends from radar chart

### DIFF
--- a/mteb/leaderboard/figures.py
+++ b/mteb/leaderboard/figures.py
@@ -243,13 +243,12 @@ def radar_chart(df: pd.DataFrame) -> go.Figure:
             ),
         ),
         legend=dict(
-            orientation="h",
-            yanchor="bottom",
-            y=-0.6,
+            orientation="v",
+            yanchor="middle",
+            y=0.5,
             xanchor="left",
-            x=-0.05,
-            entrywidthmode="fraction",
-            entrywidth=1 / 5,
+            x=1.1,
         ),
+        margin=dict(l=200, r=150, t=50, b=50),
     )
     return fig

--- a/mteb/leaderboard/figures.py
+++ b/mteb/leaderboard/figures.py
@@ -244,11 +244,11 @@ def radar_chart(df: pd.DataFrame) -> go.Figure:
         ),
         legend=dict(
             orientation="v",
-            yanchor="middle",
-            y=0.5,
+            yanchor="top",
+            y=1.5,
             xanchor="left",
-            x=1.1,
+            x=1.4,
         ),
-        margin=dict(l=200, r=150, t=50, b=50),
+        margin=dict(l=170, r=300, t=100, b=50),
     )
     return fig

--- a/mteb/leaderboard/figures.py
+++ b/mteb/leaderboard/figures.py
@@ -227,7 +227,7 @@ def radar_chart(df: pd.DataFrame) -> go.Figure:
             )
         )
     fig.update_layout(
-        font=dict(size=16, color="black"),  # noqa
+        font=dict(size=13, color="black"),  # noqa
         template="plotly_white",
         polar=dict(
             radialaxis=dict(
@@ -243,12 +243,17 @@ def radar_chart(df: pd.DataFrame) -> go.Figure:
             ),
         ),
         legend=dict(
-            orientation="v",
-            yanchor="top",
-            y=1.5,
-            xanchor="left",
-            x=1.4,
+            orientation="h",
+            yanchor="bottom",
+            y=-0.35,
+            xanchor="center",
+            x=0.4,
+            itemwidth=30,
+            font=dict(size=13),
+            entrywidth=0.6,
+            entrywidthmode="fraction",
         ),
-        margin=dict(l=170, r=300, t=100, b=50),
+        margin=dict(l=0, r=16, t=30, b=30),
+        autosize=True,
     )
     return fig


### PR DESCRIPTION
This PR is related to the issue #2156 to remove overlapping legends from the radar chart


### Code Quality
<!-- Please do not delete this -->
- [x] **Code Formatted**: Format the code using `make lint` to maintain consistent style.

The Radar Plot now looks like below where the legend is shifted to the right.
![newplot (4)](https://github.com/user-attachments/assets/7d58a1b8-9fed-4192-be2b-fd01d4f9adcf)


