### PR TITLE
ci: dont run test_dataset_on_hf in every pr

### DIFF
--- a/.github/workflows/dataset_loading.yml
+++ b/.github/workflows/dataset_loading.yml
@@ -1,0 +1,26 @@
+name: Dataset Loading
+
+on:
+  pull_request:
+    paths:
+      - 'mteb/tasks/**.py'
+  schedule:
+    - cron: '0 0 */2 * *' # every 2 days
+
+jobs:
+  extract-and-run:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+        cache: 'pip'
+
+    - name: Install dependencies and run test
+      run: |
+        make dataset-load-test BASE_BRANCH=${{ github.event.pull_request.base.ref }}

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ lint-check:
 
 test:
 	@echo "--- 🧪 Running tests ---"
-	pytest -n auto 
+	pytest -n auto
 
 test-with-coverage:
 	@echo "--- 🧪 Running tests with coverage ---"
@@ -43,6 +43,13 @@ model-load-test:
 	pip install ".[dev, speedtask, pylate,gritlm,xformers,model2vec]"
 	python scripts/extract_model_names.py $(BASE_BRANCH) --return_one_model_name_per_file
 	python tests/test_models/model_loading.py --model_name_file scripts/model_names.txt
+
+
+dataset-load-test:
+	@echo "--- 🚀 Running dataset load test ---"
+	pip install ".[dev, speedtask]"
+	NO_SKIP=1 pytest -n auto tests/test_tasks/test_all_abstasks.py::test_dataset_on_hf
+
 
 run-leaderboard:
 	@echo "--- 🚀 Running leaderboard locally ---"

--- a/tests/test_tasks/test_all_abstasks.py
+++ b/tests/test_tasks/test_all_abstasks.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from unittest.mock import Mock, patch
-
+import os
 import pytest
 import requests
 
@@ -65,7 +65,7 @@ def test_load_data(
         if not task.is_multilingual:
             mock_dataset_transform.assert_called_once()
 
-
+@pytest.mark.skipif(condition=os.getenv("NO_SKIP", 0) == 1, reason="Just in separate CI Job")
 @pytest.mark.flaky(
     reruns=3,
     reruns_delay=5,


### PR DESCRIPTION
ref: https://github.com/embeddings-benchmark/mteb/issues/2200
test: test_dataset_on_hf

It is just running in pr with changes in `'mteb/tasks/**.py'`
or every 2 days 

### Code Quality
<!-- Please do not delete this -->
- [x] **Code Formatted**: Format the code using `make lint` to maintain consistent style.

### Documentation
<!-- Please do not delete this -->
- [ ] **Updated Documentation**: Add or update documentation to reflect the changes introduced in this PR.

### Testing
<!-- Please do not delete this -->
- [ ] **New Tests Added**: Write tests to cover new functionality. Validate with `make test-with-coverage`.
- [x] **Tests Passed**: Run tests locally using `make test` or `make test-with-coverage` to ensure no existing functionality is broken.

