### PR TITLE
fix: change `np.bool` to `np.bool_`

### DIFF
--- a/mteb/types/_encoder_io.py
+++ b/mteb/types/_encoder_io.py
@@ -27,7 +27,7 @@ class EncodeKwargs(TypedDict):
 
 
 # --- Output types ---
-Array = NDArray[np.floating | np.integer | np.bool] | torch.Tensor
+Array = NDArray[np.floating | np.integer | np.bool_] | torch.Tensor
 """General array type, can be a numpy array (float, int, or bool) or a torch tensor."""
 
 


### PR DESCRIPTION
Change `np.bool` to `np.bool_` to keep numpy `v1` compatability. `np.bool` was introduced in `v2` and `np.bool_` [is alias to `np.bool`](https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.bool_)