### PR TITLE
add prompt dict for Jasper_Token_Compression_600M

### DIFF
--- a/mteb/models/model_implementations/jasper_models.py
+++ b/mteb/models/model_implementations/jasper_models.py
@@ -328,15 +328,8 @@ jasper_en_v1 = ModelMeta(
 )
 
 
-class JasperTokenCompressionLoader(InstructSentenceTransformerModel):
-    def __init__(self, model_name: str, revision: str, **kwargs: Any):
-        super().__init__(model_name, revision, **kwargs)
-        if isinstance(kwargs.get("max_seq_length"), int):
-            self.model.max_seq_length = kwargs["max_seq_length"]
-
-
 Jasper_Token_Compression_600M = ModelMeta(
-    loader=JasperTokenCompressionLoader,
+    loader=InstructSentenceTransformerModel,
     loader_kwargs=jasper_token_compression_600m_loader_kwargs,
     name="infgrad/Jasper-Token-Compression-600M",
     languages=["eng-Latn", "zho-Hans"],


### PR DESCRIPTION
 @Samoed 
Hello, as you suggested, I have added a prompt_dict. Actual testing shows that the Chinese and English MTEB results are consistent with those already submitted.

There are changes in the MTEB (Law, v1) results, and I will update the PR(https://github.com/embeddings-benchmark/results/pull/325) for the results.

Here is the reproduction code:
```
import mteb

if __name__ == "__main__":
    benchmark_name = "MTEB(cmn, v1)"  # MTEB(eng, v2), MTEB(cmn, v1), MTEB(Law, v1),
    model = mteb.get_model("infgrad/Jasper-Token-Compression-600M")
    mteb.MTEB(tasks=list(mteb.get_benchmark(benchmark_name).tasks)).run(model)

```