### PR TITLE
Added Memory Usage column on leaderboard

### DIFF
--- a/mteb/leaderboard/table.py
+++ b/mteb/leaderboard/table.py
@@ -157,6 +157,13 @@ def scores_to_tables(
         "Number of Parameters",
         model_metas.map(lambda m: format_n_parameters(m.n_parameters)),
     )
+    joint_table.insert(
+        1,
+        "Memory Usage (MB)",
+        model_metas.map(
+            lambda m: str(int(m.memory_usage_mb)) if m.memory_usage_mb else "Unknown"
+        ),
+    )
     tasks = get_tasks(tasks=list(data["task_name"].unique()))
     joint_table.insert(
         1, "Zero-shot", model_metas.map(lambda m: m.zero_shot_percentage(tasks))


### PR DESCRIPTION
This PR is addition of memory usage column for models on leaderboard.
Closes #1935 
<details>
<summary> The leaderboard looks like: </summary> 
<img width="1471" alt="Screenshot 2025-03-25 at 10 47 26 AM" src="https://github.com/user-attachments/assets/b438867f-dfce-4090-933e-4715eff9e248" />
</details>


### Code Quality
<!-- Please do not delete this -->
- [x] **Code Formatted**: Format the code using `make lint` to maintain consistent style.

### Documentation
<!-- Please do not delete this -->
- [ ] **Updated Documentation**: Add or update documentation to reflect the changes introduced in this PR.

### Testing
<!-- Please do not delete this -->
- [ ] **New Tests Added**: Write tests to cover new functionality. Validate with `make test-with-coverage`.
- [x] **Tests Passed**: Run tests locally using `make test` or `make test-with-coverage` to ensure no existing functionality is broken.