### PR TITLE
Add Voyage 3.5 model configuration

### DIFF
--- a/mteb/models/voyage_models.py
+++ b/mteb/models/voyage_models.py
@@ -143,6 +143,31 @@ model_prompts = {
     PromptType.document.value: "document",
 }
 
+voyage_3_5 = ModelMeta(
+    name="voyageai/voyage-3.5",
+    revision="1",
+    release_date="2025-01-21",
+    languages=None,  # supported languages not specified
+    loader=partial(
+        VoyageWrapper,
+        model_name="voyage-3.5",
+        model_prompts=model_prompts,
+    ),
+    max_tokens=32000,
+    embed_dim=1024,
+    open_weights=False,
+    n_parameters=None,
+    memory_usage_mb=None,
+    license=None,
+    reference="https://docs.voyageai.com/docs/embeddings",
+    similarity_fn_name="cosine",
+    framework=["API"],
+    use_instructions=True,
+    training_datasets=VOYAGE_TRAINING_DATA,
+    public_training_code=None,
+    public_training_data=None,
+)
+
 voyage_large_2_instruct = ModelMeta(
     name="voyageai/voyage-large-2-instruct",
     revision="1",


### PR DESCRIPTION
- [ ] I have filled out the ModelMeta object to the extent possible
- [ ]  I have ensured that my model can be loaded using
  - [ ]  mteb.get_model(model_name, revision) and
  - [ ]  mteb.get_model_meta(model_name, revision)
- [ ] I have tested the implementation works on a representative set of tasks.
- [ ] The model is public, i.e. is available either as an API or the wieght are publicly avaiable to download