### PR TITLE
Add HumanEvalRetrieval task

### DIFF
--- a/mteb/descriptive_stats/Retrieval/HumanEvalRetrieval.json
+++ b/mteb/descriptive_stats/Retrieval/HumanEvalRetrieval.json
@@ -1,0 +1,20 @@
+{
+    "test": {
+        "number_of_characters": 46334,
+        "num_samples": 316,
+        "num_queries": 158,
+        "num_documents": 158,
+        "min_document_length": 23,
+        "average_document_length": 291.253164556962,
+        "max_document_length": 1200,
+        "unique_documents": 158,
+        "min_query_length": 2,
+        "average_query_length": 2.0,
+        "max_query_length": 2,
+        "unique_queries": 158,
+        "min_relevant_docs_per_query": 1,
+        "average_relevant_docs_per_query": 1.0,
+        "max_relevant_docs_per_query": 1,
+        "unique_relevant_docs": 158
+    }
+}

--- a/mteb/tasks/Retrieval/__init__.py
+++ b/mteb/tasks/Retrieval/__init__.py
@@ -12,6 +12,7 @@ from .code.CodeTransOceanContestRetrieval import *
 from .code.CodeTransOceanDLRetrieval import *
 from .code.COIRCodeSearchNetRetrieval import *
 from .code.CosQARetrieval import *
+from .code.HumanEvalRetrieval import *
 from .code.StackOverflowQARetrieval import *
 from .code.SyntheticText2SqlRetrieval import *
 from .dan.DanFeverRetrieval import *

--- a/mteb/tasks/Retrieval/code/HumanEvalRetrieval.py
+++ b/mteb/tasks/Retrieval/code/HumanEvalRetrieval.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from mteb.abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+
+
+class HumanEvalRetrieval(AbsTaskRetrieval):
+    metadata = {
+        "name": "HumanEvalRetrieval",
+        "description": "HumanEval dataset adapted for code retrieval evaluation.",
+        "reference": "https://arxiv.org/abs/2107.03374",
+        "dataset": {
+            "path": "zeroshot/humaneval-embedding-benchmark",
+            "revision": "5e5d4171b86e0bb96b57159d991cbbbd73efcac0",
+            "trust_remote_code": True,
+        },
+        "type": "Retrieval",
+        "category": "s2s",
+        "modalities": ["text"],
+        "eval_splits": ["test"],
+        "eval_langs": ["eng-Latn"],
+        "main_score": "ndcg_at_10",
+        "revision": "5e5d4171b86e0bb96b57159d991cbbbd73efcac0",
+        "domains": ["Programming"],
+        "task_subtypes": ["Code retrieval"],
+        "license": "mit",
+        "annotations_creators": "derived",
+        "dialect": [],
+        "sample_creation": "found",
+        "bibtex_citation": """@article{chen2021evaluating,
+  title={Evaluating Large Language Models Trained on Code},
+  author={Chen, Mark and Tworek, Jerry and Jun, Heewoo and Yuan, Qiming and de Oliveira Pinto, Henrique Pon{\'e} and Kaplan, Jared and Edwards, Harri and Burda, Yura and Joseph, Nicholas and Brockman, Greg and others},
+  journal={arXiv preprint arXiv:2107.03374},
+  year={2021}
+}""",
+        "descriptive_stats": {
+            "n_samples": {"test": 158},
+            "avg_character_length": {
+                "test": {
+                    "average_document_length": 491.4240506329114,
+                    "average_query_length": 135.9936708860759,
+                    "num_documents": 158,
+                    "num_queries": 158,
+                    "average_relevant_docs_per_query": 1.0,
+                }
+            },
+        },
+    }
+
+    def load_data(self, **kwargs):
+        if self.data_loaded:
+            return
+
+        self.corpus = {}
+        self.queries = {}
+        self.relevant_docs = {}
+
+        from datasets import load_dataset
+
+        # Load the three configurations
+        corpus_ds = load_dataset(self.metadata_dict["dataset"]["path"], "corpus")[
+            "corpus"
+        ]
+        queries_ds = load_dataset(self.metadata_dict["dataset"]["path"], "queries")[
+            "queries"
+        ]
+        qrels_ds = load_dataset(self.metadata_dict["dataset"]["path"], "default")[
+            "test"
+        ]
+
+        # Process corpus
+        for item in corpus_ds:
+            self.corpus[item["id"]] = {"title": "", "text": item["text"]}
+
+        # Process queries
+        for item in queries_ds:
+            self.queries[item["id"]] = item["text"]
+
+        # Process qrels (relevant documents)
+        for item in qrels_ds:
+            query_id = item["query_id"]
+            if query_id not in self.relevant_docs:
+                self.relevant_docs[query_id] = {}
+            self.relevant_docs[query_id][item["corpus_id"]] = item["score"]
+
+        self.data_loaded = True

--- a/mteb/tasks/Retrieval/code/HumanEvalRetrieval.py
+++ b/mteb/tasks/Retrieval/code/HumanEvalRetrieval.py
@@ -8,17 +8,17 @@ from ....abstasks.AbsTaskRetrieval import AbsTaskRetrieval
 class HumanEvalRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="HumanEvalRetrieval",
-        description="164 programming problems with a handwritten function signature, docstring, body, and several unit tests",
+        description="A code retrieval task based on 164 Python programming problems from HumanEval. Each query is a natural language description of a programming task (e.g., 'Check if in given list of numbers, are any two numbers closer to each other than given threshold'), and the corpus contains Python code implementations. The task is to retrieve the correct code snippet that solves the described problem. Queries are problem descriptions while the corpus contains Python function implementations with proper indentation and logic.",
         reference="https://huggingface.co/datasets/embedding-benchmark/HumanEval",
         dataset={
             "path": "embedding-benchmark/HumanEval",
-            "revision": "ed1f48a",
+            "revision": "ed1f48aca747f10bac146795328e2f03326e7625",
         },
         type="Retrieval",
         category="s2s",
         modalities=["text"],
         eval_splits=["test"],
-        eval_langs=["eng-Latn"],
+        eval_langs=["eng-Latn", "python-Code"],
         main_score="ndcg_at_10",
         date=("2021-01-01", "2021-12-31"),
         domains=["Programming"],
@@ -27,7 +27,14 @@ class HumanEvalRetrieval(AbsTaskRetrieval):
         annotations_creators="derived",
         dialect=[],
         sample_creation="found",
-        bibtex_citation="",
+        bibtex_citation="""@article{chen2021evaluating,
+  title={Evaluating Large Language Models Trained on Code},
+  author={Chen, Mark and Tworek, Jerry and Jun, Heewoo and Yuan, Qiming and Pinto, Henrique Ponde de Oliveira and Kaplan, Jared and Edwards, Harri and Burda, Yuri and Joseph, Nicholas and Brockman, Greg and Ray, Alex and Puri, Raul and Krueger, Gretchen and Petrov, Michael and Khlaaf, Heidy and Sastry, Girish and Mishkin, Pamela and Chan, Brooke and Gray, Scott and Ryder, Nick and Pavlov, Mikhail and Power, Alethea and Kaiser, Lukasz and Bavarian, Mohammad and Winter, Clemens and Tillet, Philippe and Such, Felipe Petroski and Cummings, Dave and Plappert, Matthias and Chantzis, Fotios and Barnes, Elizabeth and Herbert-Voss, Ariel and Guss, William Hebgen and Nichol, Alex and Paino, Alex and Tezak, Nikolas and Tang, Jie and Babuschkin, Igor and Balaji, Suchir and Jain, Shantanu and Saunders, William and Hesse, Christopher and Carr, Andrew N. and Leike, Jan and Achiam, Joshua and Misra, Vedant and Morikawa, Evan and Radford, Alec and Knight, Matthew and Brundage, Miles and Murati, Mira and Mayer, Katie and Welinder, Peter and McGrew, Bob and Amodei, Dario and McCandlish, Sam and Sutskever, Ilya and Zaremba, Wojciech},
+  year={2021},
+  eprint={2107.03374},
+  archivePrefix={arXiv},
+  primaryClass={cs.LG}
+}""",
     )
 
     def load_data(self, **kwargs):

--- a/mteb/tasks/Retrieval/code/HumanEvalRetrieval.py
+++ b/mteb/tasks/Retrieval/code/HumanEvalRetrieval.py
@@ -1,50 +1,40 @@
 from __future__ import annotations
 
-from mteb.abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+from ....abstasks.AbsTaskRetrieval import AbsTaskRetrieval
 
 
 class HumanEvalRetrieval(AbsTaskRetrieval):
-    metadata = {
-        "name": "HumanEvalRetrieval",
-        "description": "HumanEval dataset adapted for code retrieval evaluation.",
-        "reference": "https://arxiv.org/abs/2107.03374",
-        "dataset": {
+    metadata = TaskMetadata(
+        name="HumanEvalRetrieval",
+        description="HumanEval dataset adapted for code retrieval evaluation.",
+        reference="https://arxiv.org/abs/2107.03374",
+        dataset={
             "path": "zeroshot/humaneval-embedding-benchmark",
             "revision": "5e5d4171b86e0bb96b57159d991cbbbd73efcac0",
             "trust_remote_code": True,
         },
-        "type": "Retrieval",
-        "category": "s2s",
-        "modalities": ["text"],
-        "eval_splits": ["test"],
-        "eval_langs": ["eng-Latn"],
-        "main_score": "ndcg_at_10",
-        "revision": "5e5d4171b86e0bb96b57159d991cbbbd73efcac0",
-        "domains": ["Programming"],
-        "task_subtypes": ["Code retrieval"],
-        "license": "mit",
-        "annotations_creators": "derived",
-        "dialect": [],
-        "sample_creation": "found",
-        "bibtex_citation": """@article{chen2021evaluating,
+        type="Retrieval",
+        category="s2s",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2021-01-01", "2021-12-31"),
+        domains=["Programming"],
+        task_subtypes=["Code retrieval"],
+        license="mit",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation="""@article{chen2021evaluating,
   title={Evaluating Large Language Models Trained on Code},
   author={Chen, Mark and Tworek, Jerry and Jun, Heewoo and Yuan, Qiming and de Oliveira Pinto, Henrique Pon{\'e} and Kaplan, Jared and Edwards, Harri and Burda, Yura and Joseph, Nicholas and Brockman, Greg and others},
   journal={arXiv preprint arXiv:2107.03374},
   year={2021}
 }""",
-        "descriptive_stats": {
-            "n_samples": {"test": 158},
-            "avg_character_length": {
-                "test": {
-                    "average_document_length": 491.4240506329114,
-                    "average_query_length": 135.9936708860759,
-                    "num_documents": 158,
-                    "num_queries": 158,
-                    "average_relevant_docs_per_query": 1.0,
-                }
-            },
-        },
-    }
+    )
 
     def load_data(self, **kwargs):
         if self.data_loaded:

--- a/mteb/tasks/Retrieval/code/HumanEvalRetrieval.py
+++ b/mteb/tasks/Retrieval/code/HumanEvalRetrieval.py
@@ -13,7 +13,6 @@ class HumanEvalRetrieval(AbsTaskRetrieval):
         dataset={
             "path": "embedding-benchmark/HumanEval",
             "revision": "ed1f48a",
-            "trust_remote_code": True,
         },
         type="Retrieval",
         category="s2s",
@@ -42,15 +41,21 @@ class HumanEvalRetrieval(AbsTaskRetrieval):
         from datasets import load_dataset
 
         # Load the three configurations
-        corpus_ds = load_dataset(self.metadata_dict["dataset"]["path"], "corpus")[
-            "corpus"
-        ]
-        queries_ds = load_dataset(self.metadata_dict["dataset"]["path"], "queries")[
-            "queries"
-        ]
-        qrels_ds = load_dataset(self.metadata_dict["dataset"]["path"], "default")[
-            "test"
-        ]
+        corpus_ds = load_dataset(
+            self.metadata_dict["dataset"]["path"],
+            "corpus",
+            revision=self.metadata_dict["dataset"]["revision"],
+        )["corpus"]
+        queries_ds = load_dataset(
+            self.metadata_dict["dataset"]["path"],
+            "queries",
+            revision=self.metadata_dict["dataset"]["revision"],
+        )["queries"]
+        qrels_ds = load_dataset(
+            self.metadata_dict["dataset"]["path"],
+            "default",
+            revision=self.metadata_dict["dataset"]["revision"],
+        )["test"]
 
         # Process corpus
         for item in corpus_ds:

--- a/mteb/tasks/Retrieval/code/HumanEvalRetrieval.py
+++ b/mteb/tasks/Retrieval/code/HumanEvalRetrieval.py
@@ -67,9 +67,9 @@ class HumanEvalRetrieval(AbsTaskRetrieval):
 
         # Process qrels (relevant documents)
         for item in qrels_ds:
-            query_id = item["query_id"]
+            query_id = item["query-id"]
             if query_id not in self.relevant_docs:
                 self.relevant_docs[query_id] = {}
-            self.relevant_docs[query_id][item["corpus_id"]] = item["score"]
+            self.relevant_docs[query_id][item["corpus-id"]] = item["score"]
 
         self.data_loaded = True

--- a/mteb/tasks/Retrieval/code/HumanEvalRetrieval.py
+++ b/mteb/tasks/Retrieval/code/HumanEvalRetrieval.py
@@ -8,11 +8,10 @@ from ....abstasks.AbsTaskRetrieval import AbsTaskRetrieval
 class HumanEvalRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="HumanEvalRetrieval",
-        description="HumanEval dataset adapted for code retrieval evaluation.",
-        reference="https://arxiv.org/abs/2107.03374",
+        description="164 programming problems with a handwritten function signature, docstring, body, and several unit tests",
+        reference="https://huggingface.co/datasets/embedding-benchmark/HumanEval",
         dataset={
-            "path": "zeroshot/humaneval-embedding-benchmark",
-            "revision": "5e5d4171b86e0bb96b57159d991cbbbd73efcac0",
+            "path": "embedding-benchmark/HumanEval",
             "trust_remote_code": True,
         },
         type="Retrieval",
@@ -21,19 +20,12 @@ class HumanEvalRetrieval(AbsTaskRetrieval):
         eval_splits=["test"],
         eval_langs=["eng-Latn"],
         main_score="ndcg_at_10",
-        date=("2021-01-01", "2021-12-31"),
         domains=["Programming"],
         task_subtypes=["Code retrieval"],
         license="mit",
         annotations_creators="derived",
         dialect=[],
         sample_creation="found",
-        bibtex_citation="""@article{chen2021evaluating,
-  title={Evaluating Large Language Models Trained on Code},
-  author={Chen, Mark and Tworek, Jerry and Jun, Heewoo and Yuan, Qiming and de Oliveira Pinto, Henrique Pon{\'e} and Kaplan, Jared and Edwards, Harri and Burda, Yura and Joseph, Nicholas and Brockman, Greg and others},
-  journal={arXiv preprint arXiv:2107.03374},
-  year={2021}
-}""",
     )
 
     def load_data(self, **kwargs):

--- a/mteb/tasks/Retrieval/code/HumanEvalRetrieval.py
+++ b/mteb/tasks/Retrieval/code/HumanEvalRetrieval.py
@@ -28,12 +28,12 @@ class HumanEvalRetrieval(AbsTaskRetrieval):
         dialect=[],
         sample_creation="found",
         bibtex_citation="""@article{chen2021evaluating,
-  title={Evaluating Large Language Models Trained on Code},
-  author={Chen, Mark and Tworek, Jerry and Jun, Heewoo and Yuan, Qiming and Pinto, Henrique Ponde de Oliveira and Kaplan, Jared and Edwards, Harri and Burda, Yuri and Joseph, Nicholas and Brockman, Greg and Ray, Alex and Puri, Raul and Krueger, Gretchen and Petrov, Michael and Khlaaf, Heidy and Sastry, Girish and Mishkin, Pamela and Chan, Brooke and Gray, Scott and Ryder, Nick and Pavlov, Mikhail and Power, Alethea and Kaiser, Lukasz and Bavarian, Mohammad and Winter, Clemens and Tillet, Philippe and Such, Felipe Petroski and Cummings, Dave and Plappert, Matthias and Chantzis, Fotios and Barnes, Elizabeth and Herbert-Voss, Ariel and Guss, William Hebgen and Nichol, Alex and Paino, Alex and Tezak, Nikolas and Tang, Jie and Babuschkin, Igor and Balaji, Suchir and Jain, Shantanu and Saunders, William and Hesse, Christopher and Carr, Andrew N. and Leike, Jan and Achiam, Joshua and Misra, Vedant and Morikawa, Evan and Radford, Alec and Knight, Matthew and Brundage, Miles and Murati, Mira and Mayer, Katie and Welinder, Peter and McGrew, Bob and Amodei, Dario and McCandlish, Sam and Sutskever, Ilya and Zaremba, Wojciech},
-  year={2021},
-  eprint={2107.03374},
-  archivePrefix={arXiv},
-  primaryClass={cs.LG}
+  archiveprefix = {arXiv},
+  author = {Chen, Mark and Tworek, Jerry and Jun, Heewoo and Yuan, Qiming and Pinto, Henrique Ponde de Oliveira and Kaplan, Jared and Edwards, Harri and Burda, Yuri and Joseph, Nicholas and Brockman, Greg and Ray, Alex and Puri, Raul and Krueger, Gretchen and Petrov, Michael and Khlaaf, Heidy and Sastry, Girish and Mishkin, Pamela and Chan, Brooke and Gray, Scott and Ryder, Nick and Pavlov, Mikhail and Power, Alethea and Kaiser, Lukasz and Bavarian, Mohammad and Winter, Clemens and Tillet, Philippe and Such, Felipe Petroski and Cummings, Dave and Plappert, Matthias and Chantzis, Fotios and Barnes, Elizabeth and Herbert-Voss, Ariel and Guss, William Hebgen and Nichol, Alex and Paino, Alex and Tezak, Nikolas and Tang, Jie and Babuschkin, Igor and Balaji, Suchir and Jain, Shantanu and Saunders, William and Hesse, Christopher and Carr, Andrew N. and Leike, Jan and Achiam, Joshua and Misra, Vedant and Morikawa, Evan and Radford, Alec and Knight, Matthew and Brundage, Miles and Murati, Mira and Mayer, Katie and Welinder, Peter and McGrew, Bob and Amodei, Dario and McCandlish, Sam and Sutskever, Ilya and Zaremba, Wojciech},
+  eprint = {2107.03374},
+  primaryclass = {cs.LG},
+  title = {Evaluating Large Language Models Trained on Code},
+  year = {2021},
 }""",
     )
 

--- a/mteb/tasks/Retrieval/code/HumanEvalRetrieval.py
+++ b/mteb/tasks/Retrieval/code/HumanEvalRetrieval.py
@@ -34,10 +34,6 @@ class HumanEvalRetrieval(AbsTaskRetrieval):
         if self.data_loaded:
             return
 
-        self.corpus = {}
-        self.queries = {}
-        self.relevant_docs = {}
-
         from datasets import load_dataset
 
         # Load the three configurations
@@ -57,19 +53,29 @@ class HumanEvalRetrieval(AbsTaskRetrieval):
             revision=self.metadata.dataset["revision"],
         )["test"]
 
+        # Initialize data structures with 'test' split
+        corpus = {}
+        queries = {}
+        relevant_docs = {}
+
         # Process corpus
         for item in corpus_ds:
-            self.corpus[item["id"]] = {"title": "", "text": item["text"]}
+            corpus[item["id"]] = {"title": "", "text": item["text"]}
 
         # Process queries
         for item in queries_ds:
-            self.queries[item["id"]] = item["text"]
+            queries[item["id"]] = item["text"]
 
         # Process qrels (relevant documents)
         for item in qrels_ds:
             query_id = item["query-id"]
-            if query_id not in self.relevant_docs:
-                self.relevant_docs[query_id] = {}
-            self.relevant_docs[query_id][item["corpus-id"]] = item["score"]
+            if query_id not in relevant_docs:
+                relevant_docs[query_id] = {}
+            relevant_docs[query_id][item["corpus-id"]] = int(item["score"])
+
+        # Organize data by splits as expected by MTEB
+        self.corpus = {"test": corpus}
+        self.queries = {"test": queries}
+        self.relevant_docs = {"test": relevant_docs}
 
         self.data_loaded = True

--- a/mteb/tasks/Retrieval/code/HumanEvalRetrieval.py
+++ b/mteb/tasks/Retrieval/code/HumanEvalRetrieval.py
@@ -12,6 +12,7 @@ class HumanEvalRetrieval(AbsTaskRetrieval):
         reference="https://huggingface.co/datasets/embedding-benchmark/HumanEval",
         dataset={
             "path": "embedding-benchmark/HumanEval",
+            "revision": "ed1f48a",
             "trust_remote_code": True,
         },
         type="Retrieval",

--- a/mteb/tasks/Retrieval/code/HumanEvalRetrieval.py
+++ b/mteb/tasks/Retrieval/code/HumanEvalRetrieval.py
@@ -42,19 +42,19 @@ class HumanEvalRetrieval(AbsTaskRetrieval):
 
         # Load the three configurations
         corpus_ds = load_dataset(
-            self.metadata_dict["dataset"]["path"],
+            self.metadata.dataset["path"],
             "corpus",
-            revision=self.metadata_dict["dataset"]["revision"],
+            revision=self.metadata.dataset["revision"],
         )["corpus"]
         queries_ds = load_dataset(
-            self.metadata_dict["dataset"]["path"],
+            self.metadata.dataset["path"],
             "queries",
-            revision=self.metadata_dict["dataset"]["revision"],
+            revision=self.metadata.dataset["revision"],
         )["queries"]
         qrels_ds = load_dataset(
-            self.metadata_dict["dataset"]["path"],
+            self.metadata.dataset["path"],
             "default",
-            revision=self.metadata_dict["dataset"]["revision"],
+            revision=self.metadata.dataset["revision"],
         )["test"]
 
         # Process corpus

--- a/mteb/tasks/Retrieval/code/HumanEvalRetrieval.py
+++ b/mteb/tasks/Retrieval/code/HumanEvalRetrieval.py
@@ -21,12 +21,14 @@ class HumanEvalRetrieval(AbsTaskRetrieval):
         eval_splits=["test"],
         eval_langs=["eng-Latn"],
         main_score="ndcg_at_10",
+        date=("2021-01-01", "2021-12-31"),
         domains=["Programming"],
         task_subtypes=["Code retrieval"],
         license="mit",
         annotations_creators="derived",
         dialect=[],
         sample_creation="found",
+        bibtex_citation="",
     )
 
     def load_data(self, **kwargs):


### PR DESCRIPTION
https://github.com/embeddings-benchmark/mteb/issues/3014

- HumanEval dataset for code retrieval tasks
- 158 queries, 158 documents

- [x] I have run the following models on the task (adding the results to the pr). These can be run using the mteb run -m {model_name} -t {task_name} command.
  - [ ] sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2
  - [x] intfloat/multilingual-e5-small
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [x] I have considered the size of the dataset and reduced it if it is too big (2048 examples is typically large enough for most tasks)