### PR TITLE
dedup colnomic_7b and fix loader

### DIFF
--- a/mteb/models/model_implementations/colqwen_models.py
+++ b/mteb/models/model_implementations/colqwen_models.py
@@ -378,7 +378,7 @@ colnomic_3b = ModelMeta(
 colnomic_7b = ModelMeta(
     loader=ColQwen2_5Wrapper,
     loader_kwargs=dict(
-        torch_dtype=torch.float16, attn_implementation="flash_attention_2"
+        torch_dtype=torch.float16,
     ),
     name="nomic-ai/colnomic-embed-multimodal-7b",
     model_type=["late-interaction"],


### PR DESCRIPTION
Upon investigating the error, I discovered that the `colnomic_7b` object was declared twice. I removed the duplicate entry and updated the wrapper as the model is based on Qwen2.5. I verified that the model works correctly after these changes.

```
  File "/home/yongbinchoi/kovidore-benchmark/kovidore/evaluate.py", line 664, in run_benchmark
    model = mteb.get_model(model_name)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yongbinchoi/kovidore-benchmark/.venv/lib/python3.12/site-packages/mteb/models/get_model_meta.py", line 105, in get_model
    model = meta.load_model(device=device, **kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yongbinchoi/kovidore-benchmark/.venv/lib/python3.12/site-packages/mteb/models/model_meta.py", line 271, in load_model
    model: MTEBModels = self.loader(self.name, revision=self.revision, **_kwargs)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yongbinchoi/kovidore-benchmark/.venv/lib/python3.12/site-packages/mteb/models/model_implementations/colqwen_models.py", line 41, in __init__
    super().__init__(
  File "/home/yongbinchoi/kovidore-benchmark/.venv/lib/python3.12/site-packages/mteb/models/model_implementations/colpali_models.py", line 45, in __init__
    self.mdl = model_class.from_pretrained(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yongbinchoi/kovidore-benchmark/.venv/lib/python3.12/site-packages/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py", line 34, in from_pretrained
    return super().from_pretrained(*args, **kwargs, key_mapping=key_mapping)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yongbinchoi/kovidore-benchmark/.venv/lib/python3.12/site-packages/transformers/modeling_utils.py", line 277, in _wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/yongbinchoi/kovidore-benchmark/.venv/lib/python3.12/site-packages/transformers/modeling_utils.py", line 5048, in from_pretrained
    ) = cls._load_pretrained_model(
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yongbinchoi/kovidore-benchmark/.venv/lib/python3.12/site-packages/transformers/modeling_utils.py", line 5468, in _load_pretrained_model
    _error_msgs, disk_offload_index = load_shard_file(args)
                                      ^^^^^^^^^^^^^^^^^^^^^
  File "/home/yongbinchoi/kovidore-benchmark/.venv/lib/python3.12/site-packages/transformers/modeling_utils.py", line 843, in load_shard_file
    disk_offload_index = _load_state_dict_into_meta_model(
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yongbinchoi/kovidore-benchmark/.venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/yongbinchoi/kovidore-benchmark/.venv/lib/python3.12/site-packages/transformers/modeling_utils.py", line 770, in _load_state_dict_into_meta_model
    _load_parameter_into_model(model, param_name, param.to(param_device))
  File "/home/yongbinchoi/kovidore-benchmark/.venv/lib/python3.12/site-packages/transformers/modeling_utils.py", line 667, in _load_parameter_into_model
    module.load_state_dict({param_type: tensor}, strict=False, assign=True)
  File "/home/yongbinchoi/kovidore-benchmark/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 2629, in load_state_dict
    raise RuntimeError(
RuntimeError: Error(s) in loading state_dict for Linear:
        size mismatch for bias: copying a param with shape torch.Size([3584]) from checkpoint, the shape in current model is torch.Size([1280]).
```