### PR TITLE
fix: improve messages for running missing splits

### DIFF
--- a/mteb/evaluate.py
+++ b/mteb/evaluate.py
@@ -440,7 +440,7 @@ def evaluate(
 
     if existing_results:
         logger.info(
-            f"Found existing results for {task.metadata.name}, only running missing splits: {list(missing_eval.keys())}"
+            f"Found existing results for {task.metadata.name}, only running missing splits (subsets): {missing_eval}"
         )
 
     if isinstance(model, ModelMeta):


### PR DESCRIPTION
It now looks like:
```
INFO:mteb.evaluate:Found existing results for MassiveIntentClassification, only running missing splits (subset): {'validation': ['hy', 'jv', 'fr', 'hu', 'tl', 'az', 'zh-CN', 'ms', 'ar', 'pt', 'ja', 'tr', 'hi', 'lv', 'sw', 'nl', 'en', 'ko', 'mn', 'zh-TW', 'kn', 'am', 'he', 'my', 'sq', 'vi', 'fi', 'ru', 'cy', 'it', 'pl', 'el', 'de', 'te', 'af', 'ro', 'sl', 'fa', 'ur', 'ml', 'is', 'bn', 'es', 'km', 'ka', 'th', 'ta', 'id'], 'test': ['hy', 'jv', 'fr', 'hu', 'tl', 'az', 'zh-CN', 'ms', 'ar', 'pt', 'ja', 'tr', 'hi', 'lv', 'sw', 'nl', 'en', 'ko', 'mn', 'zh-TW', 'kn', 'am', 'he', 'my', 'sq', 'vi', 'fi', 'ru', 'cy', 'it', 'pl', 'el', 'de', 'te', 'af', 'ro', 'sl', 'fa', 'ur', 'ml', 'is', 'bn', 'es', 'km', 'ka', 'th', 'ta', 'id']}
```

while previously it looked like:

```
INFO:mteb.evaluate:Found existing results for MassiveIntentClassification, only running missing splits: ['validation', 'test']
```

This can be confusing as I could think that I already ran test without having run "test": "da"