### PR TITLE
fix: Avoiding stating warning if what is logged is not a warning

### DIFF
--- a/mteb/models/search_wrappers.py
+++ b/mteb/models/search_wrappers.py
@@ -147,7 +147,7 @@ class SearchEncoderWrapper:
         top_k: int,
         encode_kwargs: dict[str, Any],
     ) -> dict[str, list[tuple[float, str]]]:
-        logger.info("Encoding Corpus in batches... Warning: This might take a while!")
+        logger.info("Encoding Corpus in batches (this might take a while)...")
         itr = range(0, len(self.task_corpus), self.corpus_chunk_size)
 
         result_heaps = {qid: [] for qid in query_idx_to_id.values()}


### PR DESCRIPTION
Stating warning here might lead devs to think it should be considered a warning. It is just a info message.

Also changes to that "..." appears at the end

