### PR TITLE
fix: AttributeError in ColPaliEngineWrapper similarity method

### DIFF
--- a/mteb/models/colpali_models.py
+++ b/mteb/models/colpali_models.py
@@ -131,7 +131,7 @@ class ColPaliEngineWrapper:
         return scores.softmax(dim=-1)
 
     def similarity(self, a, b):
-        return self.processor.score(a, b)
+        return self.processor.score(a, b, device=self.device)
 
 
 class ColPaliWrapper(ColPaliEngineWrapper):

--- a/mteb/models/colpali_models.py
+++ b/mteb/models/colpali_models.py
@@ -131,7 +131,7 @@ class ColPaliEngineWrapper:
         return scores.softmax(dim=-1)
 
     def similarity(self, a, b):
-        return self.processor.score(a, b, **self.processor_kwargs)
+        return self.processor.score(a, b)
 
 
 class ColPaliWrapper(ColPaliEngineWrapper):


### PR DESCRIPTION
Hi! 😁

I'm using `ColPali` models to evaluate ViDoRe benchmarks and encountered an `AttributeError`. The issue occurs because `ColPaliEngineWrapper.similarity()` tries to use `self.processor_kwargs`, which is not defined in the class. **I've temporarily resolved this by removing the `**self.processor_kwargs` reference.**

```
Traceback (most recent call last):
  File "/KoVidore-benchmark/kovidore/evaluate.py", line 495, in run_benchmark
    results = evaluation.run(model, output_folder=f"results/{model_name}", encode_kwargs = {'batch_size': batch_size})
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/KoVidore-benchmark/.venv/lib/python3.12/site-packages/mteb/evaluation/MTEB.py", line 672, in run
    raise e
  File "/KoVidore-benchmark/.venv/lib/python3.12/site-packages/mteb/evaluation/MTEB.py", line 625, in run
    results, tick, tock = self._run_eval(
                          ^^^^^^^^^^^^^^^
  File "/KoVidore-benchmark/.venv/lib/python3.12/site-packages/mteb/evaluation/MTEB.py", line 307, in *run*eval
    results = task.evaluate(
              ^^^^^^^^^^^^^^
  File "/KoVidore-benchmark/.venv/lib/python3.12/site-packages/mteb/abstasks/Image/AbsTaskAny2AnyRetrieval.py", line 329, in evaluate
    scores[hf_subset] = self._evaluate_subset(
                        ^^^^^^^^^^^^^^^^^^^^^^
  File "/KoVidore-benchmark/.venv/lib/python3.12/site-packages/mteb/abstasks/Image/AbsTaskAny2AnyRetrieval.py", line 338, in *evaluate*subset
    results = retriever(corpus, queries)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/KoVidore-benchmark/.venv/lib/python3.12/site-packages/mteb/evaluation/evaluators/Image/Any2AnyRetrievalEvaluator.py", line 317, in **call**
    return self.retriever.search(
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/KoVidore-benchmark/.venv/lib/python3.12/site-packages/mteb/evaluation/evaluators/Image/Any2AnyRetrievalEvaluator.py", line 231, in search
    cos_scores = score_function(query_embeddings, sub_corpus_embeddings)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/KoVidore-benchmark/.venv/lib/python3.12/site-packages/mteb/models/colpali_models.py", line 134, in similarity
    return self.processor.score(a, b, **self.processor_kwargs)
                                        ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'ColPaliWrapper' object has no attribute 'processor_kwargs'
```

This issue likely stems from [this discussion](https://github.com/embeddings-benchmark/mteb/pull/2942#discussion_r2226299563). 
The ColPali Engine's [score_multi_vector](https://github.com/illuin-tech/colpali/blob/9bee9b2b72e37cde453d3e4656a1f032bad9194e/colpali_engine/utils/processing_utils.py#L128) method can accept optional arguments like `batch_size` and `device`. However, should we allow passing these parameters for the similarity scoring method at the `ColPaliEngineWrapper` level?  I believe this is conceptually different from the batch size and device used for embedding generation. So I'm not sure where these arguments should be received and passed through. Any ideas or suggestions would be welcome!

Thanks!!