### PR TITLE
fix: Don't pass embed dim to `openai/text-embedding-ada-002`

### DIFF
--- a/mteb/models/model_implementations/openai_models.py
+++ b/mteb/models/model_implementations/openai_models.py
@@ -91,10 +91,6 @@ class OpenAIModel(AbsEncoder):
 
         from openai import NotGiven
 
-        if self.model_name == "text-embedding-ada-002" and self._embed_dim is not None:
-            logger.warning(
-                "Reducing embedding size available only for text-embedding-3-* models"
-            )
         sentences = [text for batch in inputs for text in batch["text"]]
 
         mask_sents = [(i, t) for i, t in enumerate(sentences) if t.strip()]
@@ -122,13 +118,22 @@ class OpenAIModel(AbsEncoder):
 
         no_empty_embeddings = []
 
+        # Set dimensions only for models that support it
+        dimensions = (
+            self._embed_dim or NotGiven()
+            if not self.model_name == "text-embedding-ada-002"
+            else NotGiven()
+        )
+        default_kwargs = dict(
+            model=self.model_name,
+            encoding_format="float",
+            dimensions=dimensions,
+        )
+
         for sublist in tqdm(sublists, leave=False, disable=not show_progress_bar):
             try:
                 response = self._client.embeddings.create(
-                    input=sublist,
-                    model=self.model_name,
-                    encoding_format="float",
-                    dimensions=self._embed_dim or NotGiven(),
+                    input=sublist, **default_kwargs
                 )
             except Exception as e:
                 # Sleep due to too many requests
@@ -138,19 +143,13 @@ class OpenAIModel(AbsEncoder):
                 time.sleep(10)
                 try:
                     response = self._client.embeddings.create(
-                        input=sublist,
-                        model=self.model_name,
-                        encoding_format="float",
-                        dimensions=self._embed_dim or NotGiven(),
+                        input=sublist, **default_kwargs
                     )
                 except Exception as e:
                     logger.info("Sleeping for 60 seconds due to error", e)
                     time.sleep(60)
                     response = self._client.embeddings.create(
-                        input=sublist,
-                        model=self.model_name,
-                        encoding_format="float",
-                        dimensions=self._embed_dim or NotGiven(),
+                        input=sublist, **default_kwargs
                     )
             no_empty_embeddings.extend(self._to_numpy(response))
 


### PR DESCRIPTION
It does not support embed dim.

closes #3687

tested imp. with the below code to ensure that it works with both old and new models

```py
import mteb

mdl = mteb.get_model("openai/text-embedding-ada-002")
task = mteb.get_task("STSBenchmark", eval_splits=["test"])
mteb.evaluate(mdl, task, cache=None)
mdl = mteb.get_model("openai/text-embedding-3-small")
mteb.evaluate(mdl, task, cache=None)
```

