### PR TITLE
model: Add the model ManiacLabs/miniac-embed

### DIFF
--- a/mteb/models/model_implementations/maniac_labs_models.py
+++ b/mteb/models/model_implementations/maniac_labs_models.py
@@ -6,14 +6,12 @@ LEAF-distilled embedding model: E5-small-unsupervised backbone, mxbai-embed-larg
 
 from mteb.models import ModelMeta, sentence_transformers_loader
 
-model_prompts = {"query": "Represent this sentence for searching relevant passages: "}
-
 MINIAC_EMBED_TRAINING_DATASETS = {
     "fineweb",
     "cc_news",
     "english-words-definitions",
     "amazon-qa",
-    "msmarco",
+    "MSMARCO",
     "PubMedQA",
     "trivia_qa",
     "LoTTE",
@@ -21,9 +19,7 @@ MINIAC_EMBED_TRAINING_DATASETS = {
 
 miniac_embed = ModelMeta(
     loader=sentence_transformers_loader,
-    loader_kwargs=dict(
-        model_prompts=model_prompts,
-    ),
+    loader_kwargs=dict(),
     name="ManiacLabs/miniac-embed",
     model_type=["dense"],
     revision="0fe5413163ce75cf13e6351b39a8b6f321b64e79",


### PR DESCRIPTION
Adds [ManiacLabs/miniac-embed](https://huggingface.co/ManiacLabs/miniac-embed). Sentence Transformers–compatible; 1024-d output, cosine similarity.

**New file:** `mteb/models/model_implementations/maniac_labs.py`

---

## Checklist

- [ X] I have filled out the ModelMeta object to the extent possible
- [ X] I have ensured that my model can be loaded using
  - [X ] `mteb.get_model(model_name, revision)` and
  - [ X] `mteb.get_model_meta(model_name, revision)`
- [ X] I have tested the implementation works on a representative set of tasks.
- [ X] The model is public, i.e., is available either as an API or the weights are publicly available to download
