### PR TITLE
Fixing Google embedding task type for STS

### DIFF
--- a/mteb/models/google_models.py
+++ b/mteb/models/google_models.py
@@ -37,7 +37,7 @@ MODEL_PROMPTS = {
     "Classification": "CLASSIFICATION",
     "MultilabelClassification": "CLASSIFICATION",
     "Clustering": "CLUSTERING",
-    "STS": "SIMILARITY",
+    "STS": "SEMANTIC_SIMILARITY",
     PromptType.query.value: "RETRIEVAL_QUERY",
     PromptType.passage.value: "RETRIEVAL_DOCUMENT",
 }


### PR DESCRIPTION
Hi,

this is a little fix for an invalid task type of the Google embedding models.

The type `SIMILARITY` is invalid. The correct one is `SEMANTIC_SIMILARITY`. 

See https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/task-types#supported_task_types

Best,
Malte

### Checklist
<!-- please do not delete this checklist -->

- [x] I did not add a dataset, or if I did, I added the [dataset checklist](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md#submit-a-pr) to the PR and completed it.
- [x] I did not add a model, or if I did, I added the [model checklist](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_model.md#submitting-your-model-as-a-pr) to the PR and completed it.
