### PR TITLE
ci: Pre-commit should not be forced

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 install:
 	@echo "--- 🚀 Installing project dependencies ---"
 	uv sync --extra image --group dev
-	uv run --no-sync pre-commit install
 
 install-for-tests:
 	@echo "--- 🚀 Installing project dependencies for test ---"


### PR DESCRIPTION
We want to support people using pre-commit, but we don't want to force it.
