### PR TITLE
[MAEB] add statistics to overview

### DIFF
--- a/scripts/generate_maeb_overview_tables.py
+++ b/scripts/generate_maeb_overview_tables.py
@@ -333,7 +333,7 @@ def generate_audio_tasks_table(df: pd.DataFrame) -> str:
         "    \\begin{tabular}{llcccclc}",
         "    \\toprule",
         "    \\textbf{Dataset} & \\textbf{Citation} & \\textbf{MAEB} & "
-        + "\\textbf{N. Samples} & \\textbf{Total Secs} & "
+        + "\\textbf{N. Samples} & \\textbf{Total Duration(s)} & "
         + "\\textbf{N. Langs} & "
         + "\\textbf{Domains} & \\textbf{Main Metric} \\\\",
         "    \\midrule",


### PR DESCRIPTION
Added statistics to tasks overview table (targets https://github.com/embeddings-benchmark/mteb/pull/3867 branch)

<img width="946" height="1012" alt="image" src="https://github.com/user-attachments/assets/d6cbe02a-48ff-4ab4-ba4a-50b9d150ac07" />
