### PR TITLE
add model: bflhc/Octen-Embedding-0.6B

### DIFF
--- a/mteb/models/model_implementations/octen_models.py
+++ b/mteb/models/model_implementations/octen_models.py
@@ -163,6 +163,36 @@ _PREDEFINED_PROMPTS = {
     "German1Retrieval": "Given a query, retrieve relevant passages",
 }
 
+Octen_Embedding_0B6 = ModelMeta(
+    loader=InstructSentenceTransformerModel,
+    loader_kwargs=dict(
+        instruction_template=instruction_template,
+        apply_instruction_to_passages=True,
+        prompts_dict=_PREDEFINED_PROMPTS,
+        max_seq_length=18480,
+        model_kwargs={"torch_dtype": "bfloat16"},
+    ),
+    name="bflhc/Octen-Embedding-0.6B",
+    languages=multilingual_langs,
+    open_weights=True,
+    revision="1a00a4e837bd788f6f8d91bc43201a5e52cf8ef8",
+    release_date="2026-01-10",
+    n_parameters=595776512,
+    memory_usage_mb=1136,
+    embed_dim=1024,
+    max_tokens=32768,
+    license="apache-2.0",
+    reference="https://huggingface.co/bflhc/Octen-Embedding-0.6B",
+    similarity_fn_name="cosine",
+    framework=["Sentence Transformers", "PyTorch", "safetensors"],
+    use_instructions=True,
+    public_training_code=None,
+    public_training_data=None,
+    training_datasets=training_data,
+    citation=OCTEN_CITATION,
+    adapted_from="Qwen/Qwen3-Embedding-0.6B",
+)
+
 Octen_Embedding_4B = ModelMeta(
     loader=InstructSentenceTransformerModel,
     loader_kwargs=dict(


### PR DESCRIPTION
- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [x] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e., is available either as an API or the weights are publicly available to download