### PR TITLE
make search encoder compatible with encoder

### DIFF
--- a/mteb/models/search_wrappers.py
+++ b/mteb/models/search_wrappers.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import torch
 from datasets import Dataset
+from torch.utils.data import DataLoader
 
 from mteb._create_dataloaders import (
     create_dataloader,
@@ -11,6 +12,7 @@ from mteb._create_dataloaders import (
 from mteb.abstasks.task_metadata import TaskMetadata
 from mteb.types import (
     Array,
+    BatchedInput,
     CorpusDatasetType,
     PromptType,
     QueryDatasetType,
@@ -285,6 +287,42 @@ class SearchEncoderWrapper:
                 heapq.heappush(result_heaps[query_id], (score, corpus_id))
 
         return result_heaps
+
+    def encode(
+        self,
+        inputs: DataLoader[BatchedInput],
+        *,
+        task_metadata: TaskMetadata,
+        hf_split: str,
+        hf_subset: str,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
+    ) -> Array:
+        """Encode inputs using the model' s encode."""
+        return self.model.encode(
+            inputs,
+            task_metadata=task_metadata,
+            hf_split=hf_split,
+            hf_subset=hf_subset,
+            prompt_type=prompt_type,
+            **kwargs,
+        )
+
+    def similarity(
+        self,
+        embeddings1: Array,
+        embeddings2: Array,
+    ) -> Array:
+        """Compute the similarity between two collections of embeddings."""
+        return self.model.similarity(embeddings1, embeddings2)
+
+    def similarity_pairwise(
+        self,
+        embeddings1: Array,
+        embeddings2: Array,
+    ) -> Array:
+        """Compute the pairwise similarity between two collections of embeddings."""
+        return self.model.similarity_pairwise(embeddings1, embeddings2)
 
 
 class SearchCrossEncoderWrapper:

--- a/tests/test_models/test_search_wrapper_encode.py
+++ b/tests/test_models/test_search_wrapper_encode.py
@@ -1,0 +1,26 @@
+import pytest
+
+import mteb
+from mteb import AbsTask, EncoderProtocol
+from mteb.models import SearchEncoderWrapper
+from tests.mock_tasks import (
+    MockBitextMiningTask,
+    MockPairClassificationTask,
+    MockRetrievalTask,
+)
+
+
+@pytest.mark.parametrize(
+    "task",
+    [
+        MockRetrievalTask(),
+        MockPairClassificationTask(),  # uses model.similarity_pairwise
+        MockBitextMiningTask(),  # uses model.similarity
+    ],
+)
+@pytest.mark.parametrize("model", [mteb.get_model("baseline/random-encoder-baseline")])
+def test_benchmark_datasets(task: AbsTask, model: mteb.EncoderProtocol):
+    """Test that a task can be fetched and run"""
+    model = SearchEncoderWrapper(model)
+    assert isinstance(model, EncoderProtocol)
+    mteb.evaluate(model, task, cache=None)


### PR DESCRIPTION
Previously, if execute this

```python
import mteb

model = mteb.get_model("baseline/random-encoder-baseline")
task = model.get_task("SomeSTS")
mteb.evaluate(model, task, cache=None)
```
would produce error. I think it's better to add this option if user wrap encoder model with search encoder to be able to execute all tasks