### PR TITLE
fix: Add IFIR relevant tasks

### DIFF
--- a/mteb/benchmarks/benchmarks.py
+++ b/mteb/benchmarks/benchmarks.py
@@ -274,6 +274,33 @@ MTEB_RETRIEVAL_WITH_INSTRUCTIONS = Benchmark(
 """,
 )
 
+MTEB_RETRIEVAL_WITH_DOMAIN_INSTRUCTIONS = Benchmark(
+    name="IFIR",
+    display_name="IFIR",
+    tasks=get_tasks(
+        tasks=[
+            "IFIRAila",
+            "IFIRCds",
+            "IFIRFiQA",
+            "IFIRFire",
+            "IFIRNFCorpus",
+            "IFIRPm",
+            "IFIRScifact",
+        ]
+    ),
+    description="Benchmark for Evaluating Instruction-Following in Expert-Domain Information Retrieval",
+    reference="https://arxiv.org/abs/2503.04644",
+    citation=r"""
+@inproceedings{song2025ifir,
+  title={IFIR: A Comprehensive Benchmark for Evaluating Instruction-Following in Expert-Domain Information Retrieval},
+  author={Song, Tingyu and Gan, Guo and Shang, Mingsheng and Zhao, Yilun},
+  booktitle={Proceedings of the 2025 Conference of the Nations of the Americas Chapter of the Association for Computational Linguistics: Human Language Technologies (Volume 1: Long Papers)},
+  pages={10186--10204},
+  year={2025}
+}
+""",
+)
+
 MTEB_RETRIEVAL_LAW = Benchmark(
     name="MTEB(Law, v1)",  # This benchmark is likely in the need of an update
     display_name="Legal",

--- a/mteb/tasks/Retrieval/__init__.py
+++ b/mteb/tasks/Retrieval/__init__.py
@@ -54,6 +54,13 @@ from .eng.FiQA2018Retrieval import *
 from .eng.HagridRetrieval import *
 from .eng.HellaSwagRetrieval import *
 from .eng.HotpotQARetrieval import *
+from .eng.IFIRAilaRetrieval import *
+from .eng.IFIRCdsRetrieval import *
+from .eng.IFIRFiQARetrieval import *
+from .eng.IFIRFireRetrieval import *
+from .eng.IFIRPmRetrieval import *
+from .eng.IFIRNFCorpusRetrieval import *
+from .eng.IFIRScifactRetrieval import *
 from .eng.LegalBenchConsumerContractsQARetrieval import *
 from .eng.LegalBenchCorporateLobbyingRetrieval import *
 from .eng.LegalSummarizationRetrieval import *

--- a/mteb/tasks/Retrieval/eng/IFIRAilaRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/IFIRAilaRetrieval.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+from ....abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+
+
+class IFIRAila(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="IFIRAila",
+        dataset={
+            "path": "if-ir/aila",
+            "revision": "6bce742",
+        },
+        description="Benchmark IFIR aila subset within instruction following abilities.",
+        reference="https://arxiv.org/abs/2503.04644",
+        type="Retrieval",
+        category="s2p",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_20",
+        date=None,
+        # domains=["Medical", "Academic", "Written"],
+        task_subtypes=None,
+        license=None,
+        annotations_creators=None,
+        dialect=None,
+        sample_creation=None,
+        bibtex_citation=r"""
+@inproceedings{song2025ifir,
+  title={IFIR: A Comprehensive Benchmark for Evaluating Instruction-Following in Expert-Domain Information Retrieval},
+  author={Song, Tingyu and Gan, Guo and Shang, Mingsheng and Zhao, Yilun},
+  booktitle={Proceedings of the 2025 Conference of the Nations of the Americas Chapter of the Association for Computational Linguistics: Human Language Technologies (Volume 1: Long Papers)},
+  pages={10186--10204},
+  year={2025}
+}
+""",
+    )

--- a/mteb/tasks/Retrieval/eng/IFIRCdsRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/IFIRCdsRetrieval.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+from ....abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+
+
+class IFIRCds(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="IFIRCds",
+        dataset={
+            "path": "if-ir/cds",
+            "revision": "c406767",
+        },
+        description="BBenchmark IFIR cds subset within instruction following abilities.",
+        reference="https://arxiv.org/abs/2503.04644",
+        type="Retrieval",
+        category="s2p",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_20",
+        date=None,
+        task_subtypes=None,
+        license=None,
+        annotations_creators=None,
+        dialect=None,
+        sample_creation=None,
+        bibtex_citation=r"""
+@inproceedings{song2025ifir,
+  title={IFIR: A Comprehensive Benchmark for Evaluating Instruction-Following in Expert-Domain Information Retrieval},
+  author={Song, Tingyu and Gan, Guo and Shang, Mingsheng and Zhao, Yilun},
+  booktitle={Proceedings of the 2025 Conference of the Nations of the Americas Chapter of the Association for Computational Linguistics: Human Language Technologies (Volume 1: Long Papers)},
+  pages={10186--10204},
+  year={2025}
+}
+""",
+    )

--- a/mteb/tasks/Retrieval/eng/IFIRFiQARetrieval.py
+++ b/mteb/tasks/Retrieval/eng/IFIRFiQARetrieval.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+from ....abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+
+
+class IFIRFiQA(AbsTaskRetrieval):
+    ignore_identical_ids = True
+
+    metadata = TaskMetadata(
+        name="IFIRFiQA",
+        description="Benchmark IFIR fiqa subset within instruction following abilities.",
+        reference="https://arxiv.org/abs/2503.04644",
+        dataset={
+            "path": "if-ir/fiqa",
+            "revision": "3bc52b8",
+        },
+        type="Retrieval",
+        category="s2p",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_20",
+        date=None,
+        domains=["Written", "Financial"],
+        task_subtypes=["Question answering"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        bibtex_citation=r"""
+@inproceedings{song2025ifir,
+  title={IFIR: A Comprehensive Benchmark for Evaluating Instruction-Following in Expert-Domain Information Retrieval},
+  author={Song, Tingyu and Gan, Guo and Shang, Mingsheng and Zhao, Yilun},
+  booktitle={Proceedings of the 2025 Conference of the Nations of the Americas Chapter of the Association for Computational Linguistics: Human Language Technologies (Volume 1: Long Papers)},
+  pages={10186--10204},
+  year={2025}
+}
+"""
+    )

--- a/mteb/tasks/Retrieval/eng/IFIRFireRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/IFIRFireRetrieval.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+from ....abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+
+
+class IFIRFire(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="IFIRFire",
+        dataset={
+            "path": "if-ir/fire",
+            "revision": "28e34d5",
+        },
+        description="Benchmark IFIR fire subset within instruction following abilities.",
+        reference="https://arxiv.org/abs/2503.04644",
+        type="Retrieval",
+        category="s2p",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_20",
+        date=None,
+        task_subtypes=None,
+        license=None,
+        annotations_creators=None,
+        dialect=None,
+        sample_creation=None,
+        bibtex_citation=r"""
+@inproceedings{song2025ifir,
+  title={IFIR: A Comprehensive Benchmark for Evaluating Instruction-Following in Expert-Domain Information Retrieval},
+  author={Song, Tingyu and Gan, Guo and Shang, Mingsheng and Zhao, Yilun},
+  booktitle={Proceedings of the 2025 Conference of the Nations of the Americas Chapter of the Association for Computational Linguistics: Human Language Technologies (Volume 1: Long Papers)},
+  pages={10186--10204},
+  year={2025}
+}
+""",
+    )

--- a/mteb/tasks/Retrieval/eng/IFIRNFCorpusRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/IFIRNFCorpusRetrieval.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+from ....abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+
+
+class IFIRNFCorpus(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="IFIRNFCorpus",
+        dataset={
+            "path": "if-ir/nfcorpus",
+            "revision": "1ebc94a",
+        },
+        description="Benchmark IFIR nfcorpus subset within instruction following abilities.",
+        reference="https://arxiv.org/abs/2503.04644",
+        type="Retrieval",
+        category="s2p",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_20",
+        date=None,
+        domains=["Medical", "Academic", "Written"],
+        task_subtypes=None,
+        license=None,
+        annotations_creators=None,
+        dialect=None,
+        sample_creation=None,
+        bibtex_citation=r"""
+@inproceedings{song2025ifir,
+  title={IFIR: A Comprehensive Benchmark for Evaluating Instruction-Following in Expert-Domain Information Retrieval},
+  author={Song, Tingyu and Gan, Guo and Shang, Mingsheng and Zhao, Yilun},
+  booktitle={Proceedings of the 2025 Conference of the Nations of the Americas Chapter of the Association for Computational Linguistics: Human Language Technologies (Volume 1: Long Papers)},
+  pages={10186--10204},
+  year={2025}
+}
+""",
+    )

--- a/mteb/tasks/Retrieval/eng/IFIRPmRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/IFIRPmRetrieval.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+from ....abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+
+
+class IFIRPm(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="IFIRPm",
+        dataset={
+            "path": "if-ir/pm",
+            "revision": "b7929c7",
+        },
+        description="Benchmark IFIR pm subset within instruction following abilities.",
+        reference="https://arxiv.org/abs/2503.04644",
+        type="Retrieval",
+        category="s2p",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_20",
+        date=None,
+        task_subtypes=None,
+        license=None,
+        annotations_creators=None,
+        dialect=None,
+        sample_creation=None,
+        bibtex_citation=r"""
+@inproceedings{song2025ifir,
+  title={IFIR: A Comprehensive Benchmark for Evaluating Instruction-Following in Expert-Domain Information Retrieval},
+  author={Song, Tingyu and Gan, Guo and Shang, Mingsheng and Zhao, Yilun},
+  booktitle={Proceedings of the 2025 Conference of the Nations of the Americas Chapter of the Association for Computational Linguistics: Human Language Technologies (Volume 1: Long Papers)},
+  pages={10186--10204},
+  year={2025}
+}
+""",
+    )

--- a/mteb/tasks/Retrieval/eng/IFIRScifactRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/IFIRScifactRetrieval.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+from ....abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+
+
+class IFIRNFCorpus(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="IFIRScifact",
+        dataset={
+            "path": "if-ir/scifact_open",
+            "revision": "a487005",
+        },
+        description="Benchmark IFIR scifact_open subset within instruction following abilities.",
+        reference="https://arxiv.org/abs/2503.04644",
+        type="Retrieval",
+        category="s2p",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_20",
+        date=None,
+        task_subtypes=None,
+        license=None,
+        annotations_creators=None,
+        dialect=None,
+        sample_creation=None,
+        bibtex_citation=r"""
+@inproceedings{song2025ifir,
+  title={IFIR: A Comprehensive Benchmark for Evaluating Instruction-Following in Expert-Domain Information Retrieval},
+  author={Song, Tingyu and Gan, Guo and Shang, Mingsheng and Zhao, Yilun},
+  booktitle={Proceedings of the 2025 Conference of the Nations of the Americas Chapter of the Association for Computational Linguistics: Human Language Technologies (Volume 1: Long Papers)},
+  pages={10186--10204},
+  year={2025}
+}
+""",
+    )


### PR DESCRIPTION
- [x] I have outlined why this dataset is filling an existing gap in mteb
- [x] I have tested that the dataset runs with the mteb package.

- [x] I have run the following models on the task (adding the results to the pr). These can be run using the mteb run -m {model_name} -t {task_name} command.
  - [x] sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2
  - [x] intfloat/multilingual-e5-smal

- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
