### PR TITLE
Feat rteb sider UI

### DIFF
--- a/mteb/benchmarks/benchmarks/rteb_benchmarks.py
+++ b/mteb/benchmarks/benchmarks/rteb_benchmarks.py
@@ -12,7 +12,7 @@ RTEB_CITATION = r"""@article{rteb2024,
 
 RTEB_MAIN = Benchmark(
     name="RTEB(beta)",
-    display_name="RTEB Retrieval Embedding Benchmark",
+    display_name="Retrieval Embedding Benchmark",
     icon="https://github.com/DennisSuitters/LibreICONS/raw/2d2172d15e3c6ca03c018629d60050e4b99e5c55/svg-color/libre-gui-search.svg",
     tasks=get_tasks(
         tasks=[
@@ -54,7 +54,7 @@ RTEB_MAIN = Benchmark(
 
 RTEB_ENGLISH = Benchmark(
     name="RTEB(eng, beta)",
-    display_name="English ",
+    display_name="English Retrieval",
     icon="https://github.com/lipis/flag-icons/raw/refs/heads/main/flags/4x3/us.svg",
     tasks=get_tasks(
         tasks=[
@@ -89,7 +89,7 @@ RTEB_ENGLISH = Benchmark(
 
 RTEB_FRENCH = Benchmark(
     name="RTEB(fr, beta)",
-    display_name="French ",
+    display_name="French Retrieval",
     icon="https://github.com/lipis/flag-icons/raw/260c91531be024944c6514130c5defb2ebb02b7d/flags/4x3/fr.svg",
     tasks=get_tasks(
         tasks=[
@@ -107,7 +107,7 @@ RTEB_FRENCH = Benchmark(
 
 RTEB_GERMAN = Benchmark(
     name="RTEB(deu, beta)",
-    display_name="German ",
+    display_name="German Retrieval",
     icon="https://github.com/lipis/flag-icons/raw/260c91531be024944c6514130c5defb2ebb02b7d/flags/4x3/de.svg",
     tasks=get_tasks(
         tasks=[
@@ -141,7 +141,7 @@ RTEB_JAPANESE = Benchmark(
 
 RTEB_FINANCE = Benchmark(
     name="RTEB(fin, beta)",
-    display_name="Finance ",
+    display_name="Finance Retrieval",
     icon="https://github.com/DennisSuitters/LibreICONS/raw/2d2172d15e3c6ca03c018629d60050e4b99e5c55/svg-color/libre-gui-price-tag.svg",
     tasks=get_tasks(
         tasks=[
@@ -162,7 +162,7 @@ RTEB_FINANCE = Benchmark(
 
 RTEB_LEGAL = Benchmark(
     name="RTEB(Law, beta)",
-    display_name="Legal ",
+    display_name="Legal  Retrieval",
     icon="https://github.com/DennisSuitters/LibreICONS/raw/2d2172d15e3c6ca03c018629d60050e4b99e5c55/svg-color/libre-map-library.svg",
     tasks=get_tasks(
         tasks=[
@@ -183,7 +183,7 @@ RTEB_LEGAL = Benchmark(
 
 RTEB_CODE = Benchmark(
     name="RTEB(Code, beta)",
-    display_name="Code ",
+    display_name="Code Retrieval",
     icon="https://github.com/DennisSuitters/LibreICONS/raw/2d2172d15e3c6ca03c018629d60050e4b99e5c55/svg-color/libre-tech-electronics.svg",
     tasks=get_tasks(
         tasks=[
@@ -205,7 +205,7 @@ RTEB_CODE = Benchmark(
 
 RTEB_HEALTHCARE = Benchmark(
     name="RTEB(Health, beta)",
-    display_name="Healthcare ",
+    display_name="Healthcare Retrieval",
     icon="https://github.com/DennisSuitters/LibreICONS/raw/2d2172d15e3c6ca03c018629d60050e4b99e5c55/svg-color/libre-map-hospital.svg",
     tasks=get_tasks(
         tasks=[

--- a/mteb/benchmarks/benchmarks/rteb_benchmarks.py
+++ b/mteb/benchmarks/benchmarks/rteb_benchmarks.py
@@ -54,7 +54,7 @@ RTEB_MAIN = Benchmark(
 
 RTEB_ENGLISH = Benchmark(
     name="RTEB(eng, beta)",
-    display_name="English",
+    display_name="English ",
     icon="https://github.com/lipis/flag-icons/raw/refs/heads/main/flags/4x3/us.svg",
     tasks=get_tasks(
         tasks=[
@@ -89,7 +89,7 @@ RTEB_ENGLISH = Benchmark(
 
 RTEB_FRENCH = Benchmark(
     name="RTEB(fr, beta)",
-    display_name="French",
+    display_name="French ",
     icon="https://github.com/lipis/flag-icons/raw/260c91531be024944c6514130c5defb2ebb02b7d/flags/4x3/fr.svg",
     tasks=get_tasks(
         tasks=[
@@ -107,7 +107,7 @@ RTEB_FRENCH = Benchmark(
 
 RTEB_GERMAN = Benchmark(
     name="RTEB(deu, beta)",
-    display_name="German",
+    display_name="German ",
     icon="https://github.com/lipis/flag-icons/raw/260c91531be024944c6514130c5defb2ebb02b7d/flags/4x3/de.svg",
     tasks=get_tasks(
         tasks=[
@@ -125,7 +125,7 @@ RTEB_GERMAN = Benchmark(
 
 RTEB_JAPANESE = Benchmark(
     name="RTEB(jpn, beta)",
-    display_name="Japanese",
+    display_name="Japanese ",
     icon="https://github.com/lipis/flag-icons/raw/260c91531be024944c6514130c5defb2ebb02b7d/flags/4x3/jp.svg",
     tasks=get_tasks(
         tasks=[
@@ -141,7 +141,7 @@ RTEB_JAPANESE = Benchmark(
 
 RTEB_FINANCE = Benchmark(
     name="RTEB(fin, beta)",
-    display_name="Finance",
+    display_name="Finance ",
     icon="https://github.com/DennisSuitters/LibreICONS/raw/2d2172d15e3c6ca03c018629d60050e4b99e5c55/svg-color/libre-gui-price-tag.svg",
     tasks=get_tasks(
         tasks=[
@@ -162,7 +162,7 @@ RTEB_FINANCE = Benchmark(
 
 RTEB_LEGAL = Benchmark(
     name="RTEB(Law, beta)",
-    display_name="Legal",
+    display_name="Legal ",
     icon="https://github.com/DennisSuitters/LibreICONS/raw/2d2172d15e3c6ca03c018629d60050e4b99e5c55/svg-color/libre-map-library.svg",
     tasks=get_tasks(
         tasks=[
@@ -183,7 +183,7 @@ RTEB_LEGAL = Benchmark(
 
 RTEB_CODE = Benchmark(
     name="RTEB(Code, beta)",
-    display_name="Code",
+    display_name="Code ",
     icon="https://github.com/DennisSuitters/LibreICONS/raw/2d2172d15e3c6ca03c018629d60050e4b99e5c55/svg-color/libre-tech-electronics.svg",
     tasks=get_tasks(
         tasks=[
@@ -205,7 +205,7 @@ RTEB_CODE = Benchmark(
 
 RTEB_HEALTHCARE = Benchmark(
     name="RTEB(Health, beta)",
-    display_name="Healthcare",
+    display_name="Healthcare ",
     icon="https://github.com/DennisSuitters/LibreICONS/raw/2d2172d15e3c6ca03c018629d60050e4b99e5c55/svg-color/libre-map-hospital.svg",
     tasks=get_tasks(
         tasks=[

--- a/mteb/benchmarks/benchmarks/rteb_benchmarks.py
+++ b/mteb/benchmarks/benchmarks/rteb_benchmarks.py
@@ -54,7 +54,7 @@ RTEB_MAIN = Benchmark(
 
 RTEB_ENGLISH = Benchmark(
     name="RTEB(eng, beta)",
-    display_name="RTEB English",
+    display_name="English",
     icon="https://github.com/lipis/flag-icons/raw/refs/heads/main/flags/4x3/us.svg",
     tasks=get_tasks(
         tasks=[
@@ -89,7 +89,7 @@ RTEB_ENGLISH = Benchmark(
 
 RTEB_FRENCH = Benchmark(
     name="RTEB(fr, beta)",
-    display_name="RTEB French",
+    display_name="French",
     icon="https://github.com/lipis/flag-icons/raw/260c91531be024944c6514130c5defb2ebb02b7d/flags/4x3/fr.svg",
     tasks=get_tasks(
         tasks=[
@@ -107,7 +107,7 @@ RTEB_FRENCH = Benchmark(
 
 RTEB_GERMAN = Benchmark(
     name="RTEB(deu, beta)",
-    display_name="RTEB German",
+    display_name="German",
     icon="https://github.com/lipis/flag-icons/raw/260c91531be024944c6514130c5defb2ebb02b7d/flags/4x3/de.svg",
     tasks=get_tasks(
         tasks=[
@@ -125,7 +125,7 @@ RTEB_GERMAN = Benchmark(
 
 RTEB_JAPANESE = Benchmark(
     name="RTEB(jpn, beta)",
-    display_name="RTEB Japanese",
+    display_name="Japanese",
     icon="https://github.com/lipis/flag-icons/raw/260c91531be024944c6514130c5defb2ebb02b7d/flags/4x3/jp.svg",
     tasks=get_tasks(
         tasks=[
@@ -141,7 +141,7 @@ RTEB_JAPANESE = Benchmark(
 
 RTEB_FINANCE = Benchmark(
     name="RTEB(fin, beta)",
-    display_name="RTEB Finance",
+    display_name="Finance",
     icon="https://github.com/DennisSuitters/LibreICONS/raw/2d2172d15e3c6ca03c018629d60050e4b99e5c55/svg-color/libre-gui-price-tag.svg",
     tasks=get_tasks(
         tasks=[
@@ -162,7 +162,7 @@ RTEB_FINANCE = Benchmark(
 
 RTEB_LEGAL = Benchmark(
     name="RTEB(Law, beta)",
-    display_name="RTEB Legal",
+    display_name="Legal",
     icon="https://github.com/DennisSuitters/LibreICONS/raw/2d2172d15e3c6ca03c018629d60050e4b99e5c55/svg-color/libre-map-library.svg",
     tasks=get_tasks(
         tasks=[
@@ -183,7 +183,7 @@ RTEB_LEGAL = Benchmark(
 
 RTEB_CODE = Benchmark(
     name="RTEB(Code, beta)",
-    display_name="RTEB Code",
+    display_name="Code",
     icon="https://github.com/DennisSuitters/LibreICONS/raw/2d2172d15e3c6ca03c018629d60050e4b99e5c55/svg-color/libre-tech-electronics.svg",
     tasks=get_tasks(
         tasks=[
@@ -205,7 +205,7 @@ RTEB_CODE = Benchmark(
 
 RTEB_HEALTHCARE = Benchmark(
     name="RTEB(Health, beta)",
-    display_name="RTEB Healthcare",
+    display_name="Healthcare",
     icon="https://github.com/DennisSuitters/LibreICONS/raw/2d2172d15e3c6ca03c018629d60050e4b99e5c55/svg-color/libre-map-hospital.svg",
     tasks=get_tasks(
         tasks=[

--- a/mteb/leaderboard/benchmark_selector.py
+++ b/mteb/leaderboard/benchmark_selector.py
@@ -31,7 +31,7 @@ class MenuEntry:
 
 BENCHMARK_ENTRIES = [
     MenuEntry(
-        name="Select Benchmark",
+        name="General Purpose",
         description="",
         open=False,
         benchmarks=mteb.get_benchmarks(["MTEB(Multilingual, v2)", "MTEB(eng, v2)"])
@@ -50,7 +50,7 @@ BENCHMARK_ENTRIES = [
                 ),
             ),
             MenuEntry(
-                "Domain-Specific",
+                "Domain -Specific",
                 mteb.get_benchmarks(
                     [
                         "MTEB(Code, v1)",

--- a/mteb/leaderboard/benchmark_selector.py
+++ b/mteb/leaderboard/benchmark_selector.py
@@ -88,17 +88,9 @@ BENCHMARK_ENTRIES = [
                 "Miscellaneous",  # All of these are retrieval benchmarks
                 mteb.get_benchmarks(
                     [
-                        "BEIR",
                         "BEIR-NL",
-                        "NanoBEIR",
-                        "BRIGHT",
-                        "BRIGHT (long)",
                         "BuiltBench(eng)",
-                        "CoIR",
-                        "FollowIR",
-                        "LongEmbed",
                         "MINERSBitextMining",
-                        "RAR-b",
                     ]
                 ),
             ),
@@ -108,7 +100,7 @@ BENCHMARK_ENTRIES = [
 
 RTEB_BENCHMARK_ENTRIES = [
     MenuEntry(
-        name="RTEB (Retrieval)",
+        name="Retrieval",
         description=None,
         open=False,
         benchmarks=[
@@ -124,6 +116,21 @@ RTEB_BENCHMARK_ENTRIES = [
                 description=None,
                 open=False,
                 benchmarks=[RTEB_ENGLISH, RTEB_FRENCH, RTEB_GERMAN],
+            ),
+            MenuEntry(
+                "Miscellaneous",
+                mteb.get_benchmarks(
+                    [
+                        "BEIR",
+                        "NanoBEIR",
+                        "BRIGHT",
+                        "BRIGHT (long)",
+                        "CoIR",
+                        "FollowIR",
+                        "LongEmbed",
+                        "RAR-b",
+                    ]
+                ),
             ),
         ],
     )


### PR DESCRIPTION
fixes to #3212

reran it locally as it seems like the current image it outdated

 - removed RTEB
 - renamed to general purpose
 - renamed task to "{prev_name} Retrieval" to prevent future bugs in people removing the "_". If we want to use the space we probably need to add a test to ensure distinct display names