### PR TITLE
Update typo in usage.md

### DIFF
--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -181,7 +181,7 @@ For instance to select the 56 English datasets that form the English leaderboard
 
 ```python
 import mteb
-benchmark = mteb.get_benchmark("MTEB(eng, v2)")
+benchmark = mteb.get_benchmark("MTEB(eng, v1)")
 evaluation = mteb.MTEB(tasks=benchmark)
 ```
 


### PR DESCRIPTION
`(eng, v2)` only contains the 41 filtered tasks. `(eng, v1)` contain the whole 56 tasks

### Checklist
<!-- please do not delete this checklist -->

- [x] I did not add a dataset, or if I did, I added the [dataset checklist](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md#submit-a-pr) to the PR and completed it.
- [x] I did not add a model, or if I did, I added the [model checklist](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_model.md#submitting-your-model-as-a-pr) to the PR and completed it.
