### PR TITLE
fix: NomicWrapper `get_prompt_name` call

### DIFF
--- a/mteb/models/model_implementations/nomic_models.py
+++ b/mteb/models/model_implementations/nomic_models.py
@@ -64,7 +64,7 @@ class NomicWrapper(SentenceTransformerEncoderWrapper):
     ) -> Array:
         # default to search_document if input_type and prompt_name are not provided
         prompt_name = (
-            self.get_prompt_name(self.model_prompts, task_metadata, prompt_type)
+            self.get_prompt_name(task_metadata, prompt_type)
             or PromptType.document.value
         )
         sentences = [text for batch in inputs for text in batch["text"]]


### PR DESCRIPTION
This PR fixes a bug in `NomicWrapper` where `get_prompt_name` was called with an extra argument (`self.model_prompts`), causing a `TypeError`.

The `get_prompt_name` method inherited from `AbsEncoder` already accesses `self.model_prompts` internally and does not accept it as an argument.

## Changes
- Removed `self.model_prompts` argument from the `get_prompt_name` call in `mteb/models/model_implementations/nomic_models.py`.

## Related Issue
Fixes #3994 