### PR TITLE
fix: incorrect revision for SNLRetrieval

### DIFF
--- a/mteb/tasks/Retrieval/nob/snl_retrieval.py
+++ b/mteb/tasks/Retrieval/nob/snl_retrieval.py
@@ -11,7 +11,7 @@ class SNLRetrieval(AbsTaskRetrieval):
         name="SNLRetrieval",
         dataset={
             "path": "adrlau/navjordj-SNL_summarization_copy",  # TODO: replace with mteb/SNLRetrieval after #2820 is resolved.
-            "revision": "3d3d27aa7af8941408cefc3991ada5d12a4273d1",
+            "revision": "22c474c88fb4678052f9099bb917ad8f9e155f9f",
         },
         description="Webscrabed articles and ingresses from the Norwegian lexicon 'Det Store Norske Leksikon'.",
         reference="https://huggingface.co/datasets/mteb/SNLRetrieval",


### PR DESCRIPTION
The provided revisions doesn't seem to be present on:
adrlau/navjordj-SNL_summarization_copy

Replacing with latest revision

