### PR TITLE
fix: remove docker system prune command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,6 @@ jobs:
             /usr/local/share/powershell \
             /usr/share/dotnet \
             /usr/share/swift
-          docker system prune -af
 
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Removed unnecessary docker system prune command from the workflow.

Close https://github.com/embeddings-benchmark/mteb/issues/3669

