### PR TITLE
fix: add prompt to NanoDBPedia

### DIFF
--- a/mteb/tasks/Retrieval/eng/NanoDBPediaRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/NanoDBPediaRetrieval.py
@@ -31,6 +31,9 @@ class NanoDBPediaRetrieval(AbsTaskRetrieval):
         dialect=[],
         sample_creation="found",
         bibtex_citation="""@article{lehmann2015dbpedia, title={DBpedia: A large-scale, multilingual knowledge base extracted from Wikipedia}, author={Lehmann, Jens and et al.}, journal={Semantic Web}, year={2015}}""",
+        prompt={
+            "query": "Given a query, retrieve relevant entity descriptions from DBPedia"
+        },
         adapted_from=["DBPedia"],
     )
 


### PR DESCRIPTION
Hello mteb maintainers, @Muennighoff,  @Samoed 

The original DBPedia has a prompt, but since NanoDBPedia did not have one, I added it
It would be grateful if you could check.

Thank you.

- Seongtae Hong