### PR TITLE
Add IFIR in retrieval dataset.

### DIFF
--- a/mteb/tasks/Retrieval/__init__.py
+++ b/mteb/tasks/Retrieval/__init__.py
@@ -54,6 +54,7 @@ from .eng.FiQA2018Retrieval import *
 from .eng.HagridRetrieval import *
 from .eng.HellaSwagRetrieval import *
 from .eng.HotpotQARetrieval import *
+from .eng.IFRetrieval import *
 from .eng.LegalBenchConsumerContractsQARetrieval import *
 from .eng.LegalBenchCorporateLobbyingRetrieval import *
 from .eng.LegalSummarizationRetrieval import *

--- a/mteb/tasks/Retrieval/eng/IFRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/IFRetrieval.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from collections import defaultdict
+
+import datasets
+
+from mteb.abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+from mteb.abstasks.MultilingualTask import MultilingualTask
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+DOMAINS = [
+    "fiqa",
+    "nfcorpus",
+    "scifact_open",
+    "aila",
+    "fire",
+    "pm",
+    "cds"
+]
+
+DOMAINS_langs = {split: ["eng"] for split in DOMAINS}
+
+class IFRetrieval(MultilingualTask, AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="IFRetrieval",
+        dataset={
+            "path": "if-ir/ifir",
+            "revision": "1b0c836",
+        },
+        reference="https://huggingface.co/datasets/if-ir/ifir",
+        description="IFIR retrieval dataset.",
+        type="Retrieval",
+        category="s2p",
+        eval_splits=["test"],
+        eval_langs=DOMAINS_langs,
+        main_score="ndcg_at_20",
+        license="cc-by-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        modalities=["text"],
+        bibtex_citation=r"""@inproceedings{song2025ifir,
+  title={IFIR: A Comprehensive Benchmark for Evaluating Instruction-Following in Expert-Domain Information Retrieval},
+  author={Song, Tingyu and Gan, Guo and Shang, Mingsheng and Zhao, Yilun},
+  booktitle={Proceedings of the 2025 Conference of the Nations of the Americas Chapter of the Association for Computational Linguistics: Human Language Technologies (Volume 1: Long Papers)},
+  pages={10186--10204},
+  year={2025}
+}""",
+    )
+    
+    def load_ifir_data(
+        self,
+        path: str,
+        domains: list,
+        eval_splits: list,
+        cache_dir: str | None = None,
+        revision: str | None = None,
+    ):
+        corpus = {domain: {split: None for split in eval_splits} for domain in DOMAINS}
+        queries = {domain: {split: None for split in eval_splits} for domain in DOMAINS}
+        relevant_docs = {
+            domain: {split: None for split in eval_splits} for domain in DOMAINS
+        }
+
+        for domain in domains:
+            domain_corpus = datasets.load_dataset(
+                path, "corpus", split=domain, cache_dir=cache_dir, revision=revision
+            )
+            domain_queries = datasets.load_dataset(
+                path, "queries", split=domain, cache_dir=cache_dir, revision=revision
+            )
+            qrels = datasets.load_dataset(
+                path, "qrels", split=domain, cache_dir=cache_dir, revision=revision
+            )
+            corpus[domain]["test"] = {
+                e["_id"]: {"text": e["text"]} for e in domain_corpus
+            }
+            queries[domain]["test"] = {
+                e["_id"]: e["text"] for e in domain_queries
+            }
+            relevant_docs[domain]["test"] = {}
+
+            for e in qrels:
+                qid = e["query-id"]
+                doc_id = e["corpus-id"]
+                if qid not in relevant_docs[domain]["test"]:
+                    relevant_docs[domain]["test"][qid] = defaultdict(dict)
+                relevant_docs[domain]["test"][qid].update({doc_id: 1})
+
+        corpus = datasets.DatasetDict(corpus)
+        queries = datasets.DatasetDict(queries)
+        relevant_docs = datasets.DatasetDict(relevant_docs)
+        return corpus, queries, relevant_docs
+
+
+    def load_data(self, **kwargs):
+        if self.data_loaded:
+            return
+
+        self.corpus, self.queries, self.relevant_docs = self.load_ifir_data(
+            path=self.metadata_dict["dataset"]["path"],
+            domains=DOMAINS,
+            eval_splits=self.metadata_dict["eval_splits"],
+            cache_dir=kwargs.get("cache_dir", None),
+            revision=self.metadata_dict["dataset"]["revision"],
+        )
+        self.data_loaded = True
+


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->

### Code Quality
<!-- Please do not delete this -->
- [ ] **Code Formatted**: Format the code using `make lint` to maintain consistent style.

### Documentation
<!-- Please do not delete this -->
- [ ] **Updated Documentation**: Add or update documentation to reflect the changes introduced in this PR.

### Testing
<!-- Please do not delete this -->
- [ ] **New Tests Added**: Write tests to cover new functionality. Validate with `make test-with-coverage`.
- [ ] **Tests Passed**: Run tests locally using `make test` or `make test-with-coverage` to ensure no existing functionality is broken.


### Adding datasets checklist
<!-- see also https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md -->

**Reason for dataset addition**: ... <!-- Add reason for adding dataset here. E.g. it covers task/language/domain previously not covered -->

- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb -m {model_name} -t {task_name}` command.
  - [x] `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
  - [x] `intfloat/multilingual-e5-small`
- [ ] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [ ] If the dataset is too big (e.g. >2048 examples), considering using `self.stratified_subsampling() under dataset_transform()`
- [x] I have filled out the metadata object in the dataset file (find documentation on it [here](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md#2-creating-the-metadata-object)).
- [ ] Run tests locally to make sure nothing is broken using `make test`.
- [ ] Run the formatter to format the code using `make lint`.
