### PR TITLE
dataset: add BillSum datasets

### DIFF
--- a/mteb/leaderboard/benchmark_selector.py
+++ b/mteb/leaderboard/benchmark_selector.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import gradio as gr
+from build.lib.mteb.benchmarks.benchmarks import MTEB_multilingual
 
 import mteb
-from build.lib.mteb.benchmarks.benchmarks import MTEB_multilingual
 from mteb import Benchmark
 
 DEFAULT_BENCHMARK_NAME = MTEB_multilingual.name

--- a/mteb/tasks/Classification/slk/CSFDSKMovieReviewSentimentClassification.py
+++ b/mteb/tasks/Classification/slk/CSFDSKMovieReviewSentimentClassification.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from mteb.abstasks.AbsTaskClassification import AbsTaskClassification
 from mteb.abstasks.TaskMetadata import TaskMetadata
 
+N_SAMPLES = 2048
 
 class CSFDSKMovieReviewSentimentClassification(AbsTaskClassification):
     superseded_by = "CSFDSKMovieReviewSentimentClassification.v2"
@@ -43,8 +44,6 @@ class CSFDSKMovieReviewSentimentClassification(AbsTaskClassification):
     samples_per_label = 20
 
     def dataset_transform(self):
-        N_SAMPLES = 2048
-
         self.dataset = self.dataset.rename_columns(
             {"comment": "text", "rating_int": "label"}
         )

--- a/mteb/tasks/Classification/slk/CSFDSKMovieReviewSentimentClassification.py
+++ b/mteb/tasks/Classification/slk/CSFDSKMovieReviewSentimentClassification.py
@@ -5,6 +5,7 @@ from mteb.abstasks.TaskMetadata import TaskMetadata
 
 N_SAMPLES = 2048
 
+
 class CSFDSKMovieReviewSentimentClassification(AbsTaskClassification):
     superseded_by = "CSFDSKMovieReviewSentimentClassification.v2"
     metadata = TaskMetadata(

--- a/mteb/tasks/Retrieval/__init__.py
+++ b/mteb/tasks/Retrieval/__init__.py
@@ -29,6 +29,8 @@ from .eng.AILAStatutesRetrieval import *
 from .eng.AlphaNLIRetrieval import *
 from .eng.ARCChallengeRetrieval import *
 from .eng.ArguAnaRetrieval import *
+from .eng.BillSumCA import *
+from .eng.BillSumUS import *
 from .eng.BrightRetrieval import *
 from .eng.BuiltBenchRetrieval import *
 from .eng.ChemHotpotQARetrieval import *

--- a/mteb/tasks/Retrieval/eng/BarExamQA.py
+++ b/mteb/tasks/Retrieval/eng/BarExamQA.py
@@ -27,17 +27,20 @@ class BarExamQA(AbsTaskRetrieval):
         annotations_creators="expert-annotated",
         dialect=[],
         sample_creation="found",
-        bibtex_citation="""\
-@inproceedings{Zheng_2025, series={CSLAW ’25},
-   title={A Reasoning-Focused Legal Retrieval Benchmark},
-   url={http://dx.doi.org/10.1145/3709025.3712219},
-   DOI={10.1145/3709025.3712219},
-   booktitle={Proceedings of the Symposium on Computer Science and Law on ZZZ},
-   publisher={ACM},
-   author={Zheng, Lucia and Guha, Neel and Arifov, Javokhir and Zhang, Sarah and Skreta, Michal and Manning, Christopher D. and Henderson, Peter and Ho, Daniel E.},
-   year={2025},
-   month=mar, pages={169–193},
-   collection={CSLAW ’25},
-   eprint={2505.03970}
-}""",
+        bibtex_citation=r"""
+@inproceedings{Zheng_2025,
+  author = {Zheng, Lucia and Guha, Neel and Arifov, Javokhir and Zhang, Sarah and Skreta, Michal and Manning, Christopher D. and Henderson, Peter and Ho, Daniel E.},
+  booktitle = {Proceedings of the Symposium on Computer Science and Law on ZZZ},
+  collection = {CSLAW ’25},
+  doi = {10.1145/3709025.3712219},
+  eprint = {2505.03970},
+  month = mar,
+  pages = {169–193},
+  publisher = {ACM},
+  series = {CSLAW ’25},
+  title = {A Reasoning-Focused Legal Retrieval Benchmark},
+  url = {http://dx.doi.org/10.1145/3709025.3712219},
+  year = {2025},
+}
+""",
     )

--- a/mteb/tasks/Retrieval/eng/BillSumCA.py
+++ b/mteb/tasks/Retrieval/eng/BillSumCA.py
@@ -8,7 +8,7 @@ from ....abstasks.AbsTaskRetrieval import AbsTaskRetrieval
 class BillSumCA(AbsTaskRetrieval):
     metadata = TaskMetadata(
         dataset={
-            "path": "isaacus/mteb-BillSumUS",
+            "path": "isaacus/mteb-BillSumCA",
             "revision": "5014f29d7fdde6f9073a75b72be53ed73eed60c6",
         },
         name="BillSumCA",

--- a/mteb/tasks/Retrieval/eng/BillSumCA.py
+++ b/mteb/tasks/Retrieval/eng/BillSumCA.py
@@ -22,7 +22,7 @@ class BillSumCA(AbsTaskRetrieval):
         main_score="ndcg_at_10",
         date=("2024-08-14", "2025-07-18"),
         domains=["Legal", "Government"],
-        task_subtypes=None,
+        task_subtypes=[],
         license="cc0-1.0",
         annotations_creators="expert-annotated",
         dialect=[],

--- a/mteb/tasks/Retrieval/eng/BillSumCA.py
+++ b/mteb/tasks/Retrieval/eng/BillSumCA.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+from ....abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+
+
+class BillSumCA(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        dataset={
+            "path": "isaacus/mteb-BillSumUS",
+            "revision": "5014f29d7fdde6f9073a75b72be53ed73eed60c6",
+        },
+        name="BillSumCA",
+        description="A benchmark for retrieving Californian bills based on summary prompts.",
+        reference="https://huggingface.co/datasets/FiscalNote/billsum",
+        type="Retrieval",
+        category="t2t",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2024-08-14", "2025-07-18"),
+        domains=["Legal", "Government"],
+        task_subtypes=None,
+        license="cc0-1.0",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation="""\
+@inproceedings{Eidelman_2019,
+   title={BillSum: A Corpus for Automatic Summarization of US Legislation},
+   url={http://dx.doi.org/10.18653/v1/D19-5406},
+   DOI={10.18653/v1/d19-5406},
+   booktitle={Proceedings of the 2nd Workshop on New Frontiers in Summarization},
+   publisher={Association for Computational Linguistics},
+   author={Eidelman, Vladimir},
+   year={2019},
+   pages={48–56} }
+""",
+    )

--- a/mteb/tasks/Retrieval/eng/BillSumCA.py
+++ b/mteb/tasks/Retrieval/eng/BillSumCA.py
@@ -27,15 +27,16 @@ class BillSumCA(AbsTaskRetrieval):
         annotations_creators="expert-annotated",
         dialect=[],
         sample_creation="found",
-        bibtex_citation="""\
+        bibtex_citation=r"""
 @inproceedings{Eidelman_2019,
-   title={BillSum: A Corpus for Automatic Summarization of US Legislation},
-   url={http://dx.doi.org/10.18653/v1/D19-5406},
-   DOI={10.18653/v1/d19-5406},
-   booktitle={Proceedings of the 2nd Workshop on New Frontiers in Summarization},
-   publisher={Association for Computational Linguistics},
-   author={Eidelman, Vladimir},
-   year={2019},
-   pages={48–56} }
+  author = {Eidelman, Vladimir},
+  booktitle = {Proceedings of the 2nd Workshop on New Frontiers in Summarization},
+  doi = {10.18653/v1/d19-5406},
+  pages = {48–56},
+  publisher = {Association for Computational Linguistics},
+  title = {BillSum: A Corpus for Automatic Summarization of US Legislation},
+  url = {http://dx.doi.org/10.18653/v1/D19-5406},
+  year = {2019},
+}
 """,
     )

--- a/mteb/tasks/Retrieval/eng/BillSumCA.py
+++ b/mteb/tasks/Retrieval/eng/BillSumCA.py
@@ -12,7 +12,7 @@ class BillSumCA(AbsTaskRetrieval):
             "revision": "5014f29d7fdde6f9073a75b72be53ed73eed60c6",
         },
         name="BillSumCA",
-        description="A benchmark for retrieving Californian bills based on summary prompts.",
+        description="A benchmark for retrieving Californian bills based on their summaries.",
         reference="https://huggingface.co/datasets/FiscalNote/billsum",
         type="Retrieval",
         category="t2t",

--- a/mteb/tasks/Retrieval/eng/BillSumUS.py
+++ b/mteb/tasks/Retrieval/eng/BillSumUS.py
@@ -12,7 +12,7 @@ class BillSumUS(AbsTaskRetrieval):
             "revision": "0c063eb9b2f3085bbbc48f8d51f21a179254187e",
         },
         name="BillSumUS",
-        description="A benchmark for retrieving US bills based on summary prompts.",
+        description="A benchmark for retrieving US federal bills based on their summaries.",
         reference="https://huggingface.co/datasets/FiscalNote/billsum",
         type="Retrieval",
         category="t2t",

--- a/mteb/tasks/Retrieval/eng/BillSumUS.py
+++ b/mteb/tasks/Retrieval/eng/BillSumUS.py
@@ -27,15 +27,16 @@ class BillSumUS(AbsTaskRetrieval):
         annotations_creators="expert-annotated",
         dialect=[],
         sample_creation="found",
-        bibtex_citation="""\
+        bibtex_citation=r"""
 @inproceedings{Eidelman_2019,
-   title={BillSum: A Corpus for Automatic Summarization of US Legislation},
-   url={http://dx.doi.org/10.18653/v1/D19-5406},
-   DOI={10.18653/v1/d19-5406},
-   booktitle={Proceedings of the 2nd Workshop on New Frontiers in Summarization},
-   publisher={Association for Computational Linguistics},
-   author={Eidelman, Vladimir},
-   year={2019},
-   pages={48–56} }
+  author = {Eidelman, Vladimir},
+  booktitle = {Proceedings of the 2nd Workshop on New Frontiers in Summarization},
+  doi = {10.18653/v1/d19-5406},
+  pages = {48–56},
+  publisher = {Association for Computational Linguistics},
+  title = {BillSum: A Corpus for Automatic Summarization of US Legislation},
+  url = {http://dx.doi.org/10.18653/v1/D19-5406},
+  year = {2019},
+}
 """,
     )

--- a/mteb/tasks/Retrieval/eng/BillSumUS.py
+++ b/mteb/tasks/Retrieval/eng/BillSumUS.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+from ....abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+
+
+class BillSumUS(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        dataset={
+            "path": "isaacus/mteb-BillSumUS",
+            "revision": "0c063eb9b2f3085bbbc48f8d51f21a179254187e",
+        },
+        name="BillSumUS",
+        description="A benchmark for retrieving US bills based on summary prompts.",
+        reference="https://huggingface.co/datasets/FiscalNote/billsum",
+        type="Retrieval",
+        category="t2t",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2024-08-14", "2025-07-18"),
+        domains=["Legal", "Government"],
+        task_subtypes=None,
+        license="cc0-1.0",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation="""\
+@inproceedings{Eidelman_2019,
+   title={BillSum: A Corpus for Automatic Summarization of US Legislation},
+   url={http://dx.doi.org/10.18653/v1/D19-5406},
+   DOI={10.18653/v1/d19-5406},
+   booktitle={Proceedings of the 2nd Workshop on New Frontiers in Summarization},
+   publisher={Association for Computational Linguistics},
+   author={Eidelman, Vladimir},
+   year={2019},
+   pages={48–56} }
+""",
+    )

--- a/mteb/tasks/Retrieval/eng/BillSumUS.py
+++ b/mteb/tasks/Retrieval/eng/BillSumUS.py
@@ -22,7 +22,7 @@ class BillSumUS(AbsTaskRetrieval):
         main_score="ndcg_at_10",
         date=("2024-08-14", "2025-07-18"),
         domains=["Legal", "Government"],
-        task_subtypes=None,
+        task_subtypes=[],
         license="cc0-1.0",
         annotations_creators="expert-annotated",
         dialect=[],


### PR DESCRIPTION
Hi,
I’m submitting this pull request to push the [Californian](https://huggingface.co/datasets/isaacus/mteb-BillSumCA) and [US](https://huggingface.co/datasets/isaacus/mteb-BillSumUS) splits of the [BillSum](https://huggingface.co/datasets/FiscalNote/billsum) dataset to MTEB.

BillSum is a dataset created by FiscalNote for the purposes of training and evaluating models capable of summarizing federal and state legislation.

We have reframed the problem in terms of the retrieval of bills based on their summaries, making our reformatted datasets suitable for the evaluation of legal information retrieval models.

We want to improve the coverage of legal domain tasks on MTEB and we believe this dataset will contribute to increasing the diversity and difficulty of MTEB.

This pull request is being submitted courtesy of [Isaacus, a legal AI research company](https://isaacus.com/).

You may find the original dataset here:
https://huggingface.co/datasets/FiscalNote/billsum

Note that the original dataset contained a large number of examples in both the federal US and Californian test splits and so, we have reduced both splits to 500 randomly selected examples.

## Checklist
- [x] I have outlined why this dataset is filling an existing gap in mteb
- [x] I have tested that the dataset runs with the mteb package.
- [x] I have run the following models on the task (adding the results to the pr). These can be run using the mteb run -m {model_name} -t {task_name} command.
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [x] I have considered the size of the dataset and reduced it if it is too big (2048 examples is typically large enough for most tasks)