### PR TITLE
Add Background Gradients in Summary and Task Table

### DIFF
--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -21,7 +21,7 @@ from mteb.benchmarks.benchmarks import MTEB_multilingual
 from mteb.custom_validators import MODALITIES
 from mteb.languages import ISO_TO_LANGUAGE
 from mteb.leaderboard.figures import performance_size_plot, radar_chart
-from mteb.leaderboard.table import scores_to_tables
+from mteb.leaderboard.table import create_tables
 
 logging.getLogger("mteb.load_results.task_results").setLevel(
     logging.WARNING
@@ -234,7 +234,7 @@ filtered_models = filter_models(
     zero_shot_setting="allow_all",
 )
 
-summary_table, per_task_table = scores_to_tables(
+summary_table, per_task_table = create_tables(
     [entry for entry in default_scores if entry["model_name"] in filtered_models]
 )
 
@@ -809,7 +809,7 @@ see existing implementations [here](https://github.com/embeddings-benchmark/mteb
                 filtered_scores.append(entry)
         else:
             filtered_scores = scores
-        summary, per_task = scores_to_tables(filtered_scores, search_query)
+        summary, per_task = create_tables(filtered_scores, search_query)
         elapsed = time.time() - start_time
         logger.info(f"update_tables callback: {elapsed}s")
         return summary, per_task

--- a/mteb/leaderboard/table.py
+++ b/mteb/leaderboard/table.py
@@ -293,6 +293,7 @@ def create_tables(
     scores_long: list[dict], search_query: str | None = None
 ) -> tuple[gr.DataFrame, gr.DataFrame]:
     result = scores_to_tables(scores_long, search_query)
+    # dataframe with No Results is returned, so no need to apply styling
     if len(result) == 2:
         joint_table, per_task = result
         return joint_table, per_task

--- a/mteb/leaderboard/table.py
+++ b/mteb/leaderboard/table.py
@@ -209,6 +209,16 @@ def scores_to_tables(
     # setting model name column to markdown
     column_types[1] = "markdown"
     score_columns = ["Mean (Task)", "Mean (TaskType)", *mean_per_type.columns]
+
+    return apply_styling(joint_table, per_task, score_columns, column_types)
+
+
+def apply_styling(
+    joint_table: pd.DataFrame,
+    per_task: pd.DataFrame,
+    score_columns: list[str],
+    column_types: list[str],
+) -> tuple[gr.DataFrame, gr.DataFrame]:
     excluded_columns = [
         "Rank (Borda)",
         "Model",

--- a/mteb/leaderboard/table.py
+++ b/mteb/leaderboard/table.py
@@ -221,9 +221,7 @@ def scores_to_tables(
     ]
     light_green_cmap = create_light_green_cmap()
     numeric_data = joint_table.copy()
-    for col in score_columns + ["Zero-shot"]:
-        if col in numeric_data.columns:
-            numeric_data[col] = numeric_data[col].replace(-1, np.nan)
+    numeric_data["Zero-shot"] = numeric_data["Zero-shot"].replace(-1, np.nan)
     joint_table["Zero-shot"] = joint_table["Zero-shot"].apply(format_zero_shot)
     joint_table[score_columns] = joint_table[score_columns].map(format_scores)
     joint_table_style = joint_table.style.format(
@@ -239,7 +237,7 @@ def scores_to_tables(
 
     # Apply background gradients for each selected column
     for col in gradient_columns:
-        if col in joint_table.columns and numeric_data[col].notna().sum() > 0:
+        if col in joint_table.columns:
             mask = numeric_data[col].notna()
             if col != "Zero-shot":
                 gmap_values = numeric_data[col] * 100
@@ -254,17 +252,16 @@ def scores_to_tables(
             )
     task_score_columns = per_task.select_dtypes("number").columns
     per_task[task_score_columns] *= 100
-    per_task_numeric = per_task.copy()
     per_task_style = per_task.style.format(
         "{:.2f}", subset=task_score_columns, na_rep=""
     ).highlight_max(subset=task_score_columns, props="font-weight: bold")
     for col in task_score_columns:
-        if col != "Model" and per_task_numeric[col].notna().sum() > 0:
-            mask = per_task_numeric[col].notna()
+        if col != "Model":
+            mask = per_task[col].notna()
             per_task_style = per_task_style.background_gradient(
                 cmap=light_green_cmap,
                 subset=pd.IndexSlice[mask, col],
-                gmap=per_task_numeric[col].loc[mask],
+                gmap=per_task[col].loc[mask],
             )
     return (
         gr.DataFrame(

--- a/scripts/make_leaderboard.py
+++ b/scripts/make_leaderboard.py
@@ -7,7 +7,7 @@ import os
 import pandas as pd
 
 import mteb
-from mteb.leaderboard.table import scores_to_tables
+from mteb.leaderboard.table import create_tables
 from mteb.load_results import load_results
 
 logging.basicConfig(level=logging.INFO)
@@ -64,7 +64,7 @@ def load_leaderboard(
     scores_long = benchmark_results_filtered.get_scores(format="long")
 
     # Convert scores into leaderboard tables
-    summary_gr_df, per_task_gr_df = scores_to_tables(scores_long=scores_long)
+    summary_gr_df, per_task_gr_df = create_tables(scores_long=scores_long)
 
     # Convert Gradio DataFrames to Pandas
     summary_df = pd.DataFrame(


### PR DESCRIPTION
This PR is related to applying background gradients for all columns in summary table performance per task table on leaderboard for better visibility as described in issue #2382 

Closes #2382 
<details>
<summary> Summary Table </summary>
<img width="1474" alt="Screenshot 2025-03-26 at 10 37 57 PM" src="https://github.com/user-attachments/assets/6dcd4603-21b8-4829-81fa-28b0705fc60e" />
</details>

<details>
<summary> Performance Per Task Table </summary>
<img width="1477" alt="Screenshot 2025-03-26 at 8 19 47 PM" src="https://github.com/user-attachments/assets/398f2932-31ef-400e-88fd-fe046d310de5" />

</details>

### Code Quality
<!-- Please do not delete this -->
- [x] **Code Formatted**: Format the code using `make lint` to maintain consistent style.

### Documentation
<!-- Please do not delete this -->
- [ ] **Updated Documentation**: Add or update documentation to reflect the changes introduced in this PR.

### Testing
<!-- Please do not delete this -->
- [ ] **New Tests Added**: Write tests to cover new functionality. Validate with `make test-with-coverage`.
- [x] **Tests Passed**: Run tests locally using `make test` or `make test-with-coverage` to ensure no existing functionality is broken.