### PR TITLE
tests: Add tests for dataset quality

### DIFF
--- a/tests/test_tasks/test_task_quality.py
+++ b/tests/test_tasks/test_task_quality.py
@@ -332,7 +332,7 @@ def _task_quality(task: AbsTask) -> list[str]:
 
 
 def test_dataset_quality():
-    tasks = get_tasks(exclude_superseded=False, exclude_aggregate=False)
+    tasks = get_tasks(exclude_superseded=False, exclude_aggregate=True)
 
     errors: list[str] = []
     for task in tasks:


### PR DESCRIPTION
This test ensures a minimum quality of task for future submissions

Currently, it tests for:
- text duplicates
- train test leakage
- too short documents

I suspect we can likely add many more tests to this in future PRs

I would argue that this fixes #375 (by preventing duplicates it in future datasets)

fixes #375
fixes #3370