### PR TITLE
model: Add ModelMeta for geoffsee/auto-g-embed-st

### DIFF
--- a/mteb/models/model_implementations/geoffsee_models.py
+++ b/mteb/models/model_implementations/geoffsee_models.py
@@ -1,0 +1,33 @@
+from mteb.models.model_meta import ModelMeta, ScoringFunction
+from mteb.models.sentence_transformer_wrapper import sentence_transformers_loader
+
+auto_g_embed_st = ModelMeta(
+    loader=sentence_transformers_loader,
+    name="geoffsee/auto-g-embed-st",
+    model_type=["dense"],
+    revision="3e0bf6004ec386dea06d55dda4efe38fd96b5f7b",
+    release_date="2026-02-08",
+    languages=["eng-Latn"],
+    open_weights=True,
+    n_parameters=22_713_216,
+    n_embedding_parameters=11_720_448,
+    memory_usage_mb=87,
+    embed_dim=384,
+    license="mit",
+    max_tokens=256,
+    reference="https://huggingface.co/geoffsee/auto-g-embed-st",
+    similarity_fn_name=ScoringFunction.COSINE,
+    framework=[
+        "Sentence Transformers",
+        "PyTorch",
+        "safetensors",
+        "Transformers",
+    ],
+    use_instructions=False,
+    superseded_by=None,
+    adapted_from="sentence-transformers/all-MiniLM-L6-v2",
+    training_datasets=set(),  # no known overlap with MTEB datasets
+    public_training_code="https://github.com/geoffsee/auto-g-embed",
+    public_training_data=None,
+    citation=None,
+)


### PR DESCRIPTION
Adds MTEB model implementation metadata for `geoffsee/auto-g-embed-st` so leaderboard submissions can reference the official implementation.

What was added:
- `mteb/models/model_implementations/geoffsee_models.py`
- `ModelMeta` entry for `geoffsee/auto-g-embed-st` pinned to revision `3e0bf6004ec386dea06d55dda4efe38fd96b5f7b`

Validation performed locally:
- `mteb.get_model_meta("geoffsee/auto-g-embed-st", revision=...)`
- `mteb.get_model("geoffsee/auto-g-embed-st", revision=...)`
- Backend `SentenceTransformer.encode` smoke check (`(1, 384)` output)
- Representative task run with `mteb.evaluate(..., tasks=["SciFact"])` produced `main_score=0.64872`

Checklist:
- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [x] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e., is available either as an API or the weights are publicly available to download