### PR TITLE
fix: jasper models embeddings having nan values

### DIFF
--- a/mteb/models/jasper_models.py
+++ b/mteb/models/jasper_models.py
@@ -68,7 +68,7 @@ jasper_en_v1 = ModelMeta(
         config_kwargs={"is_text_encoder": True, "vector_dim": 12288},
         model_kwargs={
             "attn_implementation": "sdpa",
-            "torch_dtype": torch.float16,
+            "torch_dtype": torch.bfloat16,
         },
         trust_remote_code=True,
         max_seq_length=2048,


### PR DESCRIPTION
Closes #2474 

Changed to bfloat16. @Samoed @KennethEnevoldsen 