### PR TITLE
Add OpenAI models with 512 dimension

### DIFF
--- a/mteb/models/openai_models.py
+++ b/mteb/models/openai_models.py
@@ -224,3 +224,57 @@ text_embedding_ada_002 = ModelMeta(
     license=None,
     similarity_fn_name=None,
 )
+
+text_embedding_3_small_512 = ModelMeta(
+    name="openai/text-embedding-3-small-dim-512",
+    revision="3",
+    release_date="2024-01-25",
+    languages=None,  # supported languages not specified
+    loader=partial(  # type: ignore
+        OpenAIWrapper,
+        model_name="text-embedding-3-small",
+        tokenizer_name="cl100k_base",
+        max_tokens=8191,
+        embed_dim=512,
+    ),
+    max_tokens=8191,
+    embed_dim=512,
+    open_weights=False,
+    n_parameters=None,
+    memory_usage_mb=None,
+    license=None,
+    reference="https://openai.com/index/new-embedding-models-and-api-updates/",
+    similarity_fn_name="cosine",
+    framework=["API"],
+    use_instructions=False,
+    public_training_code=None,
+    public_training_data=None,  # assumed
+    training_datasets=None,
+)
+
+text_embedding_3_large_512 = ModelMeta(
+    name="openai/text-embedding-3-large-dim-512",
+    revision="3",
+    release_date="2024-01-25",
+    languages=None,  # supported languages not specified
+    loader=partial(  # type: ignore
+        OpenAIWrapper,
+        model_name="text-embedding-3-large",
+        tokenizer_name="cl100k_base",
+        max_tokens=8191,
+        embed_dim=512,
+    ),
+    max_tokens=8191,
+    embed_dim=512,
+    open_weights=False,
+    reference="https://openai.com/index/new-embedding-models-and-api-updates/",
+    framework=["API"],
+    use_instructions=False,
+    n_parameters=None,
+    memory_usage_mb=None,
+    public_training_code=None,
+    public_training_data=None,  # assumed
+    training_datasets=None,
+    license=None,
+    similarity_fn_name=None,
+)

--- a/mteb/models/openai_models.py
+++ b/mteb/models/openai_models.py
@@ -226,7 +226,7 @@ text_embedding_ada_002 = ModelMeta(
 )
 
 text_embedding_3_small_512 = ModelMeta(
-    name="openai/text-embedding-3-small-dim-512",
+    name="openai/text-embedding-3-small (embed_dim=512)",
     revision="3",
     release_date="2024-01-25",
     languages=None,  # supported languages not specified
@@ -253,7 +253,7 @@ text_embedding_3_small_512 = ModelMeta(
 )
 
 text_embedding_3_large_512 = ModelMeta(
-    name="openai/text-embedding-3-large-dim-512",
+    name="openai/text-embedding-3-large (embed_dim=512)",
     revision="3",
     release_date="2024-01-25",
     languages=None,  # supported languages not specified


### PR DESCRIPTION
https://github.com/embeddings-benchmark/mteb/issues/3002
https://github.com/embeddings-benchmark/mteb/issues/3003

Add OpenAI/text-embedding-3-small (512 dim)
Add OpenAI/text-embedding-3-large (512 dim)

- [x] I have filled out the ModelMeta object to the extent possible
- [x]  I have ensured that my model can be loaded using
  - [x]  mteb.get_model(model_name, revision) and
  - [x]  mteb.get_model_meta(model_name, revision)
- [x] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e. is available either as an API or the wieght are publicly avaiable to download