### PR TITLE
fix: resolve hash randomization in retrieval task ID generation

### DIFF
--- a/mteb/tasks/retrieval/kat/georgian_faq_retrieval.py
+++ b/mteb/tasks/retrieval/kat/georgian_faq_retrieval.py
@@ -46,10 +46,17 @@ class GeorgianFAQRetrieval(AbsTaskRetrieval):
             split=_EVAL_SPLIT,
             revision=self.metadata.dataset["revision"],
         )
-        question_ids = {
-            question: _id for _id, question in enumerate(set(data["question"]))
-        }
-        answer_ids = {answer: _id for _id, answer in enumerate(set(data["answer"]))}
+
+        question_ids = {}
+        answer_ids = {}
+
+        for row in data:
+            question = row["question"]
+            answer = row["answer"]
+            if question not in question_ids:
+                question_ids[question] = len(question_ids)
+            if answer not in answer_ids:
+                answer_ids[answer] = len(answer_ids)
 
         for row in data:
             question = row["question"]

--- a/mteb/tasks/retrieval/multilingual/belebele_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/belebele_retrieval.py
@@ -230,10 +230,11 @@ class BelebeleRetrieval(AbsTaskRetrieval):
             ds_corpus = self.dataset[lang_corpus]
             ds_question = self.dataset[lang_question]
 
-            question_ids = {
-                question: _id
-                for _id, question in enumerate(set(ds_question["question"]))
-            }
+            question_ids = {}
+            for row in ds_question:
+                question = row["question"]
+                if question not in question_ids:
+                    question_ids[question] = len(question_ids)
 
             link_to_context_id = {}
             context_idx = 0

--- a/mteb/tasks/retrieval/multilingual/public_health_qa_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/public_health_qa_retrieval.py
@@ -32,10 +32,15 @@ def _load_publichealthqa_data(
             split=split,
             revision=revision,
         )
-        question_ids = {
-            question: _id for _id, question in enumerate(set(data["question"]))
-        }
-        answer_ids = {answer: _id for _id, answer in enumerate(set(data["answer"]))}
+
+        question_ids = {}
+        answer_ids = {}
+
+        for row in data:
+            if row["question"] is not None and row["question"] not in question_ids:
+                question_ids[row["question"]] = len(question_ids)
+            if row["answer"] is not None and row["answer"] not in answer_ids:
+                answer_ids[row["answer"]] = len(answer_ids)
 
         for row in data:
             if row["question"] is None or row["answer"] is None:


### PR DESCRIPTION
## 🐛 Bug Fix: Hash Randomization in Query ID Generation

### Summary
This PR fixes non-deterministic query ID assignment in three retrieval tasks caused by Python hash randomization when using `enumerate(set())`.

### Problem

**Root Cause:**
Python's hash randomization (PEP 456) causes `set()` to have unpredictable iteration order across process runs. This results in the same query receiving different IDs on each evaluation.

**Example:**
```python
# Run 1: "What is COVID-19?" → Q31
# Run 2: "What is COVID-19?" → Q36  # ❌ Different ID!
# Run 3: "What is COVID-19?" → Q18  # ❌ Different ID again!
```

### Impact on Real-World Use Cases

1. **❌ Error Analysis Broken**
   - Cannot track specific query failures across runs
   - Debugging logs become unusable

2. **❌ Two-Stage Reranking Fails**
   - First-stage retrieval cached by query ID
   - Second-stage reranker cannot match cached predictions
   - ID mismatch causes incorrect query-document pairing

3. **❌ Prediction Cache Invalid**
   ```python
   # cache/predictions.json (from previous run)
   {"Q31": ["doc1", "doc2", "doc3"]}

   # Current run
   queries = {"Q36": "What is COVID-19?"}  # ❌ Q31 != Q36
   # Cannot reuse cached predictions
   ```


### Solution

Replace `enumerate(set())` with first-occurrence order tracking:

**Before:**
```python
question_ids = {
    question: _id for _id, question in enumerate(set(data["question"]))
}
```

**After:**
```python
# Use first-occurrence order to ensure deterministic ID assignment
# regardless of Python hash randomization (PEP 456)
question_ids = {}
for row in data:
    if row["question"] is not None and row["question"] not in question_ids:
        question_ids[row["question"]] = len(question_ids)
```

### Affected Tasks

- **PublicHealthQARetrieval** (8 languages including Korean)
- **BelebeleRetrieval** (122 language variants including Korean)
- **GeorgianFAQRetrieval** (Georgian)

---

### Related Issues

This fix addresses reproducibility issues in Korean and multilingual retrieval benchmarks where cached predictions become invalid across evaluation runs.