### PR TITLE
Formatting issue in Performance Plot

### DIFF
--- a/mteb/leaderboard/figures.py
+++ b/mteb/leaderboard/figures.py
@@ -50,7 +50,10 @@ def parse_model_name(name: str) -> str:
 
 def parse_float(value) -> float:
     try:
-        return float(value)
+        if value == "Infinite":
+            return np.inf
+        else: 
+            return float(value)
     except ValueError:
         return np.nan
 
@@ -113,6 +116,9 @@ def performance_size_plot(df: pd.DataFrame) -> go.Figure:
         return go.Figure()
     min_score, max_score = df["Mean (Task)"].min(), df["Mean (Task)"].max()
     df["sqrt(dim)"] = np.sqrt(df["Embedding Dimensions"])
+    df["Max Tokens"] = df["Max Tokens"].apply(
+        lambda x: "Unknown" if pd.isna(x) else ("Infinite" if np.isinf(x) else str(int(x)))
+    )
     fig = px.scatter(
         df,
         x="Number of Parameters",

--- a/mteb/leaderboard/figures.py
+++ b/mteb/leaderboard/figures.py
@@ -58,6 +58,14 @@ def parse_float(value) -> float:
         return np.nan
 
 
+def process_max_tokens(x):
+    if pd.isna(x):
+        return "Unknown"
+    if np.isinf(x):
+        return "Infinite"
+    return str(int(x))
+
+
 models_to_annotate = [
     "all-MiniLM-L6-v2",
     "GritLM-7B",
@@ -116,11 +124,7 @@ def performance_size_plot(df: pd.DataFrame) -> go.Figure:
         return go.Figure()
     min_score, max_score = df["Mean (Task)"].min(), df["Mean (Task)"].max()
     df["sqrt(dim)"] = np.sqrt(df["Embedding Dimensions"])
-    df["Max Tokens"] = df["Max Tokens"].apply(
-        lambda x: "Unknown"
-        if pd.isna(x)
-        else ("Infinite" if np.isinf(x) else str(int(x)))
-    )
+    df["Max Tokens"] = df["Max Tokens"].apply(lambda x: process_max_tokens(x))
     fig = px.scatter(
         df,
         x="Number of Parameters",

--- a/mteb/leaderboard/figures.py
+++ b/mteb/leaderboard/figures.py
@@ -52,7 +52,7 @@ def parse_float(value) -> float:
     try:
         if value == "Infinite":
             return np.inf
-        else: 
+        else:
             return float(value)
     except ValueError:
         return np.nan
@@ -117,7 +117,9 @@ def performance_size_plot(df: pd.DataFrame) -> go.Figure:
     min_score, max_score = df["Mean (Task)"].min(), df["Mean (Task)"].max()
     df["sqrt(dim)"] = np.sqrt(df["Embedding Dimensions"])
     df["Max Tokens"] = df["Max Tokens"].apply(
-        lambda x: "Unknown" if pd.isna(x) else ("Infinite" if np.isinf(x) else str(int(x)))
+        lambda x: "Unknown"
+        if pd.isna(x)
+        else ("Infinite" if np.isinf(x) else str(int(x)))
     )
     fig = px.scatter(
         df,


### PR DESCRIPTION
This PR is related to formatting issue of "Max Tokens" specifically for Static Embedding Models related to issue #2159 . The issue occurred because some models have "Max Tokens" as `"Infinite"`or `"Unknown"`

### Code Quality
<!-- Please do not delete this -->
- [x] **Code Formatted**: Format the code using `make lint` to maintain consistent style.

After changes, the Performance Plot looks like this:

<details>
<summary>For model with Max Tokens as "Infinite": </summary>
<img width="745" alt="Image" src="https://github.com/user-attachments/assets/1f48b186-ba5a-4ad3-8821-0e0045a57a82" />
</details>

<details>
<summary>For model with Max Tokens as "Unknown": </summary>
<img width="747" alt="Image" src="https://github.com/user-attachments/assets/80aa3b73-54b9-4281-a0e1-3b2499e06212" />
</details>

<details>
<summary>For model with Max Tokens as Some Integer value: </summary>
<img width="765" alt="Screenshot 2025-03-04 at 10 56 47 PM" src="https://github.com/user-attachments/assets/018c420d-cdda-49b9-8a92-61420631ee1f" />
</details>