### PR TITLE
[v2] Dataset card generation

### DIFF
--- a/mteb/abstasks/AbsTask.py
+++ b/mteb/abstasks/AbsTask.py
@@ -444,7 +444,7 @@ class AbsTask(ABC):
         if not self.data_loaded:
             self.load_data()
 
-        dataset_card = self.generate_dataset_card()
+        dataset_card = self.metadata.generate_dataset_card()
         dataset_card.push_to_hub(repo_name, commit_message="Add dataset card")
         self._push_dataset_to_hub(repo_name)
 
@@ -474,18 +474,3 @@ class AbsTask(ABC):
 
     def __hash__(self) -> int:
         return hash(self.metadata)
-
-    def generate_dataset_card(self) -> DatasetCard:
-        """Generates a dataset card for the task.
-
-        Returns:
-            DatasetCard: The dataset card for the task.
-        """
-        path = Path(__file__).parent / "dataset_card_template.md"
-        dataset_card_data, template_kwargs = self.metadata.create_dataset_card_data()
-        dataset_card = DatasetCard.from_template(
-            card_data=dataset_card_data,
-            template_path=str(path),
-            **template_kwargs,
-        )
-        return dataset_card

--- a/mteb/abstasks/AbsTask.py
+++ b/mteb/abstasks/AbsTask.py
@@ -482,9 +482,10 @@ class AbsTask(ABC):
             DatasetCard: The dataset card for the task.
         """
         path = Path(__file__).parent / "dataset_card_template.md"
-        dataset_card_data = self.metadata.create_dataset_card_data()
+        dataset_card_data, template_kwargs = self.metadata.create_dataset_card_data()
         dataset_card = DatasetCard.from_template(
             card_data=dataset_card_data,
             template_path=str(path),
+            **template_kwargs,
         )
         return dataset_card

--- a/mteb/abstasks/AbsTaskRetrieval.py
+++ b/mteb/abstasks/AbsTaskRetrieval.py
@@ -564,7 +564,8 @@ class AbsTaskRetrieval(AbsTask):
                 sections[split] = Dataset.from_list(
                     [converter(idx, item) for idx, item in data[split][column].items()]
                 )
-            DatasetDict(sections).push_to_hub(repo_name, suffix)
+            if len(sections) > 0:
+                DatasetDict(sections).push_to_hub(repo_name, suffix)
 
         for subset in self.dataset:
             logger.info(f"Converting {subset} of {self.metadata.name}")

--- a/mteb/abstasks/TaskMetadata.py
+++ b/mteb/abstasks/TaskMetadata.py
@@ -558,8 +558,8 @@ class TaskMetadata(BaseModel):
                 task_categories=dataset_type,
                 task_ids=self.task_subtypes,
                 tags=tags,
-                domains=self.domains,
             ),
+            # parameters for readme generation
             dict(
                 citation=self.bibtex_citation,
                 dataset_description=self.description,
@@ -567,6 +567,7 @@ class TaskMetadata(BaseModel):
                 descritptive_stats=descriptive_stats,
                 dataset_task_name=self.name,
                 category=self.category,
+                domains=", ".join(self.domains),
             ),
         )
 

--- a/mteb/abstasks/TaskMetadata.py
+++ b/mteb/abstasks/TaskMetadata.py
@@ -555,7 +555,7 @@ class TaskMetadata(BaseModel):
                 annotations_creators=[self.annotations_creators],
                 multilinguality=multilinguality,
                 source_datasets=source_datasets,
-                task_category=dataset_type,
+                task_categories=dataset_type,
                 task_ids=self.task_subtypes,
                 tags=tags,
                 domains=self.domains,

--- a/mteb/abstasks/TaskMetadata.py
+++ b/mteb/abstasks/TaskMetadata.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Union
 
-from huggingface_hub import DatasetCardData
+from huggingface_hub import DatasetCard, DatasetCardData
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -490,7 +490,7 @@ class TaskMetadata(BaseModel):
             "BitextMining": "translation",
             "Classification": "text-classification",
             "MultilabelClassification": "text-classification",
-            "Clustering": "zero-shot-classification",  # not sure
+            "Clustering": "text-clustering",
             "PairClassification": "text-classification",
             "Reranking": "text-ranking",
             "Retrieval": "text-retrieval",
@@ -503,7 +503,7 @@ class TaskMetadata(BaseModel):
             "Any2AnyRetrieval": "image-retrieval",  # currently not real HF type
             "Any2AnyMultilingualRetrieval": "image-retrieval",  # currently not real HF type
             "VisionCentricQA": "visual-question-answering",
-            "ImageClustering": "zero-shot-image-classification",
+            "ImageClustering": "image-clustering",
             "ImageClassification": "image-classification",
             "ImageMultilabelClassification": "image-classification",
             "DocumentUnderstanding": "image-retrieval",  # currently not real HF type
@@ -569,3 +569,18 @@ class TaskMetadata(BaseModel):
                 category=self.category,
             ),
         )
+
+    def generate_dataset_card(self) -> DatasetCard:
+        """Generates a dataset card for the task.
+
+        Returns:
+            DatasetCard: The dataset card for the task.
+        """
+        path = Path(__file__).parent / "dataset_card_template.md"
+        dataset_card_data, template_kwargs = self.create_dataset_card_data()
+        dataset_card = DatasetCard.from_template(
+            card_data=dataset_card_data,
+            template_path=str(path),
+            **template_kwargs,
+        )
+        return dataset_card

--- a/mteb/abstasks/TaskMetadata.py
+++ b/mteb/abstasks/TaskMetadata.py
@@ -478,11 +478,11 @@ class TaskMetadata(BaseModel):
     def revision(self) -> str:
         return self.dataset["revision"]
 
-    def create_dataset_card_data(self) -> DatasetCardData:
+    def create_dataset_card_data(self) -> tuple[DatasetCardData, dict[str, str]]:
         """Create a DatasetCardData object from the task metadata.
 
         Returns:
-            DatasetCardData: The DatasetCardData object.
+            A DatasetCardData object with the metadata for the task with kwargs to card
         """
         # todo figure out datasets with multiple types. E. g. one dataset as classification and ZeroShotClassification
         mteb_task_type_to_datasets = {
@@ -544,18 +544,28 @@ class TaskMetadata(BaseModel):
         tags = ["mteb"]
         tags.extend(self.modalities)
 
-        return DatasetCardData(
-            language=languages,
-            license=self.license if self.license != "not specified" else "unknown",
-            annotations_creators=[self.annotations_creators],
-            multilinguality=multilinguality,
-            source_datasets=source_datasets,
-            task_category=dataset_type,
-            task_ids=self.task_subtypes,
-            tags=tags,
-            domains=self.domains,
-            # params for dataset template
-            citation_bibtex=self.bibtex_citation,
-            dataset_summary=self.description,
-            dataset_reference=self.reference,
+        descriptive_stats = self.descriptive_stats
+        if descriptive_stats is not None:
+            descriptive_stats = json.dumps(descriptive_stats, indent=4)
+
+        return (
+            DatasetCardData(
+                language=languages,
+                license=self.license if self.license != "not specified" else "unknown",
+                annotations_creators=[self.annotations_creators],
+                multilinguality=multilinguality,
+                source_datasets=source_datasets,
+                task_category=dataset_type,
+                task_ids=self.task_subtypes,
+                tags=tags,
+                domains=self.domains,
+            ),
+            dict(
+                citation=self.bibtex_citation,
+                dataset_description=self.description,
+                dataset_reference=self.reference,
+                descritptive_stats=descriptive_stats,
+                dataset_task_name=self.name,
+                category=self.category,
+            ),
         )

--- a/mteb/abstasks/dataset_card_template.md
+++ b/mteb/abstasks/dataset_card_template.md
@@ -13,11 +13,11 @@
 
 {{ dataset_description }}
 
-|                |                                             |
-|----------------|---------------------------------------------|
-| Task category: | {{ category }}                              |
-| Domains        | {{ domains }}                               |
-| Reference      | {{ dataset_reference | default("", true) }} |
+|               |                                             |
+|---------------|---------------------------------------------|
+| Task category | {{ category }}                              |
+| Domains       | {{ domains }}                               |
+| Reference     | {{ dataset_reference | default("", true) }} |
 
 
 ## How to evaluate on this task

--- a/mteb/abstasks/dataset_card_template.md
+++ b/mteb/abstasks/dataset_card_template.md
@@ -4,16 +4,59 @@
 {{ card_data }}
 ---
 <!-- adapted from https://github.com/huggingface/huggingface_hub/blob/v0.30.2/src/huggingface_hub/templates/datasetcard_template.md -->
+# {{ dataset_task_name }}
 
-# Dataset Card for {{ pretty_name | default("Dataset Name", true) }}
+{{ dataset_description }}
 
-{{ dataset_summary | default("", true) }}
+> This dataset is included as a task in [`mteb`](https://github.com/embeddings-benchmark/mteb).
 
-<-- Datasets want link to arxiv in readme to autolink dataset with paper -->
+- Task category: {{ category }}
+- Domains: {{ domains }}
+
+## How to evaluate on this task
+
+```python
+import mteb
+
+task = mteb.get_tasks(["{{ dataset_task_name }}"])
+evaluator = mteb.MTEB(task)
+
+model = mteb.get_model(YOUR_MODEL)
+evaluator.run(model)
+```
+
+<!-- Datasets want link to arxiv in readme to autolink dataset with paper -->
 Reference: {{ dataset_reference | default("", true) }}
 
 ## Citation
 
+If you use this dataset, please cite the dataset as well as [mteb](https://github.com/embeddings-benchmark/mteb), as this dataset likely includes additional processing as a part of the [MMTEB Contribution](https://github.com/embeddings-benchmark/mteb/tree/main/docs/mmteb).
+
 ```bibtex
-{{ citation_bibtex }}
+{{ citation }}
+
+@article{enevoldsen2025mmtebmassivemultilingualtext,
+  title={MMTEB: Massive Multilingual Text Embedding Benchmark},
+  author={Kenneth Enevoldsen and Isaac Chung and Imene Kerboua and Márton Kardos and Ashwin Mathur and David Stap and Jay Gala and Wissam Siblini and Dominik Krzemiński and Genta Indra Winata and Saba Sturua and Saiteja Utpala and Mathieu Ciancone and Marion Schaeffer and Gabriel Sequeira and Diganta Misra and Shreeya Dhakal and Jonathan Rystrøm and Roman Solomatin and Ömer Çağatan and Akash Kundu and Martin Bernstorff and Shitao Xiao and Akshita Sukhlecha and Bhavish Pahwa and Rafał Poświata and Kranthi Kiran GV and Shawon Ashraf and Daniel Auras and Björn Plüster and Jan Philipp Harries and Loïc Magne and Isabelle Mohr and Mariya Hendriksen and Dawei Zhu and Hippolyte Gisserot-Boukhlef and Tom Aarsen and Jan Kostkan and Konrad Wojtasik and Taemin Lee and Marek Šuppa and Crystina Zhang and Roberta Rocca and Mohammed Hamdy and Andrianos Michail and John Yang and Manuel Faysse and Aleksei Vatolin and Nandan Thakur and Manan Dey and Dipam Vasani and Pranjal Chitale and Simone Tedeschi and Nguyen Tai and Artem Snegirev and Michael Günther and Mengzhou Xia and Weijia Shi and Xing Han Lù and Jordan Clive and Gayatri Krishnakumar and Anna Maksimova and Silvan Wehrli and Maria Tikhonova and Henil Panchal and Aleksandr Abramov and Malte Ostendorff and Zheng Liu and Simon Clematide and Lester James Miranda and Alena Fenogenova and Guangyu Song and Ruqiya Bin Safi and Wen-Ding Li and Alessia Borghini and Federico Cassano and Hongjin Su and Jimmy Lin and Howard Yen and Lasse Hansen and Sara Hooker and Chenghao Xiao and Vaibhav Adlakha and Orion Weller and Siva Reddy and Niklas Muennighoff},
+  publisher = {arXiv},
+  journal={arXiv preprint arXiv:2502.13595},
+  year={2025},
+  url={https://arxiv.org/abs/2502.13595},
+  doi = {10.48550/arXiv.2502.13595},
+}
+
+@article{muennighoff2022mteb,
+  author = {Muennighoff, Niklas and Tazi, Nouamane and Magne, Lo{\"\i}c and Reimers, Nils},
+  title = {MTEB: Massive Text Embedding Benchmark},
+  publisher = {arXiv},
+  journal={arXiv preprint arXiv:2210.07316},
+  year = {2022}
+  url = {https://arxiv.org/abs/2210.07316},
+  doi = {10.48550/ARXIV.2210.07316},
+}
+```
+
+# Dataset Statistics
+```json
+{{ descritptive_stats | default("{}", true) }}
 ```

--- a/mteb/abstasks/dataset_card_template.md
+++ b/mteb/abstasks/dataset_card_template.md
@@ -1,0 +1,19 @@
+---
+# For reference on dataset card metadata, see the spec: https://github.com/huggingface/hub-docs/blob/main/datasetcard.md?plain=1
+# Doc / guide: https://huggingface.co/docs/hub/datasets-cards
+{{ card_data }}
+---
+<!-- adapted from https://github.com/huggingface/huggingface_hub/blob/v0.30.2/src/huggingface_hub/templates/datasetcard_template.md -->
+
+# Dataset Card for {{ pretty_name | default("Dataset Name", true) }}
+
+{{ dataset_summary | default("", true) }}
+
+<-- Datasets want link to arxiv in readme to autolink dataset with paper -->
+Reference: {{ dataset_reference | default("", true) }}
+
+## Citation
+
+```bibtex
+{{ citation_bibtex }}
+```

--- a/mteb/abstasks/dataset_card_template.md
+++ b/mteb/abstasks/dataset_card_template.md
@@ -4,16 +4,25 @@
 {{ card_data }}
 ---
 <!-- adapted from https://github.com/huggingface/huggingface_hub/blob/v0.30.2/src/huggingface_hub/templates/datasetcard_template.md -->
-# {{ dataset_task_name }}
+
+<div align="center" style="padding: 40px 20px; background-color: white; border-radius: 12px; box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05); max-width: 600px; margin: 0 auto;">
+  <h1 style="font-size: 3.5rem; color: #1a1a1a; margin: 0 0 20px 0; letter-spacing: 2px; font-weight: 700;">{{ dataset_task_name }}</h1>
+  <div style="font-size: 1.5rem; color: #4a4a4a; margin-bottom: 5px; font-weight: 300;">An <a href="https://github.com/embeddings-benchmark/mteb" style="color: #2c5282; font-weight: 600; text-decoration: none;" onmouseover="this.style.textDecoration='underline'" onmouseout="this.style.textDecoration='none'">MTEB</a> dataset</div>
+  <div style="font-size: 0.9rem; color: #2c5282; margin-top: 10px;">Massive Text Embedding Benchmark</div>
+</div>
 
 {{ dataset_description }}
 
-> This dataset is included as a task in [`mteb`](https://github.com/embeddings-benchmark/mteb).
+|                |                                             |
+|----------------|---------------------------------------------|
+| Task category: | {{ category }}                              |
+| Domains        | {{ domains }}                               |
+| Reference      | {{ dataset_reference | default("", true) }} |
 
-- Task category: {{ category }}
-- Domains: {{ domains }}
 
 ## How to evaluate on this task
+
+You can evaluate an embedding model on this dataset using the following code:
 
 ```python
 import mteb
@@ -26,7 +35,7 @@ evaluator.run(model)
 ```
 
 <!-- Datasets want link to arxiv in readme to autolink dataset with paper -->
-Reference: {{ dataset_reference | default("", true) }}
+To learn more about how to run models on `mteb` task check out the [GitHub repitory](https://github.com/embeddings-benchmark/mteb). 
 
 ## Citation
 
@@ -57,6 +66,24 @@ If you use this dataset, please cite the dataset as well as [mteb](https://githu
 ```
 
 # Dataset Statistics
+<details>
+  <summary> Dataset Statistics</summary>
+
+The following code contains the descriptive statistics from the task. These can also be obtained using:
+
+```python
+import mteb
+
+task = mteb.get_task("{{ dataset_task_name }}")
+
+desc_stats = task.metadata.descriptive_stats
+```
+
 ```json
 {{ descritptive_stats | default("{}", true) }}
 ```
+
+</details>
+
+---
+*This dataset card was automatically generated using [MTEB](https://github.com/embeddings-benchmark/mteb)*

--- a/mteb/tasks/PairClassification/multilingual/XNLI.py
+++ b/mteb/tasks/PairClassification/multilingual/XNLI.py
@@ -112,10 +112,10 @@ class XNLIV2(AbsTaskPairClassification):
             "path": "mteb/XNLIV2",
             "revision": "06108371a8bceee5024a527c4330baa29eb5a013",
         },
-        description="""
-        This is subset of 'XNLI 2.0: Improving XNLI dataset and performance on Cross Lingual Understanding'
-        with languages that were not part of the original XNLI plus three (verified) languages that are not strongly covered in MTEB
-        """,
+        description=(
+            "This is subset of 'XNLI 2.0: Improving XNLI dataset and performance on Cross Lingual Understanding' "
+            "with languages that were not part of the original XNLI plus three (verified) languages that are not strongly covered in MTEB"
+        ),
         reference="https://arxiv.org/pdf/2301.06527",
         category="t2t",
         modalities=["text"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ exclude = ["tests", "results"]
 
 [tool.setuptools.package-data]
 "*" = ["*.json"]
+"mteb.abstasks" = ["dataset_card_template.md"]
 
 [tool.ruff]
 

--- a/tests/test_reproducible_workflow.py
+++ b/tests/test_reproducible_workflow.py
@@ -51,7 +51,6 @@ def test_reproducibility_workflow(
         "Summarization",
         "InstructionRetrieval",
         "InstructionReranking",
-        "Speed",
     ),
 )
 def test_validate_task_to_prompt_name(task_name: str | AbsTask):


### PR DESCRIPTION
Closes https://github.com/embeddings-benchmark/mteb/issues/1892

I've generated readme for `XNLIV2` https://huggingface.co/datasets/mteb/XNLIV2 and `AlloprofReranking` https://huggingface.co/datasets/mteb/AlloprofReranking

```python
import mteb

task = mteb.get_task("XNLIV2")
task_card = task.generate_dataset_card()
task_card.push_to_hub("mteb/XNLIV2")
```

Currently, updating a `DatasetCard` requires pushing all data to the Hub, because Hugging Face stores dataset information in the `README`. When the card is regenerated, the split information can break. Although there's a method to load the full dataset card, there isn’t a way to directly load the existing `DatasetCardData`.


### Code Quality
<!-- Please do not delete this -->
- [ ] **Code Formatted**: Format the code using `make lint` to maintain consistent style.

### Documentation
<!-- Please do not delete this -->
- [ ] **Updated Documentation**: Add or update documentation to reflect the changes introduced in this PR.

### Testing
<!-- Please do not delete this -->
- [ ] **New Tests Added**: Write tests to cover new functionality. Validate with `make test-with-coverage`.
- [ ] **Tests Passed**: Run tests locally using `make test` or `make test-with-coverage` to ensure no existing functionality is broken.


### Adding datasets checklist
<!-- see also https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md -->

**Reason for dataset addition**: ... <!-- Add reason for adding dataset here. E.g. it covers task/language/domain previously not covered -->

- [ ] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb -m {model_name} -t {task_name}` command.
  - [ ] `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
  - [ ] `intfloat/multilingual-e5-small`
- [ ] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [ ] If the dataset is too big (e.g. >2048 examples), considering using `self.stratified_subsampling() under dataset_transform()`
- [ ] I have filled out the metadata object in the dataset file (find documentation on it [here](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md#2-creating-the-metadata-object)).
- [ ] Run tests locally to make sure nothing is broken using `make test`.
- [ ] Run the formatter to format the code using `make lint`.


### Adding a model checklist
<!--
When adding a model to the model registry
see also https://github.com/embeddings-benchmark/mteb/blob/main/docs/reproducible_workflow.md
-->

 - [ ] I have filled out the ModelMeta object to the extent possible
 - [ ] I have ensured that my model can be loaded using
   - [ ] `mteb.get_model(model_name, revision)` and
   - [ ] `mteb.get_model_meta(model_name, revision)`
 - [ ] I have tested the implementation works on a representative set of tasks.
