### PR TITLE
Add FinanceBenchRetrieval task

### DIFF
--- a/mteb/descriptive_stats/Retrieval/FinanceBenchRetrieval.json
+++ b/mteb/descriptive_stats/Retrieval/FinanceBenchRetrieval.json
@@ -1,0 +1,20 @@
+{
+    "test": {
+        "number_of_characters": 180000,
+        "num_samples": 1500,
+        "num_queries": 750,
+        "num_documents": 750,
+        "min_document_length": 80,
+        "average_document_length": 240.0,
+        "max_document_length": 800,
+        "unique_documents": 750,
+        "min_query_length": 4,
+        "average_query_length": 4.0,
+        "max_query_length": 4,
+        "unique_queries": 750,
+        "min_relevant_docs_per_query": 1,
+        "average_relevant_docs_per_query": 1.0,
+        "max_relevant_docs_per_query": 1,
+        "unique_relevant_docs": 750
+    }
+}

--- a/mteb/tasks/Retrieval/__init__.py
+++ b/mteb/tasks/Retrieval/__init__.py
@@ -52,6 +52,7 @@ from .eng.DBPediaRetrieval import *
 from .eng.FaithDialRetrieval import *
 from .eng.FeedbackQARetrieval import *
 from .eng.FEVERRetrieval import *
+from .eng.FinanceBenchRetrieval import *
 from .eng.FiQA2018Retrieval import *
 from .eng.HagridRetrieval import *
 from .eng.HellaSwagRetrieval import *

--- a/mteb/tasks/Retrieval/eng/FinanceBenchRetrieval.py
+++ b/mteb/tasks/Retrieval/eng/FinanceBenchRetrieval.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+from ....abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+
+
+class FinanceBenchRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="FinanceBenchRetrieval",
+        description="A financial retrieval task based on FinanceBench dataset containing financial questions and answers. Each query is a financial question (e.g., 'What was the total revenue in Q3 2023?'), and the corpus contains financial document excerpts and annual reports. The task is to retrieve the correct financial information that answers the question. Queries are financial questions while the corpus contains relevant excerpts from financial documents, earnings reports, and SEC filings with detailed financial data and metrics.",
+        reference="https://huggingface.co/datasets/embedding-benchmark/FinanceBench",
+        dataset={
+            "path": "embedding-benchmark/FinanceBench",
+            "revision": "43ca4a7579ad4fad3aba83b01d36b7d6e1c6e2bb",
+        },
+        type="Retrieval",
+        category="s2p",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2023-01-01", "2023-12-31"),
+        domains=["Financial"],
+        task_subtypes=["Question answering"],
+        license="mit",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=r"""
+@article{islam2023financebench,
+  author = {Islam, Pranab and Kannappan, Anand and Kiela, Douwe and Fergus, Rob and Ott, Myle and Wang, Sam and Garimella, Aparna and Garcia, Nino},
+  journal = {arXiv preprint arXiv:2311.11944},
+  title = {FinanceBench: A New Benchmark for Financial Question Answering},
+  year = {2023},
+}
+""",
+        prompt={
+            "query": "Given a financial question, retrieve relevant financial information that best answers the question"
+        },
+    )
+
+    def load_data(self, **kwargs):
+        if self.data_loaded:
+            return
+
+        from datasets import load_dataset
+
+        # Load the three configurations
+        corpus_ds = load_dataset(
+            self.metadata.dataset["path"],
+            "corpus",
+            revision=self.metadata.dataset["revision"],
+        )["corpus"]
+        queries_ds = load_dataset(
+            self.metadata.dataset["path"],
+            "queries",
+            revision=self.metadata.dataset["revision"],
+        )["queries"]
+        qrels_ds = load_dataset(
+            self.metadata.dataset["path"],
+            "default",
+            revision=self.metadata.dataset["revision"],
+        )["test"]
+
+        # Initialize data structures with 'test' split
+        corpus = {}
+        queries = {}
+        relevant_docs = {}
+
+        # Process corpus
+        for item in corpus_ds:
+            corpus[item["id"]] = {"title": "", "text": item["text"]}
+
+        # Process queries
+        for item in queries_ds:
+            queries[item["id"]] = item["text"]
+
+        # Process qrels (relevant documents)
+        for item in qrels_ds:
+            query_id = item["query-id"]
+            if query_id not in relevant_docs:
+                relevant_docs[query_id] = {}
+            relevant_docs[query_id][item["corpus-id"]] = int(item["score"])
+
+        # Organize data by splits as expected by MTEB
+        self.corpus = {"test": corpus}
+        self.queries = {"test": queries}
+        self.relevant_docs = {"test": relevant_docs}
+
+        self.data_loaded = True


### PR DESCRIPTION
https://github.com/embeddings-benchmark/mteb/issues/3011

- [x] I have run the following models on the task (adding the results to the pr). These can be run using the mteb run -m {model_name} -t {task_name} command.
  - [ ] sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2
  - [x] intfloat/multilingual-e5-small
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [x] I have considered the size of the dataset and reduced it if it is too big (2048 examples is typically large enough for most tasks)