### PR TITLE
add new prefixes to releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,7 +183,12 @@ tag_format = "{version}"
 [tool.semantic_release.commit_parser_options]
 major_types = ["breaking"]
 minor_types = ["feat"]
-patch_types = ["fix", "perf"]
+patch_types = [
+    "fix",
+    "perf",
+    "model",
+    "dataset",
+]
 
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Now we’re using `fix` for new models and datasets to bump the MTEB version. I propose adding new prefixes to indicate version bumps. 

CC @KennethEnevoldsen 

### Checklist
<!-- please do not delete this checklist -->

- [ ] I did not add a dataset, or if I did, I added the [dataset checklist](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md#submit-a-pr) to the PR and completed it.
- [ ] I did not add a model, or if I did, I added the [model checklist](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_model.md#submitting-your-model-as-a-pr) to the PR and completed it.
