### PR TITLE
Build image on leaderboard refresh

### DIFF
--- a/.github/workflows/leaderboard_refresh.yaml
+++ b/.github/workflows/leaderboard_refresh.yaml
@@ -9,6 +9,41 @@ jobs:
   rebuild:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if image with current SHA exists
+        id: image
+        run: |
+          if docker manifest inspect ghcr.io/${{ github.repository }}/leaderboard:${{ github.sha }} > /dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push Docker image (if missing)
+        if: steps.image.outputs.exists != 'true'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}/leaderboard:${{ github.sha }}
+            ghcr.io/${{ github.repository }}/leaderboard:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - name: Trigger Factory Rebuild
         run: |
           curl -X POST \


### PR DESCRIPTION
Currently, we build our image only on if our dependencies are changed https://github.com/embeddings-benchmark/mteb/blob/5ca338787d79e0c0bd1f1b7ee1317520682c818c/.github/workflows/leaderboard_docker.yml#L5-L10, but this not takes that users adding new models and tasks ref https://github.com/embeddings-benchmark/results/pull/408#issuecomment-3819301245. 

I've changed our leaderboard refresh action to also update build new version of image