### PR TITLE
fix: `BedrockModel` initialization arguments

### DIFF
--- a/mteb/models/model_implementations/bedrock_models.py
+++ b/mteb/models/model_implementations/bedrock_models.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 class BedrockModel(AbsEncoder):
     def __init__(
         self,
+        model_name: str,
         model_id: str,
         provider: str,
         max_tokens: int,


### PR DESCRIPTION
This PR resolves a `TypeError` when loading Bedrock models. The `BedrockModel.__init__` method was not correctly handling the `model_name` positional argument passed by `ModelMeta.load_model`, leading to a collision with the `model_id` keyword argument.

This change adds `model_name` as the first argument to `BedrockModel.__init__` to properly accept the positional argument.

This addresses the issue #3998 