### PR TITLE
ci: Add stale workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,7 +1,6 @@
 name: 🐞 Bug Report
 description: Create a bug report to help us improve
 type: bug
-labels: ["bug"]
 body:
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,6 +1,7 @@
 name: 🐞 Bug Report
 description: Create a bug report to help us improve
 type: bug
+labels: ["bug"]
 body:
   - type: textarea
     attributes:

--- a/.github/workflows/stale_pr.yml
+++ b/.github/workflows/stale_pr.yml
@@ -15,6 +15,6 @@ jobs:
           stale-pr-label: 'stale'
           days-before-pr-stale: 14
           days-before-pr-close: 7
-          any-of-issue-labels: 'Bug'
+          any-of-issue-labels: 'more information needed'
           stale-pr-message: 'This pull request has been automatically marked as stale due to inactivity.'
           close-pr-message: 'This pull request has been automatically closed due to inactivity.'

--- a/.github/workflows/stale_pr.yml
+++ b/.github/workflows/stale_pr.yml
@@ -1,4 +1,4 @@
-name: Close stale PRs
+name: Label and Close stale PRs
 on:
   schedule:
     - cron: '30 1 * * *' # runs daily at 1:30 AM

--- a/.github/workflows/stale_pr.yml
+++ b/.github/workflows/stale_pr.yml
@@ -1,0 +1,16 @@
+name: Close stale PRs
+on:
+  schedule:
+    - cron: '30 1 * * *' # runs daily at 1:30 AM
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9.1.0
+        with:
+          stale-pr-label: 'stale'
+          days-before-pr-stale: 14
+          days-before-pr-close: 7
+          any-of-issue-labels: 'Bug'
+          stale-pr-message: 'This pull request has been automatically marked as stale due to inactivity.'
+          close-pr-message: 'This pull request has been automatically closed due to inactivity.'

--- a/.github/workflows/stale_pr.yml
+++ b/.github/workflows/stale_pr.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/stale@v9.1.0
         with:
           stale-pr-label: 'stale'
+          stale-issue-label: 'stale'
           days-before-pr-stale: 14
           days-before-pr-close: 7
           any-of-issue-labels: 'more information needed'

--- a/.github/workflows/stale_pr.yml
+++ b/.github/workflows/stale_pr.yml
@@ -5,6 +5,10 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v9.1.0
         with:


### PR DESCRIPTION
Fixes https://github.com/embeddings-benchmark/mteb/issues/3064
- Labels a "needs-more-infomation" issue stale after 60 days
- Closes a stale "needs-more-infomation" issue after 7 days
- Labels a PR stale after 14 days
- Closes a stale PR after 7 days

Any update (update/comment) can reset the stale idle time on the issues/PRs.

If you add a model or a dataset, please add the corresponding checklist:

* [dataset checklist](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md#submit-a-pr)
* [model checklist](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_model.md#submitting-your-model-as-a-pr)
