### PR TITLE
fix: Updated revision for jina-embeddings-v4

### DIFF
--- a/mteb/models/jina_models.py
+++ b/mteb/models/jina_models.py
@@ -545,6 +545,7 @@ jina_embeddings_v4 = ModelMeta(
     loader=partial(  # type: ignore
         JinaV4Wrapper,
         model="jinaai/jina-embeddings-v4",
+        revision="4a58ca57710c49f51896e4bc820e202fbf64904b",
         trust_remote_code=True,
         model_prompts={
             "Retrieval-query": "retrieval.query",
@@ -556,7 +557,7 @@ jina_embeddings_v4 = ModelMeta(
     name="jinaai/jina-embeddings-v4",
     languages=XLMR_LANGUAGES,
     open_weights=True,
-    revision="26239889730c735ed7e9a4db9180c8935faf4ba0",
+    revision="4a58ca57710c49f51896e4bc820e202fbf64904b",
     release_date="2025-06-24",  # official release date
     modalities=["image", "text"],
     n_parameters=int(3.8 * 1e9),


### PR DESCRIPTION
We should remove the hardcoded revision from the jina-embeddings-v4 loader, as the specified version is incompatible with the latest Transformers release and causes evaluation to fail