### PR TITLE
[MAEB] Wav2Clip Text Encoder

### DIFF
--- a/mteb/models/model_implementations/wav2clip_model.py
+++ b/mteb/models/model_implementations/wav2clip_model.py
@@ -78,13 +78,13 @@ class Wav2ClipZeroShotWrapper(AbsEncoder):
                 if wav.shape[-1] < max_length:
                     # Pad with zeros
                     pad_length = max_length - wav.shape[-1]
-                    padded_wav = torch.nn.functional.pad(wav, (0, pad_length))
+                    padded_wav = np.pad(wav, (0, pad_length), mode="constant")
                 else:
                     padded_wav = wav
                 padded_wavs.append(padded_wav)
 
-            # Stack into batch tensor
-            batch_tensor = torch.stack(padded_wavs).cpu().detach().numpy()
+            # Stack into batch array
+            batch_tensor = np.stack(padded_wavs)
 
             # Process entire batch at once
             batch_embeds = self.embed_audio(batch_tensor, self.audio_model)


### PR DESCRIPTION
Related to https://github.com/embeddings-benchmark/mteb/issues/3545

@Samoed  I've double-checked the paper (arXiv:2110.11499v2), and it seem to confirm that we can use the standard CLIP text encoder.

1. The CLIP model is not tuned. The paper explicitly states in Section 2: "Throughout distillation, the original CLIP model weights are kept frozen". 
2. The authors note that "we get image and text modality for free". 
3. In their own evaluation (Section 3.2), they describe the process as extracting "CLIP text and Wav2CLIP audio embeddings".

Since the text encoder is identical to the standard CLIP encoder, I think we can safely get the text embeddings from the original CLIP model, and they will be mathematically aligned with the audio embeddings from wav2clip.