### PR TITLE
model: add two Japanese models sarashina-embedding-{v1, v2}-1b

### DIFF
--- a/mteb/models/model_implementations/sarashina_embedding_models.py
+++ b/mteb/models/model_implementations/sarashina_embedding_models.py
@@ -105,7 +105,7 @@ def sarashina_instruction_template(
     if not instruction:
         return ""
     if prompt_type == PromptType.document:
-        return instruction
+        return "text: "
     return f"task: {instruction}\nquery: "
 
 


### PR DESCRIPTION
This PR adds two models in the `sarashina-embedding` series: [v1-1b](https://huggingface.co/sbintuitions/sarashina-embedding-v1-1b) and [v2-1b](https://huggingface.co/sbintuitions/sarashina-embedding-v2-1b).

- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [x] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e., is available either as an API or the weights are publicly available to download
