### PR TITLE
fix(models): ensure prompt_type is passed to format_instruction

### DIFF
--- a/mteb/models/wrapper.py
+++ b/mteb/models/wrapper.py
@@ -200,5 +200,5 @@ class Wrapper:
     ) -> str:
         instruction = self.get_instruction(task_name, prompt_type, prompts_dict)
         if self.instruction_template:
-            return self.format_instruction(instruction)
+            return self.format_instruction(instruction, prompt_type)
         return instruction


### PR DESCRIPTION
Close #3215

This pull request makes a small change to the `get_task_instruction` method in `mteb/models/wrapper.py`, updating the call to `format_instruction` to include the `prompt_type` parameter. This ensures that the instruction formatting can now take into account the prompt type, potentially allowing for more flexible or context-aware instruction generation.