### PR TITLE
ci: reduce parallel runs for when checking if a dataset exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ model-load-test:
 
 dataset-load-test:
 	@echo "--- 🚀 Running dataset load test ---"
-	pytest -n auto -m test_datasets
+	pytest -m test_datasets
 
 leaderboard-build-test:
 	@echo "--- 🚀 Running leaderboard build test ---"


### PR DESCRIPTION
The hope is that this will prevent many of the current [errors](https://github.com/embeddings-benchmark/mteb/actions/runs/17019125199/job/48245690831)

I am welcoming of alternative solutions.