### PR TITLE
model: Add spartan8806/atles-champion-embedding model

### DIFF
--- a/mteb/models/model_implementations/spartan8806_atles_champion.py
+++ b/mteb/models/model_implementations/spartan8806_atles_champion.py
@@ -21,6 +21,6 @@ spartan8806_atles_champion_embedding = ModelMeta(
     use_instructions=False,
     training_datasets={"STSBenchmark"},
     adapted_from="sentence-transformers/all-mpnet-base-v2",
-    public_training_code="https://huggingface.co/spartan8806/atles-champion-embedding",
-    public_training_data="https://huggingface.co/datasets/sentence-transformers/stsb",
+    public_training_code=None,
+    public_training_data=None,
 )


### PR DESCRIPTION
# Add ATLES Champion Embedding Model

Adds support for `spartan8806/atles-champion-embedding` to MTEB.

## Model Details
- **HuggingFace**: https://huggingface.co/spartan8806/atles-champion-embedding
- **Framework**: Sentence Transformers
- **Base Model**: all-mpnet-base-v2
- **Embedding Dimension**: 768
- **Max Tokens**: 512
- **Parameters**: 110M

## Performance (STS-B Test Set)
- **Pearson**: 0.8445
- **Spearman**: 0.8374
- **Average**: 0.8410
- **Top-10 worldwide performance**

## Related PR
Results submission: embeddings-benchmark/results#320

## Checklist
- [x] Model is publicly available on HuggingFace
- [x] Model uses sentence-transformers framework
- [x] ModelMeta includes all required fields
- [x] Wrapper class properly configured
- [x] License: Apache 2.0

## License
Apache 2.0 (open source)