### PR TITLE
leaderboard fix

### DIFF
--- a/mteb/leaderboard/table.py
+++ b/mteb/leaderboard/table.py
@@ -230,6 +230,7 @@ def apply_styling(
         "Number of Parameters",
         "Embedding Dimensions",
         "Max Tokens",
+        "Memory Usage (MB)",
     ]
     gradient_columns = [
         col for col in joint_table.columns if col not in excluded_columns


### PR DESCRIPTION
This PR is just quick fix because after merge of PR #2392 the command `python -m mteb.leaderboard.app` was returning error, because in PR #2428, a new column name "Memory Usage (MB)" is added to leaderboard which needs to be excluded from gradient background styling. 


### Code Quality
<!-- Please do not delete this -->
- [x] **Code Formatted**: Format the code using `make lint` to maintain consistent style.

### Documentation
<!-- Please do not delete this -->
- [ ] **Updated Documentation**: Add or update documentation to reflect the changes introduced in this PR.

### Testing
<!-- Please do not delete this -->
- [ ] **New Tests Added**: Write tests to cover new functionality. Validate with `make test-with-coverage`.
- [x] **Tests Passed**: Run tests locally using `make test` or `make test-with-coverage` to ensure no existing functionality is broken.