### PR TITLE
model: add voyage-4-nano

### DIFF
--- a/mteb/models/model_implementations/voyage_models.py
+++ b/mteb/models/model_implementations/voyage_models.py
@@ -125,7 +125,6 @@ VOYAGE_TOTAL_TOKEN_LIMITS = {
     "voyage-3-lite": 120_000,
     "voyage-code-2": 120_000,
     "voyage-3-m-exp": 120_000,
-    "voyage-4-nano": 32_000,
 }
 
 


### PR DESCRIPTION
Closes #4073 

- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [x] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e., is available either as an API or the weights are publicly available to download

`make test` and `make lint` are all passing
 
Tested on the following tasks with different values for `truncate_dim`:
 - NanoNFCorpusRetrieval (Retrieval)
 - NanoSciFactRetrieval (Retrieval)
 - STS12 (STS)
 - Banking77Classification (Classification)
 - SprintDuplicateQuestions (PairClassification)