### PR TITLE
fix prompt_dict to prompt_dicts

### DIFF
--- a/mteb/models/model_implementations/mod_models.py
+++ b/mteb/models/model_implementations/mod_models.py
@@ -170,7 +170,7 @@ def mod_instruct_loader(
         revision=revision,
         instruction_template=instruction_template,
         apply_instruction_to_passages=False,
-        prompt_dict=PREDEFINED_PROMPTS,
+        prompt_dicts=PREDEFINED_PROMPTS,
         **kwargs,
     )
     encoder = model.model._first_module()


### PR DESCRIPTION
- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [x] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e., is available either as an API or the weights are publicly available to download