### PR TITLE
Extending the RTEB benchmark

### DIFF
--- a/mteb/benchmarks/benchmarks/rteb_benchmarks.py
+++ b/mteb/benchmarks/benchmarks/rteb_benchmarks.py
@@ -31,6 +31,7 @@ RTEB_MAIN = Benchmark(
             "FreshStackRetrieval",
             "ChatDoctorRetrieval",
             "CUREv1",
+            "MIRACLRetrievalHardNegatives",
             # Closed datasets
             "Code1Retrieval",
             "JapaneseCode1Retrieval",
@@ -47,7 +48,7 @@ RTEB_MAIN = Benchmark(
             "JapaneseLegal1Retrieval",
         ],
     ),
-    description="RTEB (Retrieval Embedding Benchmark) is a comprehensive benchmark for evaluating text retrieval models across multiple specialized domains including legal, finance, code, and healthcare. It contains 28 diverse retrieval tasks designed to test models' ability to understand domain-specific terminology and retrieve relevant documents in specialized contexts across English, French, German, and Japanese languages.",
+    description="RTEB (Retrieval Embedding Benchmark) is a comprehensive benchmark for evaluating text retrieval models across multiple specialized domains including legal, finance, code, and healthcare. It contains 29 diverse retrieval tasks designed to test models' ability to understand domain-specific terminology and retrieve relevant documents in specialized contexts across English, French, German, and Japanese languages.",
     citation=RTEB_CITATION,
     contacts=["fzowl"],
 )

--- a/mteb/models/voyage_models.py
+++ b/mteb/models/voyage_models.py
@@ -205,6 +205,33 @@ model_prompts = {
     PromptType.document.value: "document",
 }
 
+voyage_3_large = ModelMeta(
+    name="voyageai/voyage-3-large",  # Date of publication of this post https://blog.voyageai.com/2025/01/07/voyage-3-large/
+    revision="1",
+    release_date="2025-01-07",
+    languages=None,  # supported languages not specified
+    loader=partial(  # type: ignore
+        VoyageWrapper,
+        model_name="voyage-3-large",
+        max_tokens=32000,
+        model_prompts=model_prompts,
+    ),
+    max_tokens=32000,
+    embed_dim=1024,
+    open_weights=False,
+    n_parameters=None,
+    memory_usage_mb=None,
+    license=None,
+    reference="https://blog.voyageai.com/2025/01/07/voyage-3-large/",
+    similarity_fn_name="cosine",
+    framework=["API"],
+    use_instructions=True,
+    training_datasets=VOYAGE_TRAINING_DATA,
+    public_training_code=None,
+    public_training_data=None,
+)
+
+
 voyage_3_5 = ModelMeta(
     name="voyageai/voyage-3.5",
     revision="1",


### PR DESCRIPTION
Extending the RTEB benchmark with MIRACLRetrievalHardNegatives task
Adding another voyageai model

- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] mteb.get_model(model_name, revision) and
  - [x] mteb.get_model_meta(model_name, revision)
- [x] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e. is available either as an API or the wieght are publicly avaiable to download