### PR TITLE
Add MetaCLIP 2 model integration

### DIFF
--- a/mteb/models/model_implementations/metaclip_models.py
+++ b/mteb/models/model_implementations/metaclip_models.py
@@ -46,12 +46,10 @@ class MetaClip2Model(AbsEncoder):
         self.model = AutoModel.from_pretrained(
             model_name,
             revision=revision,
-            trust_remote_code=True,
         ).to(self.device)
         self.processor = AutoProcessor.from_pretrained(
             model_name,
             revision=revision,
-            trust_remote_code=True,
         )
 
     def get_text_embeddings(


### PR DESCRIPTION
Closes #3552

Add support for facebook/metaclip-2-mt5-worldwide-b32, a multilingual vision-language model using mT5 tokenizer for worldwide language support.

- 254M parameters, 512 embedding dimension
- Supports 99 languages (XLMR language set)
- Handles MetaCLIP 2's BaseModelOutputWithPooling return format

If you add a model or a dataset, please add the corresponding checklist:

- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [x] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e., is available either as an API or the weights are publicly available to download
