### PR TITLE
Editing init to add GovReport and BarExamQA tasks

### DIFF
--- a/mteb/tasks/Retrieval/__init__.py
+++ b/mteb/tasks/Retrieval/__init__.py
@@ -29,6 +29,7 @@ from .eng.AILAStatutesRetrieval import *
 from .eng.AlphaNLIRetrieval import *
 from .eng.ARCChallengeRetrieval import *
 from .eng.ArguAnaRetrieval import *
+from .eng.BarExamQA import *
 from .eng.BillSumCA import *
 from .eng.BillSumUS import *
 from .eng.BrightRetrieval import *
@@ -53,6 +54,7 @@ from .eng.FaithDialRetrieval import *
 from .eng.FeedbackQARetrieval import *
 from .eng.FEVERRetrieval import *
 from .eng.FiQA2018Retrieval import *
+from .eng.GovReport import *
 from .eng.HagridRetrieval import *
 from .eng.HellaSwagRetrieval import *
 from .eng.HotpotQARetrieval import *


### PR DESCRIPTION
I have edited the Retrieval init file to import the previously added GovReport and BarExamQA tasks so that they are visible to users.  This PR is to update the changes.