### PR TITLE
ci: refactor TaskMetadata eval langs test

### DIFF
--- a/mteb/abstasks/TaskMetadata.py
+++ b/mteb/abstasks/TaskMetadata.py
@@ -328,6 +328,10 @@ class TaskMetadata(BaseModel):
     @staticmethod
     def _check_language_code(code):
         """This method checks that the language code (e.g. "eng-Latn") is valid."""
+        if "-" not in code:
+            raise ValueError(
+                f"Language code should be specified as a BCP-47 language tag (e.g. 'eng-Latn'). Got: {code}"
+            )
         lang, script = code.split("-")
         if script == "Code":
             if lang in PROGRAMMING_LANGS:

--- a/tests/test_TaskMetadata.py
+++ b/tests/test_TaskMetadata.py
@@ -5,6 +5,7 @@ import logging
 import pytest
 
 from mteb import AbsTask
+from mteb.abstasks.aggregated_task import AbsTaskAggregate
 from mteb.abstasks.TaskMetadata import TaskMetadata
 from mteb.overview import get_tasks
 
@@ -179,10 +180,6 @@ _HISTORIC_DATASETS = [
     "TamilNewsClassification",
     "TenKGnadClusteringP2P.v2",
     "TenKGnadClusteringS2S.v2",
-    "SynPerChatbotConvSAClassification",
-    "CQADupstackRetrieval-Fa",
-    "VisualSTS17Eng",
-    "VisualSTS17Multilingual",
 ]
 
 
@@ -393,13 +390,14 @@ def test_all_metadata_is_filled_and_valid():
         if (
             task.metadata.name in _HISTORIC_DATASETS
             or task.metadata.name.replace("HardNegatives", "") in _HISTORIC_DATASETS
+            or isinstance(task, AbsTaskAggregate)
         ):
             continue
 
         if not task.metadata.is_filled():
             unfilled_metadata.append(task.metadata.name)
         else:
-            if not task.metadata.validate_metadata():
+            if task.metadata.validate_metadata() is not None:
                 invalid_metadata.append(task.metadata.name)
 
     if unfilled_metadata or invalid_metadata:

--- a/tests/test_TaskMetadata.py
+++ b/tests/test_TaskMetadata.py
@@ -357,23 +357,55 @@ def test_filled_metadata_is_filled():
     )
 
 
+def test_invalid_metadata_eval_lang_is_invalid():
+    with pytest.raises(ValueError):
+        TaskMetadata(
+            name="MyTask",
+            dataset={
+                "path": "test/dataset",
+                "revision": "1.0",
+            },
+            description="testing",
+            reference="https://aclanthology.org/W19-6138/",
+            type="Classification",
+            category="s2s",
+            modalities=["text"],
+            eval_splits=["test"],
+            eval_langs=["eng_Latn"],  # uses underscore instead of dash
+            main_score="map",
+            date=("2021-01-01", "2021-12-31"),
+            domains=["Non-fiction", "Written"],
+            license="mit",
+            task_subtypes=["Thematic clustering"],
+            annotations_creators="expert-annotated",
+            dialect=[],
+            sample_creation="found",
+            bibtex_citation="Someone et al",
+        ).validate_metadata()
+
+
 def test_all_metadata_is_filled_and_valid():
     all_tasks = get_tasks()
 
     unfilled_metadata = []
+    invalid_metadata = []
     for task in all_tasks:
         if (
-            task.metadata.name not in _HISTORIC_DATASETS
-            and task.metadata.name.replace("HardNegatives", "")
-            not in _HISTORIC_DATASETS
+            task.metadata.name in _HISTORIC_DATASETS
+            or task.metadata.name.replace("HardNegatives", "") in _HISTORIC_DATASETS
         ):
-            if not task.metadata.is_filled() and (
-                not task.metadata.validate_metadata()
-            ):
-                unfilled_metadata.append(task.metadata.name)
-    if unfilled_metadata:
+            continue
+
+        if not task.metadata.is_filled():
+            unfilled_metadata.append(task.metadata.name)
+        else:
+            if not task.metadata.validate_metadata():
+                invalid_metadata.append(task.metadata.name)
+
+    if unfilled_metadata or invalid_metadata:
         raise ValueError(
-            f"The metadata of the following datasets is not filled: {unfilled_metadata}"
+            f"The metadata of the following datasets is not filled: {unfilled_metadata}."
+            + f"The metadata of the following datasets is invalid: {invalid_metadata}."
         )
 
 

--- a/tests/test_TaskMetadata.py
+++ b/tests/test_TaskMetadata.py
@@ -180,6 +180,23 @@ _HISTORIC_DATASETS = [
     "TamilNewsClassification",
     "TenKGnadClusteringP2P.v2",
     "TenKGnadClusteringS2S.v2",
+    "ClimateFEVERHardNegatives",
+    "DBPediaHardNegatives",
+    "FEVERHardNegatives",
+    "HotpotQAHardNegatives",
+    "MSMARCOHardNegatives",
+    "NQHardNegatives",
+    "QuoraRetrievalHardNegatives",
+    "TopiOCQAHardNegatives",
+    "MIRACLRetrievalHardNegatives",
+    "NeuCLIR2022RetrievalHardNegatives",
+    "NeuCLIR2023RetrievalHardNegatives",
+    "DBPedia-PLHardNegatives",
+    "HotpotQA-PLHardNegatives",
+    "MSMARCO-PLHardNegatives",
+    "NQ-PLHardNegatives",
+    "Quora-PLHardNegatives",
+    "RiaNewsRetrievalHardNegatives",
 ]
 
 
@@ -387,10 +404,8 @@ def test_all_metadata_is_filled_and_valid():
     unfilled_metadata = []
     invalid_metadata = []
     for task in all_tasks:
-        if (
-            task.metadata.name in _HISTORIC_DATASETS
-            or task.metadata.name.replace("HardNegatives", "") in _HISTORIC_DATASETS
-            or isinstance(task, AbsTaskAggregate)
+        if task.metadata.name in _HISTORIC_DATASETS or isinstance(
+            task, AbsTaskAggregate
         ):
             continue
 


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->
Fixes #2500

- Currently, a TaskMetadata with eval_langs=["eng_Latn"] will pass tests/test_TaskMetadata.py::test_all_metadata_is_filled_and_valid (when it should fail)
- unnest the if statements in test_all_metadata_is_filled_and_valid
- add check if "-" is in the code to avoid the uncaught error.
- skip AbsTaskAggregate instead of manually adding each instance in `_HISTORIC_DATASETS`

### Code Quality
<!-- Please do not delete this -->
- [x] **Code Formatted**: Format the code using `make lint` to maintain consistent style.

### Documentation
<!-- Please do not delete this -->
- [ ] **Updated Documentation**: Add or update documentation to reflect the changes introduced in this PR.

### Testing
<!-- Please do not delete this -->
- [x] **New Tests Added**: Write tests to cover new functionality. Validate with `make test-with-coverage`.
- [x] **Tests Passed**: Run tests locally using `make test` or `make test-with-coverage` to ensure no existing functionality is broken.

