### PR TITLE
fix: correct reference link for MIRACLVisionRetrieval task

### DIFF
--- a/mteb/tasks/retrieval/multilingual/miracl_vision_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/miracl_vision_retrieval.py
@@ -112,7 +112,7 @@ class MIRACLVisionRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="MIRACLVisionRetrieval",
         description="Retrieve associated pages according to questions.",
-        reference="https://arxiv.org/pdf/2407.01449",
+        reference="https://arxiv.org/abs/2505.11651",
         dataset={
             "path": "nvidia/miracl-vision",
             "revision": "309e1696433408fbd555959cf1da968f3814f8b6",


### PR DESCRIPTION
This pull request updates the reference URL in the metadata for the `MIRACLVisionRetrieval` task to point to the correct arXiv abstract.

- Metadata update:
  * Changed the `reference` field in the `TaskMetadata` of `MIRACLVisionRetrieval` to use the correct arXiv abstract URL (`https://arxiv.org/abs/2505.11651`).