### PR TITLE
[v2] `mteb.evaluate` now saves `model_meta.json`

### DIFF
--- a/mteb/cache.py
+++ b/mteb/cache.py
@@ -10,8 +10,6 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, cast
 
-from idna import encode
-
 from mteb.abstasks.AbsTask import AbsTask
 from mteb.load_results.benchmark_results import BenchmarkResults, ModelResult
 from mteb.load_results.task_results import TaskResult

--- a/mteb/cache.py
+++ b/mteb/cache.py
@@ -8,7 +8,7 @@ import subprocess
 from collections import defaultdict
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, cast
+from typing import cast
 
 from mteb.abstasks.AbsTask import AbsTask
 from mteb.load_results.benchmark_results import BenchmarkResults, ModelResult
@@ -138,7 +138,6 @@ class ResultCache:
         task_result: TaskResult,
         model_name: str | ModelMeta,
         model_revision: str | None = None,
-        encode_kwargs: dict[str, Any] | None = None,
     ) -> None:
         """Save the task results to the local cache directory in the location {model_name}/{model_revision}/{task_name}.json. Where model_name is a
         path-normalized model name. In addition we also save a model_meta.json in the revision folder to preserve the model metadata.

--- a/tests/test_evaluation/test_evaluate.py
+++ b/tests/test_evaluation/test_evaluate.py
@@ -7,6 +7,7 @@ import pytest
 import mteb
 from mteb.abstasks.AbsTask import AbsTask
 from mteb.cache import ResultCache
+from mteb.models import model_meta
 from mteb.models.encoder_interface import Encoder
 from tests.test_benchmark.mock_models import MockSentenceTransformer
 from tests.test_benchmark.mock_tasks import (
@@ -52,8 +53,10 @@ def test_evaluate_with_cache(
         results.model_name.replace("/", "__"),
         results.model_revision,  # type: ignore
     )
+    model_meta_path = path.parent / "model_meta.json"
     assert path.exists() and path.is_file(), "cache file should exist"
     assert path.suffix == ".json", "cache file should be a json file"
+    assert model_meta_path.exists(), "no model meta path is saved"
 
     result = results[0]
     assert result.task_name == task.metadata.name, "results should match the task"

--- a/tests/test_evaluation/test_evaluate.py
+++ b/tests/test_evaluation/test_evaluate.py
@@ -7,7 +7,6 @@ import pytest
 import mteb
 from mteb.abstasks.AbsTask import AbsTask
 from mteb.cache import ResultCache
-from mteb.models import model_meta
 from mteb.models.encoder_interface import Encoder
 from tests.test_benchmark.mock_models import MockSentenceTransformer
 from tests.test_benchmark.mock_tasks import (


### PR DESCRIPTION
Fixes #2847
