### PR TITLE
fix: materialize corpus id to speed up evaluation

### DIFF
--- a/mteb/models/search_wrappers.py
+++ b/mteb/models/search_wrappers.py
@@ -191,6 +191,7 @@ class SearchEncoderWrapper:
             cos_scores_top_k_idx = cos_scores_top_k_idx.cpu().tolist()
             cos_scores_top_k_values = cos_scores_top_k_values.cpu().tolist()
 
+            sub_corpus_ids = list(sub_corpus_ids)
             for query_itr in range(len(query_embeddings)):
                 query_id = query_idx_to_id[query_itr]
                 for sub_corpus_id, score in zip(


### PR DESCRIPTION
I was running some model evaluations for FEVER-VN dataset on the  AITeamVN/Vietnamese_Embedding_V2 model then I found out that it took so long to run. Both CPU + GPU was idling during the whole evaluation.

I was already using latest mteb==2.1.4 and datasets==4.3.0

Here is a an example of the running log 

```
2025-11-02 21:57:37,151 - mteb.models.search_wrappers - INFO - Encoding Batch 2/109...
Batches: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1563/1563 [04:28<00:00,  5.83it/s]
2025-11-02 22:02:13,541 - mteb.models.search_wrappers - INFO - Computing Similarities...
2025-11-02 22:30:11,984 - mteb.models.search_wrappers - INFO - Encoding Batch 3/109...
Batches: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1563/1563 [04:28<00:00,  5.83it/s]
2025-11-02 22:02:13,541 - mteb.models.search_wrappers - INFO - Computing Similarities...
2025-11-02 22:30:11,984 - mteb.models.search_wrappers - INFO - Encoding Batch 3/109...
Batches: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1563/1563 [08:19<00:00,  3.13it/s]
2025-11-02 22:38:37,836 - mteb.models.search_wrappers - INFO - Computing Similarities...
```

Notice almost ~30m between batch!

With some profiling, this is where the slowness happens `corpus_id = sub_corpus_ids[sub_corpus_id]`. Then I realize that we can just materialize the list. After this changes, this is blazing fast now 😄 