### PR TITLE
[MAEB] CLAP Token Length Error from Fleurs

### DIFF
--- a/mteb/models/model_implementations/clap_models.py
+++ b/mteb/models/model_implementations/clap_models.py
@@ -100,7 +100,6 @@ class ClapZeroShotWrapper(AbsEncoder):
                 return_tensors="pt",
                 padding=True,
                 truncation=True,
-                max_length=512,
             )
             inputs = {k: v.to(self.device) for k, v in inputs.items()}
 


### PR DESCRIPTION
- Added manual truncation of 512 tokens in text processor.

Error:
[long_text_2e372dd9-4045-493f-96af-33117e7f99a3.txt](https://github.com/user-attachments/files/24093461/long_text_2e372dd9-4045-493f-96af-33117e7f99a3.txt)
