### PR TITLE
test: cache datasets check to avoid failing ci 

### DIFF
--- a/.github/workflows/dataset_loading.yml
+++ b/.github/workflows/dataset_loading.yml
@@ -13,6 +13,13 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Cache Hugging Face
+      id: cache-hf
+      uses: actions/cache@v4
+      with:
+        key: cache-dataset-loading
+        path: ${{ github.workspace }}/.cache/dataset_check_cache.json
+
     - name: Set up Python
       uses: actions/setup-python@v4
       with:

--- a/mteb/models/ops_moa_models.py
+++ b/mteb/models/ops_moa_models.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
+from functools import partial
+
+from sentence_transformers import SentenceTransformer
+
 from mteb.model_meta import ModelMeta
 from mteb.models.wrapper import Wrapper
-from functools import partial
-from sentence_transformers import SentenceTransformer
-import torch
-import torch.nn as nn
-from huggingface_hub import snapshot_download
 
 
 class CustomWrapper(Wrapper):


### PR DESCRIPTION
Enhance the dataset availability test by caching the result when the dataset is available. The test should be skipped if it has already been performed by another CI on the same day.

Example: 
https://github.com/embeddings-benchmark/mteb/actions/runs/14171665536/job/39696653523

### Code Quality
<!-- Please do not delete this -->
- [x] **Code Formatted**: Format the code using `make lint` to maintain consistent style.


### Testing
<!-- Please do not delete this -->
- [ ] **New Tests Added**: Write tests to cover new functionality. Validate with `make test-with-coverage`.
- [x] **Tests Passed**: Run tests locally using `make test` or `make test-with-coverage` to ensure no existing functionality is broken.

