### PR TITLE
[MIEB] Specify only the multilingual AggTask for MIEB-lite

### DIFF
--- a/mteb/benchmarks/benchmarks.py
+++ b/mteb/benchmarks/benchmarks.py
@@ -1624,8 +1624,8 @@ MIEB_LITE = Benchmark(
             # VisualSTS
             "STS13VisualSTS",
             "STS15VisualSTS",
-            "STS17MultilingualVisualSTS",
-            "STSBenchmarkMultilingualVisualSTS",
+            "VisualSTS17Multilingual",
+            "VisualSTS-b-Multilingual",
             # Any2AnyRetrieval
             "CIRRIT2IRetrieval",
             "CUB200I2IRetrieval",


### PR DESCRIPTION
In MIEB-lite, specify the multilingual parts of the multilingual visualSTS tasks (i.e. the AggTasks that _exclude_ English) to match the paper.

I'm afk right now - will spin up a local LB to double check. 