### PR TITLE
Remove padding after pylate encoding

### DIFF
--- a/mteb/models/model_implementations/pylate_models.py
+++ b/mteb/models/model_implementations/pylate_models.py
@@ -328,13 +328,10 @@ class MultiVectorModel(AbsEncoder, PylateSearchEncoder):
             inputs,
             prompt_name=prompt_name,
             is_query=prompt_type == PromptType.query,
-            convert_to_tensor=True,
             **kwargs,
         )
 
-        # encode returns a list of tensors shaped (x, token_dim), pad to uniform length
-        pred = torch.nn.utils.rnn.pad_sequence(pred, batch_first=True, padding_value=0)
-        return pred.cpu().numpy()
+        return pred
 
 
 colbert_v2 = ModelMeta(


### PR DESCRIPTION
Hello,

As pointed out in the [original merging of PyLate ](https://github.com/embeddings-benchmark/mteb/pull/3183) and [the following discussion](https://github.com/embeddings-benchmark/mteb/issues/3283), after the encoding through PyLate models, there is an unnecessary padding operation because PyLate indexes handle padding on their own.

Originally, I observed some deltas, but lately when running new benches with new models, I actually have scores of 0, while with my scripts I had normal results. I checked the code and tested running with MTEB but without the padding and the scores are normal again. I cannot share a reproducible minimal code because the models are unfortunately not public for now but given that the padding is not needed and the code works great without it, I propose to remove it anyways.

I am not totally sure why this can totally _break_ some results, maybe it's the fact that we double cast it (here and in PyLate) or maybe I missed one effect of this particular padding call.

Close https://github.com/embeddings-benchmark/mteb/issues/3283