### PR TITLE
fix: Set default input_type for VoyageMultiModalModelWrapper

### DIFF
--- a/mteb/models/model_implementations/voyage_v.py
+++ b/mteb/models/model_implementations/voyage_v.py
@@ -149,7 +149,7 @@ def voyage_v_loader(model_name, **kwargs):
             show_progress_bar: bool = True,
             **kwargs: Any,
         ) -> Array:
-            input_type = "document" # default
+            input_type = "document"  # default
             if prompt_type is not None:
                 if prompt_type == PromptType.document:
                     input_type = "document"


### PR DESCRIPTION
if Input_type is None it leads to an error 