### PR TITLE
fix bm25 on small datasets

### DIFF
--- a/mteb/models/bm25.py
+++ b/mteb/models/bm25.py
@@ -91,7 +91,9 @@ def bm25_loader(**kwargs):
             logger.info(f"Retrieving Results... {len(queries):,} queries")
 
             queries_results, queries_scores = retriever.retrieve(
-                query_token_strs, corpus=corpus_with_ids, k=top_k
+                query_token_strs,
+                corpus=corpus_with_ids,
+                k=min(top_k, len(corpus_with_ids)),
             )
 
             # Iterate over queries


### PR DESCRIPTION
`k` shouldn't be greater than number of documents, otherwise error will be raised. Got it during https://github.com/embeddings-benchmark/results/pull/289