### PR TITLE
mock implementation of sparse Encoders

### DIFF
--- a/mteb/evaluation/evaluators/ClusteringEvaluator.py
+++ b/mteb/evaluation/evaluators/ClusteringEvaluator.py
@@ -7,6 +7,7 @@ import sklearn
 import sklearn.cluster
 from datasets import Dataset
 from sklearn import metrics
+import torch
 from torch.utils.data import DataLoader
 
 from mteb.abstasks.task_metadata import TaskMetadata
@@ -50,6 +51,9 @@ class ClusteringEvaluator(Evaluator):
             batch_size=self.clustering_batch_size,
             n_init="auto",
         )
+        # TODO: refactor:
+        if isinstance(corpus_embeddings, torch.Tensor) and corpus_embeddings.is_sparse:
+            corpus_embeddings = corpus_embeddings.to_dense()
         clustering_model.fit(corpus_embeddings)
         cluster_assignment = clustering_model.labels_
 

--- a/tests/test_benchmark/test_benchmark.py
+++ b/tests/test_benchmark/test_benchmark.py
@@ -27,6 +27,7 @@ from .mock_models import (
     MockSentenceTransformer,
     MockSentenceTransformersbf16Encoder,
     MockSentenceTransformerWrapper,
+    MockSparseEncoder,
     MockTorchEncoder,
     MockTorchfp16Encoder,
 )
@@ -64,6 +65,7 @@ def test_mulitple_mteb_tasks(tasks: list[AbsTask], model: mteb.Encoder, tmp_path
         MockTorchEncoder(),
         MockTorchfp16Encoder(),
         MockSentenceTransformersbf16Encoder(),
+        MockSparseEncoder(),
     ],
 )
 def test_benchmark_encoders_on_task(


### PR DESCRIPTION
Implements a naïve support for some for sparse encoders. The goal here is to capture some of the problems we have to solve.

Generally it seems like the we can't slice or index a sparse tensor and thus have to implement wrappers for these.

When we hand the vector off to a classfier we have to convert it to dense (even though the classifier itself does support sparse matrices, e.g. for logistic regression).

intended as a comment for #2873
