### PR TITLE
fix: Add @classmethod for @field_validators in TaskMetadata 

### DIFF
--- a/mteb/abstasks/TaskMetadata.py
+++ b/mteb/abstasks/TaskMetadata.py
@@ -251,6 +251,7 @@ class TaskMetadata(BaseModel):
         self.eval_langs_are_valid(self.eval_langs)
 
     @field_validator("dataset")
+    @classmethod
     def _check_dataset_path_is_specified(
         cls, dataset: dict[str, Any]
     ) -> dict[str, Any]:
@@ -258,6 +259,7 @@ class TaskMetadata(BaseModel):
         return dataset
 
     @field_validator("dataset")
+    @classmethod
     def _check_dataset_revision_is_specified(
         cls, dataset: dict[str, Any]
     ) -> dict[str, Any]:
@@ -265,6 +267,7 @@ class TaskMetadata(BaseModel):
         return dataset
 
     @field_validator("prompt")
+    @classmethod
     def _check_prompt_is_valid(
         cls, prompt: str | PromptDict | None
     ) -> str | PromptDict | None:


### PR DESCRIPTION
To use `field_validator` we need to add `classmethod` after it https://docs.pydantic.dev/latest/concepts/validators/#__tabbed_1_2

```python
class Model(BaseModel):
    number: int

    @field_validator('number', mode='after')  
    @classmethod
    def is_even(cls, value: int) -> int:
        if value % 2 == 1:
            raise ValueError(f'{value} is not an even number')
        return value  
```