### PR TITLE
fix: Rename GovReport to GovReportRetrieval and ensure it is imported

### DIFF
--- a/mteb/tasks/Retrieval/__init__.py
+++ b/mteb/tasks/Retrieval/__init__.py
@@ -53,6 +53,7 @@ from .eng.FaithDialRetrieval import *
 from .eng.FeedbackQARetrieval import *
 from .eng.FEVERRetrieval import *
 from .eng.FiQA2018Retrieval import *
+from .eng.GovReport import *
 from .eng.HagridRetrieval import *
 from .eng.HellaSwagRetrieval import *
 from .eng.HotpotQARetrieval import *

--- a/mteb/tasks/Retrieval/eng/GovReport.py
+++ b/mteb/tasks/Retrieval/eng/GovReport.py
@@ -11,7 +11,7 @@ class GovReport(AbsTaskRetrieval):
             "path": "isaacus/mteb-GovReport",
             "revision": "4482db2a053706c0aef0ab7bf1878d29bb0295f8",
         },
-        name="GovReport",
+        name="GovReportRetrieval",
         description="A dataset for evaluating the ability of information retrieval models to retrieve lengthy US government reports from their summaries.",
         reference="https://huggingface.co/datasets/launch/gov_report",
         type="Retrieval",


### PR DESCRIPTION
Rename for consistency and import to make sure `get_task` works