### PR TITLE
dataset: add GovReport dataset

### DIFF
--- a/mteb/tasks/Retrieval/eng/GovReport.py
+++ b/mteb/tasks/Retrieval/eng/GovReport.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+from ....abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+
+
+class GovReport(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        dataset={
+            "path": "isaacus/mteb-GovReport",
+            "revision": "4482db2a053706c0aef0ab7bf1878d29bb0295f8",
+        },
+        name="GovReport",
+        description="This dataset tests the ability of information retrieval models to identify US government reports.",
+        reference="https://huggingface.co/datasets/launch/gov_report",
+        type="Retrieval",
+        category="t2t",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2021-06-06", "2025-07-28"),
+        domains=["Legal", "Government"],
+        task_subtypes=[],
+        license="cc-by-4.0",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation="""\
+@inproceedings{huang-etal-2021-efficient,
+    title = "Efficient Attentions for Long Document Summarization",
+    author = "Huang, Luyang  and
+      Cao, Shuyang  and
+      Parulian, Nikolaus  and
+      Ji, Heng  and
+      Wang, Lu",
+    booktitle = "Proceedings of the 2021 Conference of the North American Chapter of the Association for Computational Linguistics: Human Language Technologies",
+    month = jun,
+    year = "2021",
+    address = "Online",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2021.naacl-main.112",
+    doi = "10.18653/v1/2021.naacl-main.112",
+    pages = "1419--1436",
+    abstract = "The quadratic computational and memory complexities of large Transformers have limited their scalability for long document summarization. In this paper, we propose Hepos, a novel efficient encoder-decoder attention with head-wise positional strides to effectively pinpoint salient information from the source. We further conduct a systematic study of existing efficient self-attentions. Combined with Hepos, we are able to process ten times more tokens than existing models that use full attentions. For evaluation, we present a new dataset, GovReport, with significantly longer documents and summaries. Results show that our models produce significantly higher ROUGE scores than competitive comparisons, including new state-of-the-art results on PubMed. Human evaluation also shows that our models generate more informative summaries with fewer unfaithful errors.",
+    eprint={2104.02112}
+}""",
+    )

--- a/mteb/tasks/Retrieval/eng/GovReport.py
+++ b/mteb/tasks/Retrieval/eng/GovReport.py
@@ -12,7 +12,7 @@ class GovReport(AbsTaskRetrieval):
             "revision": "4482db2a053706c0aef0ab7bf1878d29bb0295f8",
         },
         name="GovReport",
-        description="This dataset tests the ability of information retrieval models to identify US government reports.",
+        description="A dataset for evaluating the ability of information retrieval models to retrieve lengthy US government reports from their summaries.",
         reference="https://huggingface.co/datasets/launch/gov_report",
         type="Retrieval",
         category="t2t",


### PR DESCRIPTION
Hi,
I’m submitting this pull request to push the [GovReport](https://huggingface.co/datasets/launch/gov_report) dataset to MTEB.
 
GovReport is a dataset created by LAUNCH Lab for the purposes of training and evaluating models capable of summarizing lengthy (on average, 9k-tokens-long) US government reports.
 
We have reframed the problem in terms of the retrieval of reports based on their summaries, making our reformatted datasets suitable for the evaluation of legal and governmental information retrieval models.
We want to improve the coverage of legal tasks on MTEB and we believe this dataset will contribute to increasing the diversity and difficulty of MTEB.
This pull request is being submitted courtesy of [Isaacus, a legal AI research company](https://isaacus.com/).
 
You may find the original dataset here:
https://huggingface.co/datasets/launch/gov_report
 
## Checklist
- [x] I have outlined why this dataset is filling an existing gap in mteb
- [x] I have tested that the dataset runs with the mteb package.
- [x] I have run the following models on the task (adding the results to the pr). These can be run using the mteb run -m {model_name} -t {task_name} command.
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [x] I have considered the size of the dataset and reduced it if it is too big (2048 examples is typically large enough for most tasks)