### PR TITLE
rename seed-1.6-embedding to seed1.6-embedding

### DIFF
--- a/mteb/models/seed_1_6_embedding_models.py
+++ b/mteb/models/seed_1_6_embedding_models.py
@@ -405,7 +405,7 @@ TASK_NAME_TO_INSTRUCTION = {
 
 
 seed_embedding = ModelMeta(
-    name="Bytedance/Seed-1.6-embedding",
+    name="Bytedance/Seed1.6-embedding",
     revision="1",
     release_date="2025-06-18",
     languages=[
@@ -414,7 +414,7 @@ seed_embedding = ModelMeta(
     ],
     loader=partial(
         Seed16EmbeddingWrapper,
-        model_name="Bytedance/Seed-1.6-embedding",
+        model_name="Bytedance/Seed1.6-embedding",
         max_tokens=32000,
         available_embed_dims=[2048, 1024],
     ),


### PR DESCRIPTION
Due to ByteDance's naming convention of seed models, rename seed-1.6-embedding to seed1.6-embedding

Checklist
- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [x] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e. is available either as an API or the wieght are publicly avaiable to download 
