### PR TITLE
Updates on ColEmbed 3B and 1B model wrapper to support MTEB 2 image dataloader

### DIFF
--- a/mteb/models/model_implementations/nvidia_llama_nemoretriever_colemb.py
+++ b/mteb/models/model_implementations/nvidia_llama_nemoretriever_colemb.py
@@ -67,7 +67,9 @@ class LlamaNemoretrieverColembed(AbsEncoder):
         for batch in iterator:
             for image in batch["image"]:
                 pil_img = (
-                    image if isinstance(image, Image.Image) else F.to_pil_image(image.to("cpu"))
+                    image
+                    if isinstance(image, Image.Image)
+                    else F.to_pil_image(image.to("cpu"))
                 )
                 all_images.append(pil_img)
 


### PR DESCRIPTION
This MR enables evaluating [llama-nemoretriever-colembed-3b-v1](https://huggingface.co/nvidia/llama-nemoretriever-colembed-3b-v1) and [llama-nemoretriever-colembed-1b-v1](https://huggingface.co/nvidia/llama-nemoretriever-colembed-1b-v1) models on `ViDoRe(v3)` and `VisualDocumentRetrieval` (Vidore V1-V2) benchmarks with MTEB 2 newest API.

### Context  
After MTEB API changed for its version 2, the [llama-nemoretriever-colembed-3b-v1](https://huggingface.co/nvidia/llama-nemoretriever-colembed-3b-v1) and [llama-nemoretriever-colembed-1b-v1](https://huggingface.co/nvidia/llama-nemoretriever-colembed-1b-v1) models were not supported for MTEB 2 evaluation.

We at Nvidia have adapted our ColEmbed 3B ([MR](https://huggingface.co/nvidia/llama-nemoretriever-colembed-3b-v1/discussions/7/files)) and ColEmbed 1B ([MR](https://huggingface.co/nvidia/llama-nemoretriever-colembed-1b-v1/discussions/7/files)) code to support MTEB 2 new API, and this MR aligns the MTEB model wrappers to the HF models latest code.