### PR TITLE
Model : Tarka Embedding 350M V1

### DIFF
--- a/mteb/models/model_implementations/tarka_models.py
+++ b/mteb/models/model_implementations/tarka_models.py
@@ -341,7 +341,6 @@ tarka_embedding_150m_v1 = ModelMeta(
 )
 
 tark_embedding_350_v1_kwargs = dict(
-    device="cuda",  # use a gpu
     model_kwargs={
         "attn_implementation": "flash_attention_2",
         "torch_dtype": "bfloat16",


### PR DESCRIPTION
- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [x] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e. is available either as an API or the weight are publicly available to download