### PR TITLE
add jasper token compression model

### DIFF
--- a/mteb/models/model_implementations/jasper_models.py
+++ b/mteb/models/model_implementations/jasper_models.py
@@ -157,7 +157,8 @@ Jasper_Token_Compression_600M = ModelMeta(
     framework=["Sentence Transformers", "PyTorch"],
     use_instructions=True,
     public_training_code=None,
-    public_training_data="https://huggingface.co/datasets/cfli/bge-full-data",
+    # public_training_data: unsupervised data for distillation
+    public_training_data="https://huggingface.co/datasets/infgrad/jasper_text_distill_dataset",
     training_datasets=bge_m3_training_data
     | bge_chinese_training_data
     | bge_full_data


### PR DESCRIPTION
- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [x] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e. is available either as an API or the weight are publicly available to download

Dear MTEB maintainers, the following information may be helpful for your review of this PR:
1) This model uses the same prompt as the qzhou model
2) The training dataset for this model is consistent with qzhou's

