### PR TITLE
fix: Resolve conflicting dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.9,<3.13"
 dependencies = [
     "datasets>=2.19.0,<3.0.0",
     "numpy>=1.0.0,<3.0.0",
@@ -65,7 +65,12 @@ dev = [
 codecarbon = ["codecarbon"]
 speedtask = ["GPUtil>=1.4.0", "psutil>=5.9.8"]
 peft = ["peft>=0.11.0"]
-leaderboard = ["gradio>=5.16.0,<6.0.0", "gradio_rangeslider>=0.0.8", "plotly>=5.24.0,<6.0.0", "cachetools>=5.2.0"]
+leaderboard = [
+    "gradio>=5.16.0,<6.0.0; python_version > '3.9'",  # 3.10 is required for gradio
+    "gradio_rangeslider>=0.0.8", 
+    "plotly>=5.24.0,<6.0.0", 
+    "cachetools>=5.2.0"
+]
 flagembedding = ["FlagEmbedding"]
 jina = ["einops>=0.8.0"]
 flash_attention = ["flash-attn>=2.6.3"]
@@ -181,3 +186,8 @@ addopts = """
 # FileNotFoundError -> HF Cache is broken:  https://github.com/embeddings-benchmark/mteb/actions/runs/13302915091/job/37147507251?pr=2029
 # --durations=5 -> Show the 5 slowest tests
 # --reruns-delay 10 -> Delay between reruns in seconds to avoid running into the same issue again
+
+[tool.uv]
+override-dependencies = [
+    "salesforce-lavis", # salesforce-lavis is not valid with sentence transformers >=3.0.0
+]


### PR DESCRIPTION
These errors where discovered when trying to install the package using `uv`.

We have a problem with salesforce-lavis, which is not compatible with the current set of dependencies.

