### PR TITLE
Add Talemaader pair classification task

### DIFF
--- a/mteb/tasks/PairClassification/__init__.py
+++ b/mteb/tasks/PairClassification/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from .ara.ArEntail import *
 from .ces.CTKFactsNLI import *
+from .dan.TalemaaderPC import *
 from .deu.FalseFriendsDeEnPC import *
 from .eng.LegalBenchPC import *
 from .eng.PubChemAISentenceParaphrasePC import *

--- a/mteb/tasks/PairClassification/dan/TalemaaderPC.py
+++ b/mteb/tasks/PairClassification/dan/TalemaaderPC.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from mteb.abstasks.AbsTaskPairClassification import AbsTaskPairClassification
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+
+class TalemaaderPC(AbsTaskPairClassification):
+    metadata = TaskMetadata(
+        name="TalemaaderPC",
+        description="""\
+The Danish Language and Literature Society has developed a dataset for evaluating language models in Danish.
+The dataset contains a total of 1000 Danish idioms and fixed expressions with transferred meanings based on the Danish Dictionary's collection of fixed expressions with associated definitions. 
+For each of the 1000 idioms and fixed expressions, three false definitions have also been prepared.
+The dataset can be used to test the performance of language models in identifying correct definitions for Danish idioms and fixed expressions.
+""",
+        reference="https://sprogteknologi.dk/dataset/1000-talemader-evalueringsdatasaet",
+        dataset={
+            "path": "mteb/talemaader_pc",
+            "revision": "e714d53c059ca83d56c41d22f800da8245bb87fc",
+        },
+        type="PairClassification",
+        category="s2s",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["dan-Latn"],
+        main_score="max_accuracy",
+        date=("2024-11-20", "2024-11-20"),
+        domains=["Academic", "Written"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="created",
+        bibtex_citation="""
+@misc{DSLDK1000Talemader,
+  title = {1000 danske talemåder - evalueringsdatasæt},
+  author = {{Det Danske Sprog- og Litteraturselskab}},
+  year = {2024},
+  howpublished = {Sprogteknologi.dk},
+  url = {https://sprogteknologi.dk/dataset/1000-talemader-evalueringsdatasaet},
+  note = {CC-BY licensed dataset of 1000 Danish sayings and expressions},
+  publisher = {Digitaliseringsstyrelsen \& Det Danske Sprog- og Litteraturselskab},
+  language = {Danish}
+}
+""",
+    )
+
+    def dataset_transform(self):
+        _dataset = {}
+        for split in self.metadata.eval_splits:
+            hf_dataset = self.dataset[split]
+            _dataset[split] = [
+                {
+                    "sentence1": hf_dataset["sentence1"],
+                    "sentence2": hf_dataset["sentence2"],
+                    "labels": hf_dataset["label"],
+                }
+            ]
+        self.dataset = _dataset


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->


### Code Quality
<!-- Please do not delete this -->
- [x] **Code Formatted**: Format the code using `make lint` to maintain consistent style.

### Documentation
<!-- Please do not delete this -->
- [x] **Updated Documentation**: Add or update documentation to reflect the changes introduced in this PR.

### Testing
<!-- Please do not delete this -->
- [ ] **New Tests Added**: Write tests to cover new functionality. Validate with `make test-with-coverage`.
- [ ] **Tests Passed**: Run tests locally using `make test` or `make test-with-coverage` to ensure no existing functionality is broken.


### Adding datasets checklist
<!-- see also https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md -->

**Reason for dataset addition**: ... <!-- Add reason for adding dataset here. E.g. it covers task/language/domain previously not covered -->

- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb -m {model_name} -t {task_name}` command.
  - [x] `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
  - [x] `intfloat/multilingual-e5-small`
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [x] If the dataset is too big (e.g. >2048 examples), considering using `self.stratified_subsampling() under dataset_transform()`
- [x] I have filled out the metadata object in the dataset file (find documentation on it [here](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md#2-creating-the-metadata-object)).
- [x] Run tests locally to make sure nothing is broken using `make test`.
- [x] Run the formatter to format the code using `make lint`.


---

For issue #2608 :

- Dataset: https://huggingface.co/datasets/mteb/talemaader_pc
- Scores: 

<details><summary>`intfloat/multilingual-e5-small`</summary>

```json 

{
  "dataset_revision": "e714d53c059ca83d56c41d22f800da8245bb87fc",
  "task_name": "TalemaaderPC",
  "mteb_version": "1.38.3",
  "scores": {
    "test": [
      {
        "similarity_accuracy": 0.74975,
        "similarity_accuracy_threshold": 0.993789,
        "similarity_f1": 0.400241,
        "similarity_f1_threshold": 0.778437,
        "similarity_precision": 0.250314,
        "similarity_recall": 0.998,
        "similarity_ap": 0.207258,
        "cosine_accuracy": 0.74975,
        "cosine_accuracy_threshold": 0.993789,
        "cosine_f1": 0.400241,
        "cosine_f1_threshold": 0.778437,
        "cosine_precision": 0.250314,
        "cosine_recall": 0.998,
        "cosine_ap": 0.207259,
        "manhattan_accuracy": 0.74975,
        "manhattan_accuracy_threshold": 1.696614,
        "manhattan_f1": 0.400561,
        "manhattan_f1_threshold": 10.400553,
        "manhattan_precision": 0.250502,
        "manhattan_recall": 0.999,
        "manhattan_ap": 0.207256,
        "euclidean_accuracy": 0.74975,
        "euclidean_accuracy_threshold": 0.111101,
        "euclidean_f1": 0.400241,
        "euclidean_f1_threshold": 0.665677,
        "euclidean_precision": 0.250314,
        "euclidean_recall": 0.998,
        "euclidean_ap": 0.207259,
        "dot_accuracy": 0.74975,
        "dot_accuracy_threshold": 0.993789,
        "dot_f1": 0.400241,
        "dot_f1_threshold": 0.778437,
        "dot_precision": 0.250314,
        "dot_recall": 0.998,
        "dot_ap": 0.207258,
        "max_accuracy": 0.74975,
        "max_f1": 0.400561,
        "max_precision": 0.250502,
        "max_recall": 0.999,
        "max_ap": 0.207259,
        "main_score": 0.74975,
        "hf_subset": "default",
        "languages": [
          "dan-Latn"
        ]
      }
    ]
  },
  "evaluation_time": 3.6440303325653076,
  "kg_co2_emissions": null
}
```
</details>


<details><summary>`sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`</summary>

```json 

{
  "dataset_revision": "e714d53c059ca83d56c41d22f800da8245bb87fc",
  "task_name": "TalemaaderPC",
  "mteb_version": "1.38.3",
  "scores": {
    "test": [
      {
        "similarity_accuracy": 0.74975,
        "similarity_accuracy_threshold": 0.994443,
        "similarity_f1": 0.407699,
        "similarity_f1_threshold": 0.165014,
        "similarity_precision": 0.260918,
        "similarity_recall": 0.932,
        "similarity_ap": 0.211369,
        "cosine_accuracy": 0.74975,
        "cosine_accuracy_threshold": 0.994443,
        "cosine_f1": 0.407699,
        "cosine_f1_threshold": 0.165014,
        "cosine_precision": 0.260918,
        "cosine_recall": 0.932,
        "cosine_ap": 0.211369,
        "manhattan_accuracy": 0.74975,
        "manhattan_accuracy_threshold": 5.870041,
        "manhattan_f1": 0.40024,
        "manhattan_f1_threshold": 107.098724,
        "manhattan_precision": 0.250188,
        "manhattan_recall": 1.0,
        "manhattan_ap": 0.207828,
        "euclidean_accuracy": 0.74975,
        "euclidean_accuracy_threshold": 0.386649,
        "euclidean_f1": 0.40024,
        "euclidean_f1_threshold": 6.855521,
        "euclidean_precision": 0.250188,
        "euclidean_recall": 1.0,
        "euclidean_ap": 0.207601,
        "dot_accuracy": 0.74975,
        "dot_accuracy_threshold": 24.552021,
        "dot_f1": 0.409857,
        "dot_f1_threshold": 1.91462,
        "dot_precision": 0.261445,
        "dot_recall": 0.948,
        "dot_ap": 0.216,
        "max_accuracy": 0.74975,
        "max_f1": 0.409857,
        "max_precision": 0.261445,
        "max_recall": 1.0,
        "max_ap": 0.216,
        "main_score": 0.74975,
        "hf_subset": "default",
        "languages": [
          "dan-Latn"
        ]
      }
    ]
  },
  "evaluation_time": 3.898798704147339,
  "kg_co2_emissions": null
}

```
</details>
