### PR TITLE
fix: Remove the hardcoded batch_size=1 when generating text and image embeddings for Nemotron-Colembed-v2 models

### DIFF
--- a/mteb/models/model_implementations/nvidia_nemotron_colembed_vl.py
+++ b/mteb/models/model_implementations/nvidia_nemotron_colembed_vl.py
@@ -94,7 +94,6 @@ class NemotronColEmbedVL(AbsEncoder):
         ).eval()
 
     def get_text_embeddings(self, texts, batch_size: int = 32, **kwargs):
-        batch_size = 1
         return self.model.forward_queries(texts, batch_size=batch_size)
 
     def get_image_embeddings(
@@ -121,7 +120,6 @@ class NemotronColEmbedVL(AbsEncoder):
                 )
                 all_images.append(pil_img)
 
-        batch_size = 1
         return self.model.forward_images(all_images, batch_size=batch_size)
 
     def calculate_probs(self, text_embeddings, image_embeddings):


### PR DESCRIPTION
This PR addresses the issue raised in https://github.com/embeddings-benchmark/mteb/pull/4036#issuecomment-3844720063 and removes the hardcoded `batch_size=1` from the `get_text_embeddings` and `get_image_embeddings` functions used for the Nemotron-Colembed-v2 models.
