### PR TITLE
fix: Prevent incorrectly passing "selector_state" to `get_benchmark`

### DIFF
--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -16,10 +16,10 @@ import pandas as pd
 
 import mteb
 from mteb.abstasks.TaskMetadata import TASK_DOMAIN, TASK_TYPE
-from mteb.benchmarks.benchmarks import MTEB_multilingual
 from mteb.custom_validators import MODALITIES
 from mteb.leaderboard.benchmark_selector import (
     BENCHMARK_ENTRIES,
+    DEFAULT_BENCHMARK_NAME,
     make_selector,
 )
 from mteb.leaderboard.figures import performance_size_plot, radar_chart
@@ -57,9 +57,6 @@ def produce_benchmark_link(benchmark_name: str, request: gr.Request) -> str:
     url = f"{base_url}?{params}"
     md = f"```\n{url}\n```"
     return md
-
-
-DEFAULT_BENCHMARK_NAME = MTEB_multilingual.name
 
 
 def set_benchmark_on_load(request: gr.Request):

--- a/mteb/leaderboard/benchmark_selector.py
+++ b/mteb/leaderboard/benchmark_selector.py
@@ -5,7 +5,10 @@ from dataclasses import dataclass
 import gradio as gr
 
 import mteb
+from build.lib.mteb.benchmarks.benchmarks import MTEB_multilingual
 from mteb import Benchmark
+
+DEFAULT_BENCHMARK_NAME = MTEB_multilingual.name
 
 
 @dataclass
@@ -136,7 +139,7 @@ def make_selector(entries: list[MenuEntry]) -> tuple[gr.State, gr.Column]:
     button_counter = 0
 
     with gr.Column() as column:
-        state = gr.State("selector_state")
+        state = gr.State(DEFAULT_BENCHMARK_NAME)
 
         for category_entry in entries:
             button_counter = _render_category(


### PR DESCRIPTION
The leaderboard would have (silent) errors where `get_benchmark` lead to a KeyError due to "selector_state" being passed as a default value. Setting `DEFAULT_BENCMARK_NAME` as the value solves this issue.
