### PR TITLE
fix: Allow empty string for openai models

### DIFF
--- a/mteb/models/openai_models.py
+++ b/mteb/models/openai_models.py
@@ -30,7 +30,8 @@ class OpenAIWrapper(Wrapper):
         **kwargs,
     ) -> None:
         """Wrapper for OpenAIs embedding API.
-        To handle documents larger than 8191 tokens, we truncate the document to the specified sequence length.
+        To handle documents larger than 8191 tokens, we truncate the document to the specified sequence length. If the docuement is empty we return a
+        zero vector.
         """
         requires_package(
             self,
@@ -56,7 +57,9 @@ class OpenAIWrapper(Wrapper):
                 raise ValueError(
                     f"Model {model_name} does not have a default embed_dim. Please provide an embedding dimension."
                 )
-            embed_dim = self.default_embed_dims[model_name]
+            self._embed_dim = self.default_embed_dims[model_name]
+        else:
+            self._embed_dim = embed_dim
 
         self._max_tokens = max_tokens
         self._encoding = tiktoken.get_encoding(tokenizer_name)

--- a/mteb/models/openai_models.py
+++ b/mteb/models/openai_models.py
@@ -63,6 +63,10 @@ class OpenAIWrapper(Wrapper):
                 "Reducing embedding size available only for text-embedding-3-* models"
             )
 
+        if self._embed_dim and all(not s.strip() for s in sentences):
+            logger.warning("Empty input detected - returning zero embeddings.")
+            return np.zeros((len(sentences), self._embed_dim), dtype=np.float32)
+
         trimmed_sentences = []
         for sentence in sentences:
             encoded_sentence = self._encoding.encode(sentence)

--- a/mteb/models/openai_models.py
+++ b/mteb/models/openai_models.py
@@ -51,7 +51,13 @@ class OpenAIWrapper(Wrapper):
         self._client = OpenAI()
 
         self._model_name = model_name
-        self._embed_dim = embed_dim or self.default_embed_dims.get(model_name)
+        if embed_dim is None:
+            if model_name not in self.default_embed_dims:
+                raise ValueError(
+                    f"Model {model_name} does not have a default embed_dim. Please provide an embedding dimension."
+                )
+            embed_dim = self.default_embed_dims[model_name]
+
         self._max_tokens = max_tokens
         self._encoding = tiktoken.get_encoding(tokenizer_name)
 

--- a/mteb/models/openai_models.py
+++ b/mteb/models/openai_models.py
@@ -15,11 +15,17 @@ logger = logging.getLogger(__name__)
 
 
 class OpenAIWrapper(Wrapper):
+    default_embed_dims = {
+        "text-embedding-3-small": 1536,
+        "text-embedding-3-large": 3072,
+        "text-embedding-ada-002": 1536,
+    }
+
     def __init__(
         self,
         model_name: str,
         max_tokens: int,
-        tokenizer_name: str = "cl100k_base",  # since all models use this tokenizer now
+        tokenizer_name: str = "cl100k_base",
         embed_dim: int | None = None,
         **kwargs,
     ) -> None:
@@ -43,8 +49,9 @@ class OpenAIWrapper(Wrapper):
         import tiktoken
 
         self._client = OpenAI()
+
         self._model_name = model_name
-        self._embed_dim = embed_dim
+        self._embed_dim = embed_dim or self.default_embed_dims.get(model_name)
         self._max_tokens = max_tokens
         self._encoding = tiktoken.get_encoding(tokenizer_name)
 
@@ -63,12 +70,11 @@ class OpenAIWrapper(Wrapper):
                 "Reducing embedding size available only for text-embedding-3-* models"
             )
 
-        if self._embed_dim and all(not s.strip() for s in sentences):
-            logger.warning("Empty input detected - returning zero embeddings.")
-            return np.zeros((len(sentences), self._embed_dim), dtype=np.float32)
+        mask_sents = [(i, t) for i, t in enumerate(sentences) if t.strip()]
+        mask, no_empty_sent = zip(*mask_sents) if mask_sents else ([], [])
 
         trimmed_sentences = []
-        for sentence in sentences:
+        for sentence in no_empty_sent:
             encoded_sentence = self._encoding.encode(sentence)
             if len(encoded_sentence) > self._max_tokens:
                 truncated_sentence = self.truncate_text_tokens(sentence)
@@ -88,7 +94,7 @@ class OpenAIWrapper(Wrapper):
             else kwargs.pop("show_progress_bar")
         )
 
-        all_embeddings = []
+        no_empty_embeddings = []
 
         for sublist in tqdm.tqdm(sublists, leave=False, disable=not show_progress_bar):
             try:
@@ -120,9 +126,14 @@ class OpenAIWrapper(Wrapper):
                         encoding_format="float",
                         dimensions=self._embed_dim or NotGiven(),
                     )
-            all_embeddings.extend(self._to_numpy(response))
+            no_empty_embeddings.extend(self._to_numpy(response))
 
-        return np.array(all_embeddings)
+        no_empty_embeddings = np.array(no_empty_embeddings)
+
+        all_embeddings = np.zeros((len(sentences), self._embed_dim), dtype=np.float32)
+        if mask:
+            all_embeddings[mask] = no_empty_embeddings
+        return all_embeddings
 
     def _to_numpy(self, embedding_response) -> np.ndarray:
         return np.array([e.embedding for e in embedding_response.data])
@@ -130,7 +141,7 @@ class OpenAIWrapper(Wrapper):
 
 text_embedding_3_small = ModelMeta(
     name="openai/text-embedding-3-small",
-    revision="2",
+    revision="3",
     release_date="2024-01-25",
     languages=None,  # supported languages not specified
     loader=partial(  # type: ignore
@@ -155,7 +166,7 @@ text_embedding_3_small = ModelMeta(
 )
 text_embedding_3_large = ModelMeta(
     name="openai/text-embedding-3-large",
-    revision="2",
+    revision="3",
     release_date="2024-01-25",
     languages=None,  # supported languages not specified
     loader=partial(  # type: ignore
@@ -180,7 +191,7 @@ text_embedding_3_large = ModelMeta(
 )
 text_embedding_ada_002 = ModelMeta(
     name="openai/text-embedding-ada-002",
-    revision="2",
+    revision="3",
     release_date="2022-12-15",
     languages=None,  # supported languages not specified
     loader=partial(  # type: ignore


### PR DESCRIPTION
closes: #1650

tested using:
```py
mdl = mteb.get_model("openai/text-embedding-3-large")

# text
arr = mdl.encode(["Hello world!"])
print(arr.shape)

# mixed
arr = mdl.encode(["Hello world!", ""])
print(arr.shape)
print(arr[1])

# only empty
arr = mdl.encode(["", "", ""])
print(arr.shape)
print(arr[1])
```

which returns:
```
(1, 3072)
(2, 3072)
[0. 0. 0. ... 0. 0. 0.]
(3, 3072)
[0. 0. 0. ... 0. 0. 0.]
```