### PR TITLE
fix: pylate model prompts

### DIFF
--- a/mteb/models/model_implementations/pylate_models.py
+++ b/mteb/models/model_implementations/pylate_models.py
@@ -309,7 +309,7 @@ class MultiVectorModel(AbsEncoder, PylateSearchEncoder):
         self.model = ColBERT(self.model_name, revision=revision, **kwargs)
         built_in_prompts = getattr(self.model, "prompts", None)
         if built_in_prompts and not model_prompts:
-            self.model_prompts = model_prompts
+            self.model_prompts = built_in_prompts
         elif model_prompts and built_in_prompts:
             logger.info(f"Model.prompts will be overwritten with {model_prompts}")
             self.model_prompts = self.validate_task_to_prompt_name(model_prompts)


### PR DESCRIPTION
Seems that after `v2` pylate wrapper handled prompts incorrectly. Previously, prompts where passed explicitly to `get_prompt`, but in `v2` they're taken from `self.model_prompts` and this wasn't added during refactor