### PR TITLE
fix: Add performance per language tab to more benchmarks

### DIFF
--- a/mteb/benchmarks/benchmarks/benchmarks.py
+++ b/mteb/benchmarks/benchmarks/benchmarks.py
@@ -1073,6 +1073,7 @@ MTEB_INDIC = Benchmark(
     name="MTEB(Indic, v1)",
     aliases=["MTEB(Indic)"],
     display_name="Indic",
+    language_view="all",
     icon="https://github.com/lipis/flag-icons/raw/260c91531be024944c6514130c5defb2ebb02b7d/flags/4x3/in.svg",
     tasks=MTEBTasks(
         get_tasks(
@@ -1164,6 +1165,7 @@ MTEB_EU = Benchmark(
     name="MTEB(Europe, v1)",
     aliases=["MTEB(Europe)"],
     display_name="European",
+    language_view="all",
     icon="https://github.com/lipis/flag-icons/raw/260c91531be024944c6514130c5defb2ebb02b7d/flags/4x3/eu.svg",
     tasks=get_tasks(
         tasks=[


### PR DESCRIPTION
closes #4047 

Added performance per language tab to MTEB(Europe, v1) and MTEB(Indic, v1)

MTEB(Europe, v1): 

<img width="1221" height="596" alt="image" src="https://github.com/user-attachments/assets/8734634f-040a-49c4-a963-167869bff504" />

MTEB(Indic, v1):
<img width="1214" height="609" alt="image" src="https://github.com/user-attachments/assets/c6d44295-14e9-4cf5-9545-f81503e4d2e1" />
