### PR TITLE
fix: conflict dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,6 +227,10 @@ override-dependencies = [
 ]
 conflicts = [
     [{ extra = "timm" }, { extra = "blip2" }],
+    [{ extra = "llm2vec" }, { extra = "model2vec" }],
+    # conflicting versions of transformers:
     [{ extra = "llm2vec" }, { extra = "pylate" }],
-    [{ extra = "llm2vec" }, { extra = "model2vec" }]
+    [{ extra = "colpali-engine" }, { extra = "pylate" }],
+    [{ extra = "colpali-engine" }, { extra = "llm2vec" }],
+    [{ extra = "jina-v4" }, { extra = "llm2vec" }],
 ]


### PR DESCRIPTION
Copied from `v2` with addition of `jina-v4` vs `llm2vec`