### PR TITLE
Delete cache in Model loading test only when model is loaded

### DIFF
--- a/mteb/models/align_models.py
+++ b/mteb/models/align_models.py
@@ -156,6 +156,6 @@ align_base = ModelMeta(
     similarity_fn_name=None,
     use_instructions=False,
     training_datasets={
-        # COYO-700M
+        #  COYO-700M
     },
 )


### PR DESCRIPTION

### Checklist
<!-- please do not delete this checklist -->
[Recent test failures](https://github.com/embeddings-benchmark/mteb/actions/runs/15378057257/job/43288933234?pr=2753) is showing OS errors when deleting the hugging face model cache. This might be caused by trying to remove the directory when another test process is accessing a file in it. 

Suggested fix here is to remove only the model revision that was just loaded.

- [ ] I did not add a dataset, or if I did, I added the [dataset checklist](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md#submit-a-pr) to the PR and completed it.
- [ ] I did not add a model, or if I did, I added the [model checklist](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_model.md#submitting-your-model-as-a-pr) to the PR and completed it.
