### PR TITLE
[v2] Use `mteb.evaluate` for two-stage retrieval

### DIFF
--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -431,25 +431,19 @@ cross_enc_results[0].get_score() # 0.338
 
 ### Using Late Interaction Models
 
-This section outlines how to use late interaction models for retrieval.
+This section outlines how to use late interaction models for retrieval using a ColBert model:
 
 ```python
-from mteb import MTEB
 import mteb
-
+from mteb.models.search_wrappers import SearchEncoderWrapper
 
 colbert = mteb.get_model("colbert-ir/colbertv2.0")
-tasks = mteb.get_tasks(tasks=["NFCorpus"], languages=["eng"])
+task = mteb.get_task("NanoArguAnaRetrieval")
 
-eval_splits = ["test"]
+mdl = SearchEncoderWrapper(colbert)
+mdl.corpus_chunk_size = 500
 
-evaluation = MTEB(tasks=tasks)
-
-evaluation.run(
-    colbert,
-    eval_splits=eval_splits,
-    corpus_chunk_size=500,
-)
+results = mteb.evaluate(mdl, task)
 ```
 This implementation employs the MaxSim operation to compute the similarity between sentences. While MaxSim provides high-quality results, it processes a larger number of embeddings, potentially leading to increased resource usage. To manage resource consumption, consider lowering the `corpus_chunk_size` parameter.
 

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -373,7 +373,7 @@ Python:
 import mteb
 
 # using a small model and small dataset
-encoder = mteb.get_model("minishlab/potion-base-2M")
+encoder = mteb.get_model("sentence-transformers/static-similarity-mrl-multilingual-v1")
 task = mteb.get_task("NanoArguAnaRetrieval")
 
 prediction_folder = "model_predictions"
@@ -404,7 +404,7 @@ from sentence_transformers import CrossEncoder
 
 import mteb
 
-encoder = mteb.get_model("minishlab/potion-base-2M")
+encoder = mteb.get_model("sentence-transformers/static-similarity-mrl-multilingual-v1")
 task = mteb.get_task("NanoArguAnaRetrieval")
 
 prediction_folder = "model_predictions"
@@ -455,7 +455,7 @@ There are times you may want to cache the embeddings so you can re-use them. Thi
 ```python
 # define your task(s) and model above as normal
 task = mteb.get_task("LccSentimentClassification")
-model = mteb.get_model("minishlab/M2V_base_glove_subword")
+model = mteb.get_model("sentence-transformers/static-similarity-mrl-multilingual-v1")
 
 # wrap the model with the cache wrapper
 from mteb.models.cache_wrapper import CachedEmbeddingWrapper

--- a/mteb/abstasks/AbsTask.py
+++ b/mteb/abstasks/AbsTask.py
@@ -220,7 +220,7 @@ class AbsTask(ABC):
         hf_split: str,
         hf_subset: str,
     ) -> None:
-        predictions_path = self.predictions_path(prediction_folder)
+        predictions_path = self._predictions_path(prediction_folder)
         existing_results = {
             "mteb_model_meta": {
                 "model_name": model.mteb_model_meta.name,
@@ -238,7 +238,7 @@ class AbsTask(ABC):
         with predictions_path.open("w") as predictions_file:
             json.dump(existing_results, predictions_file)
 
-    def predictions_path(
+    def _predictions_path(
         self,
         output_folder: Path | str,
     ) -> Path:

--- a/mteb/abstasks/AbsTaskRetrieval.py
+++ b/mteb/abstasks/AbsTaskRetrieval.py
@@ -587,20 +587,19 @@ class AbsTaskRetrieval(AbsTask):
 
     def convert_to_reranking(
         self,
-        top_ranked_file: str | Path,
+        top_ranked_path: str | Path,
         top_k: int = 10,
     ) -> Self:
-        """Converts a reranking task to re-ranking by loading results from model run
+        """Converts a reranking task to re-ranking by loading predictions from previous model run where the `prediction_folder` was specified.
 
         Args:
-            top_ranked_file: Path to file with the top ranked results
-            top_k: Number of results to load
+            top_ranked_path: Path to file with the top ranked predictions. 
+            top_k: Number of results to load.
 
         Returns:
-            Re-ranking task
+            The current task reformulated as a reranking task
         """
         top_ranked_path = self._predictions_path(top_ranked_path)
-        top_ranked_path = Path(top_ranked_file)
 
         if not top_ranked_path.exists():
             raise FileNotFoundError(

--- a/mteb/abstasks/AbsTaskRetrieval.py
+++ b/mteb/abstasks/AbsTaskRetrieval.py
@@ -593,7 +593,7 @@ class AbsTaskRetrieval(AbsTask):
         """Converts a reranking task to re-ranking by loading predictions from previous model run where the `prediction_folder` was specified.
 
         Args:
-            top_ranked_path: Path to file with the top ranked predictions. 
+            top_ranked_path: Path to file with the top ranked predictions.
             top_k: Number of results to load.
 
         Returns:

--- a/mteb/abstasks/AbsTaskRetrieval.py
+++ b/mteb/abstasks/AbsTaskRetrieval.py
@@ -599,6 +599,7 @@ class AbsTaskRetrieval(AbsTask):
         Returns:
             Re-ranking task
         """
+        top_ranked_path = self._predictions_path(top_ranked_path)
         top_ranked_path = Path(top_ranked_file)
 
         if not top_ranked_path.exists():

--- a/mteb/abstasks/AbsTaskRetrieval.py
+++ b/mteb/abstasks/AbsTaskRetrieval.py
@@ -593,13 +593,15 @@ class AbsTaskRetrieval(AbsTask):
         """Converts a reranking task to re-ranking by loading predictions from previous model run where the `prediction_folder` was specified.
 
         Args:
-            top_ranked_path: Path to file with the top ranked predictions.
+            top_ranked_path: Path to file or folder with the top ranked predictions.
             top_k: Number of results to load.
 
         Returns:
             The current task reformulated as a reranking task
         """
-        top_ranked_path = self._predictions_path(top_ranked_path)
+        top_ranked_path = Path(top_ranked_path)
+        if top_ranked_path.is_dir():
+            top_ranked_path = self._predictions_path(top_ranked_path)
 
         if not top_ranked_path.exists():
             raise FileNotFoundError(


### PR DESCRIPTION
fixes #2830

- Updated docs to use `mteb.evaluate` for two-stage retrieval
- Restructured so saving results is before two-stage retrieval
- Minor updates on docstring and variables (notably to avoid confusion of results and predictions)
- Updated late-interaction example (though it could use some work - see comment below)