### PR TITLE
fix: Update requirements in JinaWrapper

### DIFF
--- a/mteb/models/jina_models.py
+++ b/mteb/models/jina_models.py
@@ -141,11 +141,11 @@ class JinaWrapper(SentenceTransformerWrapper):
             raise RuntimeError(
                 f"sentence_transformers version {st_version} is lower than the required version 3.1.0"
             )
-        requires_package(self, "jina", model, "pip install 'mteb[jina]'")
+        requires_package(self, "einops", model, "pip install 'mteb[jina]'")
         import einops  # noqa: F401
 
         requires_package(
-            self, "flash_attention", model, "pip install 'mteb[flash_attention]'"
+            self, "flash_attn", model, "pip install 'mteb[flash_attention]'"
         )
         import flash_attn  # noqa: F401
 


### PR DESCRIPTION
Fixes incorrect arguments passed to `requires_package` for `einops` and `flash_attn`. The check still failed even after running suggested installation commands (`pip install 'mteb[jina]'` and `pip install 'mteb[flash_attention]'`) because the function was checking for the wrong required package names.

<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->


### Code Quality
<!-- Please do not delete this -->
- [x] **Code Formatted**: Format the code using `make lint` to maintain consistent style.

### Documentation
<!-- Please do not delete this -->
- [x] **Updated Documentation**: Add or update documentation to reflect the changes introduced in this PR.

### Testing
<!-- Please do not delete this -->
- [ ] **New Tests Added**: Write tests to cover new functionality. Validate with `make test-with-coverage`.
- [x] **Tests Passed**: Run tests locally using `make test` or `make test-with-coverage` to ensure no existing functionality is broken.