### PR TITLE
add-Data Korean PatentFnBClustering 

### DIFF
--- a/mteb/tasks/Clustering/kor/PatentFnBClustering.py
+++ b/mteb/tasks/Clustering/kor/PatentFnBClustering.py
@@ -1,0 +1,70 @@
+from mteb import MTEB
+from mteb.abstasks.AbsTaskClustering import AbsTaskClustering
+from mteb.abstasks.TaskMetadata import TaskMetadata
+import datasets
+
+# from __future__ import annotations
+
+# import random
+# from collections.abc import Iterable
+# from itertools import islice
+# from typing import TypeVar
+
+# T = TypeVar("T")
+
+# def batched(iterable: Iterable[T], n: int) -> Iterable[tuple[T, ...]]:
+#     # batched('ABCDEFG', 3) --> ABC DEF G
+#     if n < 1:
+#         raise ValueError("n must be at least one")
+#     it = iter(iterable)
+#     while batch := tuple(islice(it, n)):
+#         yield batch
+
+class PatentFnBClustering(AbsTaskClustering):
+    metadata = TaskMetadata(
+        name="PatentFnBClustering",
+        description="this is modified AI-hub patent dataset for clustering evaluation. Domain : food & beverage patent. ",
+        reference="https://huggingface.co/datasets/on-and-on/clustering_patent_FnB_manufacturing",
+        type="Clustering",
+        category="p2p",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["kor-Hang"],
+        main_score="v_measure",
+        dataset={
+            "path": "on-and-on/clustering_patent_FnB_manufacturing",
+            "revision": "b3cad5e338fcb782b7607c2dcece61fba0072c4b",
+        },
+        date=("2017-01-01", "2020-01-01"),
+        form="Written",
+        domains=["Academic", "Engineering"],
+        task_subtypes=[],
+        license="mit",
+        annotations_creators="derived",
+        dialect=[],
+        text_creation="found",
+        # bibtex_citation= ... # removed for brevity
+    )
+
+    def dataset_transform(self):
+
+
+        documents: list = []
+        labels: list = []
+
+        split = self.metadata.eval_splits[0]
+        ds = {}
+
+        documents.append(self.dataset[split]['sentences'])
+        labels.append(self.dataset[split]['labels'])
+
+        # # documents_batched = list(batched(documents, 512))
+        # # labels_batched = list(batched(labels, 512))
+
+        ds[split] = datasets.Dataset.from_dict(
+                {
+                    "sentences": documents,
+                    "labels": labels,
+                }
+            )
+        self.dataset = datasets.DatasetDict(ds)


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->

### Adding datasets checklist
<!-- see also https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md -->

**Reason for dataset addition**: ... <!-- Add reason for adding dataset here. E.g. it covers task/language/domain previously not covered -->

- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb -m {model_name} -t {task_name}` command.
  - [x] `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
  - {'test': [{'v_measure': 0.2254662003136626,
   'v_measure_std': 0.0,
   'v_measures': [0.2254662003136626],
   'main_score': 0.2254662003136626,
   'hf_subset': 'default',
   'languages': ['kor-Hang']}]}
  - [x] `intfloat/multilingual-e5-small`
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [ ] If the dataset is too big (e.g. >2048 examples), considering using `self.stratified_subsampling() under dataset_transform()`
- [x] I have filled out the metadata object in the dataset file (find documentation on it [here](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md#2-creating-the-metadata-object)).
- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [ ] Run the formatter to format the code using `make lint`. 

data-link : https://huggingface.co/datasets/on-and-on/clustering_patent_FnB_manufacturing