### PR TITLE
model: Add bisectgroup/BiCA-base 

### DIFF
--- a/mteb/models/model_implementations/bica_model.py
+++ b/mteb/models/model_implementations/bica_model.py
@@ -3,7 +3,7 @@ from mteb.models import ModelMeta, sentence_transformers_loader
 bica_base = ModelMeta(
     name="bisectgroup/BiCA-base",
     loader=sentence_transformers_loader,
-    languages=["eng-Latn"], 
+    languages=["eng-Latn"],
     open_weights=True,
     revision="31237a836e5ae908c308a256573e5f0986498574",
     release_date="2025-11-14",


### PR DESCRIPTION
- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [x] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e., is available either as an API or the weights are publicly available to download