### PR TITLE
model: Adding voyage-4 model

### DIFF
--- a/mteb/models/model_implementations/voyage_models.py
+++ b/mteb/models/model_implementations/voyage_models.py
@@ -25,6 +25,9 @@ VOYAGE_DTYPE_TRANSLATION = {
 
 # Total token limits per model based on VoyageAI documentation
 VOYAGE_TOTAL_TOKEN_LIMITS = {
+    "voyage-4-large": 120_000,
+    "voyage-4": 320_000,
+    "voyage-4-lite": 1_000_000,
     "voyage-3.5-lite": 1_000_000,
     "voyage-3.5": 320_000,
     "voyage-2": 320_000,


### PR DESCRIPTION
Adding `voyage-4` model as well. (voyage-4 tokenizer is available now)
Adding voyage-4* configs