### PR TITLE
Change `dataset on HF` test to use official api

### DIFF
--- a/tests/test_tasks/test_all_abstasks.py
+++ b/tests/test_tasks/test_all_abstasks.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 
 import huggingface_hub
 import pytest
+import requests
 
 import mteb
 from mteb import MTEB
@@ -76,12 +77,14 @@ def test_load_data(
 def test_dataset_on_hf(dataset_revision: tuple[str, str]):
     repo_id, revision = dataset_revision
     try:
-        huggingface_hub.dataset_info(repo_id, revision=revision, timeout=60)
+        huggingface_hub.dataset_info(repo_id, revision=revision, timeout=120)
     except (
         huggingface_hub.errors.RepositoryNotFoundError,
         huggingface_hub.errors.RevisionNotFoundError,
     ):
         assert False, f"Dataset {repo_id} - {revision} not available"
+    except requests.exceptions.ReadTimeout:
+        assert False, f"Dataset {repo_id} - {revision} timed out"
 
 
 def test_superseded_dataset_exists():

--- a/tests/test_tasks/test_all_abstasks.py
+++ b/tests/test_tasks/test_all_abstasks.py
@@ -76,7 +76,7 @@ def test_load_data(
 def test_dataset_on_hf(dataset_revision: tuple[str, str]):
     repo_id, revision = dataset_revision
     try:
-        huggingface_hub.dataset_info(repo_id, revision=revision, timeout=5)
+        huggingface_hub.dataset_info(repo_id, revision=revision, timeout=60)
     except (
         huggingface_hub.errors.RepositoryNotFoundError,
         huggingface_hub.errors.RevisionNotFoundError,

--- a/tests/test_tasks/test_all_abstasks.py
+++ b/tests/test_tasks/test_all_abstasks.py
@@ -77,14 +77,14 @@ def test_load_data(
 def test_dataset_on_hf(dataset_revision: tuple[str, str]):
     repo_id, revision = dataset_revision
     try:
-        huggingface_hub.dataset_info(repo_id, revision=revision, timeout=120)
+        huggingface_hub.dataset_info(repo_id, revision=revision)
     except (
         huggingface_hub.errors.RepositoryNotFoundError,
         huggingface_hub.errors.RevisionNotFoundError,
     ):
         assert False, f"Dataset {repo_id} - {revision} not available"
-    except requests.exceptions.ReadTimeout:
-        assert False, f"Dataset {repo_id} - {revision} timed out"
+    except Exception as e:
+        assert False, f"Dataset {repo_id} - {revision} failed with {e}"
 
 
 def test_superseded_dataset_exists():

--- a/tests/test_tasks/test_all_abstasks.py
+++ b/tests/test_tasks/test_all_abstasks.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import logging
 from unittest.mock import Mock, patch
 
+import huggingface_hub
 import pytest
-import requests
 
 import mteb
 from mteb import MTEB
@@ -74,13 +74,14 @@ def test_load_data(
 )
 @pytest.mark.parametrize("dataset_revision", dataset_revisions)
 def test_dataset_on_hf(dataset_revision: tuple[str, str]):
-    dataset, revision = dataset_revision
-    url = f"https://huggingface.co/datasets/{dataset}/tree/{revision}"
-    response = requests.head(url)
-
-    assert response.status_code == 200, (
-        f"Dataset {dataset} - {revision} not available. Status code: {response.status_code}"
-    )
+    repo_id, revision = dataset_revision
+    try:
+        huggingface_hub.dataset_info(repo_id, revision=revision, timeout=5)
+    except (
+        huggingface_hub.errors.RepositoryNotFoundError,
+        huggingface_hub.errors.RevisionNotFoundError,
+    ):
+        assert False, f"Dataset {repo_id} - {revision} not available"
 
 
 def test_superseded_dataset_exists():


### PR DESCRIPTION
Use official API for dataset checking. Maybe this would solve the problem with dataset checking
ref https://github.com/embeddings-benchmark/mteb/pull/2201, https://github.com/embeddings-benchmark/mteb/issues/2200


### Code Quality
<!-- Please do not delete this -->
- [X] **Code Formatted**: Format the code using `make lint` to maintain consistent style.

### Testing
<!-- Please do not delete this -->
- [X] **New Tests Added**: Write tests to cover new functionality. Validate with `make test-with-coverage`.
- [X] **Tests Passed**: Run tests locally using `make test` or `make test-with-coverage` to ensure no existing functionality is broken.

CC @sam-hey