### PR TITLE
model: add granite-embedding-english R2 models

### DIFF
--- a/mteb/models/ibm_granite_models.py
+++ b/mteb/models/ibm_granite_models.py
@@ -191,3 +191,58 @@ granite_125m_english = ModelMeta(
     use_instructions=False,
     training_datasets=granite_training_data,
 )
+
+
+granite_english_r2 = ModelMeta(
+    loader=partial(  # type: ignore
+        sentence_transformers_loader,
+        model_name="ibm-granite/granite-embedding-english-r2",
+        revision="6e7b8ce0e76270394ac4669ba4bbd7133b60b7f9",
+    ),
+    name="ibm-granite/granite-embedding-english-r2",
+    languages=["eng-Latn"],
+    open_weights=True,
+    revision="6e7b8ce0e76270394ac4669ba4bbd7133b60b7f9",
+    release_date="2025-08-15",
+    n_parameters=149_000_000,
+    memory_usage_mb=284,
+    embed_dim=768,
+    license="apache-2.0",
+    max_tokens=8192,
+    reference="https://huggingface.co/ibm-granite/granite-embedding-english-r2",
+    similarity_fn_name="cosine",
+    framework=["Sentence Transformers", "PyTorch"],
+    adapted_from=None,
+    superseded_by=None,
+    public_training_code=None,
+    public_training_data=None,
+    use_instructions=False,
+    training_datasets=granite_training_data,
+)
+
+granite_small_english_r2 = ModelMeta(
+    loader=partial(  # type: ignore
+        sentence_transformers_loader,
+        model_name="ibm-granite/granite-embedding-small-english-r2",
+        revision="54a8d2616a0844355a5164432d3f6dafb37b17a3",
+    ),
+    name="ibm-granite/granite-embedding-small-english-r2",
+    languages=["eng-Latn"],
+    open_weights=True,
+    revision="54a8d2616a0844355a5164432d3f6dafb37b17a3",
+    release_date="2025-08-15",
+    n_parameters=47_000_000,
+    memory_usage_mb=91,
+    embed_dim=384,
+    license="apache-2.0",
+    max_tokens=8192,
+    reference="https://huggingface.co/ibm-granite/granite-embedding-small-english-r2",
+    similarity_fn_name="cosine",
+    framework=["Sentence Transformers", "PyTorch"],
+    adapted_from=None,
+    superseded_by=None,
+    public_training_code=None,
+    public_training_data=None,
+    use_instructions=False,
+    training_datasets=granite_training_data,
+)


### PR DESCRIPTION
Adds Granite Embedding English R2 models

- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
    - [x] mteb.get_model(model_name, revision) and
    - [x] mteb.get_model_meta(model_name, revision)
- [x] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e. is available either as an API or the wieght are publicly avaiable to download
