### PR TITLE
fix: Add `fill_missing` parameter in `get_model_meta`

### DIFF
--- a/mteb/models/get_model_meta.py
+++ b/mteb/models/get_model_meta.py
@@ -108,7 +108,7 @@ def get_model_meta(
     model_name: str,
     revision: str | None = None,
     fetch_from_hf: bool = True,
-    compute_missing: bool = False,
+    fill_missing: bool = False,
 ) -> ModelMeta:
     """A function to fetch a model metadata object by name.
 
@@ -116,7 +116,7 @@ def get_model_meta(
         model_name: Name of the model to fetch
         revision: Revision of the model to fetch
         fetch_from_hf: Whether to fetch the model from HuggingFace Hub if not found in the registry
-        compute_missing: Computes missing attributes from the metadata including number of parameters and memory usage.
+        fill_missing: Computes missing attributes from the metadata including number of parameters and memory usage.
 
     Returns:
         A model metadata object
@@ -129,7 +129,7 @@ def get_model_meta(
                 f"Model revision {revision} not found for model {model_name}. Expected {model_meta.revision}."
             )
 
-        if compute_missing and fetch_from_hf:
+        if fill_missing and fetch_from_hf:
             original_meta_dict = model_meta.model_dump()
             new_meta = ModelMeta.from_hub(model_name)
             new_meta_dict = new_meta.model_dump(exclude_none=True)

--- a/tests/test_models/test_model_meta.py
+++ b/tests/test_models/test_model_meta.py
@@ -143,7 +143,7 @@ def test_loader_kwargs_persisted_in_metadata():
 def test_compute_missing_parameter():
     """Test that compute_missing parameter fetches missing metadata from HuggingFace Hub"""
     model_name = "sentence-transformers/all-MiniLM-L6-v2"
-    meta_with_compute = mteb.get_model_meta(model_name, compute_missing=True)
+    meta_with_compute = mteb.get_model_meta(model_name, fill_missing=True)
 
     assert meta_with_compute.n_parameters is not None
     assert meta_with_compute.memory_usage_mb is not None


### PR DESCRIPTION
closes #3693 