### PR TITLE
[v2] Retrieval use `self.dataset`

### DIFF
--- a/mteb/abstasks/AbsTask.py
+++ b/mteb/abstasks/AbsTask.py
@@ -149,7 +149,7 @@ class AbsTask(ABC):
 
         for hf_subset in hf_subsets:
             logger.info(
-                f"\nTask: {self.metadata.name}, split: {split}, subset: {hf_subset}. Running..."
+                f"Task: {self.metadata.name}, split: {split}, subset: {hf_subset}. Running..."
             )
             if hf_subset not in self.dataset and hf_subset == "default":
                 data_split = self.dataset[split]
@@ -163,6 +163,7 @@ class AbsTask(ABC):
                 encode_kwargs=encode_kwargs,
                 **kwargs,
             )
+            print(scores)
             self._add_main_score(scores[hf_subset])
         return scores
 

--- a/mteb/abstasks/AbsTaskReranking.py
+++ b/mteb/abstasks/AbsTaskReranking.py
@@ -144,7 +144,7 @@ class AbsTaskReranking(AbsTaskRetrieval):
                         top_ranked[hf_subset][split][query_id].append(doc_id)
                         relevant_docs[hf_subset][split][query_id][doc_id] = relevance
 
-            self.datset[hf_subset][split] = {
+            self.dataset[hf_subset][split] = {
                 "corpus": corpus[hf_subset][split],
                 "queries": queries[hf_subset][split],
                 "relevant_docs": relevant_docs[hf_subset][split],

--- a/mteb/abstasks/AbsTaskRetrieval.py
+++ b/mteb/abstasks/AbsTaskRetrieval.py
@@ -2,18 +2,17 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 from collections import defaultdict
+from collections.abc import Mapping
 from pathlib import Path
-from time import time
-from typing import Any, Callable
+from typing import Any, Callable, TypedDict
 
 from datasets import Dataset, DatasetDict
 
 from mteb.abstasks.TaskMetadata import DescriptiveStatistics, HFSubset
 
+from .. import Encoder
 from ..evaluation.evaluators import RetrievalEvaluator
-from ..evaluation.evaluators.utils import make_score_dict
 from ..load_results.task_results import ScoresDict
 from .AbsTask import AbsTask
 from .dataloaders import RetrievalDataLoader
@@ -95,89 +94,81 @@ class RetrievalDescriptiveStatistics(DescriptiveStatistics):
     max_top_ranked_per_query: int | None
 
 
+class SplitData(TypedDict, total=False):
+    corpus: Mapping[str, str | dict[str, str]]
+    queries: Mapping[str, str]
+    relevant_docs: Mapping[str, Mapping[str, float]]
+    instructions: Mapping[str, str] | None
+    top_ranked: Mapping[str, list[str]] | None
+
+
 class AbsTaskRetrieval(AbsTask):
     """Abstract class for retrieval experiments.
 
     Child-classes must implement the following properties:
 
-    self.corpus: dict[str, dict[str, str]]
-        Semantically, it should contain dict[split_name, dict[sample_id, dict[str, str]]]
-        E.g. {"test": {"document_one": {"_id": "d1", "title": "title", "text": "text"}}}
-
-    self.queries: dict[str, dict[str, Union[str, list[str]]]]
-        Semantically, it should contain dict[split_name, dict[sample_id, str]] or dict[split_name, dict[sample_id, list[str]]] for conversations
-        E.g. {"test": {"q1": "query"}}
-        or {"test": {"q1": ["turn1", "turn2", "turn3"]}}
-
-    self.relevant_docs: dict[str, dict[str, dict[str, int]]]
-        Semantically, it should contain dict[split_name, dict[sample_id, dict[doc_id, score]]]
-        E.g.: {"test": {"q1": {"document_one": 1}}}
-
-    Child classes may optionally implement the following properties (top_ranked for reranking and instructions if needed):
-
-    self.top_ranked: dict[str, dict[str, list[str]]] or dict[str, dict[str, dict[str, float]]]
-        Semantically, it should contain dict[split_name, dict[sample_id, list[doc_id]]] or dict[split_name, dict[sample_id, dict[doc_id, score]]]
-        E.g.: {"test": {"q1": ["document_one", "document_two"]}} or {"test": {"q1": {"document_one": 1, "document_two": 0.5}}}
-
-    self.instructions: dict[str, dict[str, str]] or dict[str, dict[str, list[str]]]
-        Semantically, it should contain dict[split_name, dict[sample_id, str]]. If there are multiple instructions per query, please duplicate the queries and give them unique ids for consolidation.
-        E.g. {"test": {"query-id1": "instruction text"}}
+    self.dataset: dict[str, dict[str, dict[str, Any]]]
+        A dictionary containing all dataset components with the following structure:
+        {
+            hf_subset: {
+                split: {
+                    'corpus': dict[str, dict[str, str]],  # doc_id -> doc
+                    'queries': dict[str, Union[str, List[str]]],  # query_id -> query
+                    'relevant_docs': dict[str, dict[str, int]],  # query_id -> doc_id -> score
+                    'instructions': Optional[dict[str, str]],  # query_id -> instruction
+                    'top_ranked': Optional[dict[str, List[str]]]  # query_id -> doc_ids
+                }
+            }
+        }
     """
 
     ignore_identical_ids: bool = False
     abstask_prompt = "Retrieve text based on user query."
-    instructions = None
-    top_ranked = None
+    top_k = 100
+    dataset: dict[str, dict[str, SplitData]]
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.dataset = defaultdict(
+            lambda: defaultdict(
+                lambda: {
+                    "corpus": {},
+                    "queries": {},
+                    "relevant_docs": {},
+                    "instructions": None,
+                    "top_ranked": None,
+                }
+            )
+        )
 
     def load_data(self, **kwargs):
         if self.data_loaded:
             return
-
-        self.corpus = defaultdict(dict)
-        self.queries = defaultdict(dict)
-        self.relevant_docs = defaultdict(dict)
-        self.instructions = None
-        self.top_ranked = None
 
         dataset_path = self.metadata.dataset["path"]
         eval_splits = kwargs.get("eval_splits", self.metadata.eval_splits)
         trust_remote_code = self.metadata.dataset.get("trust_remote_code", False)
         revision = self.metadata.dataset["revision"]
 
-        def process_data(split: str, lang: str | None = None):
+        def process_data(split: str, hf_subset: str = "default"):
             """Helper function to load and process data for a given split and language"""
-            corpus, queries, qrels, instructions, top_ranked = RetrievalDataLoader(
-                hf_repo=dataset_path,
-                revision=revision,
-                trust_remote_code=trust_remote_code,
-                split=split,
-                config=lang,
-            ).load()
+            corpus, queries, relevant_docs, instructions, top_ranked = (
+                RetrievalDataLoader(
+                    hf_repo=dataset_path,
+                    revision=revision,
+                    trust_remote_code=trust_remote_code,
+                    split=split,
+                    config=hf_subset,
+                ).load()
+            )
 
-            if lang:
-                self.corpus[lang][split] = corpus
-                self.queries[lang][split] = queries
-                self.relevant_docs[lang][split] = qrels
-            else:
-                self.corpus[split] = corpus
-                self.queries[split] = queries
-                self.relevant_docs[split] = qrels
-
-            if instructions:
-                if self.instructions is None:
-                    self.instructions = defaultdict(dict)
-                if lang:
-                    self.instructions[lang][split] = instructions
-                else:
-                    self.instructions[split] = instructions
-
-            if top_ranked:
-                if self.top_ranked is None:
-                    self.top_ranked = defaultdict(dict)
-                if lang:
-                    self.top_ranked[lang][split] = top_ranked
-                else:
-                    self.top_ranked[split] = top_ranked
+            self.dataset[hf_subset][split] = {
+                "corpus": corpus,
+                "queries": queries,
+                "relevant_docs": relevant_docs,
+                "instructions": instructions,
+                "top_ranked": top_ranked,
+            }
 
         if self.metadata.is_multilingual:
             for lang in self.metadata.eval_langs:
@@ -197,156 +188,123 @@ class AbsTaskRetrieval(AbsTask):
         encode_kwargs: dict[str, Any] = {},
         **kwargs,
     ) -> dict[HFSubset, ScoresDict]:
-        retriever = RetrievalEvaluator(
-            retriever=model,
-            encode_kwargs=encode_kwargs,
-            **kwargs,
-        )
+        """Evaluate the model on the retrieval task.
 
+        Args:
+            model: Model to evaluate
+            split: Split to evaluate on
+            subsets_to_run: Optional list of subsets to evaluate on
+            encode_kwargs: Keyword arguments passed to the encoder
+            **kwargs: Additional keyword arguments passed to the evaluator
+
+        Returns:
+            Dictionary mapping subsets to their evaluation scores
+        """
         scores = {}
         hf_subsets = self.hf_subsets
         if subsets_to_run is not None:
             hf_subsets = [s for s in hf_subsets if s in subsets_to_run]
 
         for hf_subset in hf_subsets:
-            logger.info(f"Subset: {hf_subset}")
-
-            if hf_subset == "default" and "default" not in self.corpus:
-                corpus = self.corpus[split]
-                queries = self.queries[split]
-                relevant_docs = self.relevant_docs[split]
-                top_ranked = self.top_ranked[split] if self.top_ranked else None
-                instructions = self.instructions[split] if self.instructions else None
-            else:
-                corpus = self.corpus[hf_subset][split]
-                queries = self.queries[hf_subset][split]
-                relevant_docs = self.relevant_docs[hf_subset][split]
-                top_ranked = (
-                    self.top_ranked[hf_subset][split] if self.top_ranked else None
-                )
-                instructions = (
-                    self.instructions[hf_subset][split] if self.instructions else None
-                )
+            logger.info(f"Evaluating subset: {hf_subset}")
 
             scores[hf_subset] = self._evaluate_subset(
-                retriever,
-                corpus,
-                queries,
-                relevant_docs,
-                split,
-                hf_subset,
-                top_ranked,
-                instructions,
+                model,
+                self.dataset[hf_subset][split],
+                encode_kwargs,
+                hf_split=split,
+                hf_subset=hf_subset,
                 **kwargs,
             )
         return scores
 
     def _evaluate_subset(
         self,
-        retriever: RetrievalEvaluator,
-        corpus: dict[str, dict[str, str]],
-        queries: dict[str, str],
-        relevant_docs: dict[str, dict[str, int]],
+        model: Encoder,
+        data_split: DatasetDict | Dataset,
+        encode_kwargs: dict[str, Any],
         hf_split: str,
         hf_subset: str,
-        top_ranked: dict[str, list[str]] | None = None,
-        instructions: dict[str, str] | None = None,
+        # retrieval specific args
         save_predictions: bool = False,
         export_errors: bool = False,
         save_qrels: bool = False,
         output_folder: str = "results",
         results: dict[str, dict[str, float]] | None = None,
-        top_k: int | None = None,
         **kwargs,
     ) -> ScoresDict:
-        """Evaluate the retrieval task for a given subset of the dataset.
+        """Evaluate a model on a specific subset of the data.
 
         Args:
-            retriever: Evaluation object
-            corpus: Corpus to evaluate on
-            queries: Queries to evaluate on
-            relevant_docs: Relevant documents for the queries
-            hf_subset: Subset of the dataset
-            hf_split: Split of the dataset
-            top_ranked: Top ranked documents (used for reranking)
-            instructions: Instructions for the queries (used for InstructRetrieval/Reranking)
-            save_predictions: Whether to save the predictions
+            model: Model to evaluate
+            data_split: Data split to evaluate on
+            encode_kwargs: Keyword arguments passed to the encoder
+            hf_split: Split to evaluate on
+            hf_subset: Subset to evaluate on
+            save_predictions: Whether to save predictions
             export_errors: Whether to export errors
             save_qrels: Whether to save the qrels
             output_folder: Folder to save the results
             results: Results from retrieval from previous run
-            top_k: Top k documents to consider
-            **kwargs: kwargs
+            **kwargs: Additional keyword arguments passed to the evaluator
 
         Returns:
-            ScoresDict: Evaluation scores
+            Dictionary of evaluation scores
         """
-        if not results:
-            # perform the retrieval here
-            start_time = time()
+        retriever = RetrievalEvaluator(
+            retriever=model,
+            encode_kwargs=encode_kwargs,
+            **kwargs,
+        )
+
+        if results is None:
             results = retriever(
-                corpus,
-                queries,
-                instructions=instructions,
-                top_ranked=top_ranked,
+                corpus=data_split["corpus"],
+                queries=data_split["queries"],
                 task_metadata=self.metadata,
                 hf_split=hf_split,
                 hf_subset=hf_subset,
+                instructions=data_split["instructions"],
+                top_ranked=data_split["top_ranked"],
                 **kwargs,
             )
-            end_time = time()
-            logger.info(f"Time taken to retrieve: {end_time - start_time:.2f} seconds")
 
         if save_predictions or export_errors or save_qrels:
             output_folder = Path(output_folder)
-            if not os.path.isdir(output_folder):
-                os.makedirs(output_folder)
+            if not output_folder.exists():
+                output_folder.mkdir(parents=True)
 
         if save_predictions:
-            if top_k is not None:
-                for qid in list(results.keys()):
-                    doc_ids = set(
-                        sorted(
-                            results[qid], key=lambda x: results[qid][x], reverse=True
-                        )[:top_k]
-                    )
-                    results[qid] = {
-                        k: v for k, v in results[qid].items() if k in doc_ids
-                    }
-            qrels_save_path = (
+            # Filter results to only include documents in the corpus
+            doc_ids = set(data_split["corpus"].keys())
+            filtered_results = {
+                qid: {k: v for k, v in results[qid].items() if k in doc_ids}
+                for qid in results
+            }
+            predictions_path = (
                 output_folder / f"{self.metadata.name}_{hf_subset}_predictions.json"
             )
-
-            with open(qrels_save_path, "w") as f:
-                json.dump(results, f)
+            predictions_path.write_text(json.dumps(filtered_results))
 
         if save_qrels:
             with open(
                 output_folder / f"{self.metadata.name}_{hf_subset}_qrels.json", "w"
             ) as f:
-                json.dump(relevant_docs, f)
+                json.dump(data_split["relevant_docs"], f)
 
         ndcg, _map, recall, precision, naucs, task_scores = retriever.evaluate(
-            relevant_docs,
-            results,
-            retriever.k_values,
-            ignore_identical_ids=self.ignore_identical_ids,
+            qrels=data_split["relevant_docs"],
+            results=results,
+            k_values=retriever.k_values,
             task_metadata=self.metadata,
+            ignore_identical_ids=self.ignore_identical_ids,
         )
-
-        mrr, naucs_mrr = retriever.evaluate_custom(
-            relevant_docs, results, retriever.k_values, "mrr"
-        )
-        scores = make_score_dict(
-            ndcg, _map, recall, precision, mrr, naucs, naucs_mrr, task_scores
-        )
-        self._add_main_score(scores)
 
         if export_errors:
             errors = {}
 
-            top_k = top_k or 1
-            if not save_predictions and top_k == 1:
+            top_k = self.top_k
+            if not save_predictions:
                 for qid in results.keys():
                     doc_scores = results[qid]
                     sorted_docs = sorted(
@@ -354,7 +312,7 @@ class AbsTaskRetrieval(AbsTask):
                     )[:top_k]
                     results[qid] = dict(sorted_docs)
             for qid, retrieved_docs in results.items():
-                expected_docs = relevant_docs[qid]
+                expected_docs = data_split["relevant_docs"][qid]
                 false_positives = [
                     doc for doc in retrieved_docs if doc not in expected_docs
                 ]
@@ -367,34 +325,18 @@ class AbsTaskRetrieval(AbsTask):
                         "false_negatives": false_negatives,
                     }
 
-            errors_save_path = (
-                output_folder / f"{self.metadata.name}_{hf_subset}_errors.json"
-            )
-            with open(errors_save_path, "w") as f:
-                json.dump(errors, f)
-
-        return scores
+        return task_scores
 
     def _calculate_metrics_from_split(
         self, split: str, hf_subset: str | None = None, compute_overall: bool = False
     ) -> RetrievalDescriptiveStatistics:
-        top_ranked = None
-        instructions = None
-        if hf_subset and hf_subset in self.queries:
-            # BrightRetrieval has different splits for different subsets of the corpus.
-            if (
-                self.corpus.get(hf_subset, None) is None
-                or self.corpus[hf_subset].get(split, None) is None
-            ):
-                return {}
-
-            queries = self.queries[hf_subset][split]
-            corpus = self.corpus[hf_subset][split]
-            relevant_docs = self.relevant_docs[hf_subset][split]
-            if self.instructions is not None:
-                instructions = self.instructions[hf_subset][split]
-            if self.top_ranked is not None:
-                top_ranked = self.top_ranked[hf_subset][split]
+        if hf_subset and hf_subset in self.dataset:
+            split_data = self.dataset[hf_subset][split]
+            queries = split_data["queries"]
+            corpus = split_data["corpus"]
+            relevant_docs = split_data["relevant_docs"]
+            instructions = split_data["instructions"]
+            top_ranked = split_data["top_ranked"]
         elif compute_overall:
             queries = {}
             corpus = {}
@@ -402,35 +344,34 @@ class AbsTaskRetrieval(AbsTask):
             instructions = {}
             top_ranked = {}
             for hf_subset in self.metadata.eval_langs:
-                # BrightRetrieval has different splits for different subsets of the corpus.
-                if (
-                    self.corpus.get(hf_subset, None) is None
-                    or self.corpus[hf_subset].get(split, None) is None
-                ):
-                    continue
-                queries.update(process_docs(self.queries, hf_subset, split))
-                corpus.update(process_docs(self.corpus, hf_subset, split))
+                split_data = self.dataset[hf_subset][split]
+                queries.update(process_docs(split_data["queries"], hf_subset, split))
+                corpus.update(process_docs(split_data["corpus"], hf_subset, split))
                 relevant_docs.update(
-                    process_relevant_docs(self.relevant_docs, hf_subset, split)
+                    process_relevant_docs(split_data["relevant_docs"], hf_subset, split)
                 )
-                if self.instructions is not None:
+                if (
+                    "instructions" in split_data
+                    and split_data["instructions"] is not None
+                ):
                     instructions.update(
-                        process_docs(self.instructions, hf_subset, split)
+                        process_docs(split_data["instructions"], hf_subset, split)
                     )
-                if self.top_ranked is not None:
-                    top_ranked.update(process_docs(self.top_ranked, hf_subset, split))
+                if "top_ranked" in split_data and split_data["top_ranked"] is not None:
+                    top_ranked.update(
+                        process_docs(split_data["top_ranked"], hf_subset, split)
+                    )
         else:
-            if "default" in self.queries and split != "default":
+            if "default" in self.dataset and split != "default":
                 return self._calculate_metrics_from_split(
                     split=split, hf_subset="default"
                 )
-            queries = self.queries[split]
-            corpus = self.corpus[split]
-            relevant_docs = self.relevant_docs[split]
-            if self.instructions is not None:
-                instructions = self.instructions[split]
-            if self.top_ranked is not None:
-                top_ranked = self.top_ranked[split]
+            split_data = self.dataset["default"][split]
+            queries = split_data["queries"]
+            corpus = split_data["corpus"]
+            relevant_docs = split_data["relevant_docs"]
+            instructions = split_data["instructions"]
+            top_ranked = split_data["top_ranked"]
 
         query_len = calculate_queries_length(queries)
         doc_len = calculate_corpus_length(corpus)
@@ -451,7 +392,7 @@ class AbsTaskRetrieval(AbsTask):
         )
         qrels_per_doc = num_qrels_non_zero / len(relevant_docs) if num_queries else 0
 
-        if self.instructions is not None:
+        if instructions is not None:
             instructions_len = [
                 len(instruction) for instruction in instructions.values()
             ]
@@ -467,7 +408,7 @@ class AbsTaskRetrieval(AbsTask):
             max_instruction_length = None
             unique_instructions = None
 
-        if self.top_ranked is not None and num_queries:
+        if top_ranked is not None and num_queries:
             top_ranked_per_query = [len(docs) for docs in top_ranked.values()]
             num_top_ranked = len(top_ranked_per_query)
             min_top_ranked_per_query = min(top_ranked_per_query)
@@ -537,15 +478,15 @@ class AbsTaskRetrieval(AbsTask):
             DatasetDict(sections).push_to_hub(repo_name, suffix)
 
         if self.metadata.is_multilingual:
-            for lang in self.queries:
+            for lang in self.dataset["queries"]:
                 logger.info(f"Converting {lang} of {self.metadata.name}")
                 push_section(
-                    self.queries[lang],
+                    self.dataset["queries"][lang],
                     f"{lang}-queries",
                     lambda idx, text: {"_id": idx, "text": text},
                 )
                 push_section(
-                    self.corpus[lang],
+                    self.dataset["corpus"][lang],
                     f"{lang}-corpus",
                     lambda idx, text: {
                         "_id": idx,
@@ -555,7 +496,7 @@ class AbsTaskRetrieval(AbsTask):
                 )
                 # Handle relevant_docs separately since one entry expands to multiple records.
                 relevant_sections = {}
-                for split, queries in self.relevant_docs[lang].items():
+                for split, queries in self.dataset["relevant_docs"][lang].items():
                     entries = []
                     for query_id, docs in queries.items():
                         for doc_id, score in docs.items():
@@ -569,36 +510,38 @@ class AbsTaskRetrieval(AbsTask):
                     relevant_sections[split] = Dataset.from_list(entries)
                 DatasetDict(relevant_sections).push_to_hub(repo_name, f"{lang}-qrels")
 
-                if self.instructions:
+                if self.dataset["instructions"]:
                     push_section(
-                        self.instructions[lang],
+                        self.dataset["instructions"][lang],
                         f"{lang}-instruction",
                         lambda idx, text: {"query-id": idx, "instruction": text},
                     )
-                if self.top_ranked:
+                if self.dataset["top_ranked"]:
                     push_section(
-                        self.top_ranked[lang],
+                        self.dataset["top_ranked"][lang],
                         f"{lang}-top_ranked",
                         lambda idx, docs: {"query-id": idx, "corpus-ids": docs},
                     )
         else:
             # For non-multilingual cases, flatten the structure if a "default" key exists.
-            if "default" in self.queries:
-                self.queries = self.queries["default"]
-                self.corpus = self.corpus["default"]
-                self.relevant_docs = self.relevant_docs["default"]
-                if self.instructions:
-                    self.instructions = self.instructions["default"]
-                if self.top_ranked:
-                    self.top_ranked = self.top_ranked["default"]
+            if "default" in self.dataset["queries"]:
+                self.dataset["queries"] = self.dataset["queries"]["default"]
+                self.dataset["corpus"] = self.dataset["corpus"]["default"]
+                self.dataset["relevant_docs"] = self.dataset["relevant_docs"]["default"]
+                if self.dataset["instructions"]:
+                    self.dataset["instructions"] = self.dataset["instructions"][
+                        "default"
+                    ]
+                if self.dataset["top_ranked"]:
+                    self.dataset["top_ranked"] = self.dataset["top_ranked"]["default"]
 
             push_section(
-                self.queries,
+                self.dataset["queries"],
                 "queries",
                 lambda idx, text: {"_id": idx, "text": text},
             )
             push_section(
-                self.corpus,
+                self.dataset["corpus"],
                 "corpus",
                 lambda idx, text: {
                     "_id": idx,
@@ -608,7 +551,7 @@ class AbsTaskRetrieval(AbsTask):
             )
             # Process relevant_docs with flattening.
             relevant_sections = {}
-            for split, queries in self.relevant_docs.items():
+            for split, queries in self.dataset["relevant_docs"].items():
                 entries = []
                 for query_id, docs in queries.items():
                     for doc_id, score in docs.items():
@@ -618,15 +561,15 @@ class AbsTaskRetrieval(AbsTask):
                 relevant_sections[split] = Dataset.from_list(entries)
             DatasetDict(relevant_sections).push_to_hub(repo_name, "default")
 
-            if self.instructions:
+            if self.dataset["instructions"]:
                 push_section(
-                    self.instructions,
+                    self.dataset["instructions"],
                     "instruction",
                     lambda idx, text: {"query-id": idx, "instruction": text},
                 )
-            if self.top_ranked:
+            if self.dataset["top_ranked"]:
                 push_section(
-                    self.top_ranked,
+                    self.dataset["top_ranked"],
                     "top_ranked",
                     lambda idx, docs: {"query-id": idx, "corpus-ids": docs},
                 )

--- a/mteb/abstasks/dataloaders.py
+++ b/mteb/abstasks/dataloaders.py
@@ -41,7 +41,7 @@ class RetrievalDataLoader:
         self.hf_repo = hf_repo
         self.trust_remote_code = trust_remote_code
         self.split = split
-        self.config = config
+        self.config = config if config != "default" else None
 
     def load(
         self,
@@ -57,7 +57,6 @@ class RetrievalDataLoader:
         configs = get_dataset_config_names(
             self.hf_repo, self.revision, trust_remote_code=self.trust_remote_code
         )
-
         logger.info("Loading Corpus...")
         self._load_corpus(self.config)
         logger.info("Loaded %d %s Documents.", len(self.corpus), self.split.upper())

--- a/mteb/evaluation/evaluators/model_classes.py
+++ b/mteb/evaluation/evaluators/model_classes.py
@@ -28,11 +28,12 @@ logger = logging.getLogger(__name__)
 
 # Adapted from https://github.com/beir-cellar/beir/blob/f062f038c4bfd19a8ca942a9910b1e0d218759d4/beir/retrieval/search/dense/exact_search.py#L12
 class DenseRetrievalExactSearch:
+    corpus_chunk_size: int = 50000
+
     def __init__(
         self,
         model: Encoder,
         encode_kwargs: dict[str, Any] = {},
-        corpus_chunk_size: int = 50000,
         previous_results: str | Path | None = None,
         **kwargs: Any,
     ):
@@ -42,7 +43,6 @@ class DenseRetrievalExactSearch:
         if "show_progress_bar" not in encode_kwargs:
             self.encode_kwargs["show_progress_bar"] = True
 
-        self.corpus_chunk_size = corpus_chunk_size
         if isinstance(previous_results, Path):
             self.previous_results = str(previous_results)
         else:

--- a/mteb/evaluation/evaluators/utils.py
+++ b/mteb/evaluation/evaluators/utils.py
@@ -60,7 +60,6 @@ def recall_cap(
     capped_recall = defaultdict(list)
 
     k_max = max(k_values)
-    logging.info("\n")
 
     for query_id, doc_scores in results.items():
         top_hits = sorted(doc_scores.items(), key=lambda item: item[1], reverse=True)[
@@ -74,7 +73,9 @@ def recall_cap(
                 row[0] for row in top_hits[0:k] if qrels[query_id].get(row[0], 0) > 0
             ]
             denominator = min(len(query_relevant_docs), k)
-            capped_recall[f"R_cap@{k}"].append(len(retrieved_docs) / denominator)
+            if denominator == 0:
+                capped_recall[f"R_cap_at_{k}"].append(None)
+            capped_recall[f"R_cap_at_{k}"].append(len(retrieved_docs) / denominator)
     return capped_recall
 
 
@@ -91,7 +92,6 @@ def hole(
             annotated_corpus.add(doc_id)
 
     k_max = max(k_values)
-    logging.info("\n")
 
     for _, scores in results.items():
         top_hits = sorted(scores.items(), key=lambda item: item[1], reverse=True)[
@@ -101,7 +101,7 @@ def hole(
             hole_docs = [
                 row[0] for row in top_hits[0:k] if row[0] not in annotated_corpus
             ]
-            Hole[f"Hole@{k}"].append(len(hole_docs) / k)
+            Hole[f"Hole_at_{k}"].append(len(hole_docs) / k)
     return Hole
 
 

--- a/mteb/evaluation/evaluators/utils.py
+++ b/mteb/evaluation/evaluators/utils.py
@@ -24,20 +24,14 @@ except Exception:
     pass
 
 
-# From https://github.com/beir-cellar/beir/blob/f062f038c4bfd19a8ca942a9910b1e0d218759d4/beir/retrieval/custom_metrics.py#L4
 def mrr(
     qrels: dict[str, dict[str, int]],
     results: dict[str, dict[str, float]],
     k_values: list[int],
-    output_type: str = "mean",
-) -> tuple[dict[str, float]]:
-    MRR = {}
-
-    for k in k_values:
-        MRR[f"MRR@{k}"] = []
+) -> dict[str, list[float]]:
+    MRR = defaultdict(list)
 
     k_max, top_hits = max(k_values), {}
-    logging.info("\n")
 
     for query_id, doc_scores in results.items():
         top_hits[query_id] = sorted(
@@ -55,15 +49,6 @@ def mrr(
                     rr = 1.0 / (rank + 1)
                     break
             MRR[f"MRR@{k}"].append(rr)
-
-    if output_type == "mean":
-        for k in k_values:
-            MRR[f"MRR@{k}"] = round(sum(MRR[f"MRR@{k}"]) / len(qrels), 5)
-            logging.info("MRR@{}: {:.4f}".format(k, MRR[f"MRR@{k}"]))
-
-    elif output_type == "all":
-        pass
-
     return MRR
 
 
@@ -71,12 +56,8 @@ def recall_cap(
     qrels: dict[str, dict[str, int]],
     results: dict[str, dict[str, float]],
     k_values: list[int],
-    output_type: str = "mean",
-) -> tuple[dict[str, float]]:
-    capped_recall = {}
-
-    for k in k_values:
-        capped_recall[f"R_cap@{k}"] = []
+) -> dict[str, list[float]]:
+    capped_recall = defaultdict(list)
 
     k_max = max(k_values)
     logging.info("\n")
@@ -94,17 +75,6 @@ def recall_cap(
             ]
             denominator = min(len(query_relevant_docs), k)
             capped_recall[f"R_cap@{k}"].append(len(retrieved_docs) / denominator)
-
-    if output_type == "mean":
-        for k in k_values:
-            capped_recall[f"R_cap@{k}"] = round(
-                sum(capped_recall[f"R_cap@{k}"]) / len(qrels), 5
-            )
-            logging.info("R_cap@{}: {:.4f}".format(k, capped_recall[f"R_cap@{k}"]))
-
-    elif output_type == "all":
-        pass
-
     return capped_recall
 
 
@@ -112,12 +82,8 @@ def hole(
     qrels: dict[str, dict[str, int]],
     results: dict[str, dict[str, float]],
     k_values: list[int],
-    output_type: str = "mean",
-) -> dict[str, float]:
-    Hole = {}
-
-    for k in k_values:
-        Hole[f"Hole@{k}"] = []
+) -> dict[str, list[float]]:
+    Hole = defaultdict(list)
 
     annotated_corpus = set()
     for _, docs in qrels.items():
@@ -136,15 +102,6 @@ def hole(
                 row[0] for row in top_hits[0:k] if row[0] not in annotated_corpus
             ]
             Hole[f"Hole@{k}"].append(len(hole_docs) / k)
-
-    if output_type == "mean":
-        for k in k_values:
-            Hole[f"Hole@{k}"] = round(Hole[f"Hole@{k}"] / len(qrels), 5)
-            logging.info("Hole@{}: {:.4f}".format(k, Hole[f"Hole@{k}"]))
-
-    elif output_type == "all":
-        pass
-
     return Hole
 
 
@@ -152,15 +109,10 @@ def top_k_accuracy(
     qrels: dict[str, dict[str, int]],
     results: dict[str, dict[str, float]],
     k_values: list[int],
-    output_type: str = "mean",
-) -> dict[str, float]:
-    top_k_acc = {}
-
-    for k in k_values:
-        top_k_acc[f"Accuracy@{k}"] = []
+) -> dict[str, list[float]]:
+    top_k_acc = defaultdict(list)
 
     k_max, top_hits = max(k_values), {}
-    logging.info("\n")
 
     for query_id, doc_scores in results.items():
         top_hits[query_id] = [
@@ -179,17 +131,6 @@ def top_k_accuracy(
                 if relevant_doc_id in top_hits[query_id][0:k]:
                     top_k_acc[f"Accuracy@{k}"].append(1.0)
                     break
-
-    if output_type == "mean":
-        for k in k_values:
-            top_k_acc[f"Accuracy@{k}"] = round(
-                top_k_acc[f"Accuracy@{k}"] / len(qrels), 5
-            )
-            logging.info("Accuracy@{}: {:.4f}".format(k, top_k_acc[f"Accuracy@{k}"]))
-
-    elif output_type == "all":
-        pass
-
     return top_k_acc
 
 

--- a/mteb/tasks/InstructionRetrieval/eng/InstructIR.py
+++ b/mteb/tasks/InstructionRetrieval/eng/InstructIR.py
@@ -14,7 +14,7 @@ class InstructIR(AbsTaskRetrieval):
             "path": "mteb/InstructIR-mteb",
             "revision": "42c3afabe480643b755a7099dbf0f9ebeedaf6ca",
         },
-        type="Reranking",
+        type="InstructionRetrieval",
         category="t2t",
         modalities=["text"],
         eval_splits=["test"],

--- a/mteb/tasks/InstructionRetrieval/multilingual/__init__.py
+++ b/mteb/tasks/InstructionRetrieval/multilingual/__init__.py
@@ -1,3 +1,0 @@
-from __future__ import annotations
-
-__all__ = []

--- a/tests/test_benchmark/mock_tasks.py
+++ b/tests/test_benchmark/mock_tasks.py
@@ -1185,33 +1185,25 @@ class MockRerankingTask(AbsTaskRetrieval):
     )
 
     def load_data(self, **kwargs):
-        self.queries = {
-            "test": {
+        self.dataset["default"]["test"] = {
+            "queries": {
                 "q1": "This is a test sentence",
                 "q2": "This is another test sentence",
-            }
-        }
-        self.corpus = {
-            "test": {
+            },
+            "corpus": {
                 "d1": "This is a positive sentence",
                 "d2": "This is a negative sentence",
-            }
-        }
-
-        self.relevant_docs = {
-            "test": {
+            },
+            "relevant_docs": {
                 "q1": {"d1": 1, "d2": 0},
                 "q2": {"d1": 0, "d2": 1},
             },
-        }
-
-        self.top_ranked = {
-            "test": {
+            "top_ranked": {
                 "q1": ["d1", "d2"],
                 "q2": ["d2", "d1"],
             },
+            "instructions": None,
         }
-        self.instructions = None
         self.data_loaded = True
 
 
@@ -1317,42 +1309,28 @@ class MockMultilingualRerankingTask(AbsTaskRetrieval):
     metadata.eval_langs = multilingual_eval_langs
 
     def load_data(self, **kwargs):
-        queries = {
-            "test": {
+        base_datasplit = {
+            "queries": {
                 "q1": "This is a test sentence",
                 "q2": "This is another test sentence",
-            }
-        }
-        self.queries = {"eng": queries, "fra": queries}
-        corpus = {
-            "test": {
+            },
+            "corpus": {
                 "d1": "This is a positive sentence",
-                "d2": "This is another positive sentence",
-            }
-        }
-        self.corpus = {"eng": corpus, "fra": corpus}
-
-        relevant_docs = {
-            "test": {
+                "d2": "This is a negative sentence",
+            },
+            "relevant_docs": {
                 "q1": {"d1": 1, "d2": 0},
                 "q2": {"d1": 0, "d2": 1},
             },
-        }
-        self.relevant_docs = {
-            "eng": relevant_docs,
-            "fra": relevant_docs,
-        }
-        top_ranked = {
-            "test": {
+            "top_ranked": {
                 "q1": ["d1", "d2"],
                 "q2": ["d2", "d1"],
             },
+            "instructions": None,
         }
-        self.top_ranked = {
-            "eng": top_ranked,
-            "fra": top_ranked,
-        }
-        self.instructions = None
+        self.dataset["eng"]["test"] = base_datasplit
+        self.dataset["fra"]["test"] = base_datasplit
+
         self.data_loaded = True
 
 
@@ -1426,40 +1404,24 @@ class MockRetrievalTask(AbsTaskRetrieval):
     )
 
     def load_data(self, **kwargs):
-        self.queries = {
-            "test": {
+        base_datasplit = {
+            "queries": {
                 "q1": "This is a test sentence",
                 "q2": "This is another test sentence",
             },
-            "val": {
-                "q1": "This is a test sentence",
-                "q2": "This is another test sentence",
-            },
-        }
-
-        self.corpus = {
-            "test": {
+            "corpus": {
                 "d1": "This is a positive sentence",
-                "d2": "This is another positive sentence",
+                "d2": "This is a negative sentence",
             },
-            "val": {
-                "d1": "This is a positive sentence",
-                "d2": "This is another positive sentence",
-            },
-        }
-
-        self.relevant_docs = {
-            "test": {
+            "relevant_docs": {
                 "q1": {"d1": 1, "d2": 0},
                 "q2": {"d1": 0, "d2": 1},
             },
-            "val": {
-                "q1": {"d1": 1, "d2": 0},
-                "q2": {"d1": 0, "d2": 1},
-            },
+            "top_ranked": None,
+            "instructions": None,
         }
-        self.top_ranked = None
-        self.instructions = None
+        self.dataset["default"]["test"] = base_datasplit
+        self.dataset["default"]["val"] = base_datasplit
         self.data_loaded = True
 
 
@@ -1654,45 +1616,25 @@ class MockMultilingualRetrievalTask(AbsTaskRetrieval):
     metadata.eval_langs = multilingual_eval_langs
 
     def load_data(self, **kwargs):
-        queries = {
-            "test": {
+        base_datasplit = {
+            "queries": {
                 "q1": "This is a test sentence",
                 "q2": "This is another test sentence",
             },
-            "val": {
-                "q1": "This is a test sentence",
-                "q2": "This is another test sentence",
-            },
-        }
-        self.queries = {"eng": queries, "fra": queries}
-        corpus = {
-            "test": {
+            "corpus": {
                 "d1": "This is a positive sentence",
-                "d2": "This is another positive sentence",
+                "d2": "This is a negative sentence",
             },
-            "val": {
-                "d1": "This is a positive sentence",
-                "d2": "This is another positive sentence",
-            },
-        }
-        self.corpus = {"eng": corpus, "fra": corpus}
-
-        relevant_docs = {
-            "test": {
+            "relevant_docs": {
                 "q1": {"d1": 1, "d2": 0},
                 "q2": {"d1": 0, "d2": 1},
             },
-            "val": {
-                "q1": {"d1": 1, "d2": 0},
-                "q2": {"d1": 0, "d2": 1},
-            },
+            "top_ranked": None,
+            "instructions": None,
         }
-        self.relevant_docs = {
-            "eng": relevant_docs,
-            "fra": relevant_docs,
-        }
-        self.top_ranked = None
-        self.instructions = None
+        for subset in ["eng", "fra"]:
+            for split in ["test", "val"]:
+                self.dataset[subset][split] = base_datasplit
         self.data_loaded = True
 
 
@@ -1929,32 +1871,26 @@ class MockInstructionRetrieval(AbsTaskRetrieval):
     )
 
     def load_data(self, **kwargs):
-        self.queries = {
-            "test": {
+        base_datasplit = {
+            "queries": {
                 "q1": "This is a test sentence",
                 "q2": "This is another test sentence",
-            }
-        }
-        self.corpus = {
-            "test": {
+            },
+            "corpus": {
                 "d1": "This is a positive sentence",
-                "d2": "This is another positive sentence",
-            }
-        }
-
-        self.relevant_docs = {
-            "test": {
+                "d2": "This is a negative sentence",
+            },
+            "relevant_docs": {
                 "q1": {"d1": 1, "d2": 0},
                 "q2": {"d1": 0, "d2": 1},
             },
-        }
-        self.instructions = {
-            "test": {
+            "top_ranked": None,
+            "instructions": {
                 "q1": "This is a test instruction",
                 "q2": "This is another test instruction",
-            }
+            },
         }
-        self.top_ranked = None
+        self.dataset["default"]["test"] = base_datasplit
         self.data_loaded = True
 
 
@@ -1999,37 +1935,29 @@ class MockInstructionReranking(AbsTaskRetrieval):
     )
 
     def load_data(self, **kwargs):
-        self.queries = {
-            "test": {
+        base_datasplit = {
+            "queries": {
                 "q1": "This is a test sentence",
                 "q2": "This is another test sentence",
-            }
-        }
-        self.corpus = {
-            "test": {
+            },
+            "corpus": {
                 "d1": "This is a positive sentence",
-                "d2": "This is another positive sentence",
-            }
-        }
-
-        self.relevant_docs = {
-            "test": {
+                "d2": "This is a negative sentence",
+            },
+            "relevant_docs": {
                 "q1": {"d1": 1, "d2": 0},
                 "q2": {"d1": 0, "d2": 1},
             },
-        }
-        self.instructions = {
-            "test": {
-                "q1": "This is a test instruction",
-                "q2": "This is another test instruction",
-            }
-        }
-        self.top_ranked = {
-            "test": {
+            "top_ranked": {
                 "q1": ["d1", "d2"],
                 "q2": ["d2", "d1"],
-            }
+            },
+            "instructions": {
+                "q1": "This is a test instruction",
+                "q2": "This is another test instruction",
+            },
         }
+        self.dataset["default"]["test"] = base_datasplit
         self.data_loaded = True
 
 
@@ -2135,49 +2063,28 @@ class MockMultilingualInstructionRetrieval(AbsTaskRetrieval):
     metadata.eval_langs = multilingual_eval_langs
 
     def load_data(self, **kwargs):
-        queries = {
-            "test": {
+        base_datasplit = {
+            "queries": {
                 "q1": "This is a test sentence",
                 "q2": "This is another test sentence",
-            }
-        }
-        self.queries = {
-            "eng": queries,
-            "fra": queries,
-        }
-        corpus = {
-            "test": {
+            },
+            "corpus": {
                 "d1": "This is a positive sentence",
-                "d2": "This is another positive sentence",
-            }
-        }
-        self.corpus = {
-            "eng": corpus,
-            "fra": corpus,
-        }
-
-        relevant_docs = {
-            "test": {
+                "d2": "This is a negative sentence",
+            },
+            "relevant_docs": {
                 "q1": {"d1": 1, "d2": 0},
                 "q2": {"d1": 0, "d2": 1},
             },
-        }
-        self.relevant_docs = {
-            "eng": relevant_docs,
-            "fra": relevant_docs,
-        }
-
-        instructions = {
-            "test": {
+            "top_ranked": None,
+            "instructions": {
                 "q1": "This is a test instruction",
                 "q2": "This is another test instruction",
-            }
+            },
         }
-        self.instructions = {
-            "eng": instructions,
-            "fra": instructions,
-        }
-        self.top_ranked = None
+        for subset in ["eng", "fra"]:
+            self.dataset[subset]["test"] = base_datasplit
+        self.data_loaded = True
 
 
 class MockMultilingualInstructionReranking(AbsTaskRetrieval):
@@ -2282,60 +2189,31 @@ class MockMultilingualInstructionReranking(AbsTaskRetrieval):
     metadata.eval_langs = multilingual_eval_langs
 
     def load_data(self, **kwargs):
-        queries = {
-            "test": {
+        base_datasplit = {
+            "queries": {
                 "q1": "This is a test sentence",
                 "q2": "This is another test sentence",
-            }
-        }
-        self.queries = {
-            "eng": queries,
-            "fra": queries,
-        }
-        corpus = {
-            "test": {
+            },
+            "corpus": {
                 "d1": "This is a positive sentence",
-                "d2": "This is another positive sentence",
-            }
-        }
-
-        self.corpus = {
-            "eng": corpus,
-            "fra": corpus,
-        }
-
-        relevant_docs = {
-            "test": {
+                "d2": "This is a negative sentence",
+            },
+            "relevant_docs": {
                 "q1": {"d1": 1, "d2": 0},
                 "q2": {"d1": 0, "d2": 1},
             },
-        }
-
-        self.relevant_docs = {
-            "eng": relevant_docs,
-            "fra": relevant_docs,
-        }
-
-        instructions = {
-            "test": {
-                "q1": "This is a test instruction",
-                "q2": "This is another test instruction",
-            }
-        }
-        self.instructions = {
-            "eng": instructions,
-            "fra": instructions,
-        }
-        top_ranked = {
-            "test": {
+            "top_ranked": {
                 "q1": ["d1", "d2"],
                 "q2": ["d2", "d1"],
-            }
+            },
+            "instructions": {
+                "q1": "This is a test instruction",
+                "q2": "This is another test instruction",
+            },
         }
-        self.top_ranked = {
-            "eng": top_ranked,
-            "fra": top_ranked,
-        }
+        for subset in ["eng", "fra"]:
+            for split in ["test", "val"]:
+                self.dataset[subset][split] = base_datasplit
         self.data_loaded = True
 
 


### PR DESCRIPTION
This not totally fix of https://github.com/embeddings-benchmark/mteb/issues/2030, but a step to it to make `retrieval` to use `self.dataset` instead of corpus, queries, etc.

Here is results comparison with `minishlab/potion-base-2M`

| task_name                    |   main_score (PR) |   main_score (main) |
|:-----------------------------|------------------:|--------------------:|
| AskUbuntuDupQuestions        |          0.52906  |            0.52906  |
| InstructIR                   |          0.107624 |            0.107624 |
| NevIR                        |          0.110629 |            0.110629 |
| Robust04InstructionRetrieval |         -0.039893 |           -0.039893 |
| SCIDOCS                      |          0.08163  |            0.08163  |
| SciDocsRR                    |          0.66139  |            0.66139  |
| SciFact                      |          0.3655   |            0.3655   |
| mFollowIRCrossLingual        |         -0.020629 |           -0.020629 |

### Code Quality
<!-- Please do not delete this -->
- [X] **Code Formatted**: Format the code using `make lint` to maintain consistent style.

### Documentation
<!-- Please do not delete this -->
- [ ] **Updated Documentation**: Add or update documentation to reflect the changes introduced in this PR.

### Testing
<!-- Please do not delete this -->
- [ ] **New Tests Added**: Write tests to cover new functionality. Validate with `make test-with-coverage`.
- [ ] **Tests Passed**: Run tests locally using `make test` or `make test-with-coverage` to ensure no existing functionality is broken.


### Adding datasets checklist
<!-- see also https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md -->

**Reason for dataset addition**: ... <!-- Add reason for adding dataset here. E.g. it covers task/language/domain previously not covered -->

- [ ] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb -m {model_name} -t {task_name}` command.
  - [ ] `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
  - [ ] `intfloat/multilingual-e5-small`
- [ ] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [ ] If the dataset is too big (e.g. >2048 examples), considering using `self.stratified_subsampling() under dataset_transform()`
- [ ] I have filled out the metadata object in the dataset file (find documentation on it [here](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md#2-creating-the-metadata-object)).
- [ ] Run tests locally to make sure nothing is broken using `make test`.
- [ ] Run the formatter to format the code using `make lint`.


### Adding a model checklist
<!--
When adding a model to the model registry
see also https://github.com/embeddings-benchmark/mteb/blob/main/docs/reproducible_workflow.md
-->

 - [ ] I have filled out the ModelMeta object to the extent possible
 - [ ] I have ensured that my model can be loaded using
   - [ ] `mteb.get_model(model_name, revision)` and
   - [ ] `mteb.get_model_meta(model_name, revision)`
 - [ ] I have tested the implementation works on a representative set of tasks.
