### PR TITLE
model: Adding Ops-Colqwen3 models

### DIFF
--- a/mteb/models/model_implementations/ops_colqwen3_models.py
+++ b/mteb/models/model_implementations/ops_colqwen3_models.py
@@ -153,7 +153,7 @@ OPS_COLQWEN3_TRAINING_DATA = {
     "HotpotQA",
     "FEVER",
     "NQ",
-    "MIRACL",
+    "MIRACLRetrieval",
     "WebInstructSub",  # MathStackExchange and ScienceStackExchange only
     "MrTyDi",
 }


### PR DESCRIPTION
- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [x] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e., is available either as an API or the weights are publicly available to download