### PR TITLE
fix: Add option to remove benchmark from leaderboard

### DIFF
--- a/mteb/benchmarks/benchmark.py
+++ b/mteb/benchmarks/benchmark.py
@@ -47,6 +47,7 @@ class Benchmark:
     reference: UrlString | None = None
     citation: str | None = None
     contacts: list[str] | None = None
+    display_on_leaderboard: bool = True
 
     def __iter__(self):
         return iter(self.tasks)

--- a/mteb/benchmarks/benchmarks.py
+++ b/mteb/benchmarks/benchmarks.py
@@ -1144,6 +1144,7 @@ CODE_RAG = Benchmark(
       primaryClass={cs.SE},
       url={https://arxiv.org/abs/2406.14497},
     }""",
+    display_on_leaderboard=False,
 )
 
 BEIR = Benchmark(

--- a/mteb/benchmarks/get_benchmark.py
+++ b/mteb/benchmarks/get_benchmark.py
@@ -79,8 +79,13 @@ def get_benchmark(
 
 
 def get_benchmarks(
-    names: list[str] | None = None,
+    names: list[str] | None = None, display_on_leaderboard: bool | None = None
 ) -> list[Benchmark]:
     if names is None:
         names = list(BENCHMARK_REGISTRY.keys())
-    return [get_benchmark(name) for name in names]
+    benchmarks = [get_benchmark(name) for name in names]
+    if display_on_leaderboard is not None:
+        benchmarks = [
+            b for b in benchmarks if b.display_on_leaderboard is display_on_leaderboard
+        ]
+    return benchmarks

--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -213,7 +213,9 @@ def filter_models(
 logger.info("Loading all benchmark results")
 all_results = load_results()
 
-benchmarks = sorted(mteb.get_benchmarks(display_on_leaderboard=True), key=lambda x: x.name)
+benchmarks = sorted(
+    mteb.get_benchmarks(display_on_leaderboard=True), key=lambda x: x.name
+)
 all_benchmark_results = {
     benchmark.name: benchmark.load_results(base_results=all_results).join_revisions()
     for benchmark in benchmarks

--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -213,7 +213,7 @@ def filter_models(
 logger.info("Loading all benchmark results")
 all_results = load_results()
 
-benchmarks = sorted(mteb.get_benchmarks(), key=lambda x: x.name)
+benchmarks = sorted(mteb.get_benchmarks(display_on_leaderboard=True), key=lambda x: x.name)
 all_benchmark_results = {
     benchmark.name: benchmark.load_results(base_results=all_results).join_revisions()
     for benchmark in benchmarks


### PR DESCRIPTION
fixes #2413

This only removed the benchmark from the leaderboard but keep it in MTEB.



### Code Quality
<!-- Please do not delete this -->
- [x] **Code Formatted**: Format the code using `make lint` to maintain consistent style.


### Testing
<!-- Please do not delete this -->
- [ ] **New Tests Added**: Write tests to cover new functionality. Validate with `make test-with-coverage`.
- [ ] **Tests Passed**: Run tests locally using `make test` or `make test-with-coverage` to ensure no existing functionality is broken.

