### PR TITLE
fix: open_clip package validation

### DIFF
--- a/mteb/models/openclip_models.py
+++ b/mteb/models/openclip_models.py
@@ -17,7 +17,7 @@ def openclip_loader(**kwargs):
     model_name = kwargs.get("model_name", "CLIP-ViT")
     requires_package(
         openclip_loader,
-        "open_clip_torch",
+        "open_clip",
         model_name,
         "pip install 'mteb[open_clip_torch]'",
     )


### PR DESCRIPTION
Hello,
Fixed the package detection issue in openclip_models.py that was not properly checking for packages.

While `open_clip_torch` is the pip installation name, the actual import should be done with `open_clip`. 
This caused the following bug even when the open_clip_torch library was properly installed:

```
ImportError: openclip_loader requires the open_clip_torch library but it was not found in your environment. If you want to load laion/CLIP-ViT-bigG-14-laion2B-39B-b160k models, please pip install 'mteb[open_clip_torch]' to install the package.
```

Verification logic:
```python
>>> importlib.util.find_spec("open_clip_torch")  # False
>>> importlib.util.find_spec("open_clip")        # True
```

Thanks! 😊