### PR TITLE
fix: `dataset_transform` signature in PubChemWikiPairClassification

### DIFF
--- a/mteb/tasks/pair_classification/multilingual/pub_chem_wiki_pair_classification.py
+++ b/mteb/tasks/pair_classification/multilingual/pub_chem_wiki_pair_classification.py
@@ -60,7 +60,7 @@ class PubChemWikiPairClassification(AbsTaskPairClassification):
 """,
     )
 
-    def dataset_transform(self) -> None:
+    def dataset_transform(self, num_proc: int = 1) -> None:
         _dataset = {}
         for lang in self.hf_subsets:
             _dataset[lang] = {}


### PR DESCRIPTION
This PR fixes a `TypeError` when running `PubChemWikiPairClassification` with `num_proc` argument. The `dataset_transform` method was missing the `num_proc` argument which is passed by the base class `load_data` method.

## Changes

- Updated `PubChemWikiPairClassification.dataset_transform` to accept `num_proc` argument (defaulting to 1).

Ref: #4000 