### PR TITLE
fix: Add docs and .load_results to ResultsCache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,7 +143,6 @@ sb.ipynb
 tests/create_meta/model_card.md
 
 # removed results from mteb repo they are now available at: https://github.com/embeddings-benchmark/results
-results/
 uv.lock
 
 # model loading tests
@@ -152,7 +151,6 @@ mteb/leaderboard/__cached_results.json
 
 # gradio
 .gradio/
-
 
 # codecarbon
 powermetrics_log.txt

--- a/docs/usage/results.md
+++ b/docs/usage/results.md
@@ -1,34 +1,68 @@
 # Loading and working with results
 
-Multiple models have already been run on tasks available within MTEB. These results are available results [repository](https://github.com/embeddings-benchmark/results).
+After running models on `mteb` you typically want to know more about the results. You can load your results from the cache using the `ResultCache` object.
+
+
 
 To make the results more easily accessible, we have designed custom functionality for retrieving from the repository. For instance, if you are selecting the best model for your French and English retrieval task on legal documents you could fetch the relevant tasks and create a dataframe of the results using the following code:
 
 ```python
 import mteb
 
+tasks = mteb.get_tasks(tasks=["STS12"])
+model_names = ["intfloat/multilingual-e5-large"]
+
+cache = ResultCache("~/.cache/mteb")
+results = cache.load_results(models=model_names, tasks=tasks)
+
+```
+
+From this you will get a results object:
+```py
+results
+# BenchmarkResults(model_results=[...](#1))
+type(results)
+# mteb.load_results.benchmark_results.BenchmarkResults
+```
+
+## Working with remote results
+
+While you can of course use local results you typically want to compare your model to existing models run using `mteb`. For MTEB all previously submitted results are available results [repository](https://github.com/embeddings-benchmark/results).
+
+You can download this using:
+
+```py
+from mteb.cache import ResultCache
+
+cache = ResultCache()
+cache.download_from_remote() # download results from the remote repository
+```
+
+From here you can work with the cache as usual. For instance, if you are selecting the best model for your French and English retrieval task on legal documents you could fetch the relevant tasks and create a dataframe of the results using the following code:
+
+```py
+from mteb.cache import ResultCache
+
 # select your tasks
 tasks = mteb.get_tasks(task_types=["Retrieval"], languages=["eng", "fra"], domains=["Legal"])
-# or use a benchmark
-tasks = mteb.get_benchmark("MTEB(Multilingual, v1)").tasks
 
 model_names = [
     "GritLM/GritLM-7B",
     "intfloat/multilingual-e5-large",
 ]
 
-results = mteb.load_results(models=model_names, tasks=tasks)
+
+cache = ResultCache()
+cache.download_from_remote() # download results from the remote repository
+
+results = cache.load_results(
+    models=model_names, 
+    tasks=tasks
+    include_remote=True, # default
+)
 ```
 
-From this you will get a results object:
-```py
-results
-# BenchmarkResults(model_results=[...](#10))
-type(results)
-# mteb.load_results.benchmark_results.BenchmarkResults
-```
-
-## Working with the result objects
+## Working with `BenchmarkResults`
 
 The result object is a convenient object in `mteb` for working with dataframes and allows you to quick examine your results.
 

--- a/tests/mock_mteb_cache/remote/results/sentence-transformers__all-MiniLM-L6-v2-dummy/8b3219a92973c328a8e22fadcfa821b5dc75636a/BornholmBitextMining.json
+++ b/tests/mock_mteb_cache/remote/results/sentence-transformers__all-MiniLM-L6-v2-dummy/8b3219a92973c328a8e22fadcfa821b5dc75636a/BornholmBitextMining.json
@@ -1,0 +1,22 @@
+{
+    "dataset_revision": "3bc5cfb4ec514264fe2db5615fac9016f7251552",
+    "evaluation_time": 2.3900349140167236,
+    "kg_co2_emissions": null,
+    "mteb_version": "1.12.75",
+    "scores": {
+        "test": [
+            {
+                "accuracy": 0.36,
+                "f1": 0.2968132161955691,
+                "hf_subset": "default",
+                "languages": [
+                    "dan-Latn"
+                ],
+                "main_score": 0.2968132161955691,
+                "precision": 0.27690919913419915,
+                "recall": 0.36
+            }
+        ]
+    },
+    "task_name": "BornholmBitextMining"
+}

--- a/tests/mock_mteb_cache/remote/results/sentence-transformers__all-MiniLM-L6-v2-dummy/8b3219a92973c328a8e22fadcfa821b5dc75636a/model_meta.json
+++ b/tests/mock_mteb_cache/remote/results/sentence-transformers__all-MiniLM-L6-v2-dummy/8b3219a92973c328a8e22fadcfa821b5dc75636a/model_meta.json
@@ -1,0 +1,17 @@
+{
+    "name": "sentence-transformers/all-MiniLM-L6-v2-dummy",
+    "revision": "8b3219a92973c328a8e22fadcfa821b5dc75636a",
+    "release_date": "2021-08-30",
+    "languages": [
+        "eng-Latn"
+    ],
+    "n_parameters": null,
+    "memory_usage": null,
+    "max_tokens": null,
+    "embed_dim": null,
+    "license": null,
+    "open_source": true,
+    "similarity_fn_name": null,
+    "framework": [],
+    "loader": null
+}

--- a/tests/test_result_cache.py
+++ b/tests/test_result_cache.py
@@ -1,0 +1,95 @@
+"""Test cases for the ResultCache class in the mteb.cache module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mteb.cache import ResultCache
+from mteb.load_results.task_results import TaskResult
+
+test_cache_path = Path(__file__).parent / "mock_mteb_cache"
+
+
+def test_result_cache() -> None:
+    cache = ResultCache(cache_path=test_cache_path)
+
+    assert cache.has_remote is True, "Cache should not have a remote repository"
+
+    # load known results from the cache
+    result = cache.load_from_cache(  # TODO: cache.load_task_result(
+        "BornholmBitextMining",
+        "sentence-transformers/all-MiniLM-L6-v2",
+        model_revision="8b3219a92973c328a8e22fadcfa821b5dc75636a",
+        raise_if_not_found=True,
+    )
+    # TODO: What happens if rev is not and there are multiple revisions
+
+    assert isinstance(result, TaskResult), "Loaded result should be a TaskResult"
+    assert result.task_name == "BornholmBitextMining", "Task name should match"
+
+
+def test_get_cache_path() -> None:
+    cache = ResultCache(cache_path=test_cache_path)
+    paths = cache.get_cache_paths(require_model_meta=False, include_remote=False)
+
+    assert isinstance(paths, list), "Cache paths should be a list"
+    assert isinstance(paths[0], Path), "Cache paths should be a list of Paths"
+
+    paths_w_meta = cache.get_cache_paths(require_model_meta=True)
+    assert len(paths_w_meta) > len(paths), (
+        "Paths with model meta should be fewer than without"
+    )
+
+    paths_w_remote = cache.get_cache_paths(
+        include_remote=True, require_model_meta=False
+    )
+
+    assert len(paths_w_remote) > len(paths), (
+        "Paths with remote should be at least as many as without"
+    )
+
+    known_model = "sentence-transformers/average_word_embeddings_levy_dependency"
+
+    paths_for_model = cache.get_cache_paths(
+        models=[known_model], require_model_meta=False
+    )
+    assert len(paths_for_model) > 0, "Should return paths for the specified model"
+
+
+def test_get_models_and_tasks() -> None:
+    cache = ResultCache(cache_path=test_cache_path)
+
+    models = cache.get_models()
+    assert isinstance(models, list), "Models should be a list"
+    assert isinstance(models[0], tuple) and len(models[0]) == 2, (
+        "Models should be a list of tuples (model_name, model_revision)"
+    )
+
+    tasks = cache.get_tasks()
+    assert isinstance(tasks, list), "Tasks should be a list"
+    assert isinstance(tasks[0], str), "Tasks should be a list of task names"
+
+
+def test_load_results():
+    cache = ResultCache(cache_path=test_cache_path)
+
+    results = cache.load_results()
+
+    known_model = "sentence-transformers/average_word_embeddings_levy_dependency"
+    known_revision = "6d9c09a789ad5dd126b476323fccfeeafcd90509"
+
+    assert known_model in [res.model_name for res in results]
+    assert known_revision in [
+        res.model_revision for res in results if res.model_name == known_model
+    ], "Known revision should be in the results"
+
+
+def test_load_result_specific_model():
+    cache = ResultCache(cache_path=test_cache_path)
+
+    model = "sentence-transformers/average_word_embeddings_levy_dependency"
+    results = cache.load_results(models=[model], require_model_meta=False)
+
+    model_names = {mdl_res.model_name for mdl_res in results.model_results}
+    assert len(model_names) == 1, "Should only have one model in the results"
+    assert model in model_names, "Model should be in the results"


### PR DESCRIPTION
- [x] Added tests
- [x] Added utility interfaces for examining the cache
- [x] Added load_results
- [x] Updated docs to use ResultsCache instead

We could also update the leaderboard to use ResultCache, but I don't want to do that in this PR. When that is done I would probably depracate `mteb.load_results` or convert it to a shorthand function for
```py
ResultCache().load_result(**kwargs)
```
Deprecating leads to less breaking changes.

Minor:
- removed `results/` from .gitignore
