### PR TITLE
misc: Speed up qrel creation in any2anyretrieval

### DIFF
--- a/mteb/abstasks/Image/AbsTaskAny2AnyRetrieval.py
+++ b/mteb/abstasks/Image/AbsTaskAny2AnyRetrieval.py
@@ -5,7 +5,7 @@ import logging
 import os
 from collections import defaultdict
 from pathlib import Path
-from time import time
+from time import asctime, time
 from typing import Any
 
 import tqdm
@@ -96,11 +96,16 @@ class HFDataLoader:
         self._load_qrels(split)
         # filter queries with no qrels
         qrels_dict = defaultdict(dict)
+        logger.info(f"{asctime()} - Done load qrels, before map qrels_dict")
 
-        def qrels_dict_init(row):
-            qrels_dict[row["query-id"]][row["corpus-id"]] = int(row["score"])
+        df = self.qrels.to_pandas()
+        query_ids = df["query-id"].to_numpy()
+        corpus_ids = df["corpus-id"].to_numpy()
+        scores = df["score"].to_numpy()
 
-        self.qrels.map(qrels_dict_init)
+        for q, c, s in zip(query_ids, corpus_ids, scores):
+            qrels_dict[q][c] = s
+        logger.info(f"{asctime()} - Done qrels_dict")
         self.qrels = qrels_dict
         self.queries = self.queries.filter(lambda x: x["id"] in self.qrels)
         logger.info("Loaded %d %s Queries.", len(self.queries), split.upper())

--- a/mteb/abstasks/Image/AbsTaskAny2AnyRetrieval.py
+++ b/mteb/abstasks/Image/AbsTaskAny2AnyRetrieval.py
@@ -104,7 +104,7 @@ class HFDataLoader:
         scores = df["score"].to_numpy()
 
         for q, c, s in zip(query_ids, corpus_ids, scores):
-            qrels_dict[q][c] = s
+            qrels_dict[q][c] = int(s)
         logger.info(f"{asctime()} - Done qrels_dict")
         self.qrels = qrels_dict
         self.queries = self.queries.filter(lambda x: x["id"] in self.qrels)


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->
Fixes #1686 

Able to get this down to 16 seconds by not using row-by-row operation and instead by using numpy. 
```
INFO:mteb.abstasks.Image.AbsTaskAny2AnyRetrieval:Fri Feb 28 16:36:45 2025 - Done load qrels, before map qrels_dict
INFO:mteb.abstasks.Image.AbsTaskAny2AnyRetrieval:Fri Feb 28 16:37:01 2025 - Done qrels_dict
```

Reproduced the same results on `mteb run -t Flickr30kT2IRetrieval -m openai/clip-vit-base-patch16` before and after the change.

### Code Quality
<!-- Please do not delete this -->
- [x] **Code Formatted**: Format the code using `make lint` to maintain consistent style.

### Documentation
<!-- Please do not delete this -->
- [x] **Updated Documentation**: Add or update documentation to reflect the changes introduced in this PR.

### Testing
<!-- Please do not delete this -->
- [x] **New Tests Added**: Write tests to cover new functionality. Validate with `make test-with-coverage`.
- [x] **Tests Passed**: Run tests locally using `make test` or `make test-with-coverage` to ensure no existing functionality is broken.
