### PR TITLE
Add and fix some Japanese datasets: ANLP datasets, JaCWIR, JQaRA

### DIFF
--- a/mteb/models/jina_models.py
+++ b/mteb/models/jina_models.py
@@ -10,10 +10,10 @@ import torch
 from sentence_transformers import __version__ as st_version
 
 from mteb.encoder_interface import PromptType
+from mteb.languages import PROGRAMMING_LANGS
 from mteb.model_meta import ModelMeta
 from mteb.models.sentence_transformer_wrapper import SentenceTransformerWrapper
 from mteb.requires_package import requires_package
-from mteb.languages import PROGRAMMING_LANGS
 
 logger = logging.getLogger(__name__)
 
@@ -234,8 +234,8 @@ class JinaV4Wrapper(SentenceTransformerWrapper):
         )
         requires_package(self, "peft", model, "pip install 'mteb[jina-v4]'")
         requires_package(self, "torchvision", model, "pip install 'mteb[jina-v4]'")
-        import peft  # noqa: F401
         import flash_attn  # noqa: F401
+        import peft  # noqa: F401
         import transformers  # noqa: F401
 
         super().__init__(model, revision, model_prompts, **kwargs)
@@ -284,8 +284,7 @@ class JinaV4Wrapper(SentenceTransformerWrapper):
 def get_programming_task_override(
     task_name: str, current_task_name: str | None
 ) -> str | None:
-    """
-    Check if task involves programming content and override with 'code' task if so.
+    """Check if task involves programming content and override with 'code' task if so.
 
     Args:
         task_name: Original task name to check

--- a/mteb/tasks/Reranking/__init__.py
+++ b/mteb/tasks/Reranking/__init__.py
@@ -9,6 +9,8 @@ from .eng.StackOverflowDupQuestions import *
 from .eng.WebLINXCandidatesReranking import *
 from .fra.AlloprofReranking import *
 from .fra.SyntecReranking import *
+from .jpn.JaCWIRReranking import *
+from .jpn.JQaRAReranking import *
 from .jpn.MMarcoReranking import *
 from .multilingual.ESCIReranking import *
 from .multilingual.MIRACLReranking import *

--- a/mteb/tasks/Reranking/jpn/JQaRAReranking.py
+++ b/mteb/tasks/Reranking/jpn/JQaRAReranking.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from typing import Any
+
+import datasets
+from datasets import Dataset
+
+from mteb.abstasks.AbsTaskReranking import AbsTaskReranking
+from mteb.abstasks.TaskMetadata import TaskMetadata
+from mteb.encoder_interface import Encoder
+from mteb.evaluation.evaluators import RerankingEvaluator
+from mteb.load_results.task_results import ScoresDict
+
+_EVAL_SPLIT = "test"
+
+
+class JQaRAReranking(AbsTaskReranking):
+    metadata = TaskMetadata(
+        name="JQaRAReranking",
+        description=(
+            "JQaRA: Japanese Question Answering with Retrieval Augmentation "
+            " - 検索拡張(RAG)評価のための日本語 Q&A データセット. JQaRA is an information retrieval task "
+            "for questions against 100 candidate data (including one or more correct answers)."
+        ),
+        reference="https://huggingface.co/datasets/hotchpotch/JQaRA",
+        dataset={
+            "path": "sbintuitions/JMTEB",
+            "revision": "b194332dfb8476c7bdd0aaf80e2c4f2a0b4274c2",
+            "trust_remote_code": True,
+        },
+        type="Reranking",
+        category="s2s",
+        modalities=["text"],
+        eval_splits=[_EVAL_SPLIT],
+        eval_langs=["jpn-Jpan"],
+        main_score="map",
+        date=("2020-01-01", "2024-12-31"),
+        domains=["Encyclopaedic", "Non-fiction", "Written"],
+        task_subtypes=["Question answering"],
+        license="cc-by-sa-4.0",
+        annotations_creators="derived",
+        dialect=["jpn-Jpan"],
+        sample_creation="found",
+        prompt="Given a Japanese question, rerank passages based on their relevance for answering the question",
+        bibtex_citation=r"""
+@misc{yuichi-tateno-2024-jqara,
+  author = {Yuichi Tateno},
+  title = {JQaRA: Japanese Question Answering with Retrieval Augmentation - 検索拡張(RAG)評価のための日本語Q&Aデータセット},
+  url = {https://huggingface.co/datasets/hotchpotch/JQaRA},
+}
+""",
+    )
+
+    def load_data(self, **kwargs):
+        if self.data_loaded:
+            return
+
+        # Load queries
+        query_list = datasets.load_dataset(
+            name="jqara-query",
+            split=_EVAL_SPLIT,
+            **self.metadata_dict["dataset"],
+        )
+
+        # Load corpus
+        corpus_list = datasets.load_dataset(
+            name="jqara-corpus",
+            split="corpus",
+            **self.metadata_dict["dataset"],
+        )
+
+        # Create corpus mapping
+        corpus_map = {}
+        for row in corpus_list:
+            corpus_map[str(row["docid"])] = row["text"]
+
+        # Transform data to RerankingEvaluator format
+        transformed_data = []
+        for row in query_list:
+            query = row["query"]
+            retrieved_docs = row["retrieved_docs"]
+            relevance_scores = row["relevance_scores"]
+
+            positive_docs = []
+            negative_docs = []
+
+            for doc_id, score in zip(retrieved_docs, relevance_scores):
+                doc_text = corpus_map.get(str(doc_id), "")
+                if doc_text:  # Only include documents that exist in corpus
+                    if score == 1:
+                        positive_docs.append(doc_text)
+                    else:
+                        negative_docs.append(doc_text)
+
+            # Only include samples with both positive and negative documents
+            if positive_docs and negative_docs:
+                transformed_data.append(
+                    {
+                        "query": query,
+                        "positive": positive_docs,
+                        "negative": negative_docs,
+                    }
+                )
+
+        # Convert to Dataset
+        from datasets import Dataset
+
+        self.dataset = {_EVAL_SPLIT: Dataset.from_list(transformed_data)}
+
+        self.data_loaded = True
+
+    def _evaluate_subset(
+        self,
+        model: Encoder,
+        data_split: Dataset,
+        *,
+        encode_kwargs: dict[str, Any] = {},
+        **kwargs: Any,
+    ) -> ScoresDict:
+        evaluator = RerankingEvaluator(
+            samples=data_split,
+            task_name=self.metadata.name,
+            encode_kwargs=encode_kwargs,
+            **kwargs,
+        )
+        scores = evaluator(model)
+
+        self._add_main_score(scores)
+        return scores

--- a/mteb/tasks/Reranking/jpn/JQaRAReranking.py
+++ b/mteb/tasks/Reranking/jpn/JQaRAReranking.py
@@ -1,15 +1,10 @@
 from __future__ import annotations
 
-from typing import Any
-
 import datasets
 from datasets import Dataset
 
 from mteb.abstasks.AbsTaskReranking import AbsTaskReranking
 from mteb.abstasks.TaskMetadata import TaskMetadata
-from mteb.encoder_interface import Encoder
-from mteb.evaluation.evaluators import RerankingEvaluator
-from mteb.load_results.task_results import ScoresDict
 
 _EVAL_SPLIT = "test"
 
@@ -106,22 +101,3 @@ class JQaRAReranking(AbsTaskReranking):
         self.dataset = {_EVAL_SPLIT: Dataset.from_list(transformed_data)}
         self.dataset_transform()  # do nothing
         self.data_loaded = True
-
-    def _evaluate_subset(
-        self,
-        model: Encoder,
-        data_split: Dataset,
-        *,
-        encode_kwargs: dict[str, Any] = {},
-        **kwargs: Any,
-    ) -> ScoresDict:
-        evaluator = RerankingEvaluator(
-            samples=data_split,
-            task_name=self.metadata.name,
-            encode_kwargs=encode_kwargs,
-            **kwargs,
-        )
-        scores = evaluator(model)
-
-        self._add_main_score(scores)
-        return scores

--- a/mteb/tasks/Reranking/jpn/JQaRAReranking.py
+++ b/mteb/tasks/Reranking/jpn/JQaRAReranking.py
@@ -103,10 +103,8 @@ class JQaRAReranking(AbsTaskReranking):
                 )
 
         # Convert to Dataset
-        from datasets import Dataset
-
         self.dataset = {_EVAL_SPLIT: Dataset.from_list(transformed_data)}
-
+        self.dataset_transform()  # do nothing
         self.data_loaded = True
 
     def _evaluate_subset(

--- a/mteb/tasks/Reranking/jpn/JaCWIRReranking.py
+++ b/mteb/tasks/Reranking/jpn/JaCWIRReranking.py
@@ -103,10 +103,8 @@ class JaCWIRReranking(AbsTaskReranking):
                 )
 
         # Convert to Dataset
-        from datasets import Dataset
-
         self.dataset = {_EVAL_SPLIT: Dataset.from_list(transformed_data)}
-
+        self.dataset_transform()  # do nothing
         self.data_loaded = True
 
     def _evaluate_subset(

--- a/mteb/tasks/Reranking/jpn/JaCWIRReranking.py
+++ b/mteb/tasks/Reranking/jpn/JaCWIRReranking.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from typing import Any
+
+import datasets
+from datasets import Dataset
+
+from mteb.abstasks.AbsTaskReranking import AbsTaskReranking
+from mteb.abstasks.TaskMetadata import TaskMetadata
+from mteb.encoder_interface import Encoder
+from mteb.evaluation.evaluators import RerankingEvaluator
+from mteb.load_results.task_results import ScoresDict
+
+_EVAL_SPLIT = "test"
+
+
+class JaCWIRReranking(AbsTaskReranking):
+    metadata = TaskMetadata(
+        name="JaCWIRReranking",
+        description=(
+            "JaCWIR is a small-scale Japanese information retrieval evaluation dataset consisting of "
+            "5000 question texts and approximately 500k web page titles and web page introductions or summaries "
+            "(meta descriptions, etc.). The question texts are created based on one of the 500k web pages, "
+            "and that data is used as a positive example for the question text."
+        ),
+        reference="https://huggingface.co/datasets/hotchpotch/JaCWIR",
+        dataset={
+            "path": "sbintuitions/JMTEB",
+            "revision": "b194332dfb8476c7bdd0aaf80e2c4f2a0b4274c2",
+            "trust_remote_code": True,
+        },
+        type="Reranking",
+        category="s2s",
+        modalities=["text"],
+        eval_splits=[_EVAL_SPLIT],
+        eval_langs=["jpn-Jpan"],
+        main_score="map",
+        date=("2020-01-01", "2024-12-31"),
+        domains=["Web", "Written"],
+        task_subtypes=["Article retrieval"],
+        license="not specified",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=r"""
+@misc{yuichi-tateno-2024-jacwir,
+  author = {Yuichi Tateno},
+  title = {JaCWIR: Japanese Casual Web IR - 日本語情報検索評価のための小規模でカジュアルなWebタイトルと概要のデータセット},
+  url = {https://huggingface.co/datasets/hotchpotch/JaCWIR},
+}
+""",
+    )
+
+    def load_data(self, **kwargs):
+        if self.data_loaded:
+            return
+
+        # Load queries
+        query_list = datasets.load_dataset(
+            name="jacwir-reranking-query",
+            split=_EVAL_SPLIT,
+            **self.metadata_dict["dataset"],
+        )
+
+        # Load corpus
+        corpus_list = datasets.load_dataset(
+            name="jacwir-reranking-corpus",
+            split="corpus",
+            **self.metadata_dict["dataset"],
+        )
+
+        # Create corpus mapping
+        corpus_map = {}
+        for row in corpus_list:
+            corpus_map[str(row["docid"])] = row["text"]
+
+        # Transform data to RerankingEvaluator format
+        transformed_data = []
+        for row in query_list:
+            query = row["query"]
+            retrieved_docs = row["retrieved_docs"]
+            relevance_scores = row["relevance_scores"]
+
+            positive_docs = []
+            negative_docs = []
+
+            for doc_id, score in zip(retrieved_docs, relevance_scores):
+                doc_text = corpus_map.get(str(doc_id), "")
+                if doc_text:  # Only include documents that exist in corpus
+                    if score == 1:
+                        positive_docs.append(doc_text)
+                    else:
+                        negative_docs.append(doc_text)
+
+            # Only include samples with both positive and negative documents
+            if positive_docs and negative_docs:
+                transformed_data.append(
+                    {
+                        "query": query,
+                        "positive": positive_docs,
+                        "negative": negative_docs,
+                    }
+                )
+
+        # Convert to Dataset
+        from datasets import Dataset
+
+        self.dataset = {_EVAL_SPLIT: Dataset.from_list(transformed_data)}
+
+        self.data_loaded = True
+
+    def _evaluate_subset(
+        self,
+        model: Encoder,
+        data_split: Dataset,
+        *,
+        encode_kwargs: dict[str, Any] = {},
+        **kwargs: Any,
+    ) -> ScoresDict:
+        evaluator = RerankingEvaluator(
+            samples=data_split,
+            task_name=self.metadata.name,
+            encode_kwargs=encode_kwargs,
+            **kwargs,
+        )
+        scores = evaluator(model)
+
+        self._add_main_score(scores)
+        return scores

--- a/mteb/tasks/Reranking/jpn/JaCWIRReranking.py
+++ b/mteb/tasks/Reranking/jpn/JaCWIRReranking.py
@@ -1,15 +1,10 @@
 from __future__ import annotations
 
-from typing import Any
-
 import datasets
 from datasets import Dataset
 
 from mteb.abstasks.AbsTaskReranking import AbsTaskReranking
 from mteb.abstasks.TaskMetadata import TaskMetadata
-from mteb.encoder_interface import Encoder
-from mteb.evaluation.evaluators import RerankingEvaluator
-from mteb.load_results.task_results import ScoresDict
 
 _EVAL_SPLIT = "test"
 
@@ -106,22 +101,3 @@ class JaCWIRReranking(AbsTaskReranking):
         self.dataset = {_EVAL_SPLIT: Dataset.from_list(transformed_data)}
         self.dataset_transform()  # do nothing
         self.data_loaded = True
-
-    def _evaluate_subset(
-        self,
-        model: Encoder,
-        data_split: Dataset,
-        *,
-        encode_kwargs: dict[str, Any] = {},
-        **kwargs: Any,
-    ) -> ScoresDict:
-        evaluator = RerankingEvaluator(
-            samples=data_split,
-            task_name=self.metadata.name,
-            encode_kwargs=encode_kwargs,
-            **kwargs,
-        )
-        scores = evaluator(model)
-
-        self._add_main_score(scores)
-        return scores

--- a/mteb/tasks/Retrieval/__init__.py
+++ b/mteb/tasks/Retrieval/__init__.py
@@ -113,9 +113,11 @@ from .fra.BSARDRetrieval import *
 from .fra.FQuADRetrieval import *
 from .fra.SyntecRetrieval import *
 from .hun.HunSum2 import *
+from .jpn.JaCWIRRetrieval import *
 from .jpn.JaGovFaqsRetrieval import *
 from .jpn.JaqketRetrieval import *
 from .jpn.JaQuADRetrieval import *
+from .jpn.NLPJournalAbsArticleRetrieval import *
 from .jpn.NLPJournalAbsIntroRetrieval import *
 from .jpn.NLPJournalTitleAbsRetrieval import *
 from .jpn.NLPJournalTitleIntroRetrieval import *

--- a/mteb/tasks/Retrieval/jpn/JaCWIRRetrieval.py
+++ b/mteb/tasks/Retrieval/jpn/JaCWIRRetrieval.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import datasets
+
+from mteb.abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+_EVAL_SPLIT = "test"
+
+
+class JaCWIRRetrieval(AbsTaskRetrieval):
+    ignore_identical_ids = True
+
+    metadata = TaskMetadata(
+        name="JaCWIRRetrieval",
+        description="""JaCWIR is a small-scale Japanese information retrieval evaluation dataset consisting of
+5000 question texts and approximately 500k web page titles and web page introductions or summaries
+(meta descriptions, etc.). The question texts are created based on one of the 500k web pages,
+and that data is used as a positive example for the question text.""",
+        reference="https://huggingface.co/datasets/hotchpotch/JaCWIR",
+        dataset={
+            "path": "sbintuitions/JMTEB",
+            "revision": "b194332dfb8476c7bdd0aaf80e2c4f2a0b4274c2",
+            "trust_remote_code": True,
+        },
+        type="Retrieval",
+        category="s2s",
+        modalities=["text"],
+        eval_splits=[_EVAL_SPLIT],
+        eval_langs=["jpn-Jpan"],
+        main_score="ndcg_at_10",
+        date=("2000-01-01", "2024-12-31"),
+        domains=["Web", "Written"],
+        task_subtypes=["Article retrieval"],
+        license="not specified",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=r"""
+@misc{yuichi-tateno-2024-jacwir,
+  author = {Yuichi Tateno},
+  title = {JaCWIR: Japanese Casual Web IR - 日本語情報検索評価のための小規模でカジュアルなWebタイトルと概要のデータセット},
+  url = {https://huggingface.co/datasets/hotchpotch/JaCWIR},
+}
+""",
+    )
+
+    def load_data(self, **kwargs):
+        if self.data_loaded:
+            return
+
+        query_list = datasets.load_dataset(
+            name="jacwir-retrieval-query",
+            split=_EVAL_SPLIT,
+            **self.metadata_dict["dataset"],
+        )
+
+        queries = {}
+        qrels = {}
+        for row_id, row in enumerate(query_list):
+            queries[str(row_id)] = row["query"]
+            # Handle relevant_docs which should be a list
+            relevant_docs = row["relevant_docs"]
+            if not isinstance(relevant_docs, list):
+                relevant_docs = [relevant_docs]
+            qrels[str(row_id)] = {str(doc_id): 1 for doc_id in relevant_docs}
+
+        corpus_list = datasets.load_dataset(
+            name="jacwir-retrieval-corpus",
+            split="corpus",
+            **self.metadata_dict["dataset"],
+        )
+
+        corpus = {str(row["docid"]): {"text": row["text"]} for row in corpus_list}
+
+        self.corpus = {_EVAL_SPLIT: corpus}
+        self.queries = {_EVAL_SPLIT: queries}
+        self.relevant_docs = {_EVAL_SPLIT: qrels}
+
+        self.data_loaded = True

--- a/mteb/tasks/Retrieval/jpn/NLPJournalAbsArticleRetrieval.py
+++ b/mteb/tasks/Retrieval/jpn/NLPJournalAbsArticleRetrieval.py
@@ -39,7 +39,15 @@ class NLPJournalAbsArticleRetrievalV2(AbsTaskRetrieval):
         annotations_creators="derived",
         dialect=[],
         sample_creation="found",
-        bibtex_citation="",
+        adapted_from=["NLPJournalAbsArticleRetrieval"],
+        bibtex_citation=r"""
+@misc{jmteb,
+  author = {Li, Shengzhe and Ohagi, Masaya and Ri, Ryokan},
+  howpublished = {\url{https://huggingface.co/datasets/sbintuitions/JMTEB}},
+  title = {{J}{M}{T}{E}{B}: {J}apanese {M}assive {T}ext {E}mbedding {B}enchmark},
+  year = {2024},
+}
+""",
     )
 
     def load_data(self, **kwargs):
@@ -104,7 +112,14 @@ class NLPJournalAbsArticleRetrieval(AbsTaskRetrieval):
         annotations_creators="derived",
         dialect=[],
         sample_creation="found",
-        bibtex_citation="",
+        bibtex_citation=r"""
+@misc{jmteb,
+  author = {Li, Shengzhe and Ohagi, Masaya and Ri, Ryokan},
+  howpublished = {\url{https://huggingface.co/datasets/sbintuitions/JMTEB}},
+  title = {{J}{M}{T}{E}{B}: {J}apanese {M}assive {T}ext {E}mbedding {B}enchmark},
+  year = {2024},
+}
+""",
     )
 
     def load_data(self, **kwargs):

--- a/mteb/tasks/Retrieval/jpn/NLPJournalAbsArticleRetrieval.py
+++ b/mteb/tasks/Retrieval/jpn/NLPJournalAbsArticleRetrieval.py
@@ -8,22 +8,23 @@ from mteb.abstasks.TaskMetadata import TaskMetadata
 _EVAL_SPLIT = "test"
 
 
-class NLPJournalAbsArticleRetrieval(AbsTaskRetrieval):
+class NLPJournalAbsArticleRetrievalV2(AbsTaskRetrieval):
     ignore_identical_ids = True
 
     metadata = TaskMetadata(
-        name="NLPJournalAbsArticleRetrieval",
+        name="NLPJournalAbsArticleRetrieval.V2",
         description=(
             "This dataset was created from the Japanese NLP Journal LaTeX Corpus. "
             "The titles, abstracts and introductions of the academic papers were shuffled. "
-            "The goal is to find the corresponding full article with the given abstract."
+            "The goal is to find the corresponding full article with the given abstract. "
+            "This is the V2 dataset (last updated 2025-06-15)."
         ),
         reference="https://huggingface.co/datasets/sbintuitions/JMTEB",
         dataset={
             "path": "sbintuitions/JMTEB",
             "revision": "b194332dfb8476c7bdd0aaf80e2c4f2a0b4274c2",
             "trust_remote_code": True,
-            "dataset_version": "latest",
+            "dataset_version": "v2",
         },
         type="Retrieval",
         category="s2s",
@@ -41,43 +42,91 @@ class NLPJournalAbsArticleRetrieval(AbsTaskRetrieval):
         bibtex_citation="",
     )
 
-    def __init__(self, dataset_version: str = "latest", **kwargs):
-        """Initialize the NLPJournalAbsArticleRetrieval task.
-
-        Args:
-            dataset_version: Version of the NLP Journal dataset to use.
-                           Options: "v1", "v2", "latest". Default is "latest".
-            **kwargs: placeholder
-        """
-        super().__init__(**kwargs)
-        self.dataset_version = dataset_version
-
     def load_data(self, **kwargs):
         if self.data_loaded:
             return
 
-        # Add dataset_version to the dataset loading kwargs
-        dataset_kwargs = self.metadata_dict["dataset"].copy()
-        dataset_kwargs["dataset_version"] = self.dataset_version
-
         query_list = datasets.load_dataset(
             name="nlp_journal_abs_article-query",
             split=_EVAL_SPLIT,
-            **dataset_kwargs,
+            **self.metadata_dict["dataset"],
         )
 
         queries = {}
         qrels = {}
         for row_id, row in enumerate(query_list):
             queries[str(row_id)] = row["query"]
-            # Handle relevant_docs which should be a list
-            relevant_docs = row["relevant_docs"]
-            if not isinstance(relevant_docs, list):
-                relevant_docs = [relevant_docs]
-            qrels[str(row_id)] = {str(doc_id): 1 for doc_id in relevant_docs}
+            qrels[str(row_id)] = {str(row["relevant_docs"]): 1}
 
         corpus_list = datasets.load_dataset(
-            name="nlp_journal_abs_article-corpus", split="corpus", **dataset_kwargs
+            name="nlp_journal_abs_article-corpus",
+            split="corpus",
+            **self.metadata_dict["dataset"],
+        )
+
+        corpus = {str(row["docid"]): {"text": row["text"]} for row in corpus_list}
+
+        self.corpus = {_EVAL_SPLIT: corpus}
+        self.queries = {_EVAL_SPLIT: queries}
+        self.relevant_docs = {_EVAL_SPLIT: qrels}
+
+        self.data_loaded = True
+
+
+class NLPJournalAbsArticleRetrieval(AbsTaskRetrieval):
+    ignore_identical_ids = True
+
+    metadata = TaskMetadata(
+        name="NLPJournalAbsArticleRetrieval",
+        description=(
+            "This dataset was created from the Japanese NLP Journal LaTeX Corpus. "
+            "The titles, abstracts and introductions of the academic papers were shuffled. "
+            "The goal is to find the corresponding full article with the given abstract. "
+            "This is the V1 dataset (last updated 2020-06-15)."
+        ),
+        reference="https://huggingface.co/datasets/sbintuitions/JMTEB",
+        dataset={
+            "path": "sbintuitions/JMTEB",
+            "revision": "b194332dfb8476c7bdd0aaf80e2c4f2a0b4274c2",
+            "trust_remote_code": True,
+            "dataset_version": "v1",
+        },
+        type="Retrieval",
+        category="s2s",
+        modalities=["text"],
+        eval_splits=[_EVAL_SPLIT],
+        eval_langs=["jpn-Jpan"],
+        main_score="ndcg_at_10",
+        date=("1994-10-10", "2020-06-15"),
+        domains=["Academic", "Written"],
+        task_subtypes=["Article retrieval"],
+        license="cc-by-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation="",
+    )
+
+    def load_data(self, **kwargs):
+        if self.data_loaded:
+            return
+
+        query_list = datasets.load_dataset(
+            name="nlp_journal_abs_article-query",
+            split=_EVAL_SPLIT,
+            **self.metadata_dict["dataset"],
+        )
+
+        queries = {}
+        qrels = {}
+        for row_id, row in enumerate(query_list):
+            queries[str(row_id)] = row["query"]
+            qrels[str(row_id)] = {str(row["relevant_docs"]): 1}
+
+        corpus_list = datasets.load_dataset(
+            name="nlp_journal_abs_article-corpus",
+            split="corpus",
+            **self.metadata_dict["dataset"],
         )
 
         corpus = {str(row["docid"]): {"text": row["text"]} for row in corpus_list}

--- a/mteb/tasks/Retrieval/jpn/NLPJournalAbsArticleRetrieval.py
+++ b/mteb/tasks/Retrieval/jpn/NLPJournalAbsArticleRetrieval.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import datasets
+
+from mteb.abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+_EVAL_SPLIT = "test"
+
+
+class NLPJournalAbsArticleRetrieval(AbsTaskRetrieval):
+    ignore_identical_ids = True
+
+    metadata = TaskMetadata(
+        name="NLPJournalAbsArticleRetrieval",
+        description=(
+            "This dataset was created from the Japanese NLP Journal LaTeX Corpus. "
+            "The titles, abstracts and introductions of the academic papers were shuffled. "
+            "The goal is to find the corresponding full article with the given abstract."
+        ),
+        reference="https://huggingface.co/datasets/sbintuitions/JMTEB",
+        dataset={
+            "path": "sbintuitions/JMTEB",
+            "revision": "b194332dfb8476c7bdd0aaf80e2c4f2a0b4274c2",
+            "trust_remote_code": True,
+            "dataset_version": "latest",
+        },
+        type="Retrieval",
+        category="s2s",
+        modalities=["text"],
+        eval_splits=[_EVAL_SPLIT],
+        eval_langs=["jpn-Jpan"],
+        main_score="ndcg_at_10",
+        date=("1994-10-10", "2025-06-15"),
+        domains=["Academic", "Written"],
+        task_subtypes=["Article retrieval"],
+        license="cc-by-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation="",
+    )
+
+    def __init__(self, dataset_version: str = "latest", **kwargs):
+        """Initialize the NLPJournalAbsArticleRetrieval task.
+
+        Args:
+            dataset_version: Version of the NLP Journal dataset to use.
+                           Options: "v1", "v2", "latest". Default is "latest".
+            **kwargs: placeholder
+        """
+        super().__init__(**kwargs)
+        self.dataset_version = dataset_version
+
+    def load_data(self, **kwargs):
+        if self.data_loaded:
+            return
+
+        # Add dataset_version to the dataset loading kwargs
+        dataset_kwargs = self.metadata_dict["dataset"].copy()
+        dataset_kwargs["dataset_version"] = self.dataset_version
+
+        query_list = datasets.load_dataset(
+            name="nlp_journal_abs_article-query",
+            split=_EVAL_SPLIT,
+            **dataset_kwargs,
+        )
+
+        queries = {}
+        qrels = {}
+        for row_id, row in enumerate(query_list):
+            queries[str(row_id)] = row["query"]
+            # Handle relevant_docs which should be a list
+            relevant_docs = row["relevant_docs"]
+            if not isinstance(relevant_docs, list):
+                relevant_docs = [relevant_docs]
+            qrels[str(row_id)] = {str(doc_id): 1 for doc_id in relevant_docs}
+
+        corpus_list = datasets.load_dataset(
+            name="nlp_journal_abs_article-corpus", split="corpus", **dataset_kwargs
+        )
+
+        corpus = {str(row["docid"]): {"text": row["text"]} for row in corpus_list}
+
+        self.corpus = {_EVAL_SPLIT: corpus}
+        self.queries = {_EVAL_SPLIT: queries}
+        self.relevant_docs = {_EVAL_SPLIT: qrels}
+
+        self.data_loaded = True

--- a/mteb/tasks/Retrieval/jpn/NLPJournalAbsIntroRetrieval.py
+++ b/mteb/tasks/Retrieval/jpn/NLPJournalAbsIntroRetrieval.py
@@ -11,12 +11,17 @@ _EVAL_SPLIT = "test"
 class NLPJournalAbsIntroRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="NLPJournalAbsIntroRetrieval",
-        description="This dataset was created from the Japanese NLP Journal LaTeX Corpus. The titles, abstracts and introductions of the academic papers were shuffled. The goal is to find the corresponding introduction with the given abstract.",
-        reference="https://github.com/sbintuitions/JMTEB",
+        description=(
+            "This dataset was created from the Japanese NLP Journal LaTeX Corpus. "
+            "The titles, abstracts and introductions of the academic papers were shuffled. "
+            "The goal is to find the corresponding introduction with the given abstract."
+        ),
+        reference="https://huggingface.co/datasets/sbintuitions/JMTEB",
         dataset={
             "path": "sbintuitions/JMTEB",
-            "revision": "e4af6c73182bebb41d94cb336846e5a452454ea7",
+            "revision": "b194332dfb8476c7bdd0aaf80e2c4f2a0b4274c2",
             "trust_remote_code": True,
+            "dataset_version": "latest",
         },
         type="Retrieval",
         category="s2s",
@@ -24,9 +29,9 @@ class NLPJournalAbsIntroRetrieval(AbsTaskRetrieval):
         eval_splits=[_EVAL_SPLIT],
         eval_langs=["jpn-Jpan"],
         main_score="ndcg_at_10",
-        date=("2000-01-01", "2023-12-31"),
+        date=("1994-10-10", "2025-06-15"),
         domains=["Academic", "Written"],
-        task_subtypes=[],
+        task_subtypes=["Article retrieval"],
         license="cc-by-4.0",
         annotations_creators="derived",
         dialect=[],
@@ -34,14 +39,29 @@ class NLPJournalAbsIntroRetrieval(AbsTaskRetrieval):
         bibtex_citation="",
     )
 
+    def __init__(self, dataset_version: str = "latest", **kwargs):
+        """Initialize the NLPJournalAbsIntroRetrieval task.
+
+        Args:
+            dataset_version: Version of the NLP Journal dataset to use.
+                           Options: "v1", "v2", "latest". Default is "latest".
+            **kwargs: placeholder
+        """
+        super().__init__(**kwargs)
+        self.dataset_version = dataset_version
+
     def load_data(self, **kwargs):
         if self.data_loaded:
             return
 
+        # Add dataset_version to the dataset loading kwargs
+        dataset_kwargs = self.metadata_dict["dataset"].copy()
+        dataset_kwargs["dataset_version"] = self.dataset_version
+
         query_list = datasets.load_dataset(
             name="nlp_journal_abs_intro-query",
             split=_EVAL_SPLIT,
-            **self.metadata_dict["dataset"],
+            **dataset_kwargs,
         )
 
         queries = {}
@@ -53,7 +73,7 @@ class NLPJournalAbsIntroRetrieval(AbsTaskRetrieval):
         corpus_list = datasets.load_dataset(
             name="nlp_journal_abs_intro-corpus",
             split="corpus",
-            **self.metadata_dict["dataset"],
+            **dataset_kwargs,
         )
 
         corpus = {str(row["docid"]): {"text": row["text"]} for row in corpus_list}

--- a/mteb/tasks/Retrieval/jpn/NLPJournalAbsIntroRetrieval.py
+++ b/mteb/tasks/Retrieval/jpn/NLPJournalAbsIntroRetrieval.py
@@ -37,7 +37,15 @@ class NLPJournalAbsIntroRetrievalV2(AbsTaskRetrieval):
         annotations_creators="derived",
         dialect=[],
         sample_creation="found",
-        bibtex_citation="",
+        adapted_from=["NLPJournalAbsIntroRetrieval"],
+        bibtex_citation=r"""
+@misc{jmteb,
+  author = {Li, Shengzhe and Ohagi, Masaya and Ri, Ryokan},
+  howpublished = {\url{https://huggingface.co/datasets/sbintuitions/JMTEB}},
+  title = {{J}{M}{T}{E}{B}: {J}apanese {M}assive {T}ext {E}mbedding {B}enchmark},
+  year = {2024},
+}
+""",
     )
 
     def load_data(self, **kwargs):
@@ -100,7 +108,14 @@ class NLPJournalAbsIntroRetrieval(AbsTaskRetrieval):
         annotations_creators="derived",
         dialect=[],
         sample_creation="found",
-        bibtex_citation="",
+        bibtex_citation=r"""
+@misc{jmteb,
+  author = {Li, Shengzhe and Ohagi, Masaya and Ri, Ryokan},
+  howpublished = {\url{https://huggingface.co/datasets/sbintuitions/JMTEB}},
+  title = {{J}{M}{T}{E}{B}: {J}apanese {M}assive {T}ext {E}mbedding {B}enchmark},
+  year = {2024},
+}
+""",
     )
 
     def load_data(self, **kwargs):

--- a/mteb/tasks/Retrieval/jpn/NLPJournalTitleAbsRetrieval.py
+++ b/mteb/tasks/Retrieval/jpn/NLPJournalTitleAbsRetrieval.py
@@ -8,20 +8,21 @@ from mteb.abstasks.TaskMetadata import TaskMetadata
 _EVAL_SPLIT = "test"
 
 
-class NLPJournalTitleAbsRetrieval(AbsTaskRetrieval):
+class NLPJournalTitleAbsRetrievalV2(AbsTaskRetrieval):
     metadata = TaskMetadata(
-        name="NLPJournalTitleAbsRetrieval",
+        name="NLPJournalTitleAbsRetrieval.V2",
         description=(
             "This dataset was created from the Japanese NLP Journal LaTeX Corpus. "
             "The titles, abstracts and introductions of the academic papers were shuffled. "
-            "The goal is to find the corresponding abstract with the given title."
+            "The goal is to find the corresponding abstract with the given title. "
+            "This is the V2 dataset (last updated 2025-06-15)."
         ),
         reference="https://huggingface.co/datasets/sbintuitions/JMTEB",
         dataset={
             "path": "sbintuitions/JMTEB",
             "revision": "b194332dfb8476c7bdd0aaf80e2c4f2a0b4274c2",
             "trust_remote_code": True,
-            "dataset_version": "latest",
+            "dataset_version": "v2",
         },
         type="Retrieval",
         category="s2s",
@@ -39,29 +40,14 @@ class NLPJournalTitleAbsRetrieval(AbsTaskRetrieval):
         bibtex_citation="",
     )
 
-    def __init__(self, dataset_version: str = "latest", **kwargs):
-        """Initialize the NLPJournalTitleAbsRetrieval task.
-
-        Args:
-            dataset_version: Version of the NLP Journal dataset to use.
-                           Options: "v1", "v2", "latest". Default is "latest".
-            **kwargs: placeholder
-        """
-        super().__init__(**kwargs)
-        self.dataset_version = dataset_version
-
     def load_data(self, **kwargs):
         if self.data_loaded:
             return
 
-        # Add dataset_version to the dataset loading kwargs
-        dataset_kwargs = self.metadata_dict["dataset"].copy()
-        dataset_kwargs["dataset_version"] = self.dataset_version
-
         query_list = datasets.load_dataset(
             name="nlp_journal_title_abs-query",
             split=_EVAL_SPLIT,
-            **dataset_kwargs,
+            **self.metadata_dict["dataset"],
         )
 
         queries = {}
@@ -73,7 +59,70 @@ class NLPJournalTitleAbsRetrieval(AbsTaskRetrieval):
         corpus_list = datasets.load_dataset(
             name="nlp_journal_title_abs-corpus",
             split="corpus",
-            **dataset_kwargs,
+            **self.metadata_dict["dataset"],
+        )
+
+        corpus = {str(row["docid"]): {"text": row["text"]} for row in corpus_list}
+
+        self.corpus = {_EVAL_SPLIT: corpus}
+        self.queries = {_EVAL_SPLIT: queries}
+        self.relevant_docs = {_EVAL_SPLIT: qrels}
+
+        self.data_loaded = True
+
+
+class NLPJournalTitleAbsRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="NLPJournalTitleAbsRetrieval",
+        description=(
+            "This dataset was created from the Japanese NLP Journal LaTeX Corpus. "
+            "The titles, abstracts and introductions of the academic papers were shuffled. "
+            "The goal is to find the corresponding abstract with the given title. "
+            "This is the V1 dataset (last updated 2020-06-15)."
+        ),
+        reference="https://huggingface.co/datasets/sbintuitions/JMTEB",
+        dataset={
+            "path": "sbintuitions/JMTEB",
+            "revision": "b194332dfb8476c7bdd0aaf80e2c4f2a0b4274c2",
+            "trust_remote_code": True,
+            "dataset_version": "v1",
+        },
+        type="Retrieval",
+        category="s2s",
+        modalities=["text"],
+        eval_splits=[_EVAL_SPLIT],
+        eval_langs=["jpn-Jpan"],
+        main_score="ndcg_at_10",
+        date=("1994-10-10", "2020-06-15"),
+        domains=["Academic", "Written"],
+        task_subtypes=["Article retrieval"],
+        license="cc-by-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation="",
+    )
+
+    def load_data(self, **kwargs):
+        if self.data_loaded:
+            return
+
+        query_list = datasets.load_dataset(
+            name="nlp_journal_title_abs-query",
+            split=_EVAL_SPLIT,
+            **self.metadata_dict["dataset"],
+        )
+
+        queries = {}
+        qrels = {}
+        for row_id, row in enumerate(query_list):
+            queries[str(row_id)] = row["query"]
+            qrels[str(row_id)] = {str(row["relevant_docs"]): 1}
+
+        corpus_list = datasets.load_dataset(
+            name="nlp_journal_title_abs-corpus",
+            split="corpus",
+            **self.metadata_dict["dataset"],
         )
 
         corpus = {str(row["docid"]): {"text": row["text"]} for row in corpus_list}

--- a/mteb/tasks/Retrieval/jpn/NLPJournalTitleAbsRetrieval.py
+++ b/mteb/tasks/Retrieval/jpn/NLPJournalTitleAbsRetrieval.py
@@ -37,7 +37,15 @@ class NLPJournalTitleAbsRetrievalV2(AbsTaskRetrieval):
         annotations_creators="derived",
         dialect=[],
         sample_creation="found",
-        bibtex_citation="",
+        adapted_from=["NLPJournalTitleAbsRetrieval"],
+        bibtex_citation=r"""
+@misc{jmteb,
+  author = {Li, Shengzhe and Ohagi, Masaya and Ri, Ryokan},
+  howpublished = {\url{https://huggingface.co/datasets/sbintuitions/JMTEB}},
+  title = {{J}{M}{T}{E}{B}: {J}apanese {M}assive {T}ext {E}mbedding {B}enchmark},
+  year = {2024},
+}
+""",
     )
 
     def load_data(self, **kwargs):
@@ -100,7 +108,14 @@ class NLPJournalTitleAbsRetrieval(AbsTaskRetrieval):
         annotations_creators="derived",
         dialect=[],
         sample_creation="found",
-        bibtex_citation="",
+        bibtex_citation=r"""
+@misc{jmteb,
+  author = {Li, Shengzhe and Ohagi, Masaya and Ri, Ryokan},
+  howpublished = {\url{https://huggingface.co/datasets/sbintuitions/JMTEB}},
+  title = {{J}{M}{T}{E}{B}: {J}apanese {M}assive {T}ext {E}mbedding {B}enchmark},
+  year = {2024},
+}
+""",
     )
 
     def load_data(self, **kwargs):

--- a/mteb/tasks/Retrieval/jpn/NLPJournalTitleAbsRetrieval.py
+++ b/mteb/tasks/Retrieval/jpn/NLPJournalTitleAbsRetrieval.py
@@ -11,12 +11,17 @@ _EVAL_SPLIT = "test"
 class NLPJournalTitleAbsRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="NLPJournalTitleAbsRetrieval",
-        description="This dataset was created from the Japanese NLP Journal LaTeX Corpus. The titles, abstracts and introductions of the academic papers were shuffled. The goal is to find the corresponding abstract with the given title.",
-        reference="https://github.com/sbintuitions/JMTEB",
+        description=(
+            "This dataset was created from the Japanese NLP Journal LaTeX Corpus. "
+            "The titles, abstracts and introductions of the academic papers were shuffled. "
+            "The goal is to find the corresponding abstract with the given title."
+        ),
+        reference="https://huggingface.co/datasets/sbintuitions/JMTEB",
         dataset={
             "path": "sbintuitions/JMTEB",
-            "revision": "e4af6c73182bebb41d94cb336846e5a452454ea7",
+            "revision": "b194332dfb8476c7bdd0aaf80e2c4f2a0b4274c2",
             "trust_remote_code": True,
+            "dataset_version": "latest",
         },
         type="Retrieval",
         category="s2s",
@@ -24,9 +29,9 @@ class NLPJournalTitleAbsRetrieval(AbsTaskRetrieval):
         eval_splits=[_EVAL_SPLIT],
         eval_langs=["jpn-Jpan"],
         main_score="ndcg_at_10",
-        date=("2000-01-01", "2023-12-31"),
+        date=("1994-10-10", "2025-06-15"),
         domains=["Academic", "Written"],
-        task_subtypes=[],
+        task_subtypes=["Article retrieval"],
         license="cc-by-4.0",
         annotations_creators="derived",
         dialect=[],
@@ -34,14 +39,29 @@ class NLPJournalTitleAbsRetrieval(AbsTaskRetrieval):
         bibtex_citation="",
     )
 
+    def __init__(self, dataset_version: str = "latest", **kwargs):
+        """Initialize the NLPJournalTitleAbsRetrieval task.
+
+        Args:
+            dataset_version: Version of the NLP Journal dataset to use.
+                           Options: "v1", "v2", "latest". Default is "latest".
+            **kwargs: placeholder
+        """
+        super().__init__(**kwargs)
+        self.dataset_version = dataset_version
+
     def load_data(self, **kwargs):
         if self.data_loaded:
             return
 
+        # Add dataset_version to the dataset loading kwargs
+        dataset_kwargs = self.metadata_dict["dataset"].copy()
+        dataset_kwargs["dataset_version"] = self.dataset_version
+
         query_list = datasets.load_dataset(
             name="nlp_journal_title_abs-query",
             split=_EVAL_SPLIT,
-            **self.metadata_dict["dataset"],
+            **dataset_kwargs,
         )
 
         queries = {}
@@ -53,7 +73,7 @@ class NLPJournalTitleAbsRetrieval(AbsTaskRetrieval):
         corpus_list = datasets.load_dataset(
             name="nlp_journal_title_abs-corpus",
             split="corpus",
-            **self.metadata_dict["dataset"],
+            **dataset_kwargs,
         )
 
         corpus = {str(row["docid"]): {"text": row["text"]} for row in corpus_list}

--- a/mteb/tasks/Retrieval/jpn/NLPJournalTitleIntroRetrieval.py
+++ b/mteb/tasks/Retrieval/jpn/NLPJournalTitleIntroRetrieval.py
@@ -11,12 +11,17 @@ _EVAL_SPLIT = "test"
 class NLPJournalTitleIntroRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="NLPJournalTitleIntroRetrieval",
-        description="This dataset was created from the Japanese NLP Journal LaTeX Corpus. The titles, abstracts and introductions of the academic papers were shuffled. The goal is to find the corresponding introduction with the given title.",
-        reference="https://github.com/sbintuitions/JMTEB",
+        description=(
+            "This dataset was created from the Japanese NLP Journal LaTeX Corpus. "
+            "The titles, abstracts and introductions of the academic papers were shuffled. "
+            "The goal is to find the corresponding introduction with the given title."
+        ),
+        reference="https://huggingface.co/datasets/sbintuitions/JMTEB",
         dataset={
             "path": "sbintuitions/JMTEB",
-            "revision": "e4af6c73182bebb41d94cb336846e5a452454ea7",
+            "revision": "b194332dfb8476c7bdd0aaf80e2c4f2a0b4274c2",
             "trust_remote_code": True,
+            "dataset_version": "latest",
         },
         type="Retrieval",
         category="s2s",
@@ -24,9 +29,9 @@ class NLPJournalTitleIntroRetrieval(AbsTaskRetrieval):
         eval_splits=[_EVAL_SPLIT],
         eval_langs=["jpn-Jpan"],
         main_score="ndcg_at_10",
-        date=("2000-01-01", "2023-12-31"),
+        date=("1994-10-10", "2025-06-15"),
         domains=["Academic", "Written"],
-        task_subtypes=[],
+        task_subtypes=["Article retrieval"],
         license="cc-by-4.0",
         annotations_creators="derived",
         dialect=[],
@@ -34,14 +39,29 @@ class NLPJournalTitleIntroRetrieval(AbsTaskRetrieval):
         bibtex_citation="",
     )
 
+    def __init__(self, dataset_version: str = "latest", **kwargs):
+        """Initialize the NLPJournalTitleIntroRetrieval task.
+
+        Args:
+            dataset_version: Version of the NLP Journal dataset to use.
+                           Options: "v1", "v2", "latest". Default is "latest".
+            **kwargs: placeholder
+        """
+        super().__init__(**kwargs)
+        self.dataset_version = dataset_version
+
     def load_data(self, **kwargs):
         if self.data_loaded:
             return
 
+        # Add dataset_version to the dataset loading kwargs
+        dataset_kwargs = self.metadata_dict["dataset"].copy()
+        dataset_kwargs["dataset_version"] = self.dataset_version
+
         query_list = datasets.load_dataset(
             name="nlp_journal_title_intro-query",
             split=_EVAL_SPLIT,
-            **self.metadata_dict["dataset"],
+            **dataset_kwargs,
         )
 
         queries = {}
@@ -53,7 +73,7 @@ class NLPJournalTitleIntroRetrieval(AbsTaskRetrieval):
         corpus_list = datasets.load_dataset(
             name="nlp_journal_title_intro-corpus",
             split="corpus",
-            **self.metadata_dict["dataset"],
+            **dataset_kwargs,
         )
 
         corpus = {str(row["docid"]): {"text": row["text"]} for row in corpus_list}

--- a/mteb/tasks/Retrieval/jpn/NLPJournalTitleIntroRetrieval.py
+++ b/mteb/tasks/Retrieval/jpn/NLPJournalTitleIntroRetrieval.py
@@ -37,7 +37,15 @@ class NLPJournalTitleIntroRetrievalV2(AbsTaskRetrieval):
         annotations_creators="derived",
         dialect=[],
         sample_creation="found",
-        bibtex_citation="",
+        adapted_from=["NLPJournalTitleIntroRetrieval"],
+        bibtex_citation=r"""
+@misc{jmteb,
+  author = {Li, Shengzhe and Ohagi, Masaya and Ri, Ryokan},
+  howpublished = {\url{https://huggingface.co/datasets/sbintuitions/JMTEB}},
+  title = {{J}{M}{T}{E}{B}: {J}apanese {M}assive {T}ext {E}mbedding {B}enchmark},
+  year = {2024},
+}
+""",
     )
 
     def load_data(self, **kwargs):
@@ -100,7 +108,14 @@ class NLPJournalTitleIntroRetrieval(AbsTaskRetrieval):
         annotations_creators="derived",
         dialect=[],
         sample_creation="found",
-        bibtex_citation="",
+        bibtex_citation=r"""
+@misc{jmteb,
+  author = {Li, Shengzhe and Ohagi, Masaya and Ri, Ryokan},
+  howpublished = {\url{https://huggingface.co/datasets/sbintuitions/JMTEB}},
+  title = {{J}{M}{T}{E}{B}: {J}apanese {M}assive {T}ext {E}mbedding {B}enchmark},
+  year = {2024},
+}
+""",
     )
 
     def load_data(self, **kwargs):

--- a/mteb/tasks/Retrieval/jpn/NLPJournalTitleIntroRetrieval.py
+++ b/mteb/tasks/Retrieval/jpn/NLPJournalTitleIntroRetrieval.py
@@ -8,20 +8,21 @@ from mteb.abstasks.TaskMetadata import TaskMetadata
 _EVAL_SPLIT = "test"
 
 
-class NLPJournalTitleIntroRetrieval(AbsTaskRetrieval):
+class NLPJournalTitleIntroRetrievalV2(AbsTaskRetrieval):
     metadata = TaskMetadata(
-        name="NLPJournalTitleIntroRetrieval",
+        name="NLPJournalTitleIntroRetrieval.V2",
         description=(
             "This dataset was created from the Japanese NLP Journal LaTeX Corpus. "
             "The titles, abstracts and introductions of the academic papers were shuffled. "
-            "The goal is to find the corresponding introduction with the given title."
+            "The goal is to find the corresponding introduction with the given title. "
+            "This is the V2 dataset (last updated 2025-06-15)."
         ),
         reference="https://huggingface.co/datasets/sbintuitions/JMTEB",
         dataset={
             "path": "sbintuitions/JMTEB",
             "revision": "b194332dfb8476c7bdd0aaf80e2c4f2a0b4274c2",
             "trust_remote_code": True,
-            "dataset_version": "latest",
+            "dataset_version": "v2",
         },
         type="Retrieval",
         category="s2s",
@@ -39,29 +40,14 @@ class NLPJournalTitleIntroRetrieval(AbsTaskRetrieval):
         bibtex_citation="",
     )
 
-    def __init__(self, dataset_version: str = "latest", **kwargs):
-        """Initialize the NLPJournalTitleIntroRetrieval task.
-
-        Args:
-            dataset_version: Version of the NLP Journal dataset to use.
-                           Options: "v1", "v2", "latest". Default is "latest".
-            **kwargs: placeholder
-        """
-        super().__init__(**kwargs)
-        self.dataset_version = dataset_version
-
     def load_data(self, **kwargs):
         if self.data_loaded:
             return
 
-        # Add dataset_version to the dataset loading kwargs
-        dataset_kwargs = self.metadata_dict["dataset"].copy()
-        dataset_kwargs["dataset_version"] = self.dataset_version
-
         query_list = datasets.load_dataset(
             name="nlp_journal_title_intro-query",
             split=_EVAL_SPLIT,
-            **dataset_kwargs,
+            **self.metadata_dict["dataset"],
         )
 
         queries = {}
@@ -73,7 +59,70 @@ class NLPJournalTitleIntroRetrieval(AbsTaskRetrieval):
         corpus_list = datasets.load_dataset(
             name="nlp_journal_title_intro-corpus",
             split="corpus",
-            **dataset_kwargs,
+            **self.metadata_dict["dataset"],
+        )
+
+        corpus = {str(row["docid"]): {"text": row["text"]} for row in corpus_list}
+
+        self.corpus = {_EVAL_SPLIT: corpus}
+        self.queries = {_EVAL_SPLIT: queries}
+        self.relevant_docs = {_EVAL_SPLIT: qrels}
+
+        self.data_loaded = True
+
+
+class NLPJournalTitleIntroRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="NLPJournalTitleIntroRetrieval",
+        description=(
+            "This dataset was created from the Japanese NLP Journal LaTeX Corpus. "
+            "The titles, abstracts and introductions of the academic papers were shuffled. "
+            "The goal is to find the corresponding introduction with the given title. "
+            "This is the V1 dataset (last updated 2020-06-15)."
+        ),
+        reference="https://huggingface.co/datasets/sbintuitions/JMTEB",
+        dataset={
+            "path": "sbintuitions/JMTEB",
+            "revision": "b194332dfb8476c7bdd0aaf80e2c4f2a0b4274c2",
+            "trust_remote_code": True,
+            "dataset_version": "v1",
+        },
+        type="Retrieval",
+        category="s2s",
+        modalities=["text"],
+        eval_splits=[_EVAL_SPLIT],
+        eval_langs=["jpn-Jpan"],
+        main_score="ndcg_at_10",
+        date=("1994-10-10", "2020-06-15"),
+        domains=["Academic", "Written"],
+        task_subtypes=["Article retrieval"],
+        license="cc-by-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation="",
+    )
+
+    def load_data(self, **kwargs):
+        if self.data_loaded:
+            return
+
+        query_list = datasets.load_dataset(
+            name="nlp_journal_title_intro-query",
+            split=_EVAL_SPLIT,
+            **self.metadata_dict["dataset"],
+        )
+
+        queries = {}
+        qrels = {}
+        for row_id, row in enumerate(query_list):
+            queries[str(row_id)] = row["query"]
+            qrels[str(row_id)] = {str(row["relevant_docs"]): 1}
+
+        corpus_list = datasets.load_dataset(
+            name="nlp_journal_title_intro-corpus",
+            split="corpus",
+            **self.metadata_dict["dataset"],
         )
 
         corpus = {str(row["docid"]): {"text": row["text"]} for row in corpus_list}


### PR DESCRIPTION
## What's this PR

### New datasets

I added the following new Japanese datasets

- [JaCWIR](https://huggingface.co/datasets/hotchpotch/JaCWIR) for retrieval and reranking
- [JQaRA](https://huggingface.co/datasets/hotchpotch/JQaRA) for reranking

I [added](https://huggingface.co/datasets/sbintuitions/JMTEB/discussions/3) them to [JMTEB](https://huggingface.co/datasets/sbintuitions/JMTEB) (Japanese MTEB) and now synchronize them to MTEB.

### Fix existing datasets, make them versioned and add another variant

I also fixed the ANLP related datasets (`NLPJournalTitleIntroRetrieval`, `NLPJournalTitleAbsRetrieval`, `NLPJournalAbsIntroRetrieval`) as the origin dataset has been updated. For reproductivity purpose, I separated v1 (~2020-06-15, has been used for a while) and v2 (~2025-06-15, recently updated) by accessing to `dataset_version` in JMTEB to make it available to access the previous version (for reproducing results until March 2025) and the current version (with more articles). 

_I also added a new dataset (`NLPJournalAbsArticleRetrieval` and its v2) for testing the performance in longer texts.

### Summarization

To summarize, this PR added the following Japanese datasets

- JaCWIRRetrieval
- NLPJournalAbsArticleRetrieval
- JaCWIRReranking
- JQaRAReranking
- NLPJournalAbsArticleRetrieval.V2
- NLPJournalTitleIntroRetrieval.V2
- NLPJournalTitleAbsRetrieval.V2
- NLPJournalAbsIntroRetrieval.V2

and updated the following datasets

- NLPJournalTitleIntroRetrieval
- NLPJournalTitleAbsRetrieval
- NLPJournalAbsIntroRetrieval

## Checklist

- [x] I have outlined why this dataset is filling an existing gap in `mteb`
- [x] I have tested that the dataset runs with the `mteb` package.

An easy way to test it is using:
```python
from mteb import MTEB
from sentence_transformers import SentenceTransformer

# Define the sentence-transformers model name
model_name = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"

model = SentenceTransformer(model_name)
evaluation = MTEB(tasks=[YourNewTask()])
```

- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
  - [x] `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
  - [x] `intfloat/multilingual-e5-small`
  - [x] (as an example of Japanese monolingual model) `cl-nagoya/ruri-v3-130m`
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [x] I have considered the size of the dataset and reduced it if it is too big (2048 examples is typically large enough for most tasks)
