### PR TITLE
fix: update training dataset info of Seed-1.6-embedding model 

### DIFF
--- a/mteb/models/seed_1_6_embedding_models.py
+++ b/mteb/models/seed_1_6_embedding_models.py
@@ -19,6 +19,7 @@ from torch.utils.data import DataLoader
 from mteb.encoder_interface import PromptType
 from mteb.model_meta import ModelMeta
 from mteb.models.bge_models import bge_chinese_training_data
+from mteb.models.nvidia_models import nvidia_training_datasets
 from mteb.models.wrapper import Wrapper
 from mteb.requires_package import requires_package
 
@@ -130,14 +131,19 @@ def multi_thread_encode(sentences, batch_size=1, max_workers=8):
     return all_embeddings.float().cpu()
 
 
-doubao_embedding_training_data = {
-    "PAWSX": ["train"],
-    "QBQTC": ["train"],
-    "STSB": ["train"],
-    "TNews": ["train"],
-    "Waimai": ["train"],
-    "IFlyTek": ["train"],
-} | bge_chinese_training_data
+doubao_embedding_training_data = (
+    {
+        "PAWSX": ["train"],
+        "QBQTC": ["train"],
+        "STSB": ["train"],
+        "TNews": ["train"],
+        "Waimai": ["train"],
+        "IFlyTek": ["train"],
+        "MassiveScenarioClassification": ["train"],
+    }
+    | bge_chinese_training_data
+    | nvidia_training_datasets
+)
 
 
 class Seed16EmbeddingWrapper(Wrapper):


### PR DESCRIPTION
update training dataset info of Seed-1.6-embedding model according to this comment(https://github.com/embeddings-benchmark/results/pull/223#issuecomment-3004362026)

Checklist
- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [x] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e. is available either as an API or the wieght are publicly avaiable to download 