### PR TITLE
fix: Remove task performance by type tab when there is only one type

### DIFF
--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -450,7 +450,11 @@ def get_leaderboard_app(cache: ResultCache = ResultCache()) -> gr.Blocks:
 
     default_benchmark = mteb.get_benchmark(DEFAULT_BENCHMARK_NAME)
     default_results = all_benchmark_results[default_benchmark.name]
-    default_task_types = set(default_results.task_types)
+    default_task_types = {
+        task_type
+        for task_type in default_results.task_types
+        if task_type != "InstructionRetrieval"
+    }
     display_radar_chart = len(default_task_types) > 1
 
     logger.info("Step 4/7: Filtering models...")
@@ -746,7 +750,12 @@ def get_leaderboard_app(cache: ResultCache = ResultCache()) -> gr.Blocks:
                 initial_models,
             ) = _cache_on_benchmark_select(benchmark_name, all_benchmark_results)
             benchmark_results = all_benchmark_results[benchmark_name]
-            display_radar = len(set(benchmark_results.task_types)) > 1
+            eligible_task_types = {
+                task_type
+                for task_type in benchmark_results.task_types
+                if task_type != "InstructionRetrieval"
+            }
+            display_radar = len(eligible_task_types) > 1
             return (
                 gr.update(choices=languages, value=languages),
                 gr.update(choices=domains, value=domains),


### PR DESCRIPTION
closes #4046 
Added a check so that Radar Plot can't be generated when there is only 1 task type.

LB Image for RTEB: 

<img width="1496" height="760" alt="image" src="https://github.com/user-attachments/assets/374122a9-8137-4720-81d2-4bea1b72b9b5" />



LB Image for Vidore(v3):

<img width="1501" height="743" alt="image" src="https://github.com/user-attachments/assets/f30af69c-46bf-48e3-b473-14631f793ba2" />


There are other benchmarks also, which have just 1 task type, so this tab is removed.