### PR TITLE
ci: Add concurrency to tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,10 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
With concurrency, new test runs in the same PR will cancel the previous ones, which reduces CI usage. This can be helpful because when 3-4 PRs have many commits, you sometimes have to wait for runners for a some time