### PR TITLE
fix: prompt validation for tasks with `-`

### DIFF
--- a/mteb/models/wrapper.py
+++ b/mteb/models/wrapper.py
@@ -73,8 +73,10 @@ class Wrapper:
         task_types = get_args(TASK_TYPE)
         prompt_types = [e.value for e in PromptType]
         for task_name in task_to_prompt_name:
-            if "-" in task_name:
-                task_name, prompt_type = task_name.split("-")
+            if "-" in task_name and task_name.endswith(
+                (f"-{PromptType.query.value}", f"-{PromptType.passage.value}")
+            ):
+                task_name, prompt_type = task_name.rsplit("-", 1)
                 if prompt_type not in prompt_types:
                     msg = f"Prompt type {prompt_type} is not valid. Valid prompt types are {prompt_types}"
                     logger.warning(msg)

--- a/tests/test_benchmark/test_benchmark.py
+++ b/tests/test_benchmark/test_benchmark.py
@@ -305,6 +305,9 @@ def test_prompt_name_passed_to_all_encodes_with_prompts(
 
 @pytest.mark.parametrize("task_name", ["NQ-NL-query", "NQ-NL-passage"])
 def test_prompt_name_split_correctly(task_name: str, tmp_path: Path):
+    """Test that the task name is split correctly into task name and prompt type
+    for tasks with multiple `-` in their names.
+    """
     Wrapper.validate_task_to_prompt_name({task_name: task_name})
 
 

--- a/tests/test_benchmark/test_benchmark.py
+++ b/tests/test_benchmark/test_benchmark.py
@@ -15,6 +15,7 @@ import mteb
 import mteb.overview
 from mteb.create_meta import generate_readme
 from mteb.evaluation.MTEB import logger
+from mteb.models.wrapper import Wrapper
 
 from .mock_models import (
     MockCLIPEncoder,
@@ -300,6 +301,11 @@ def test_prompt_name_passed_to_all_encodes_with_prompts(
         output_folder=tmp_path.as_posix(),
         overwrite_results=True,
     )
+
+
+@pytest.mark.parametrize("task_name", ["NQ-NL-query", "NQ-NL-passage"])
+def test_prompt_name_split_correctly(task_name: str, tmp_path: Path):
+    Wrapper.validate_task_to_prompt_name({task_name: task_name})
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fix validation for tasks with multiple `-`

>  if the task dataset contains a "-", there will be an error in parsing the task_name, such as when specifying "NQ-PL-query".

Ref https://github.com/embeddings-benchmark/results/pull/217#issuecomment-2996133931
CC @YanshekWoo

