### PR TITLE
fix false positive check in typos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,7 @@ repos:
     rev: v1.38.1
     hooks:
     - id: typos
+      args: ["--diff"]
 
   - repo: local
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ lint-check:
 	# Required for CI to work, otherwise it will just pass
 	ruff format . --check						    # running ruff formatting
 	ruff check .    						        # running ruff linting
+	typos --diff
 
 test:
 	@echo "--- 🧪 Running tests ---"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -377,6 +377,13 @@ extend-exclude = [
     "mteb/tasks/reranking/eng/built_bench_reranking.py",  # prompt:   descriptions from buit asset
     "mteb/tasks/retrieval/eng/built_bench_retrieval.py",
     "mteb/tasks/retrieval/eng/llava_it2t_retrieval.py",
+    # dutch prompts
+    "mteb/tasks/classification/nld/",
+    "mteb/tasks/clustering/nld/",
+    "mteb/tasks/multilabel_classification/nld/",
+    "mteb/tasks/pair_classification/nld/",
+    "mteb/tasks/sts/nld/",
+    "mteb/tasks/retrieval/nld/",
 ]
 
 [tool.typos.type.py]


### PR DESCRIPTION
Ignore `nld` files, because of `false positive` of typos. Add typos to CI (`lint-check`)