### PR TITLE
added SpeechCommand dataset and Keyword spotting task

### DIFF
--- a/mteb/abstasks/TaskMetadata.py
+++ b/mteb/abstasks/TaskMetadata.py
@@ -61,6 +61,7 @@ TASK_SUBTYPE = Literal[
     "Duplicate Detection",
     "Environment Sound Classification",
     "Gunshot Audio Classification",
+    "Keyword Spotting",
     "Instrument Source Classification",
     "Gender Clustering",
 ]

--- a/mteb/tasks/Audio/AudioZeroshotClassification/__init__.py
+++ b/mteb/tasks/Audio/AudioZeroshotClassification/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
 
 from .eng.ESC50 import *
+from .eng.SpeechCommands import *
 from .eng.UrbanSound8k import *

--- a/mteb/tasks/Audio/AudioZeroshotClassification/eng/SpeechCommands.py
+++ b/mteb/tasks/Audio/AudioZeroshotClassification/eng/SpeechCommands.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from mteb.abstasks.Audio.AbsTaskAudioZeroshotClassification import (
+    AbsTaskAudioZeroshotClassification,
+)
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+
+class ESC50ZeroshotClassification(AbsTaskAudioZeroshotClassification):
+    metadata = TaskMetadata(
+        name="SpeechCommandsZeroshot",
+        description="Sound Classification/Keyword Spotting Dataset. This is a set of one-second .wav audio files, each containing a single spoken English word or background noise. These words are from a small set of commands, and are spoken by a variety of different speakers. With total of 30 labels",
+        reference="https://huggingface.co/datasets/google/speech_commands",
+        dataset={
+            "path": "google/speech_commands",
+            "name": "v0.01",
+            "revision": "57ba463ab37e1e7845e0626539a6f6d0fcfbe64a",
+        },
+        type="AudioZeroshotClassification",
+        category="a2a",
+        eval_splits=["train"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2018-07-07", "2018-07-13"),
+        domains=[
+            "Spoken"
+        ],  # Replace with appropriate domain from allowed list?? No appropriate domain name is available
+        task_subtypes=["Keyword Spotting"],
+        license="cc-by-nc-sa-3.0",  # Replace with appropriate license from allowed list
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["audio"],
+        sample_creation="found",
+        bibtex_citation="""@article{DBLP:journals/corr/abs-1804-03209,
+  author       = {Pete Warden},
+  title        = {Speech Commands: {A} Dataset for Limited-Vocabulary Speech Recognition},
+  journal      = {CoRR},
+  volume       = {abs/1804.03209},
+  year         = {2018},
+  url          = {http://arxiv.org/abs/1804.03209},
+  eprinttype    = {arXiv},
+  eprint       = {1804.03209},
+  timestamp    = {Mon, 13 Aug 2018 16:48:32 +0200},
+  biburl       = {https://dblp.org/rec/journals/corr/abs-1804-03209.bib},
+  bibsource    = {dblp computer science bibliography, https://dblp.org}
+}
+    }""",
+    )
+
+    audio_column_name: str = "audio"
+    label_column_name: str = "labels"
+    samples_per_label: int = 2000
+
+    def get_candidate_labels(self) -> list[str]:
+        """Return the text candidates for zeroshot classification"""
+        return [
+            "Yes",
+            "No",
+            "Up",
+            "Down",
+            "Left",
+            "Right",
+            "On",
+            "Off",
+            "Stop",
+            "Go",
+            "Zero",
+            "One",
+            "Two",
+            "Three",
+            "Four",
+            "Five",
+            "Six",
+            "Seven",
+            "Eight",
+            "Nine",
+            "Bed",
+            "Bird",
+            "Cat",
+            "Dog",
+            "Happy",
+            "House",
+            "Marvin",
+            "Sheila",
+            "Tree",
+            "Wow",
+        ]


### PR DESCRIPTION
Added google/speech-commands v1 dataset. Part of the larger #2319 issue list to add all clap models. This is a keyword spotting dataset, therefore added new type of task as well. Test results & Prompt logic in next comments

<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->


### Code Quality
<!-- Please do not delete this -->
- [:heavy_check_mark: ] **Code Formatted**: Format the code using `make lint` to maintain consistent style.

### Documentation
<!-- Please do not delete this -->
- [:heavy_check_mark:  ] **Updated Documentation**: Add or update documentation to reflect the changes introduced in this PR.

### Testing
<!-- Please do not delete this -->
- [ ] **New Tests Added**: Write tests to cover new functionality. Validate with `make test-with-coverage`.
- [ ] **Tests Passed**: Run tests locally using `make test` or `make test-with-coverage` to ensure no existing functionality is broken.


### Adding datasets checklist
<!-- see also https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md -->

**Reason for dataset addition**: ... <!-- Add reason for adding dataset here. E.g. it covers task/language/domain previously not covered -->

- [ :heavy_check_mark: ] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb -m {model_name} -t {task_name}` command.
  - [ ] `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
  - [ ] `intfloat/multilingual-e5-small`
- [ ] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [ ] If the dataset is too big (e.g. >2048 examples), considering using `self.stratified_subsampling() under dataset_transform()`
- [:heavy_check_mark:  ] I have filled out the metadata object in the dataset file (find documentation on it [here](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md#2-creating-the-metadata-object)).
- [:heavy_check_mark:  ] Run tests locally to make sure nothing is broken using `make test`.
- [:heavy_check_mark: ] Run the formatter to format the code using `make lint`.


### Adding a model checklist
<!--
When adding a model to the model registry
see also https://github.com/embeddings-benchmark/mteb/blob/main/docs/reproducible_workflow.md
-->

 - [ ] I have filled out the ModelMeta object to the extent possible
 - [ ] I have ensured that my model can be loaded using
   - [ ] `mteb.get_model(model_name, revision)` and
   - [ ] `mteb.get_model_meta(model_name, revision)`
 - [ ] I have tested the implementation works on a representative set of tasks.
