### PR TITLE
Share benchmark

### DIFF
--- a/mteb/leaderboard/url_utils.py
+++ b/mteb/leaderboard/url_utils.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import zlib
+from typing import Any
+
+# Characters used for base62 encoding (A-Z, a-z, 0-9)
+BASE62_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+
+def int_to_base62(num: int) -> str:
+    """Convert an integer to a base62 string."""
+    if num == 0:
+        return BASE62_CHARS[0]
+
+    result = ""
+    while num:
+        num, remainder = divmod(num, 62)
+        result = BASE62_CHARS[remainder] + result
+    return result
+
+
+def base62_to_int(string: str) -> int:
+    """Convert a base62 string to an integer."""
+    result = 0
+    for char in string:
+        result = result * 62 + BASE62_CHARS.index(char)
+    return result
+
+
+def encode_filter_state(filter_state: dict[str, Any]) -> str:
+    """Encode filter state dictionary to a compact base62 string
+
+    Args:
+        filter_state: Dictionary with all filter parameters
+
+    Returns:
+        A compact base62 encoded string
+    """
+    json_data = json.dumps(filter_state, separators=(",", ":"))
+
+    compressed = zlib.compress(json_data.encode("utf-8"))
+    base64_data = base64.b64encode(compressed).decode("ascii")
+
+    return base64_data.replace("+", "-").replace("/", "_").replace("=", "")
+
+
+def decode_filter_state(encoded_str: str) -> dict[str, Any]:
+    """Decode a base62 encoded string back to filter state dictionary
+
+    Args:
+        encoded_str: The compact encoded string
+
+    Returns:
+        Dictionary with all filter parameters
+    """
+    try:
+        padding = 4 - (len(encoded_str) % 4)
+        if padding < 4:
+            encoded_str = encoded_str + ("=" * padding)
+
+        encoded_str = encoded_str.replace("-", "+").replace("_", "/")
+
+        compressed = base64.b64decode(encoded_str)
+        json_data = zlib.decompress(compressed).decode("utf-8")
+
+        return json.loads(json_data)
+    except Exception as e:
+        print(f"Error decoding state: {e}")
+        return {}
+
+
+def generate_short_url(long_url: str) -> str:
+    """Generate a short identifier for a URL
+
+    Args:
+        long_url: The full benchmark URL with all parameters
+
+    Returns:
+        A short identifier (8 characters)
+    """
+    hash_obj = hashlib.sha256(long_url.encode())
+    return hash_obj.hexdigest()[:8]

--- a/mteb/models/openai_models.py
+++ b/mteb/models/openai_models.py
@@ -63,6 +63,10 @@ class OpenAIWrapper(Wrapper):
                 "Reducing embedding size available only for text-embedding-3-* models"
             )
 
+        if self._embed_dim and all(not s.strip() for s in sentences):
+            logger.warning("Empty input detected - returning zero embeddings.")
+            return np.zeros((len(sentences), self._embed_dim), dtype=np.float32)
+
         trimmed_sentences = []
         for sentence in sentences:
             encoded_sentence = self._encoding.encode(sentence)


### PR DESCRIPTION
This PR is related to creating a link for sharing a benchmark for custom benchmark means when some custom filters are applied, apart from the default one. 

@x-tabdeveloping @KennethEnevoldsen In this PR, the idea that I used was simple, like whenever we apply any filters other than the default values of each filter for that particular benchmark (which we see 1st time on the leaderboard), based on this filter state construction is done. Filter state is encoded to JSON, JSON is compressed, and converted to a base64 encoded string, and then converted to a URL. The URL will be long, still I don't think it's a problem as there is a copy button already and the user has to copy url from there and paste it, which is not a difficult thing. But, still, I have added a code to convert these long URLs to short URLs, but I don't know whether we need it or not. 

From these long URLs, it is 1st analyzed whether it's a default or custom benchmark, and then url is decoded and then tries to produce the exact same filter state as the user used at the time of sharing the benchmark.  So, overall flow is as follows: 
Original Filters → encode_filter_state → URL → decode_filter_state → Restored Filters

### Code Quality
<!-- Please do not delete this -->
- [x] **Code Formatted**: Format the code using `make lint` to maintain consistent style.

### Documentation
<!-- Please do not delete this -->
- [] **Updated Documentation**: Add or update documentation to reflect the changes introduced in this PR.

### Testing
<!-- Please do not delete this -->
- [ ] **New Tests Added**: Write tests to cover new functionality. Validate with `make test-with-coverage`.
- [x] **Tests Passed**: Run tests locally using `make test` or `make test-with-coverage` to ensure no existing functionality is broken.