### PR TITLE
Optimize validate filter scores only

### DIFF
--- a/mteb/results/task_result.py
+++ b/mteb/results/task_result.py
@@ -666,8 +666,9 @@ class TaskResult(BaseModel):
             logger.warning(
                 f"{task.metadata.name}: Missing splits {set(splits) - seen_splits}"
             )
-        # Avoid to_dict() roundtrip - use model_copy for better performance
-        return self.model_copy(update={"scores": new_scores})
+        data = self.model_dump()
+        data["scores"] = new_scores
+        return type(self).model_construct(**data)
 
     def is_mergeable(
         self,


### PR DESCRIPTION
Second step to fix https://github.com/embeddings-benchmark/mteb/issues/2580.
Follow up from #3790

1. Consolidated set conversion to single line 
2. Replaced append-in-loop with list comprehension
3. Used model_copy() instead of expensive to_dict() + from_validated() roundtrip