### PR TITLE
dataset: Add IFIR benchmark

### DIFF
--- a/mteb/benchmarks/benchmarks.py
+++ b/mteb/benchmarks/benchmarks.py
@@ -271,6 +271,33 @@ MTEB_RETRIEVAL_WITH_INSTRUCTIONS = Benchmark(
 """,
 )
 
+MTEB_RETRIEVAL_WITH_DOMAIN_INSTRUCTIONS = Benchmark(
+    name="IFIR",
+    display_name="IFIR",
+    tasks=get_tasks(
+        tasks=[
+            "IFIRAila",
+            "IFIRCds",
+            "IFIRFiQA",
+            "IFIRFire",
+            "IFIRNFCorpus",
+            "IFIRPm",
+            "IFIRScifact",
+        ]
+    ),
+    description="Benchmark for Evaluating Instruction-Following in Expert-Domain Information Retrieval",
+    reference="https://arxiv.org/abs/2503.04644",
+    citation=r"""
+@inproceedings{song2025ifir,
+  author = {Song, Tingyu and Gan, Guo and Shang, Mingsheng and Zhao, Yilun},
+  booktitle = {Proceedings of the 2025 Conference of the Nations of the Americas Chapter of the Association for Computational Linguistics: Human Language Technologies (Volume 1: Long Papers)},
+  pages = {10186--10204},
+  title = {IFIR: A Comprehensive Benchmark for Evaluating Instruction-Following in Expert-Domain Information Retrieval},
+  year = {2025},
+}
+""",
+)
+
 MTEB_RETRIEVAL_LAW = Benchmark(
     name="MTEB(Law, v1)",  # This benchmark is likely in the need of an update
     display_name="Legal",

--- a/mteb/descriptive_stats/InstructionRetrieval/IFIRAila.json
+++ b/mteb/descriptive_stats/InstructionRetrieval/IFIRAila.json
@@ -1,0 +1,31 @@
+{
+    "test": {
+        "num_samples": 2999,
+        "number_of_characters": 58518387,
+        "num_documents": 2914,
+        "min_document_length": 552,
+        "average_document_length": 19997.05765271105,
+        "max_document_length": 234967,
+        "unique_documents": 2914,
+        "num_queries": 85,
+        "min_query_length": 1175,
+        "average_query_length": 2905.423529411765,
+        "max_query_length": 5937,
+        "unique_queries": 85,
+        "none_queries": 0,
+        "num_relevant_docs": 171,
+        "min_relevant_docs_per_query": 1,
+        "average_relevant_docs_per_query": 2.011764705882353,
+        "max_relevant_docs_per_query": 10,
+        "unique_relevant_docs": 112,
+        "num_instructions": 85,
+        "min_instruction_length": 1221,
+        "average_instruction_length": 260524,
+        "max_instruction_length": 6476,
+        "unique_instructions": 85,
+        "num_top_ranked": null,
+        "min_top_ranked_per_query": null,
+        "average_top_ranked_per_query": null,
+        "max_top_ranked_per_query": null
+    }
+}

--- a/mteb/descriptive_stats/InstructionRetrieval/IFIRCds.json
+++ b/mteb/descriptive_stats/InstructionRetrieval/IFIRCds.json
@@ -1,0 +1,31 @@
+{
+    "test": {
+        "num_samples": 633997,
+        "number_of_characters": 983348753,
+        "num_documents": 633955,
+        "min_document_length": 12,
+        "average_document_length": 1551.1184453155192,
+        "max_document_length": 336124,
+        "unique_documents": 633955,
+        "num_queries": 42,
+        "min_query_length": 136,
+        "average_query_length": 225.21428571428572,
+        "max_query_length": 396,
+        "unique_queries": 42,
+        "none_queries": 0,
+        "num_relevant_docs": 466,
+        "min_relevant_docs_per_query": 1,
+        "average_relevant_docs_per_query": 11.095238095238095,
+        "max_relevant_docs_per_query": 37,
+        "unique_relevant_docs": 457,
+        "num_instructions": 43,
+        "min_instruction_length": 434,
+        "average_instruction_length": 30680,
+        "max_instruction_length": 1457,
+        "unique_instructions": 43,
+        "num_top_ranked": null,
+        "min_top_ranked_per_query": null,
+        "average_top_ranked_per_query": null,
+        "max_top_ranked_per_query": null
+    }
+}

--- a/mteb/descriptive_stats/InstructionRetrieval/IFIRFiQA.json
+++ b/mteb/descriptive_stats/InstructionRetrieval/IFIRFiQA.json
@@ -1,0 +1,31 @@
+{
+    "test": {
+        "num_samples": 59356,
+        "number_of_characters": 44332892,
+        "num_documents": 57638,
+        "min_document_length": 0,
+        "average_document_length": 767.2108157812554,
+        "max_document_length": 16990,
+        "unique_documents": 57638,
+        "num_queries": 1718,
+        "min_query_length": 18,
+        "average_query_length": 65.42200232828871,
+        "max_query_length": 158,
+        "unique_queries": 1718,
+        "none_queries": 0,
+        "num_relevant_docs": 6088,
+        "min_relevant_docs_per_query": 1,
+        "average_relevant_docs_per_query": 3.5436554132712454,
+        "max_relevant_docs_per_query": 23,
+        "unique_relevant_docs": 2925,
+        "num_instructions": 1718,
+        "min_instruction_length": 81,
+        "average_instruction_length": 447254,
+        "max_instruction_length": 739,
+        "unique_instructions": 1718,
+        "num_top_ranked": null,
+        "min_top_ranked_per_query": null,
+        "average_top_ranked_per_query": null,
+        "max_top_ranked_per_query": null
+    }
+}

--- a/mteb/descriptive_stats/InstructionRetrieval/IFIRFire.json
+++ b/mteb/descriptive_stats/InstructionRetrieval/IFIRFire.json
@@ -1,0 +1,31 @@
+{
+    "test": {
+        "num_samples": 1912,
+        "number_of_characters": 47796445,
+        "num_documents": 1745,
+        "min_document_length": 0,
+        "average_document_length": 27076.245272206303,
+        "max_document_length": 75701,
+        "unique_documents": 1745,
+        "num_queries": 167,
+        "min_query_length": 1783,
+        "average_query_length": 3283.814371257485,
+        "max_query_length": 4911,
+        "unique_queries": 167,
+        "none_queries": 0,
+        "num_relevant_docs": 565,
+        "min_relevant_docs_per_query": 1,
+        "average_relevant_docs_per_query": 3.3832335329341316,
+        "max_relevant_docs_per_query": 5,
+        "unique_relevant_docs": 500,
+        "num_instructions": 168,
+        "min_instruction_length": 2124,
+        "average_instruction_length": 618087,
+        "max_instruction_length": 5229,
+        "unique_instructions": 168,
+        "num_top_ranked": null,
+        "min_top_ranked_per_query": null,
+        "average_top_ranked_per_query": null,
+        "max_top_ranked_per_query": null
+    }
+}

--- a/mteb/descriptive_stats/InstructionRetrieval/IFIRNFCorpus.json
+++ b/mteb/descriptive_stats/InstructionRetrieval/IFIRNFCorpus.json
@@ -1,0 +1,31 @@
+{
+    "test": {
+        "num_samples": 3719,
+        "number_of_characters": 5778939,
+        "num_documents": 3633,
+        "min_document_length": 122,
+        "average_document_length": 1589.783925130746,
+        "max_document_length": 10089,
+        "unique_documents": 3633,
+        "num_queries": 86,
+        "min_query_length": 16,
+        "average_query_length": 37.83720930232558,
+        "max_query_length": 64,
+        "unique_queries": 86,
+        "none_queries": 0,
+        "num_relevant_docs": 242,
+        "min_relevant_docs_per_query": 1,
+        "average_relevant_docs_per_query": 2.813953488372093,
+        "max_relevant_docs_per_query": 8,
+        "unique_relevant_docs": 232,
+        "num_instructions": 86,
+        "min_instruction_length": 625,
+        "average_instruction_length": 76216,
+        "max_instruction_length": 1253,
+        "unique_instructions": 86,
+        "num_top_ranked": null,
+        "min_top_ranked_per_query": null,
+        "average_top_ranked_per_query": null,
+        "max_top_ranked_per_query": null
+    }
+}

--- a/mteb/descriptive_stats/InstructionRetrieval/IFIRPm.json
+++ b/mteb/descriptive_stats/InstructionRetrieval/IFIRPm.json
@@ -1,0 +1,31 @@
+{
+    "test": {
+        "num_samples": 241178,
+        "number_of_characters": 487464409,
+        "num_documents": 241006,
+        "min_document_length": 79,
+        "average_document_length": 2022.5196177688522,
+        "max_document_length": 35301,
+        "unique_documents": 241006,
+        "num_queries": 172,
+        "min_query_length": 118,
+        "average_query_length": 145.61627906976744,
+        "max_query_length": 186,
+        "unique_queries": 172,
+        "none_queries": 0,
+        "num_relevant_docs": 2685,
+        "min_relevant_docs_per_query": 1,
+        "average_relevant_docs_per_query": 15.61046511627907,
+        "max_relevant_docs_per_query": 47,
+        "unique_relevant_docs": 850,
+        "num_instructions": 172,
+        "min_instruction_length": 232,
+        "average_instruction_length": 116791,
+        "max_instruction_length": 3090,
+        "unique_instructions": 172,
+        "num_top_ranked": null,
+        "min_top_ranked_per_query": null,
+        "average_top_ranked_per_query": null,
+        "max_top_ranked_per_query": null
+    }
+}

--- a/mteb/descriptive_stats/InstructionRetrieval/IFIRScifact.json
+++ b/mteb/descriptive_stats/InstructionRetrieval/IFIRScifact.json
@@ -1,0 +1,31 @@
+{
+    "test": {
+        "num_samples": 500135,
+        "number_of_characters": 719268189,
+        "num_documents": 500000,
+        "min_document_length": 33,
+        "average_document_length": 1438.51698,
+        "max_document_length": 10222,
+        "unique_documents": 500000,
+        "num_queries": 135,
+        "min_query_length": 33,
+        "average_query_length": 71.84444444444445,
+        "max_query_length": 126,
+        "unique_queries": 135,
+        "none_queries": 0,
+        "num_relevant_docs": 735,
+        "min_relevant_docs_per_query": 1,
+        "average_relevant_docs_per_query": 5.444444444444445,
+        "max_relevant_docs_per_query": 24,
+        "unique_relevant_docs": 244,
+        "num_instructions": 135,
+        "min_instruction_length": 78,
+        "average_instruction_length": 34214,
+        "max_instruction_length": 665,
+        "unique_instructions": 135,
+        "num_top_ranked": null,
+        "min_top_ranked_per_query": null,
+        "average_top_ranked_per_query": null,
+        "max_top_ranked_per_query": null
+    }
+}

--- a/mteb/tasks/InstructionRetrieval/eng/IFIRAilaRetrieval.py
+++ b/mteb/tasks/InstructionRetrieval/eng/IFIRAilaRetrieval.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from mteb.abstasks.task_metadata import TaskMetadata
+
+from ....abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+
+
+class IFIRAila(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="IFIRAila",
+        dataset={
+            "path": "if-ir/aila",
+            "revision": "1cb8772",
+        },
+        description="Benchmark aila subset in aila within instruction following abilities. The instructions simulate lawyers' or legal assistants' nuanced queries to retrieve relevant legal documents. ",
+        reference="https://arxiv.org/abs/2503.04644",
+        type="InstructionRetrieval",
+        category="t2t",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_20",
+        date=["2024-05-01", "2024-10-16"],
+        domains=["Legal", "Written"],
+        task_subtypes=["Article retrieval"],
+        license="mit",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=r"""
+@inproceedings{song2025ifir,
+  author = {Song, Tingyu and Gan, Guo and Shang, Mingsheng and Zhao, Yilun},
+  booktitle = {Proceedings of the 2025 Conference of the Nations of the Americas Chapter of the Association for Computational Linguistics: Human Language Technologies (Volume 1: Long Papers)},
+  pages = {10186--10204},
+  title = {IFIR: A Comprehensive Benchmark for Evaluating Instruction-Following in Expert-Domain Information Retrieval},
+  year = {2025},
+}
+""",
+    )
+
+    def task_specific_scores(
+        self,
+        scores: dict[str, dict[str, float]],
+        qrels: dict[str, dict[str, int]],
+        results: dict[str, dict[str, float]],
+        hf_split: str,
+        hf_subset: str,
+    ) -> dict[str, float]:
+        scores_dict = {"level_1": [], "level_2": [], "level_3": []}
+        metric = "ndcg_cut_20"
+        for k, v in scores.items():
+            if "v1" in k:
+                scores_dict["level_1"].append(v[metric])
+            elif "v2" in k:
+                scores_dict["level_2"].append(v[metric])
+            elif "v3" in k:
+                scores_dict["level_3"].append(v[metric])
+        return {
+            "level_scores": {
+                "level_1": sum(scores_dict["level_1"]) / len(scores_dict["level_1"]),
+                "level_2": sum(scores_dict["level_2"]) / len(scores_dict["level_2"]),
+                "level_3": sum(scores_dict["level_3"]) / len(scores_dict["level_3"]),
+            }
+        }

--- a/mteb/tasks/InstructionRetrieval/eng/IFIRCdsRetrieval.py
+++ b/mteb/tasks/InstructionRetrieval/eng/IFIRCdsRetrieval.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from mteb.abstasks.task_metadata import TaskMetadata
+
+from ....abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+
+
+class IFIRCds(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="IFIRCds",
+        dataset={
+            "path": "if-ir/cds",
+            "revision": "9a05fd6",
+        },
+        description="Benchmark IFIR cds subset within instruction following abilities. The instructions simulate a doctor's nuanced queries to retrieve suitable clinical trails, treatment and diagnosis information. ",
+        reference="https://arxiv.org/abs/2503.04644",
+        type="InstructionRetrieval",
+        category="t2t",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_20",
+        date=["2024-05-01", "2024-10-16"],
+        domains=["Medical", "Written"],
+        task_subtypes=["Article retrieval"],
+        license="mit",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=r"""
+@inproceedings{song2025ifir,
+  author = {Song, Tingyu and Gan, Guo and Shang, Mingsheng and Zhao, Yilun},
+  booktitle = {Proceedings of the 2025 Conference of the Nations of the Americas Chapter of the Association for Computational Linguistics: Human Language Technologies (Volume 1: Long Papers)},
+  pages = {10186--10204},
+  title = {IFIR: A Comprehensive Benchmark for Evaluating Instruction-Following in Expert-Domain Information Retrieval},
+  year = {2025},
+}
+""",
+    )

--- a/mteb/tasks/InstructionRetrieval/eng/IFIRFiQARetrieval.py
+++ b/mteb/tasks/InstructionRetrieval/eng/IFIRFiQARetrieval.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from mteb.abstasks.task_metadata import TaskMetadata
+
+from ....abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+
+
+class IFIRFiQA(AbsTaskRetrieval):
+    ignore_identical_ids = True
+
+    metadata = TaskMetadata(
+        name="IFIRFiQA",
+        description="Benchmark IFIR fiqa subset within instruction following abilities. The instructions simulate people's daily life queries to retrieve suitable financial suggestions. ",
+        reference="https://arxiv.org/abs/2503.04644",
+        dataset={
+            "path": "if-ir/fiqa",
+            "revision": "1670fc6",
+        },
+        type="InstructionRetrieval",
+        category="t2t",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_20",
+        date=["2024-05-01", "2024-10-16"],
+        domains=["Written", "Financial"],
+        task_subtypes=["Article retrieval"],
+        license="mit",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="created",
+        bibtex_citation=r"""
+@inproceedings{song2025ifir,
+  author = {Song, Tingyu and Gan, Guo and Shang, Mingsheng and Zhao, Yilun},
+  booktitle = {Proceedings of the 2025 Conference of the Nations of the Americas Chapter of the Association for Computational Linguistics: Human Language Technologies (Volume 1: Long Papers)},
+  pages = {10186--10204},
+  title = {IFIR: A Comprehensive Benchmark for Evaluating Instruction-Following in Expert-Domain Information Retrieval},
+  year = {2025},
+}
+""",
+    )
+
+    def task_specific_scores(
+        self,
+        scores: dict[str, dict[str, float]],
+        qrels: dict[str, dict[str, int]],
+        results: dict[str, dict[str, float]],
+        hf_split: str,
+        hf_subset: str,
+    ) -> dict[str, float]:
+        scores_dict = {"level_1": [], "level_2": [], "level_3": []}
+        metric = "ndcg_cut_20"
+        for k, v in scores.items():
+            if "v1" in k:
+                scores_dict["level_1"].append(v[metric])
+            elif "v2" in k:
+                scores_dict["level_2"].append(v[metric])
+            elif "v3" in k:
+                scores_dict["level_3"].append(v[metric])
+        return {
+            "level_scores": {
+                "level_1": sum(scores_dict["level_1"]) / len(scores_dict["level_1"]),
+                "level_2": sum(scores_dict["level_2"]) / len(scores_dict["level_2"]),
+                "level_3": sum(scores_dict["level_3"]) / len(scores_dict["level_3"]),
+            }
+        }

--- a/mteb/tasks/InstructionRetrieval/eng/IFIRFireRetrieval.py
+++ b/mteb/tasks/InstructionRetrieval/eng/IFIRFireRetrieval.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from mteb.abstasks.task_metadata import TaskMetadata
+
+from ....abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+
+
+class IFIRFire(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="IFIRFire",
+        dataset={
+            "path": "if-ir/fire",
+            "revision": "0efa7b1",
+        },
+        description="Benchmark IFIR fire subset within instruction following abilities. The instructions simulate lawyers' or legal assistants' nuanced queries to retrieve relevant legal documents. ",
+        reference="https://arxiv.org/abs/2503.04644",
+        type="InstructionRetrieval",
+        category="t2t",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_20",
+        date=["2024-05-01", "2024-10-16"],
+        domains=["Written", "Legal"],
+        task_subtypes=["Article retrieval"],
+        license="mit",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=r"""
+@inproceedings{song2025ifir,
+  author = {Song, Tingyu and Gan, Guo and Shang, Mingsheng and Zhao, Yilun},
+  booktitle = {Proceedings of the 2025 Conference of the Nations of the Americas Chapter of the Association for Computational Linguistics: Human Language Technologies (Volume 1: Long Papers)},
+  pages = {10186--10204},
+  title = {IFIR: A Comprehensive Benchmark for Evaluating Instruction-Following in Expert-Domain Information Retrieval},
+  year = {2025},
+}
+""",
+    )

--- a/mteb/tasks/InstructionRetrieval/eng/IFIRNFCorpusRetrieval.py
+++ b/mteb/tasks/InstructionRetrieval/eng/IFIRNFCorpusRetrieval.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from mteb.abstasks.task_metadata import TaskMetadata
+
+from ....abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+
+
+class IFIRNFCorpus(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="IFIRNFCorpus",
+        dataset={
+            "path": "if-ir/nfcorpus",
+            "revision": "3520715",
+        },
+        description="Benchmark IFIR nfcorpus subset within instruction following abilities. The instructions in this dataset simulate nuanced queries from students or researchers to retrieve relevant science literature in the medical and biological domains. ",
+        reference="https://arxiv.org/abs/2503.04644",
+        type="InstructionRetrieval",
+        category="t2t",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_20",
+        date=["2024-05-01", "2024-10-16"],
+        domains=["Medical", "Academic", "Written"],
+        task_subtypes=["Article retrieval"],
+        license="mit",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=r"""
+@inproceedings{song2025ifir,
+  author = {Song, Tingyu and Gan, Guo and Shang, Mingsheng and Zhao, Yilun},
+  booktitle = {Proceedings of the 2025 Conference of the Nations of the Americas Chapter of the Association for Computational Linguistics: Human Language Technologies (Volume 1: Long Papers)},
+  pages = {10186--10204},
+  title = {IFIR: A Comprehensive Benchmark for Evaluating Instruction-Following in Expert-Domain Information Retrieval},
+  year = {2025},
+}
+""",
+    )

--- a/mteb/tasks/InstructionRetrieval/eng/IFIRPmRetrieval.py
+++ b/mteb/tasks/InstructionRetrieval/eng/IFIRPmRetrieval.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from mteb.abstasks.task_metadata import TaskMetadata
+
+from ....abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+
+
+class IFIRPm(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="IFIRPm",
+        dataset={
+            "path": "if-ir/pm",
+            "revision": "559fdb6",
+        },
+        description="Benchmark IFIR pm subset within instruction following abilities. The instructions simulate a doctor's nuanced queries to retrieve suitable clinical trails, treatment and diagnosis information. ",
+        reference="https://arxiv.org/abs/2503.04644",
+        type="InstructionRetrieval",
+        category="t2t",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_20",
+        date=["2024-05-01", "2024-10-16"],
+        domains=["Medical", "Written"],
+        task_subtypes=["Article retrieval"],
+        license="mit",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=r"""
+@inproceedings{song2025ifir,
+  author = {Song, Tingyu and Gan, Guo and Shang, Mingsheng and Zhao, Yilun},
+  booktitle = {Proceedings of the 2025 Conference of the Nations of the Americas Chapter of the Association for Computational Linguistics: Human Language Technologies (Volume 1: Long Papers)},
+  pages = {10186--10204},
+  title = {IFIR: A Comprehensive Benchmark for Evaluating Instruction-Following in Expert-Domain Information Retrieval},
+  year = {2025},
+}
+""",
+    )
+
+    def task_specific_scores(
+        self,
+        scores: dict[str, dict[str, float]],
+        qrels: dict[str, dict[str, int]],
+        results: dict[str, dict[str, float]],
+        hf_split: str,
+        hf_subset: str,
+    ) -> dict[str, float]:
+        # return {"robustness_at_10": robustness_at_10(qrels, results, scores)}
+        scores_dict = {"level_1": [], "level_2": [], "level_3": []}
+        metric = "ndcg_cut_20"
+        for k, v in scores.items():
+            if "v1" in k:
+                scores_dict["level_1"].append(v[metric])
+            elif "v2" in k:
+                scores_dict["level_2"].append(v[metric])
+            elif "v3" in k:
+                scores_dict["level_3"].append(v[metric])
+        return {
+            "level_scores": {
+                "level_1": sum(scores_dict["level_1"]) / len(scores_dict["level_1"]),
+                "level_2": sum(scores_dict["level_2"]) / len(scores_dict["level_2"]),
+                "level_3": sum(scores_dict["level_3"]) / len(scores_dict["level_3"]),
+            }
+        }

--- a/mteb/tasks/InstructionRetrieval/eng/IFIRScifactRetrieval.py
+++ b/mteb/tasks/InstructionRetrieval/eng/IFIRScifactRetrieval.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from mteb.abstasks.task_metadata import TaskMetadata
+
+from ....abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+
+
+class IFIRScifact(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="IFIRScifact",
+        dataset={
+            "path": "if-ir/scifact_open",
+            "revision": "1690191",
+        },
+        description="Benchmark IFIR scifact_open subset within instruction following abilities. The instructions in this dataset simulate nuanced queries from students or researchers to retrieve relevant science literature. ",
+        reference="https://arxiv.org/abs/2503.04644",
+        type="InstructionRetrieval",
+        category="t2t",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_20",
+        date=["2024-05-01", "2024-10-16"],
+        domains=["Written", "Academic"],
+        task_subtypes=["Article retrieval"],
+        license="mit",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=r"""
+@inproceedings{song2025ifir,
+  author = {Song, Tingyu and Gan, Guo and Shang, Mingsheng and Zhao, Yilun},
+  booktitle = {Proceedings of the 2025 Conference of the Nations of the Americas Chapter of the Association for Computational Linguistics: Human Language Technologies (Volume 1: Long Papers)},
+  pages = {10186--10204},
+  title = {IFIR: A Comprehensive Benchmark for Evaluating Instruction-Following in Expert-Domain Information Retrieval},
+  year = {2025},
+}
+""",
+    )
+
+    def task_specific_scores(
+        self,
+        scores: dict[str, dict[str, float]],
+        qrels: dict[str, dict[str, int]],
+        results: dict[str, dict[str, float]],
+        hf_split: str,
+        hf_subset: str,
+    ) -> dict[str, float]:
+        scores_dict = {"level_1": [], "level_2": [], "level_3": []}
+        metric = "ndcg_cut_20"
+        for k, v in scores.items():
+            if "v1" in k:
+                scores_dict["level_1"].append(v[metric])
+            elif "v2" in k:
+                scores_dict["level_2"].append(v[metric])
+            elif "v3" in k:
+                scores_dict["level_3"].append(v[metric])
+        return {
+            "level_scores": {
+                "level_1": sum(scores_dict["level_1"]) / len(scores_dict["level_1"]),
+                "level_2": sum(scores_dict["level_2"]) / len(scores_dict["level_2"]),
+                "level_3": sum(scores_dict["level_3"]) / len(scores_dict["level_3"]),
+            }
+        }

--- a/mteb/tasks/InstructionRetrieval/eng/__init__.py
+++ b/mteb/tasks/InstructionRetrieval/eng/__init__.py
@@ -1,5 +1,21 @@
 from __future__ import annotations
 
+from .IFIRAilaRetrieval import IFIRAila
+from .IFIRCdsRetrieval import IFIRCds
+from .IFIRFiQARetrieval import IFIRFiQA
+from .IFIRFireRetrieval import IFIRFire
+from .IFIRNFCorpusRetrieval import IFIRNFCorpus
+from .IFIRPmRetrieval import IFIRPm
+from .IFIRScifactRetrieval import IFIRScifact
 from .InstructIR import InstructIR
 
-__all__ = ["InstructIR"]
+__all__ = [
+    "InstructIR",
+    "IFIRAila",
+    "IFIRCds",
+    "IFIRFiQA",
+    "IFIRFire",
+    "IFIRNFCorpus",
+    "IFIRPm",
+    "IFIRScifact",
+]


### PR DESCRIPTION
- [x] I have outlined why this dataset is filling an existing gap in mteb
- [x] I have tested that the dataset runs with the mteb package.

- [ ] I have run the following models on the task (adding the results to the pr). These can be run using the mteb run -m {model_name} -t {task_name} command.
  - [ ] sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2
  - [ ] intfloat/multilingual-e5-smal

- [ ] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).