### PR TITLE
Align task prompt dict with `PromptType`

### DIFF
--- a/mteb/abstasks/TaskMetadata.py
+++ b/mteb/abstasks/TaskMetadata.py
@@ -164,7 +164,7 @@ METRIC_VALUE = Union[int, float, dict[str, Any]]
 
 
 PromptDict = TypedDict(
-    "PromptDict", dict.fromkeys(PromptType, str), total=False
+    "PromptDict", {prompt_type.value: str for prompt_type in PromptType}, total=False
 )
 """A dictionary containing the prompt used for the task.
 

--- a/mteb/abstasks/TaskMetadata.py
+++ b/mteb/abstasks/TaskMetadata.py
@@ -163,25 +163,21 @@ METRIC_NAME = str
 METRIC_VALUE = Union[int, float, dict[str, Any]]
 
 
-class PromptDict(TypedDict, total=False):
-    """A dictionary containing the prompt used for the task.
+PromptDict = TypedDict(
+    "PromptDict", dict.fromkeys(PromptType, str), total=False
+)
+"""A dictionary containing the prompt used for the task.
 
-    Args:
-        query: The prompt used for the queries in the task.
-        passage: The prompt used for the passages in the task.
-    """
-
-    query: str
-    passage: str
+Args:
+    query: The prompt used for the queries in the task.
+    document: The prompt used for the passages in the task.
+"""
 
 
 class DescriptiveStatistics(TypedDict):
     """Class for descriptive statistics."""
 
     pass
-
-
-METRIC_VALUE = Union[int, float, dict[str, Any]]
 
 
 logger = logging.getLogger(__name__)
@@ -272,7 +268,7 @@ class TaskMetadata(BaseModel):
             for key in prompt:
                 if key not in [e.value for e in PromptType]:
                     raise ValueError(
-                        "The prompt dictionary should only contain the keys 'query' and 'passage'."
+                        "The prompt dictionary should only contain the keys 'query' and 'document'."
                     )
         return prompt
 

--- a/mteb/models/codi_models.py
+++ b/mteb/models/codi_models.py
@@ -12,35 +12,35 @@ logger = logging.getLogger(__name__)
 codi_instruction = {
     "CmedqaRetrieval": {
         "query": "Given a Chinese community medical question, retrieve replies that best answer the question",
-        "passage": "",
+        "document": "",
     },
     "CovidRetrieval": {
         "query": "Given a question on COVID-19, retrieve news articles that answer the question",
-        "passage": "",
+        "document": "",
     },
     "DuRetrieval": {
         "query": "Given a Chinese search query, retrieve web passages that answer the question",
-        "passage": "",
+        "document": "",
     },
     "EcomRetrieval": {
         "query": "Given a user query from an e-commerce website, retrieve description sentences of relevant products",
-        "passage": "",
+        "document": "",
     },
     "MedicalRetrieval": {
         "query": "Given a medical question, retrieve user replies that best answer the question",
-        "passage": "",
+        "document": "",
     },
     "MMarcoRetrieval": {
         "query": "Given a web search query, retrieve relevant passages that answer the query",
-        "passage": "",
+        "document": "",
     },
     "T2Retrieval": {
         "query": "Given a Chinese search query, retrieve web passages that answer the question",
-        "passage": "",
+        "document": "",
     },
     "VideoRetrieval": {
         "query": "Given a video search query, retrieve the titles of relevant videos",
-        "passage": "",
+        "document": "",
     },
     "AFQMC": "Represent the text in conversations between users and financial customer service, retrieve semantically similar text",
     "ATEC": "Represent the text in conversations between users and financial customer service, retrieve semantically similar text",
@@ -51,19 +51,19 @@ codi_instruction = {
     "STSB": "Represent the short general domain sentences, retrieve semantically similar text",
     "T2Reranking": {
         "query": "Given a Chinese search query, retrieve web passages that answer the question",
-        "passage": "",
+        "document": "",
     },
     "MMarcoReranking": {
         "query": "Given a web search query, retrieve relevant passages that answer the query",
-        "passage": "",
+        "document": "",
     },
     "CMedQAv1-reranking": {
         "query": "Given a Chinese community medical question, retrieve replies that best answer the question",
-        "passage": "",
+        "document": "",
     },
     "CMedQAv2-reranking": {
         "query": "Given a Chinese community medical question, retrieve replies that best answer the question",
-        "passage": "",
+        "document": "",
     },
     "Ocnli": "Retrieve semantically similar text",
     "Cmnli": "Retrieve semantically similar text",


### PR DESCRIPTION
Currenly `PromptType` contains `query` and `document`, but in `TaskMetadata` `PromptDict` contains `query` and `passage`. This might lead to incorrect checking. Now `PromptDict` would have this fields:

```python
from mteb.abstasks.TaskMetadata import PromptDict
print(PromptDict.__annotations__)
# {'query': <class 'str'>, 'document': <class 'str'>}
```