### PR TITLE
fix ReasonIR instruction

### DIFF
--- a/mteb/models/model_implementations/reasonir_model.py
+++ b/mteb/models/model_implementations/reasonir_model.py
@@ -18,7 +18,7 @@ def instruction_template(
 ) -> str:
     return (
         # https://github.com/facebookresearch/ReasonIR/blob/0aac96269e455965949df16520fab72da68ffc22/evaluation/bright/configs/reasonir/economics.json#L3
-        f"<|user|>\n{instruction}<|embed|>\n"
+        f"<|user|>\n{instruction}\n<|embed|>\n"
         if (prompt_type is None or prompt_type == PromptType.query) and instruction
         else "<|embed|>\n"
     )


### PR DESCRIPTION
This pull request makes a minor formatting adjustment to the prompt template in the `reasonir_model.py` implementation. The change ensures that a newline is inserted after the instruction and before the `<|embed|>` token for improved prompt clarity.

- Added a newline after the instruction in the `instruction_template` function to separate the instruction from the `<|embed|>` token.