### PR TITLE
Add validation to model_name in `ModelMeta`

### DIFF
--- a/mteb/model_meta.py
+++ b/mteb/model_meta.py
@@ -11,7 +11,7 @@ from huggingface_hub.errors import (
     NotASafetensorsRepoError,
     SafetensorsParsingError,
 )
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 
 from mteb.abstasks.AbsTask import AbsTask
 from mteb.encoder_interface import Encoder
@@ -122,6 +122,17 @@ class ModelMeta(BaseModel):
         loader = dict_repr.pop("loader", None)
         dict_repr["loader"] = get_loader_name(loader)
         return dict_repr
+
+    @field_validator("name")
+    @classmethod
+    def check_name(cls, v: str | None) -> str | None:
+        if v is None or v == "bm25s":
+            return v
+        if "/" not in v:
+            raise ValueError(
+                "Model name must be in the format 'organization/model_name'"
+            )
+        return v
 
     def load_model(self, **kwargs: Any) -> Encoder:
         if self.loader is None:

--- a/mteb/model_meta.py
+++ b/mteb/model_meta.py
@@ -63,7 +63,7 @@ class ModelMeta(BaseModel):
 
     Attributes:
         loader: the function that loads the model. If None it will just default to loading the model using the sentence transformer library.
-        name: The name of the model, ideally the name on huggingface.
+        name: The name of the model, ideally the name on huggingface. It should be in the format "organization/model_name".
         n_parameters: The number of parameters in the model, e.g. 7_000_000 for a 7M parameter model. Can be None if the number of parameters is not known (e.g. for proprietary models) or
             if the loader returns a SentenceTransformer model from which it can be derived.
         memory_usage_mb: The memory usage of the model in MB. Can be None if the memory usage is not known (e.g. for proprietary models). To calculate it use the `calculate_memory_usage_mb` method.

--- a/mteb/models/b1ade_models.py
+++ b/mteb/models/b1ade_models.py
@@ -10,7 +10,7 @@ b1ade_training_data = {
 
 b1ade_embed = ModelMeta(
     loader=sentence_transformers_loader,
-    name="b1ade-embed",
+    name="w601sxs/b1ade-embed",
     languages=["eng-Latn"],
     revision="3bdac13927fdc888b903db93b2ffdbd90b295a69",
     open_weights=True,

--- a/mteb/models/cohere_v.py
+++ b/mteb/models/cohere_v.py
@@ -182,7 +182,7 @@ def cohere_v_loader(**kwargs):
 
 cohere_mult_3 = ModelMeta(
     loader=partial(cohere_v_loader, model_name="embed-multilingual-v3.0"),
-    name="embed-multilingual-v3.0-v",
+    name="cohere/embed-multilingual-v3.0",
     languages=[],  # Unknown, but support >100 languages
     revision="1",
     release_date="2024-10-24",
@@ -204,7 +204,7 @@ cohere_mult_3 = ModelMeta(
 
 cohere_eng_3 = ModelMeta(
     loader=partial(cohere_v_loader, model_name="embed-english-v3.0"),
-    name="embed-english-v3.0-v",
+    name="cohere/embed-english-v3.0",
     languages=["eng-Latn"],
     revision="1",
     release_date="2024-10-24",

--- a/tests/test_benchmark/mock_models.py
+++ b/tests/test_benchmark/mock_models.py
@@ -45,7 +45,7 @@ class MockTorchbf16Encoder(SentenceTransformer):
 
 class MockCLIPEncoder:
     mteb_model_meta = ModelMeta(
-        name="MockCLIPModel",
+        name="mock/MockCLIPModel",
         languages=["eng_Latn"],
         revision="3d74acf9a28c67741b2f4f2ea7635f0aaf6f0268",
         release_date="2021-02-06",
@@ -91,7 +91,7 @@ class MockCLIPEncoder:
 
 class MockMocoEncoder:
     mteb_model_meta = ModelMeta(
-        name="MockMocoModel",
+        name="mock/MockMocoModel",
         languages=["eng_Latn"],
         revision="7d091cd70772c5c0ecf7f00b5f12ca609a99d69d",
         release_date="2024-01-01",

--- a/tests/test_models/test_model_meta.py
+++ b/tests/test_models/test_model_meta.py
@@ -36,7 +36,7 @@ def test_model_memory_usage_api_model():
 )
 def test_model_similar_tasks(training_datasets):
     dummy_model_meta = ModelMeta(
-        name="test_model",
+        name="test/test_model",
         revision="test",
         release_date=None,
         languages=None,
@@ -65,6 +65,32 @@ def test_model_similar_tasks(training_datasets):
         "Touche2020Retrieval.v3",
     ]
     assert sorted(dummy_model_meta.get_training_datasets().keys()) == expected
+
+
+def test_model_name_without_prefix():
+    with pytest.raises(ValueError):
+        ModelMeta(
+            name="test_model",
+            revision="test",
+            release_date=None,
+            languages=None,
+            loader=None,
+            n_parameters=None,
+            memory_usage_mb=None,
+            max_tokens=None,
+            embed_dim=None,
+            license=None,
+            open_weights=None,
+            public_training_code=None,
+            public_training_data=None,
+            framework=[],
+            reference=None,
+            similarity_fn_name=None,
+            use_instructions=None,
+            training_datasets=None,
+            adapted_from=None,
+            superseded_by=None,
+        )
 
 
 def test_model_training_dataset_adapted():


### PR DESCRIPTION
Add validation to model_name in `ModelMeta`.


### Code Quality
<!-- Please do not delete this -->
- [X] **Code Formatted**: Format the code using `make lint` to maintain consistent style.

### Documentation
<!-- Please do not delete this -->
- [X] **Updated Documentation**: Add or update documentation to reflect the changes introduced in this PR.

### Testing
<!-- Please do not delete this -->
- [X] **New Tests Added**: Write tests to cover new functionality. Validate with `make test-with-coverage`.
- [X] **Tests Passed**: Run tests locally using `make test` or `make test-with-coverage` to ensure no existing functionality is broken.


### Adding datasets checklist
<!-- see also https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md -->

**Reason for dataset addition**: ... <!-- Add reason for adding dataset here. E.g. it covers task/language/domain previously not covered -->

- [ ] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb -m {model_name} -t {task_name}` command.
  - [ ] `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
  - [ ] `intfloat/multilingual-e5-small`
- [ ] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [ ] If the dataset is too big (e.g. >2048 examples), considering using `self.stratified_subsampling() under dataset_transform()`
- [ ] I have filled out the metadata object in the dataset file (find documentation on it [here](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md#2-creating-the-metadata-object)).
- [ ] Run tests locally to make sure nothing is broken using `make test`.
- [ ] Run the formatter to format the code using `make lint`.


### Adding a model checklist
<!--
When adding a model to the model registry
see also https://github.com/embeddings-benchmark/mteb/blob/main/docs/reproducible_workflow.md
-->

 - [ ] I have filled out the ModelMeta object to the extent possible
 - [ ] I have ensured that my model can be loaded using
   - [ ] `mteb.get_model(model_name, revision)` and
   - [ ] `mteb.get_model_meta(model_name, revision)`
 - [ ] I have tested the implementation works on a representative set of tasks.
