### PR TITLE
Update pyproject for `v2`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mteb"
-version = "2.0.0"
+version = "1.39.7"
 description = "Massive Text Embedding Benchmark"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
- Specified `v2` version
- Added maintainers
- Updated links
- removed leftovers from 3.9 