### PR TITLE
fix: vidore loading

### DIFF
--- a/mteb/tasks/retrieval/multilingual/vidore2_bench_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/vidore2_bench_retrieval.py
@@ -41,6 +41,7 @@ def _load_data(
             },
             remove_columns=["query-id", "query"],
         )
+        query_ds = query_ds.select_columns(["id", "text"])
 
         corpus_ds = load_dataset(
             path,
@@ -55,6 +56,7 @@ def _load_data(
             },
             remove_columns=["corpus-id"],
         )
+        corpus_ds = corpus_ds.select_columns(["id", "image"])
 
         qrels_ds = load_dataset(
             path,


### PR DESCRIPTION
Ref https://github.com/embeddings-benchmark/mteb/pull/3602#issuecomment-3575782743

Previously problem was that in their dataset in queries split they have column `source_type` that have list with different lengths and because of it dataset couldn't be processed correctly with dataloader https://huggingface.co/datasets/vidore/esg_reports_human_labeled_v2/viewer/queries?views%5B%5D=queries