### PR TITLE
fix: Bump gradio version to fix links on leaderboard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ mteb = "mteb.cli:main"
 image = ["torchvision>0.2.1"]
 codecarbon = ["codecarbon>=2.0.0,<3.0.0"]
 leaderboard = [
-    "gradio==5.35.0",
+    "gradio==5.49.1",
     "plotly>=5.24.0,<6.0.0",
     "cachetools>=5.2.0",
     "matplotlib>=3.9.4",


### PR DESCRIPTION
This seems to finally fix issue with links on gradio. Close https://github.com/embeddings-benchmark/mteb/issues/2869

Live on https://huggingface.co/spaces/mteb/leaderboard_2_demo 