### PR TITLE
model: Add M2-BERT model

### DIFF
--- a/mteb/models/m2bert_models.py
+++ b/mteb/models/m2bert_models.py
@@ -17,5 +17,5 @@ m2_32k = ModelMeta(
     use_instructions=False,
     public_training_code="https://github.com/HazyResearch/m2",
     public_training_data="https://huggingface.co/datasets/allenai/c4",
-    training_datasets=None, # unknown
+    training_datasets={}, # C4
 )

--- a/mteb/models/m2bert_models.py
+++ b/mteb/models/m2bert_models.py
@@ -1,0 +1,21 @@
+from mteb.model_meta import ModelMeta
+
+m2_32k = ModelMeta(
+    name="togethercomputer/m2-bert-80M-32k-retrieval",
+    languages=["eng-Latn"],
+    open_weights=True,
+    revision="a2ccdc5b5661a282c77545e586a019f387ab7a48",
+    release_date="2023-11-04",
+    n_parameters=80_000_000,
+    memory_usage_mb=305,
+    embed_dim=768,
+    license="apache-2.0",
+    max_tokens=32768,
+    reference="https://huggingface.co/togethercomputer/m2-bert-80M-32k-retrieval",
+    similarity_fn_name="cosine",
+    framework=["Sentence Transformers", "PyTorch"],
+    use_instructions=False,
+    public_training_code="https://github.com/HazyResearch/m2",
+    public_training_data="https://huggingface.co/datasets/allenai/c4",
+    training_datasets=None, # unknown
+)


### PR DESCRIPTION
- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [x] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e. is available either as an API or the weights are publicly avaiable to download

Note that `trust_remote_code=True` is required to load the model.