### PR TITLE
fix: add citation to models

### DIFF
--- a/mteb/models/model_implementations/bm25.py
+++ b/mteb/models/model_implementations/bm25.py
@@ -137,4 +137,13 @@ bm25_s = ModelMeta(
     public_training_code="https://github.com/xhluca/bm25s",
     public_training_data=None,
     training_datasets=None,
+    citation="""@misc{bm25s,
+      title={BM25S: Orders of magnitude faster lexical search via eager sparse scoring},
+      author={Xing Han Lù},
+      year={2024},
+      eprint={2407.03618},
+      archivePrefix={arXiv},
+      primaryClass={cs.IR},
+      url={https://arxiv.org/abs/2407.03618},
+}""",
 )

--- a/mteb/models/model_implementations/bmretriever_models.py
+++ b/mteb/models/model_implementations/bmretriever_models.py
@@ -60,6 +60,19 @@ class BMRetrieverWrapper(InstructSentenceTransformerModel):
         self.model = SentenceTransformer(modules=[transformer, pooling])
 
 
+BMRETRIEVER_CITATION = """
+@inproceedings{xu-etal-2024-bmretriever,
+    title = "{BMR}etriever: Tuning Large Language Models as Better Biomedical Text Retrievers",
+    author = "Xu, Ran and Shi, Wenqi and Yu, Yue and Zhuang, Yuchen and Zhu, Yanqiao and Wang, May Dongmei and Ho, Joyce C. and Zhang, Chao and Yang, Carl",
+    booktitle = "Proceedings of the 2024 Conference on Empirical Methods in Natural Language Processing",
+    month = "November",
+    year = "2024",
+    address = "Miami, Florida, USA",
+    publisher = "Association for Computational Linguistics",
+    pages = "22234--22254",
+    url = "https://aclanthology.org/2024.emnlp-main.1241/"
+}"""
+
 # https://huggingface.co/datasets/BMRetriever/biomed_retrieval_dataset
 BMRETRIEVER_TRAINING_DATA = {
     "FEVER",
@@ -93,6 +106,7 @@ BMRetriever_410M = ModelMeta(
     public_training_code=None,
     public_training_data=None,
     training_datasets=BMRETRIEVER_TRAINING_DATA,
+    citation=BMRETRIEVER_CITATION,
 )
 
 BMRetriever_1B = ModelMeta(
@@ -121,6 +135,7 @@ BMRetriever_1B = ModelMeta(
     public_training_code=None,
     public_training_data=None,
     training_datasets=BMRETRIEVER_TRAINING_DATA,
+    citation=BMRETRIEVER_CITATION,
 )
 
 BMRetriever_2B = ModelMeta(
@@ -149,6 +164,7 @@ BMRetriever_2B = ModelMeta(
     public_training_code=None,
     public_training_data=None,
     training_datasets=BMRETRIEVER_TRAINING_DATA,
+    citation=BMRETRIEVER_CITATION,
 )
 
 BMRetriever_7B = ModelMeta(
@@ -177,4 +193,5 @@ BMRetriever_7B = ModelMeta(
     public_training_code=None,
     public_training_data=None,
     training_datasets=BMRETRIEVER_TRAINING_DATA,
+    citation=BMRETRIEVER_CITATION,
 )

--- a/mteb/models/model_implementations/clip_models.py
+++ b/mteb/models/model_implementations/clip_models.py
@@ -105,6 +105,15 @@ class CLIPModel(AbsEncoder):
         raise ValueError
 
 
+CLIP_CITATION = """
+@article{radford2021learning,
+  title={Learning Transferable Visual Models From Natural Language Supervision},
+  author={Radford, Alec and Kim, Jong Wook and Hallacy, Chris and Ramesh, Aditya and Goh, Gabriel and Agarwal, Sandhini and Sastry, Girish and Askell, Amanda and Mishkin, Pamela and Clark, Jack and Krueger, Gretchen and Sutskever, Ilya},
+  journal={arXiv preprint arXiv:2103.00020},
+  year={2021}
+}"""
+
+
 clip_vit_large_patch14 = ModelMeta(
     loader=CLIPModel,  # type: ignore
     name="openai/clip-vit-large-patch14",
@@ -125,6 +134,7 @@ clip_vit_large_patch14 = ModelMeta(
     similarity_fn_name=ScoringFunction.COSINE,
     use_instructions=False,
     training_datasets=None,
+    citation=CLIP_CITATION,
 )
 
 clip_vit_base_patch32 = ModelMeta(
@@ -147,6 +157,7 @@ clip_vit_base_patch32 = ModelMeta(
     similarity_fn_name=ScoringFunction.COSINE,
     use_instructions=False,
     training_datasets=None,
+    citation=CLIP_CITATION,
 )
 
 clip_vit_base_patch16 = ModelMeta(
@@ -169,4 +180,5 @@ clip_vit_base_patch16 = ModelMeta(
     similarity_fn_name=ScoringFunction.COSINE,
     use_instructions=False,
     training_datasets=None,
+    citation=CLIP_CITATION,
 )

--- a/mteb/models/model_implementations/colpali_models.py
+++ b/mteb/models/model_implementations/colpali_models.py
@@ -184,6 +184,16 @@ class ColPaliWrapper(ColPaliEngineWrapper):
         )
 
 
+COLPALI_CITATION = """
+@misc{faysse2024colpali,
+  title={ColPali: Efficient Document Retrieval with Vision Language Models},
+  author={Faysse, Manuel and Sibille, Hugues and Wu, Tony and Omrani, Bilel and Viaud, Gautier and Hudelot, C\'eline and Colombo, Pierre},
+  year={2024},
+  eprint={2407.01449},
+  archivePrefix={arXiv},
+  primaryClass={cs.IR}
+}"""
+
 COLPALI_TRAINING_DATA = {
     # from https://huggingface.co/datasets/vidore/colpali_train_set
     "DocVQA",
@@ -215,6 +225,7 @@ colpali_v1_1 = ModelMeta(
     similarity_fn_name=ScoringFunction.MAX_SIM,
     use_instructions=True,
     training_datasets=COLPALI_TRAINING_DATA,
+    citation=COLPALI_CITATION,
 )
 
 colpali_v1_2 = ModelMeta(
@@ -240,6 +251,7 @@ colpali_v1_2 = ModelMeta(
     similarity_fn_name=ScoringFunction.MAX_SIM,
     use_instructions=True,
     training_datasets=COLPALI_TRAINING_DATA,
+    citation=COLPALI_CITATION,
 )
 
 colpali_v1_3 = ModelMeta(
@@ -265,4 +277,5 @@ colpali_v1_3 = ModelMeta(
     similarity_fn_name=ScoringFunction.MAX_SIM,
     use_instructions=True,
     training_datasets=COLPALI_TRAINING_DATA,
+    citation=COLPALI_CITATION,
 )

--- a/mteb/models/model_implementations/colqwen_models.py
+++ b/mteb/models/model_implementations/colqwen_models.py
@@ -7,7 +7,11 @@ from mteb._requires_package import (
 )
 from mteb.models.model_meta import ModelMeta
 
-from .colpali_models import COLPALI_TRAINING_DATA, ColPaliEngineWrapper
+from .colpali_models import (
+    COLPALI_CITATION,
+    COLPALI_TRAINING_DATA,
+    ColPaliEngineWrapper,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -92,6 +96,7 @@ colqwen2 = ModelMeta(
     similarity_fn_name="MaxSim",
     use_instructions=True,
     training_datasets=COLPALI_TRAINING_DATA,
+    citation=COLPALI_CITATION,
 )
 
 colqwen2_5 = ModelMeta(
@@ -117,6 +122,7 @@ colqwen2_5 = ModelMeta(
     similarity_fn_name="MaxSim",
     use_instructions=True,
     training_datasets=COLPALI_TRAINING_DATA,
+    citation=COLPALI_CITATION,
 )
 
 colnomic_7b = ModelMeta(
@@ -142,7 +148,17 @@ colnomic_7b = ModelMeta(
     similarity_fn_name="MaxSim",
     use_instructions=True,
     training_datasets=COLPALI_TRAINING_DATA,
+    citation=COLPALI_CITATION,
 )
+
+COLNOMIC_CITATION = """
+@misc{nomicembedmultimodal2025,
+  title={Nomic Embed Multimodal: Interleaved Text, Image, and Screenshots for Visual Document Retrieval},
+  author={Nomic Team},
+  year={2025},
+  publisher={Nomic AI},
+  url={https://nomic.ai/blog/posts/nomic-embed-multimodal}
+}"""
 
 COLNOMIC_TRAINING_DATA = {"VDRMultilingual"} | COLPALI_TRAINING_DATA
 COLNOMIC_LANGUAGES = [
@@ -176,6 +192,7 @@ colnomic_3b = ModelMeta(
     similarity_fn_name="MaxSim",
     use_instructions=True,
     training_datasets=COLNOMIC_TRAINING_DATA,
+    citation=COLNOMIC_CITATION,
 )
 
 colnomic_7b = ModelMeta(
@@ -201,4 +218,5 @@ colnomic_7b = ModelMeta(
     similarity_fn_name="MaxSim",
     use_instructions=True,
     training_datasets=COLNOMIC_TRAINING_DATA,
+    citation=COLNOMIC_CITATION,
 )

--- a/mteb/models/model_implementations/colsmol_models.py
+++ b/mteb/models/model_implementations/colsmol_models.py
@@ -7,7 +7,11 @@ from mteb._requires_package import (
 )
 from mteb.models.model_meta import ModelMeta
 
-from .colpali_models import COLPALI_TRAINING_DATA, ColPaliEngineWrapper
+from .colpali_models import (
+    COLPALI_CITATION,
+    COLPALI_TRAINING_DATA,
+    ColPaliEngineWrapper,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +71,7 @@ colsmol_256m = ModelMeta(
     similarity_fn_name="MaxSim",
     use_instructions=True,
     training_datasets=COLPALI_TRAINING_DATA,
+    citation=COLPALI_CITATION,
 )
 
 colsmol_500m = ModelMeta(
@@ -92,4 +97,5 @@ colsmol_500m = ModelMeta(
     similarity_fn_name="MaxSim",
     use_instructions=True,
     training_datasets=COLPALI_TRAINING_DATA,
+    citation=COLPALI_CITATION,
 )

--- a/mteb/models/model_implementations/granite_vision_embedding_models.py
+++ b/mteb/models/model_implementations/granite_vision_embedding_models.py
@@ -179,4 +179,10 @@ granite_vision_embedding = ModelMeta(
     similarity_fn_name="MaxSim",
     use_instructions=True,
     training_datasets=None,  # proprietary, not public
+    citation="""@article{karlinsky2025granitevision,
+  title={Granite Vision: a lightweight, open-source multimodal model for enterprise Intelligence},
+  author={Granite Vision Team and Karlinsky, Leonid and Arbelle, Assaf and Daniels, Abraham and Nassar, Ahmed and Alfassi, Amit and Wu, Bo and Schwartz, Eli and Joshi, Dhiraj and Kondic, Jovana and Shabtay, Nimrod and Li, Pengyuan and Herzig, Roei and Abedin, Shafiq and Perek, Shaked and Harary, Sivan and Barzelay, Udi and Raz Goldfarb, Adi and Oliva, Aude and Wieles, Ben and Bhattacharjee, Bishwaranjan and Huang, Brandon and Auer, Christoph and Gutfreund, Dan and Beymer, David and Wood, David and Kuehne, Hilde and Hansen, Jacob and Shtok, Joseph and Wong, Ken and Bathen, Luis Angel and Mishra, Mayank and Lysak, Maksym and Dolfi, Michele and Yurochkin, Mikhail and Livathinos, Nikolaos and Harel, Nimrod and Azulai, Ophir and Naparstek, Oshri and de Lima, Rafael Teixeira and Panda, Rameswar and Doveh, Sivan and Gupta, Shubham and Das, Subhro and Zawad, Syed and Kim, Yusik and He, Zexue and Brooks, Alexander and Goodhart, Gabe and Govindjee, Anita and Leist, Derek and Ibrahim, Ibrahim and Soffer, Aya and Cox, David and Soule, Kate and Lastras, Luis and Desai, Nirmit and Ofek-koifman, Shila and Raghavan, Sriram and Syeda-Mahmood, Tanveer and Staar, Peter and Drory, Tal and Feris, Rogerio},
+  journal={arXiv preprint arXiv:2502.09927},
+  year={2025}
+}""",
 )

--- a/mteb/models/model_implementations/ibm_granite_models.py
+++ b/mteb/models/model_implementations/ibm_granite_models.py
@@ -4,6 +4,13 @@ from mteb.models.model_meta import (
 )
 from mteb.models.sentence_transformer_wrapper import sentence_transformers_loader
 
+GRANITE_EMBEDDING_CITATION = """@article{awasthy2025graniteembedding,
+  title={Granite Embedding Models},
+  author={Awasthy, Parul and Trivedi, Aashka and Li, Yulong and Bornea, Mihaela and Cox, David and Daniels, Abraham and Franz, Martin and Goodhart, Gabe and Iyer, Bhavani and Kumar, Vishwajeet and Lastras, Luis and McCarley, Scott and Murthy, Rudra and P, Vignesh and Rosenthal, Sara and Roukos, Salim and Sen, Jaydeep and Sharma, Sukriti and Sil, Avirup and Soule, Kate and Sultan, Arafat and Florian, Radu},
+  journal={arXiv preprint arXiv:2502.20204},
+  year={2025}
+}"""
+
 GRANITE_LANGUAGES = [
     "ara-Latn",
     "ces-Latn",
@@ -105,6 +112,7 @@ granite_107m_multilingual = ModelMeta(
     public_training_data=None,
     use_instructions=False,
     training_datasets=granite_training_data,
+    citation=GRANITE_EMBEDDING_CITATION,
 )
 
 granite_278m_multilingual = ModelMeta(
@@ -128,6 +136,7 @@ granite_278m_multilingual = ModelMeta(
     public_training_data=None,
     use_instructions=False,
     training_datasets=granite_training_data,
+    citation=GRANITE_EMBEDDING_CITATION,
 )
 
 granite_30m_english = ModelMeta(
@@ -151,6 +160,7 @@ granite_30m_english = ModelMeta(
     public_training_data=None,
     use_instructions=False,
     training_datasets=granite_training_data,
+    citation=GRANITE_EMBEDDING_CITATION,
 )
 
 granite_125m_english = ModelMeta(
@@ -174,6 +184,7 @@ granite_125m_english = ModelMeta(
     public_training_data=None,
     use_instructions=False,
     training_datasets=granite_training_data,
+    citation=GRANITE_EMBEDDING_CITATION,
 )
 
 
@@ -198,6 +209,7 @@ granite_english_r2 = ModelMeta(
     public_training_data=None,
     use_instructions=False,
     training_datasets=granite_training_data,
+    citation=GRANITE_EMBEDDING_CITATION,
 )
 
 granite_small_english_r2 = ModelMeta(
@@ -221,4 +233,5 @@ granite_small_english_r2 = ModelMeta(
     public_training_data=None,
     use_instructions=False,
     training_datasets=granite_training_data,
+    citation=GRANITE_EMBEDDING_CITATION,
 )

--- a/mteb/models/model_implementations/inf_models.py
+++ b/mteb/models/model_implementations/inf_models.py
@@ -35,6 +35,15 @@ inf_retreiver_v1_training_data = {
     # and other private data of INF TECH (not in MTEB),
 }
 
+INF_RETRIEVER_CITATION = """@misc{infly-ai_2025,
+  author       = {Junhan Yang and Jiahe Wan and Yichen Yao and Wei Chu and Yinghui Xu and Yuan Qi},
+  title        = {inf-retriever-v1 (Revision 5f469d7)},
+  year         = 2025,
+  url          = {https://huggingface.co/infly/inf-retriever-v1},
+  doi          = {10.57967/hf/4262},
+  publisher    = {Hugging Face}
+}"""
+
 inf_retriever_v1 = ModelMeta(
     loader=sentence_transformers_loader,
     loader_kwargs=dict(
@@ -58,6 +67,7 @@ inf_retriever_v1 = ModelMeta(
     public_training_code=None,
     public_training_data=None,
     training_datasets=inf_retreiver_v1_training_data,
+    citation=INF_RETRIEVER_CITATION,
 )
 
 inf_retriever_v1_1_5b = ModelMeta(
@@ -83,4 +93,5 @@ inf_retriever_v1_1_5b = ModelMeta(
     public_training_code=None,
     public_training_data=None,
     training_datasets=inf_retreiver_v1_training_data,
+    citation=INF_RETRIEVER_CITATION,
 )

--- a/mteb/models/model_implementations/jasper_models.py
+++ b/mteb/models/model_implementations/jasper_models.py
@@ -102,4 +102,15 @@ jasper_en_v1 = ModelMeta(
     # more codes https://huggingface.co/NovaSearch/jasper_en_vision_language_v1/commit/da9b77d56c23d9398fa8f93af449102784f74e1d
     public_training_code="https://github.com/NovaSearch-Team/RAG-Retrieval/blob/c40f4638b705eb77d88305d2056901ed550f9f4b/rag_retrieval/train/embedding/README.md",
     public_training_data="https://huggingface.co/datasets/infgrad/jasper_text_distill_dataset",
+    citation="""
+@misc{zhang2025jasperstelladistillationsota,
+      title={Jasper and Stella: distillation of SOTA embedding models},
+      author={Dun Zhang and Jiacheng Li and Ziyang Zeng and Fulong Wang},
+      year={2025},
+      eprint={2412.19048},
+      archivePrefix={arXiv},
+      primaryClass={cs.IR},
+      url={https://arxiv.org/abs/2412.19048},
+}
+""",
 )

--- a/mteb/models/model_implementations/jina_clip.py
+++ b/mteb/models/model_implementations/jina_clip.py
@@ -10,6 +10,13 @@ from mteb.models.abs_encoder import AbsEncoder
 from mteb.models.model_meta import ModelMeta, ScoringFunction
 from mteb.types import Array, BatchedInput, PromptType
 
+JINA_CLIP_CITATION = """@article{koukounas2024jinaclip,
+  title={Jina CLIP: Your CLIP Model Is Also Your Text Retriever},
+  author={Koukounas, Andreas and Mastrapas, Georgios and Günther, Michael and Wang, Bo and Martens, Scott and Mohr, Isabelle and Sturua, Saba and Akram, Mohammad Kalim and Martínez, Joan Fontanals and Ognawala, Saahil and Guzman, Susana and Werk, Maximilian and Wang, Nan and Xiao, Han},
+  journal={arXiv preprint arXiv:2405.20204},
+  year={2024}
+}"""
+
 
 class JinaCLIPModel(AbsEncoder):
     def __init__(
@@ -140,4 +147,5 @@ jina_clip_v1 = ModelMeta(
         # HotpotQA
         # Natural Language Inference (NLI) dataset (Bowman et al., 2015)
     },
+    citation=JINA_CLIP_CITATION,
 )

--- a/mteb/models/model_implementations/jina_models.py
+++ b/mteb/models/model_implementations/jina_models.py
@@ -573,6 +573,15 @@ jina_embeddings_v4 = ModelMeta(
     public_training_data=None,
     training_datasets=JinaV4_TRAINING_DATA,
     adapted_from="Qwen/Qwen2.5-VL-3B-Instruct",
+    citation="""@misc{günther2025jinaembeddingsv4universalembeddingsmultimodal,
+      title={jina-embeddings-v4: Universal Embeddings for Multimodal Multilingual Retrieval},
+      author={Michael Günther and Saba Sturua and Mohammad Kalim Akram and Isabelle Mohr and Andrei Ungureanu and Sedigheh Eslami and Scott Martens and Bo Wang and Nan Wang and Han Xiao},
+      year={2025},
+      eprint={2506.18902},
+      archivePrefix={arXiv},
+      primaryClass={cs.AI},
+      url={https://arxiv.org/abs/2506.18902},
+}""",
 )
 
 
@@ -694,6 +703,14 @@ jina_embeddings_v2_base_en = ModelMeta(
     },
     public_training_code=None,
     public_training_data=None,
+    citation="""@misc{günther2023jina,
+      title={Jina Embeddings 2: 8192-Token General-Purpose Text Embeddings for Long Documents},
+      author={Michael Günther and Jackmin Ong and Isabelle Mohr and Alaeddine Abdessalem and Tanguy Abel and Mohammad Kalim Akram and Susana Guzman and Georgios Mastrapas and Saba Sturua and Bo Wang and Maximilian Werk and Nan Wang and Han Xiao},
+      year={2023},
+      eprint={2310.19923},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL}
+}""",
 )
 
 jina_embeddings_v2_small_en = ModelMeta(
@@ -749,6 +766,14 @@ jina_embeddings_v2_small_en = ModelMeta(
     },
     public_training_code=None,
     public_training_data=None,
+    citation="""@misc{günther2023jina,
+      title={Jina Embeddings 2: 8192-Token General-Purpose Text Embeddings for Long Documents},
+      author={Michael Günther and Jackmin Ong and Isabelle Mohr and Alaeddine Abdessalem and Tanguy Abel and Mohammad Kalim Akram and Susana Guzman and Georgios Mastrapas and Saba Sturua and Bo Wang and Maximilian Werk and Nan Wang and Han Xiao},
+      year={2023},
+      eprint={2310.19923},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL}
+}""",
 )
 
 jina_embedding_b_en_v1 = ModelMeta(
@@ -797,6 +822,14 @@ jina_embedding_b_en_v1 = ModelMeta(
     },
     public_training_code=None,
     public_training_data=None,
+    citation="""@misc{günther2023jina,
+      title={Jina Embeddings: A Novel Set of High-Performance Sentence Embedding Models},
+      author={Michael Günther and Louis Milliken and Jonathan Geuter and Georgios Mastrapas and Bo Wang and Han Xiao},
+      year={2023},
+      eprint={2307.11224},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL}
+}""",
 )
 
 jina_embedding_s_en_v1 = ModelMeta(
@@ -845,4 +878,12 @@ jina_embedding_s_en_v1 = ModelMeta(
     },
     public_training_code=None,
     public_training_data=None,
+    citation="""@misc{günther2023jina,
+      title={Jina Embeddings: A Novel Set of High-Performance Sentence Embedding Models},
+      author={Michael Günther and Louis Milliken and Jonathan Geuter and Georgios Mastrapas and Bo Wang and Han Xiao},
+      year={2023},
+      eprint={2307.11224},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL}
+}""",
 )

--- a/mteb/models/model_implementations/kalm_models.py
+++ b/mteb/models/model_implementations/kalm_models.py
@@ -12,6 +12,13 @@ from mteb.types import Array, BatchedInput, PromptType
 
 logger = logging.getLogger(__name__)
 
+KALM_EMBEDDING_CITATION = """@article{hu2025kalm,
+  title={KaLM-Embedding: Superior Training Data Brings A Stronger Embedding Model},
+  author={Hu, Xinshuo and Shan, Zifei and Zhao, Xinping and Sun, Zetian and Liu, Zhenyu and Li, Dongfang and Ye, Shaolin and Wei, Xinyuan and Chen, Qian and Hu, Baotian and others},
+  journal={arXiv preprint arXiv:2501.01028},
+  year={2025}
+}"""
+
 
 class KALMWrapper(InstructSentenceTransformerModel):
     def encode(
@@ -673,6 +680,7 @@ HIT_TMG__KaLM_embedding_multilingual_mini_instruct_v1 = ModelMeta(
     training_datasets=kalm_training_data,  # Replace with actual dataset if available
     adapted_from="Qwen/Qwen2-0.5B",
     superseded_by=None,
+    citation=KALM_EMBEDDING_CITATION,
 )
 
 HIT_TMG__KaLM_embedding_multilingual_mini_v1 = ModelMeta(
@@ -696,6 +704,7 @@ HIT_TMG__KaLM_embedding_multilingual_mini_v1 = ModelMeta(
     training_datasets=kalm_training_data,
     adapted_from="Qwen/Qwen2-0.5B",
     superseded_by=None,
+    citation=KALM_EMBEDDING_CITATION,
 )
 
 HIT_TMG__KaLM_embedding_multilingual_mini_instruct_v1_5 = ModelMeta(
@@ -725,6 +734,7 @@ HIT_TMG__KaLM_embedding_multilingual_mini_instruct_v1_5 = ModelMeta(
     training_datasets=kalm_training_data,
     adapted_from="HIT-TMG/KaLM-embedding-multilingual-mini-instruct-v1",
     superseded_by=None,
+    citation=KALM_EMBEDDING_CITATION,
 )
 
 HIT_TMG__KaLM_embedding_multilingual_mini_instruct_v2 = ModelMeta(
@@ -754,4 +764,5 @@ HIT_TMG__KaLM_embedding_multilingual_mini_instruct_v2 = ModelMeta(
     training_datasets=kalm_v2_training_data,
     adapted_from="HIT-TMG/KaLM-embedding-multilingual-mini-instruct-v1.5",
     superseded_by=None,
+    citation=KALM_EMBEDDING_CITATION,
 )

--- a/mteb/models/model_implementations/lens_models.py
+++ b/mteb/models/model_implementations/lens_models.py
@@ -2,6 +2,13 @@ from mteb.models.model_meta import ModelMeta, ScoringFunction
 
 from .bge_models import bge_full_data
 
+LENS_CITATION = """@article{lei2025lens,
+  title={Enhancing Lexicon-Based Text Embeddings with Large Language Models},
+  author={Lei, Yibin and Shen, Tao and Cao, Yu and Yates, Andrew},
+  journal={arXiv preprint arXiv:2501.09749},
+  year={2025}
+}"""
+
 lens_d4000 = ModelMeta(
     loader=None,
     name="yibinlei/LENS-d4000",
@@ -21,6 +28,7 @@ lens_d4000 = ModelMeta(
     public_training_data="https://huggingface.co/datasets/cfli/bge-full-data",
     training_datasets=bge_full_data,
     max_tokens=32768,
+    citation=LENS_CITATION,
 )
 
 lens_d8000 = ModelMeta(
@@ -42,4 +50,5 @@ lens_d8000 = ModelMeta(
     public_training_data="https://huggingface.co/datasets/cfli/bge-full-data",
     training_datasets=bge_full_data,
     max_tokens=32768,
+    citation=LENS_CITATION,
 )

--- a/mteb/models/model_implementations/lgai_embedding_models.py
+++ b/mteb/models/model_implementations/lgai_embedding_models.py
@@ -63,4 +63,14 @@ lgai_embedding_en = ModelMeta(
     public_training_data=None,
     adapted_from="mistralai/Mistral-7B-v0.1",
     training_datasets=E5_MISTRAL_TRAINING_DATA | LGAI_EMBEDDING_TRAINING_DATA,
+    citation="""@misc{choi2025lgaiembeddingpreviewtechnicalreport,
+      title={LGAI-EMBEDDING-Preview Technical Report},
+      author={Jooyoung Choi and Hyun Kim and Hansol Jang and Changwook Jun and Kyunghoon Bae and Hyewon Choi and Stanley Jungkyu Choi and Honglak Lee and Chulmin Yun},
+      year={2025},
+      eprint={2506.07438},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL},
+      url={https://arxiv.org/abs/2506.07438},
+}
+""",
 )

--- a/mteb/models/model_implementations/linq_models.py
+++ b/mteb/models/model_implementations/linq_models.py
@@ -6,6 +6,14 @@ from mteb.types import PromptType
 
 from .e5_instruct import E5_MISTRAL_TRAINING_DATA
 
+LINQ_EMBED_MISTRAL_CITATION = """@misc{LinqAIResearch2024,
+  title={Linq-Embed-Mistral:Elevating Text Retrieval with Improved GPT Data Through Task-Specific Control and Quality Refinement},
+  author={Junseong Kim and Seolhwa Lee and Jihoon Kwon and Sangmo Gu and Yejin Kim and Minkyung Cho and Jy-yong Sohn and Chanyeol Choi},
+  howpublished={Linq AI Research Blog},
+  year={2024},
+  url={https://getlinq.com/blog/linq-embed-mistral/}
+}"""
+
 
 def instruction_template(
     instruction: str, prompt_type: PromptType | None = None
@@ -41,4 +49,5 @@ Linq_Embed_Mistral = ModelMeta(
     public_training_data=None,
     adapted_from="intfloat/e5-mistral-7b-instruct",
     training_datasets=E5_MISTRAL_TRAINING_DATA,
+    citation=LINQ_EMBED_MISTRAL_CITATION,
 )

--- a/mteb/models/model_implementations/listconranker.py
+++ b/mteb/models/model_implementations/listconranker.py
@@ -9,6 +9,13 @@ from mteb.types import BatchedInput, PromptType
 
 from .rerankers_custom import RerankerWrapper
 
+LISTCONRANKER_CITATION = """@article{liu2025listconranker,
+  title={ListConRanker: A Contrastive Text Reranker with Listwise Encoding},
+  author={Liu, Junlong and Ma, Yue and Zhao, Ruihui and Zheng, Junhao and Ma, Qianli and Kang, Yangyang},
+  journal={arXiv preprint arXiv:2501.07111},
+  year={2025}
+}"""
+
 
 class ListConRanker(RerankerWrapper):
     def __init__(self, model_name_or_path: str, **kwargs) -> None:
@@ -122,4 +129,5 @@ listconranker = ModelMeta(
     public_training_code=None,
     public_training_data=None,
     is_cross_encoder=True,
+    citation=LISTCONRANKER_CITATION,
 )

--- a/mteb/models/model_implementations/llm2clip_models.py
+++ b/mteb/models/model_implementations/llm2clip_models.py
@@ -11,6 +11,16 @@ from mteb.models.abs_encoder import AbsEncoder
 from mteb.models.model_meta import ModelMeta, ScoringFunction
 from mteb.types import Array, BatchedInput, PromptType
 
+LLM2CLIP_CITATION = """@misc{huang2024llm2clippowerfullanguagemodel,
+  title={LLM2CLIP: Powerful Language Model Unlock Richer Visual Representation},
+  author={Weiquan Huang and Aoqi Wu and Yifan Yang and Xufang Luo and Yuqing Yang and Liang Hu and Qi Dai and Xiyang Dai and Dongdong Chen and Chong Luo and Lili Qiu},
+  year={2024},
+  eprint={2411.04997},
+  archivePrefix={arXiv},
+  primaryClass={cs.CV},
+  url={https://arxiv.org/abs/2411.04997}
+}"""
+
 MODEL2PROCESSOR = {
     "microsoft/LLM2CLIP-Openai-L-14-336": "openai/clip-vit-large-patch14-336",
     "microsoft/LLM2CLIP-Openai-B-16": "openai/clip-vit-base-patch16",
@@ -190,6 +200,7 @@ llm2clip_openai_l_14_336 = ModelMeta(
     similarity_fn_name=ScoringFunction.COSINE,
     use_instructions=True,
     training_datasets=llm2clip_training_sets,
+    citation=LLM2CLIP_CITATION,
 )
 
 # NOTE: https://huggingface.co/microsoft/LLM2CLIP-Openai-L-14-224/discussions/1
@@ -213,6 +224,7 @@ llm2clip_openai_l_14_224 = ModelMeta(
     similarity_fn_name=ScoringFunction.COSINE,
     use_instructions=True,
     training_datasets=llm2clip_training_sets,
+    citation=LLM2CLIP_CITATION,
 )
 
 llm2clip_openai_b_16 = ModelMeta(
@@ -235,4 +247,5 @@ llm2clip_openai_b_16 = ModelMeta(
     similarity_fn_name=ScoringFunction.COSINE,
     use_instructions=True,
     training_datasets=llm2clip_training_sets,
+    citation=LLM2CLIP_CITATION,
 )

--- a/mteb/models/model_implementations/mdbr_models.py
+++ b/mteb/models/model_implementations/mdbr_models.py
@@ -3,6 +3,16 @@ from mteb.models.model_implementations.mxbai_models import mixedbread_training_d
 from mteb.models.model_meta import ModelMeta
 from mteb.models.sentence_transformer_wrapper import sentence_transformers_loader
 
+LEAF_CITATION = """@misc{mdbr_leaf,
+  title={LEAF: Knowledge Distillation of Text Embedding Models with Teacher-Aligned Representations},
+  author={Robin Vujanic and Thomas Rueckstiess},
+  year={2025},
+  eprint={2509.12539},
+  archivePrefix={arXiv},
+  primaryClass={cs.IR},
+  url={https://arxiv.org/abs/2509.12539}
+}"""
+
 model_prompts = {"query": "Represent this sentence for searching relevant passages: "}
 
 LEAF_TRAINING_DATASETS = {
@@ -38,6 +48,7 @@ mdbr_leaf_ir = ModelMeta(
     public_training_code=None,
     public_training_data=None,
     training_datasets=LEAF_TRAINING_DATASETS | arctic_v1_training_datasets,
+    citation=LEAF_CITATION,
 )
 
 mdbr_leaf_mt = ModelMeta(
@@ -64,4 +75,5 @@ mdbr_leaf_mt = ModelMeta(
     public_training_code=None,
     public_training_data=None,
     training_datasets=LEAF_TRAINING_DATASETS | mixedbread_training_data,
+    citation=LEAF_CITATION,
 )

--- a/mteb/models/model_implementations/moka_models.py
+++ b/mteb/models/model_implementations/moka_models.py
@@ -3,6 +3,12 @@
 from mteb.models.model_meta import ModelMeta, ScoringFunction
 from mteb.models.sentence_transformer_wrapper import sentence_transformers_loader
 
+M3E_CITATION = """@software{MokaMassiveMixedEmbedding,
+  author = {Wang Yuxin and Sun Qingxuan and He Sicheng},
+  title = {M3E: Moka Massive Mixed Embedding Model},
+  year = {2023}
+}"""
+
 sent_trf_training_dataset = {
     # derived from datasheets
     "MSMARCO",
@@ -104,6 +110,7 @@ m3e_base = ModelMeta(
     public_training_code=None,
     public_training_data=None,  # Not published
     training_datasets=m3e_dataset,
+    citation=M3E_CITATION,
 )
 
 m3e_small = ModelMeta(
@@ -128,6 +135,7 @@ m3e_small = ModelMeta(
     public_training_code=None,
     public_training_data=None,  # Not published
     training_datasets=m3e_dataset,
+    citation=M3E_CITATION,
 )
 
 m3e_large = ModelMeta(
@@ -152,4 +160,5 @@ m3e_large = ModelMeta(
     public_training_code=None,
     public_training_data=None,  # Not published
     training_datasets=m3e_dataset,
+    citation=M3E_CITATION,
 )

--- a/mteb/models/model_implementations/qwen3_models.py
+++ b/mteb/models/model_implementations/qwen3_models.py
@@ -92,6 +92,13 @@ multilingual_langs = [
     "zho-Hans",
 ]
 
+QWEN3_CITATION = """@article{qwen3embedding,
+  title={Qwen3 Embedding: Advancing Text Embedding and Reranking Through Foundation Models},
+  author={Zhang, Yanzhao and Li, Mingxin and Long, Dingkun and Zhang, Xin and Lin, Huan and Yang, Baosong and Xie, Pengjun and Yang, An and Liu, Dayiheng and Lin, Junyang and Huang, Fei and Zhou, Jingren},
+  journal={arXiv preprint arXiv:2506.05176},
+  year={2025}
+}"""
+
 training_data = {
     "T2Retrieval",
     "DuRetrieval",
@@ -143,6 +150,7 @@ Qwen3_Embedding_0B6 = ModelMeta(
     public_training_code=None,
     public_training_data=None,
     training_datasets=training_data,
+    citation=QWEN3_CITATION,
 )
 
 Qwen3_Embedding_4B = ModelMeta(
@@ -164,6 +172,7 @@ Qwen3_Embedding_4B = ModelMeta(
     public_training_code=None,
     public_training_data=None,
     training_datasets=training_data,
+    citation=QWEN3_CITATION,
 )
 
 Qwen3_Embedding_8B = ModelMeta(
@@ -185,4 +194,5 @@ Qwen3_Embedding_8B = ModelMeta(
     public_training_code=None,
     public_training_data=None,
     training_datasets=training_data,
+    citation=QWEN3_CITATION,
 )

--- a/mteb/models/model_implementations/qzhou_models.py
+++ b/mteb/models/model_implementations/qzhou_models.py
@@ -8,6 +8,16 @@ from mteb.models.model_implementations.e5_instruct import E5_MISTRAL_TRAINING_DA
 from mteb.models.model_meta import ModelMeta
 from mteb.types import PromptType
 
+QZHOU_EMBEDDING_CITATION = """@misc{yu2025qzhouembeddingtechnicalreport,
+      title={QZhou-Embedding Technical Report},
+      author={Peng Yu and En Xu and Bin Chen and Haibiao Chen and Yinfei Xu},
+      year={2025},
+      eprint={2508.21632},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL},
+      url={https://arxiv.org/abs/2508.21632},
+}"""
+
 
 def instruction_template(
     instruction: str, prompt_type: PromptType | None = None
@@ -71,6 +81,7 @@ QZhou_Embedding = ModelMeta(
     # Not in MTEB:
     # "FreedomIntelligence/Huatuo26M-Lite",
     # "infgrad/retrieval_data_llm",
+    citation=QZHOU_EMBEDDING_CITATION,
 )
 
 QZhou_Embedding_Zh = ModelMeta(
@@ -96,4 +107,5 @@ QZhou_Embedding_Zh = ModelMeta(
     public_training_code=None,
     public_training_data=None,
     training_datasets=qzhou_zh_training_data,
+    citation=QZHOU_EMBEDDING_CITATION,
 )

--- a/mteb/models/model_implementations/reasonir_model.py
+++ b/mteb/models/model_implementations/reasonir_model.py
@@ -4,6 +4,14 @@ from mteb.models import ModelMeta
 from mteb.models.instruct_wrapper import InstructSentenceTransformerModel
 from mteb.types import PromptType
 
+REASONIR_CITATION = """@article{shao2025reasonir,
+      title={ReasonIR: Training Retrievers for Reasoning Tasks},
+      author={Rulin Shao and Rui Qiao and Varsha Kishore and Niklas Muennighoff and Xi Victoria Lin and Daniela Rus and Bryan Kian Hsiang Low and Sewon Min and Wen-tau Yih and Pang Wei Koh and Luke Zettlemoyer},
+      year={2025},
+      journal={arXiv preprint arXiv:2504.20595},
+      url={https://arxiv.org/abs/2504.20595},
+}"""
+
 
 def instruction_template(
     instruction: str, prompt_type: PromptType | None = None
@@ -52,4 +60,5 @@ ReasonIR_8B = ModelMeta(
     training_datasets=REASONIR_TRAINING_DATA,
     public_training_code="https://github.com/facebookresearch/ReasonIR/tree/main/training",
     public_training_data="https://huggingface.co/datasets/reasonir/reasonir-data",
+    citation=REASONIR_CITATION,
 )

--- a/mteb/models/model_implementations/siglip_models.py
+++ b/mteb/models/model_implementations/siglip_models.py
@@ -9,6 +9,15 @@ from mteb.models.abs_encoder import AbsEncoder
 from mteb.models.model_meta import ModelMeta, ScoringFunction
 from mteb.types import Array, BatchedInput, PromptType
 
+SIGLIP_CITATION = """@misc{zhai2023sigmoid,
+      title={Sigmoid Loss for Language Image Pre-Training},
+      author={Xiaohua Zhai and Basil Mustafa and Alexander Kolesnikov and Lucas Beyer},
+      year={2023},
+      eprint={2303.15343},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}"""
+
 
 class SiglipModelWrapper(AbsEncoder):
     def __init__(
@@ -133,6 +142,7 @@ siglip_so400m_patch14_224 = ModelMeta(
     similarity_fn_name=ScoringFunction.COSINE,
     use_instructions=False,
     training_datasets=siglip_training_datasets,
+    citation=SIGLIP_CITATION,
 )
 
 siglip_so400m_patch14_384 = ModelMeta(
@@ -155,6 +165,7 @@ siglip_so400m_patch14_384 = ModelMeta(
     similarity_fn_name=ScoringFunction.COSINE,
     use_instructions=False,
     training_datasets=siglip_training_datasets,
+    citation=SIGLIP_CITATION,
 )
 
 siglip_so400m_patch16_256_i18n = ModelMeta(
@@ -177,6 +188,7 @@ siglip_so400m_patch16_256_i18n = ModelMeta(
     similarity_fn_name=ScoringFunction.COSINE,
     use_instructions=False,
     training_datasets=siglip_training_datasets,
+    citation=SIGLIP_CITATION,
 )
 
 siglip_base_patch16_256_multilingual = ModelMeta(
@@ -199,6 +211,7 @@ siglip_base_patch16_256_multilingual = ModelMeta(
     similarity_fn_name=ScoringFunction.COSINE,
     use_instructions=False,
     training_datasets=siglip_training_datasets,
+    citation=SIGLIP_CITATION,
 )
 
 siglip_base_patch16_256 = ModelMeta(
@@ -221,6 +234,7 @@ siglip_base_patch16_256 = ModelMeta(
     similarity_fn_name=ScoringFunction.COSINE,
     use_instructions=False,
     training_datasets=siglip_training_datasets,
+    citation=SIGLIP_CITATION,
 )
 
 siglip_base_patch16_512 = ModelMeta(
@@ -243,6 +257,7 @@ siglip_base_patch16_512 = ModelMeta(
     similarity_fn_name=ScoringFunction.COSINE,
     use_instructions=False,
     training_datasets=siglip_training_datasets,
+    citation=SIGLIP_CITATION,
 )
 
 siglip_base_patch16_384 = ModelMeta(
@@ -265,6 +280,7 @@ siglip_base_patch16_384 = ModelMeta(
     similarity_fn_name=ScoringFunction.COSINE,
     use_instructions=False,
     training_datasets=siglip_training_datasets,
+    citation=SIGLIP_CITATION,
 )
 
 siglip_base_patch16_224 = ModelMeta(
@@ -287,6 +303,7 @@ siglip_base_patch16_224 = ModelMeta(
     similarity_fn_name=ScoringFunction.COSINE,
     use_instructions=False,
     training_datasets=siglip_training_datasets,
+    citation=SIGLIP_CITATION,
 )
 
 siglip_large_patch16_256 = ModelMeta(
@@ -309,6 +326,7 @@ siglip_large_patch16_256 = ModelMeta(
     similarity_fn_name=ScoringFunction.COSINE,
     use_instructions=False,
     training_datasets=siglip_training_datasets,
+    citation=SIGLIP_CITATION,
 )
 
 siglip_large_patch16_384 = ModelMeta(
@@ -331,4 +349,5 @@ siglip_large_patch16_384 = ModelMeta(
     similarity_fn_name=ScoringFunction.COSINE,
     use_instructions=False,
     training_datasets=siglip_training_datasets,
+    citation=SIGLIP_CITATION,
 )

--- a/mteb/models/model_implementations/sonar_models.py
+++ b/mteb/models/model_implementations/sonar_models.py
@@ -1,5 +1,13 @@
 from mteb.models.model_meta import ModelMeta, ScoringFunction
 
+SONAR_CITATION = """@misc{Duquenne:2023:sonar_arxiv,
+  author = {Paul-Ambroise Duquenne and Holger Schwenk and Benoit Sagot},
+  title = {{SONAR:} Sentence-Level Multimodal and Language-Agnostic Representations},
+  publisher = {arXiv},
+  year = {2023},
+  url = {https://arxiv.org/abs/2308.11466},
+}"""
+
 sonar_langs = [
     "ace-Arab",
     "ace-Latn",
@@ -229,4 +237,5 @@ sonar = ModelMeta(
     ),
     public_training_code="https://github.com/facebookresearch/SONAR",
     public_training_data=None,  # couldn't find this
+    citation=SONAR_CITATION,
 )

--- a/mteb/models/model_implementations/stella_models.py
+++ b/mteb/models/model_implementations/stella_models.py
@@ -4,6 +4,16 @@ from mteb.models.sentence_transformer_wrapper import sentence_transformers_loade
 
 from .nvidia_models import nvidia_training_datasets
 
+STELLA_CITATION = """@misc{zhang2025jasperstelladistillationsota,
+      title={Jasper and Stella: distillation of SOTA embedding models},
+      author={Dun Zhang and Jiacheng Li and Ziyang Zeng and Fulong Wang},
+      year={2025},
+      eprint={2412.19048},
+      archivePrefix={arXiv},
+      primaryClass={cs.IR},
+      url={https://arxiv.org/abs/2412.19048},
+}"""
+
 stella_zh_datasets = {
     "BQ",
     "LCQMC",
@@ -65,6 +75,7 @@ stella_en_400m = ModelMeta(
     training_datasets=nvidia_training_datasets,  # also distilled from gte-qwen (but training data is unknown) #2164
     public_training_code="https://github.com/NovaSearch-Team/RAG-Retrieval/blob/c40f4638b705eb77d88305d2056901ed550f9f4b/rag_retrieval/train/embedding/README.md",
     public_training_data=None,
+    citation=STELLA_CITATION,
 )
 
 stella_en_1_5b = ModelMeta(
@@ -92,6 +103,7 @@ stella_en_1_5b = ModelMeta(
     training_datasets=nvidia_training_datasets,  # also distilled from gte-qwen (but training data is unknown) #2164
     public_training_code="https://github.com/NovaSearch-Team/RAG-Retrieval/blob/c40f4638b705eb77d88305d2056901ed550f9f4b/rag_retrieval/train/embedding/README.md",
     public_training_data=None,
+    citation=STELLA_CITATION,
 )
 
 stella_large_zh_v3_1792d = ModelMeta(

--- a/mteb/models/model_implementations/text2vec_models.py
+++ b/mteb/models/model_implementations/text2vec_models.py
@@ -6,6 +6,13 @@ from mteb.models.model_implementations.sentence_transformers_models import (
 from mteb.models.model_meta import ModelMeta, ScoringFunction
 from mteb.models.sentence_transformer_wrapper import sentence_transformers_loader
 
+TEXT2VEC_CITATION = """@software{text2vec,
+  author = {Xu Ming},
+  title = {text2vec: A Tool for Text to Vector},
+  year = {2022},
+  url = {https://github.com/shibing624/text2vec},
+}"""
+
 # I couldn't find the large model on HF for some reason
 text2vec_base_chinese = ModelMeta(
     loader=sentence_transformers_loader,
@@ -33,6 +40,7 @@ text2vec_base_chinese = ModelMeta(
         # (Could have overlaps I'm not aware of)
     ),
     memory_usage_mb=390,
+    citation=TEXT2VEC_CITATION,
 )
 
 text2vec_base_chinese_paraphrase = ModelMeta(
@@ -61,6 +69,7 @@ text2vec_base_chinese_paraphrase = ModelMeta(
         # - shibing624/nli-zh-all/text2vec-base-chinese-paraphrase
         # (Could have overlaps I'm not aware of)
     ),
+    citation=TEXT2VEC_CITATION,
 )
 
 
@@ -105,4 +114,5 @@ text2vec_base_multilingual = ModelMeta(
         # # (Could have overlaps I'm not aware of)
     )
     | sent_trf_training_dataset,
+    citation=TEXT2VEC_CITATION,
 )

--- a/mteb/models/model_implementations/vista_models.py
+++ b/mteb/models/model_implementations/vista_models.py
@@ -10,6 +10,13 @@ from mteb.models.abs_encoder import AbsEncoder
 from mteb.models.model_meta import ModelMeta, ScoringFunction
 from mteb.types import Array, BatchedInput, PromptType
 
+VISTA_CITATION = """@article{zhou2024vista,
+  title={VISTA: Visualized Text Embedding For Universal Multi-Modal Retrieval},
+  author={Zhou, Junjie and Liu, Zheng and Xiao, Shitao and Zhao, Bo and Xiong, Yongping},
+  journal={arXiv preprint arXiv:2406.04292},
+  year={2024}
+}"""
+
 
 def vista_loader(model_name, **kwargs):
     try:  # a temporal fix for the dependency issues of vista models.
@@ -257,6 +264,7 @@ visualized_bge_base = ModelMeta(
     similarity_fn_name=ScoringFunction.COSINE,
     use_instructions=False,
     training_datasets=vista_training_datasets,
+    citation=VISTA_CITATION,
 )
 
 visualized_bge_m3 = ModelMeta(
@@ -283,4 +291,5 @@ visualized_bge_m3 = ModelMeta(
     similarity_fn_name=ScoringFunction.COSINE,
     use_instructions=False,
     training_datasets=vista_training_datasets,
+    citation=VISTA_CITATION,
 )

--- a/mteb/models/model_implementations/vlm2vec_models.py
+++ b/mteb/models/model_implementations/vlm2vec_models.py
@@ -17,6 +17,13 @@ from mteb.types import Array, BatchedInput, PromptType
 
 logger = logging.getLogger(__name__)
 
+VLM2VEC_CITATION = """@article{jiang2024vlm2vec,
+  title={VLM2Vec: Training Vision-Language Models for Massive Multimodal Embedding Tasks},
+  author={Jiang, Ziyan and Meng, Rui and Yang, Xinyi and Yavuz, Semih and Zhou, Yingbo and Chen, Wenhu},
+  journal={arXiv preprint arXiv:2410.05160},
+  year={2024}
+}"""
+
 
 class VLM2VecWrapper(AbsEncoder):
     """Adapted from https://github.com/TIGER-AI-Lab/VLM2Vec/blob/main/src/model.py"""
@@ -279,6 +286,7 @@ vlm2vec_lora = ModelMeta(
     similarity_fn_name=ScoringFunction.COSINE,
     use_instructions=True,
     training_datasets=vlm2vec_training_datasets,
+    citation=VLM2VEC_CITATION,
 )
 
 vlm2vec_full = ModelMeta(
@@ -301,4 +309,5 @@ vlm2vec_full = ModelMeta(
     similarity_fn_name=ScoringFunction.COSINE,
     use_instructions=True,
     training_datasets=vlm2vec_training_datasets,
+    citation=VLM2VEC_CITATION,
 )

--- a/mteb/models/model_implementations/youtu_models.py
+++ b/mteb/models/model_implementations/youtu_models.py
@@ -131,4 +131,12 @@ Youtu_Embedding_V1 = ModelMeta(
     public_training_code=None,
     public_training_data=None,
     training_datasets=training_data,
+    citation="""@misc{zhang2025codiemb,
+  title={CoDiEmb: A Collaborative yet Distinct Framework for Unified Representation Learning in Information Retrieval and Semantic Textual Similarity},
+  author={Zhang, Bowen and Song, Zixin and Chen, Chunquan and Zhang, Qian-Wen and Yin, Di and Sun, Xing},
+  year={2025},
+  eprint={2508.11442},
+  archivePrefix={arXiv},
+  url={https://arxiv.org/abs/2508.11442},
+}""",
 )


### PR DESCRIPTION
Close #3388

This pull request adds citation metadata to a wide range of model implementations in the `mteb/models/model_implementations` directory. The primary goal is to ensure that each model's `ModelMeta` definition now includes a formal citation, making it easier for users to reference the original research or documentation associated with each model. The changes are grouped by model family as follows:
* bm25s
* BMRetriever
* OpenAI CLIP
* ColPali
* ColQwen & ColNomic
* ColSmol
* IBM Granite Vision
* IBM Granite Embedding
* INF Retriever
* Jasper
* Jina (embedding + CLIP)
* KaLM Embedding
* LENS
* LGAI Embedding
* Linq Embed
* ListConRanker
* LLM2CLIP
* MDBR Leaf
* M3E (moka-ai)
* Qwen3 Embedding
* QZhou Embedding
* ReasonIR
* Google SigLIP
* Facebook SONAR
* NovaSearch Stella
* Shibing624 Text2Vec
* BAAI BGE Visualized
* TIGER-Lab VLM2Vec
* Tencent Youtu