### PR TITLE
model: add octen_models

### DIFF
--- a/mteb/models/model_implementations/octen_models.py
+++ b/mteb/models/model_implementations/octen_models.py
@@ -6,7 +6,9 @@ from mteb.models.models_protocols import PromptType
 def instruction_template(
     instruction: str, prompt_type: PromptType | None = None
 ) -> str:
-    if prompt_type == PromptType.document:
+    if (
+        prompt_type == PromptType.document
+    ):  # to avoid this issue: https://huggingface.co/Qwen/Qwen3-Embedding-8B/discussions/21
         return " "
     if not instruction:
         return ""


### PR DESCRIPTION
- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [x] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e., is available either as an API or the weights are publicly available to download