### PR TITLE
fix: Ensure bright uses the correct revision

### DIFF
--- a/mteb/tasks/Retrieval/eng/BrightRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/BrightRetrieval.py
@@ -105,7 +105,7 @@ class BrightRetrieval(MultilingualTask, AbsTaskRetrieval):
         name="BrightRetrieval",
         dataset={
             "path": "xlangai/BRIGHT",
-            "revision": "a75a0eb",
+            "revision": "a75a0eb483f6a5233a6efc2d63d71540a4443dfb",
         },
         reference="https://huggingface.co/datasets/xlangai/BRIGHT",
         description="Bright retrieval dataset.",


### PR DESCRIPTION
Seems like the revision wasn't specified correctly. I have respecified it and checked that it can load.

Checked using:

```py
import mteb

task = mteb.get_task("BrightRetrieval", eval_splits=["standard"])
task.load_data()
```

fixes #2811
