### PR TITLE
Fix AbsTaskTextRegression

### DIFF
--- a/mteb/abstasks/AbsTaskTextRegression.py
+++ b/mteb/abstasks/AbsTaskTextRegression.py
@@ -144,8 +144,8 @@ class AbsTaskTextRegression(AbsTask):
         if not self.data_loaded:
             self.load_data()
 
-        if "random_state" in self.model.get_params():
-            self.model = self.model.set_params(random_state=self.seed)
+        if "random_state" in self.regressor.get_params():
+            self.regressor = self.regressor.set_params(random_state=self.seed)
 
         scores = {}
         hf_subsets = self.hf_subsets


### PR DESCRIPTION
Before pull request
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/vatolin/experiments/mteb/mteb/__main__.py", line 5, in <module>
    main()
  File "/home/vatolin/experiments/mteb/mteb/cli.py", line 388, in main
    args.func(args)
  File "/home/vatolin/experiments/mteb/mteb/cli.py", line 146, in run
    eval.run(
  File "/home/vatolin/experiments/mteb/mteb/evaluation/MTEB.py", line 672, in run
    raise e
  File "/home/vatolin/experiments/mteb/mteb/evaluation/MTEB.py", line 625, in run
    results, tick, tock = self._run_eval(
                          ^^^^^^^^^^^^^^^
  File "/home/vatolin/experiments/mteb/mteb/evaluation/MTEB.py", line 307, in _run_eval
    results = task.evaluate(
              ^^^^^^^^^^^^^^
  File "/home/vatolin/experiments/mteb/mteb/abstasks/AbsTaskTextRegression.py", line 147, in evaluate
    if "random_state" in self.model.get_params():
                         ^^^^^^^^^^
AttributeError: 'RuSciBenchCitedCountRegression' object has no attribute 'model'
```