### PR TITLE
Update PyLate model revision to fix inference without FA

### DIFF
--- a/mteb/models/model_implementations/pylate_models.py
+++ b/mteb/models/model_implementations/pylate_models.py
@@ -427,7 +427,7 @@ lightonai__gte_moderncolbert_v1 = ModelMeta(
         "eng-Latn",
     ],
     open_weights=True,
-    revision="78d50a162b04dfdc45c3af6b4294ba77c24888a3",
+    revision="c1647d10d6edc6f70837f42f0a978f2df53f51dd",
     public_training_code="https://gist.github.com/NohTow/3030fe16933d8276dd5b3e9877d89f0f",
     public_training_data="https://huggingface.co/datasets/lightonai/ms-marco-en-bge-gemma",
     release_date="2025-04-30",


### PR DESCRIPTION
Hello,

As detailed [here](https://github.com/embeddings-benchmark/mteb/pull/3183#issuecomment-3376052542), there was an issue with ColBERT models using Flash Attention during training but not inference. This has been fixed in a new version of PyLate that has been released (to fix CPU inference and GPU without FA), but it also requires to use the new config from the model, which was not done because the revision of the model was set to an older one.

This fixes the issue by updating the revision to get the correct config