### PR TITLE
fix: correct inverted unload_data condition in evaluate

### DIFF
--- a/mteb/evaluate.py
+++ b/mteb/evaluate.py
@@ -132,8 +132,8 @@ def _evaluate_task(
 
     task.check_if_dataset_is_superseded()
 
-    data_loaded = task.data_loaded
-    if not data_loaded:
+    data_preloaded = task.data_loaded
+    if not data_preloaded:
         try:
             task.load_data()
         except DatasetNotFoundError as e:
@@ -176,7 +176,7 @@ def _evaluate_task(
         kg_co2_emissions=None,
     )
 
-    if data_loaded:  # only unload if we loaded the data
+    if not data_preloaded:  # only unload if we loaded the data
         task.unload_data()
 
     return result

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -271,3 +271,28 @@ def test_run_list_with_error():
     results = mteb.evaluate(model, [error_task, task], cache=None, raise_error=False)
     assert len(results.task_results) == 1
     assert len(results.exceptions) == 1
+
+
+def test_evaluate_unloads_data_when_not_preloaded():
+    """Test that evaluate() unloads data when it was not preloaded."""
+    model = MockSentenceTransformer()
+    task = MockClassificationTask()
+
+    assert task.data_loaded is False
+    mteb.evaluate(model, task, cache=None, co2_tracker=False)
+    assert task.data_loaded is False, "evaluate() should unload data it loaded"
+
+
+def test_evaluate_preserves_preloaded_data_across_multiple_calls():
+    """Test that preloaded data persists across multiple evaluate() calls."""
+    model = MockSentenceTransformer()
+    task = MockClassificationTask()
+
+    task.load_data()
+    assert task.data_loaded is True
+
+    mteb.evaluate(model, task, cache=None, co2_tracker=False)
+    _ = task.dataset["test"]  # Verify dataset wasn't unloaded
+
+    mteb.evaluate(model, task, cache=None, co2_tracker=False)
+    _ = task.dataset["test"]  # Verify dataset persists across multiple calls


### PR DESCRIPTION
## Summary

The condition `if data_loaded:` on line 179 of `evaluate.py` was inverted - it unloaded data when it was preloaded (meaning we didn't load it), instead of when we loaded it ourselves.

This causes issues when reusing task objects across multiple `evaluate()` calls. The first call would incorrectly unload preloaded data, corrupting the task object for subsequent uses.

## Changes

- Renamed variable to `data_preloaded` for clarity (captures whether data was already loaded before this function)
- Fixed the condition to `if not data_preloaded:` so we only unload data that we loaded

## Before (buggy)
```python
data_loaded = task.data_loaded
if not data_loaded:
    task.load_data()
...
if data_loaded:  # BUG: unloads when data was ALREADY loaded (not by us)
    task.unload_data()
```

## After (fixed)
```python
data_preloaded = task.data_loaded
if not data_preloaded:
    task.load_data()
...
if not data_preloaded:  # correct: only unload if we loaded it
    task.unload_data()
```

## Impact

This bug affects anyone who:
1. Pre-loads task data before calling `mteb.evaluate()`
2. Caches and reuses task objects across multiple evaluations

After the first evaluation, `unload_data()` sets `task.dataset = None` and `task.data_loaded = False`, corrupting the cached task. Subsequent uses fail with `TypeError: 'NoneType' object is not subscriptable` when `load_data()` tries to access `self.dataset[subset][split]`.