### PR TITLE
fix name of evaluator for multilabel tasks

### DIFF
--- a/mteb/tasks/audio/audio_multilabel_classification/eng/audio_set.py
+++ b/mteb/tasks/audio/audio_multilabel_classification/eng/audio_set.py
@@ -47,7 +47,7 @@ class AudioSetMultilingualClassification(AbsTaskMultilabelClassification):
         superseded_by="AudioSetMini",
     )
 
-    evaluator = MultiOutputClassifier(estimator=LogisticRegression())
+    evaluator_model = MultiOutputClassifier(estimator=LogisticRegression())
     input_column_name: str = "audio"
     label_column_name: str = "human_labels"
 
@@ -94,6 +94,6 @@ class AudioSetMiniMultilingualClassification(AbsTaskMultilabelClassification):
 """,
     )
 
-    evaluator = MultiOutputClassifier(estimator=LogisticRegression())
+    evaluator_model = MultiOutputClassifier(estimator=LogisticRegression())
     input_column_name: str = "audio"
     label_column_name: str = "human_labels"

--- a/mteb/tasks/audio/audio_multilabel_classification/eng/bird_set.py
+++ b/mteb/tasks/audio/audio_multilabel_classification/eng/bird_set.py
@@ -42,7 +42,7 @@ class BirdSetMultilabelClassification(AbsTaskMultilabelClassification):
 """,
     )
 
-    evaluator = MultiOutputClassifier(estimator=LogisticRegression())
+    evaluator_model = MultiOutputClassifier(estimator=LogisticRegression())
     input_column_name: str = "audio"
     label_column_name: str = "labels"
     samples_per_label: int = 21

--- a/mteb/tasks/audio/audio_multilabel_classification/eng/fsd2019_kaggle.py
+++ b/mteb/tasks/audio/audio_multilabel_classification/eng/fsd2019_kaggle.py
@@ -49,7 +49,7 @@ Xavier Serra},
 """,
     )
 
-    evaluator = MultiOutputClassifier(estimator=LogisticRegression())
+    evaluator_model = MultiOutputClassifier(estimator=LogisticRegression())
     input_column_name: str = "audio"
     label_column_name: str = "sound"
     samples_per_label: int = 8

--- a/mteb/tasks/audio/audio_multilabel_classification/eng/fsd50_hf.py
+++ b/mteb/tasks/audio/audio_multilabel_classification/eng/fsd50_hf.py
@@ -45,7 +45,7 @@ class FSD50HFMultilingualClassification(AbsTaskMultilabelClassification):
 """,
     )
 
-    evaluator = MultiOutputClassifier(estimator=LogisticRegression())
+    evaluator_model = MultiOutputClassifier(estimator=LogisticRegression())
     input_column_name: str = "audio"
     label_column_name: str = "labels"
     samples_per_label: int = 8


### PR DESCRIPTION
Previously `evaluator` was renamed to `evaluator_model`