### PR TITLE
ci: Temporarily limit pytrec version to "pytrec-eval-terrier>=0.5.6, <0.5.8" to prevent errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "torch>1.0.0",
     "tqdm>1.0.0",
     "rich>=0.0.0",
-    "pytrec-eval-terrier>=0.5.6",
+    "pytrec-eval-terrier>=0.5.6, <0.5.8",
     "pydantic>=2.0.0",
     "typing_extensions>=0.0.0",
     "eval_type_backport>=0.0.0",


### PR DESCRIPTION
Close https://github.com/embeddings-benchmark/mteb/issues/3056
If you add a model or a dataset, please add the corresponding checklist:

* [dataset checklist](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md#submit-a-pr)
* [model checklist](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_model.md#submitting-your-model-as-a-pr)
