### PR TITLE
fix tests to be compatible with `SentenceTransformers` `v5`

### DIFF
--- a/mteb/models/jina_models.py
+++ b/mteb/models/jina_models.py
@@ -10,10 +10,10 @@ import torch
 from sentence_transformers import __version__ as st_version
 
 from mteb.encoder_interface import PromptType
+from mteb.languages import PROGRAMMING_LANGS
 from mteb.model_meta import ModelMeta
 from mteb.models.sentence_transformer_wrapper import SentenceTransformerWrapper
 from mteb.requires_package import requires_package
-from mteb.languages import PROGRAMMING_LANGS
 
 logger = logging.getLogger(__name__)
 
@@ -234,8 +234,8 @@ class JinaV4Wrapper(SentenceTransformerWrapper):
         )
         requires_package(self, "peft", model, "pip install 'mteb[jina-v4]'")
         requires_package(self, "torchvision", model, "pip install 'mteb[jina-v4]'")
-        import peft  # noqa: F401
         import flash_attn  # noqa: F401
+        import peft  # noqa: F401
         import transformers  # noqa: F401
 
         super().__init__(model, revision, model_prompts, **kwargs)
@@ -284,8 +284,7 @@ class JinaV4Wrapper(SentenceTransformerWrapper):
 def get_programming_task_override(
     task_name: str, current_task_name: str | None
 ) -> str | None:
-    """
-    Check if task involves programming content and override with 'code' task if so.
+    """Check if task involves programming content and override with 'code' task if so.
 
     Args:
         task_name: Original task name to check

--- a/tests/test_benchmark/mock_models.py
+++ b/tests/test_benchmark/mock_models.py
@@ -133,6 +133,8 @@ class MockSentenceTransformer(SentenceTransformer):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        # by default, in SentenceTransformer, prompts are `{"query": "", "document": ""}`
+        self.prompts = {}
 
     def encode(
         self,

--- a/tests/test_benchmark/test_benchmark.py
+++ b/tests/test_benchmark/test_benchmark.py
@@ -9,7 +9,6 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 import torch
-from sentence_transformers import SentenceTransformer
 
 import mteb
 import mteb.overview
@@ -114,7 +113,7 @@ def test_prompt_name_passed_to_all_encodes(
             assert prompt_name == _task_name
             return np.zeros((len(sentences), 10))
 
-    class EncoderWithoutInstructions(SentenceTransformer):
+    class EncoderWithoutInstructions(MockSentenceTransformer):
         def encode(self, sentences, **kwargs):
             assert kwargs["prompt_name"] is None
             return super().encode(sentences, **kwargs)
@@ -138,7 +137,8 @@ def test_prompt_name_passed_to_all_encodes(
         overwrite_results=True,
     )
     # Test that the task_name is not passed down to the encoder
-    model = EncoderWithoutInstructions("average_word_embeddings_levy_dependency")
+    model = EncoderWithoutInstructions()
+    model.prompts = {}
     assert model.prompts == {}, "The encoder should not have any prompts"
     eval.run(model, output_folder=tmp_path.as_posix(), overwrite_results=True)
 

--- a/tests/test_benchmark/test_benchmark.py
+++ b/tests/test_benchmark/test_benchmark.py
@@ -138,7 +138,6 @@ def test_prompt_name_passed_to_all_encodes(
     )
     # Test that the task_name is not passed down to the encoder
     model = EncoderWithoutInstructions()
-    model.prompts = {}
     assert model.prompts == {}, "The encoder should not have any prompts"
     eval.run(model, output_folder=tmp_path.as_posix(), overwrite_results=True)
 


### PR DESCRIPTION
Previously, tests are failing with error. I think `average_word_embeddings_levy_dependency` is not fully compatible now
```
FAILED tests/test_benchmark/test_benchmark.py::test_prompt_name_passed_to_all_encodes[task_name0] - ValueError: A configuration of type rag cannot be instantiated because both `question_encoder` and `generator` sub-configurations were not passed, only {'attn_implementation': None}
```

If you add a model or a dataset, please add the corresponding checklist:

* [dataset checklist](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md#submit-a-pr)
* [model checklist](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_model.md#submitting-your-model-as-a-pr)
