### PR TITLE
[v2] Make co2 optioinal

### DIFF
--- a/mteb/MTEB.py
+++ b/mteb/MTEB.py
@@ -262,7 +262,7 @@ class MTEB:
         eval_subsets: list[str] | None = None,
         overwrite_results: bool = False,
         raise_error: bool = True,
-        co2_tracker: bool = True,
+        co2_tracker: bool = False,
         encode_kwargs: dict[str, Any] | None = None,
         **kwargs,
     ) -> list[TaskResult]:


### PR DESCRIPTION
We're decided not to use by default in `mteb.evaluate`. I aligned `mteb.MTEB` with it. Maybe test become faster. Close https://github.com/embeddings-benchmark/mteb/issues/3275