### PR TITLE
fix: Only pin model name and rank

### DIFF
--- a/mteb/leaderboard/table.py
+++ b/mteb/leaderboard/table.py
@@ -188,7 +188,7 @@ def _apply_summary_table_styling(joint_table: pd.DataFrame) -> gr.DataFrame:
         joint_table_style,
         datatype=column_types,
         interactive=False,
-        pinned_columns=3,
+        pinned_columns=2,
         column_widths=column_widths,
         wrap=True,
         show_fullscreen_button=True,


### PR DESCRIPTION
Currently we pin 3 columns, this makes it hard or impossible to view on phones. The 3rd column is also no longer garuanteed as RTEB leaderboard does not use the zero-shot column
