### PR TITLE
duplicate bright repo

### DIFF
--- a/mteb/tasks/retrieval/eng/bright_v1_1_retrieval.py
+++ b/mteb/tasks/retrieval/eng/bright_v1_1_retrieval.py
@@ -89,8 +89,8 @@ class BrightBiologyRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="BrightBiologyRetrieval",
         dataset={
-            "path": "xlangai/BRIGHT",
-            "revision": "3066d29c9651a576c8aba4832d249807b181ecae",
+            "path": "mteb/BRIGHT",
+            "revision": "c26703e6600d97c579ee2985f16cf307db13ed85",
         },
         reference="https://huggingface.co/datasets/xlangai/BRIGHT",
         description="Part of the BRIGHT benchmark for reasoning-intensive retrieval. Retrieval of web documents cited in Biology StackExchange answers.",
@@ -133,8 +133,8 @@ class BrightEarthScienceRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="BrightEarthScienceRetrieval",
         dataset={
-            "path": "xlangai/BRIGHT",
-            "revision": "3066d29c9651a576c8aba4832d249807b181ecae",
+            "path": "mteb/BRIGHT",
+            "revision": "c26703e6600d97c579ee2985f16cf307db13ed85",
         },
         reference="https://huggingface.co/datasets/xlangai/BRIGHT",
         description="Part of the BRIGHT benchmark for reasoning-intensive retrieval. Retrieval of web documents cited in Earth Science StackExchange answers.",
@@ -177,8 +177,8 @@ class BrightEconomicsRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="BrightEconomicsRetrieval",
         dataset={
-            "path": "xlangai/BRIGHT",
-            "revision": "3066d29c9651a576c8aba4832d249807b181ecae",
+            "path": "mteb/BRIGHT",
+            "revision": "c26703e6600d97c579ee2985f16cf307db13ed85",
         },
         reference="https://huggingface.co/datasets/xlangai/BRIGHT",
         description="Part of the BRIGHT benchmark for reasoning-intensive retrieval. Retrieval of web documents cited in Economics StackExchange answers.",
@@ -221,8 +221,8 @@ class BrightPsychologyRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="BrightPsychologyRetrieval",
         dataset={
-            "path": "xlangai/BRIGHT",
-            "revision": "3066d29c9651a576c8aba4832d249807b181ecae",
+            "path": "mteb/BRIGHT",
+            "revision": "c26703e6600d97c579ee2985f16cf307db13ed85",
         },
         reference="https://huggingface.co/datasets/xlangai/BRIGHT",
         description="Part of the BRIGHT benchmark for reasoning-intensive retrieval. Retrieval of web documents cited in Psychology StackExchange answers.",
@@ -265,8 +265,8 @@ class BrightRoboticsRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="BrightRoboticsRetrieval",
         dataset={
-            "path": "xlangai/BRIGHT",
-            "revision": "3066d29c9651a576c8aba4832d249807b181ecae",
+            "path": "mteb/BRIGHT",
+            "revision": "c26703e6600d97c579ee2985f16cf307db13ed85",
         },
         reference="https://huggingface.co/datasets/xlangai/BRIGHT",
         description="Part of the BRIGHT benchmark for reasoning-intensive retrieval. Retrieval of web documents cited in Robotics StackExchange answers.",
@@ -309,8 +309,8 @@ class BrightStackoverflowRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="BrightStackoverflowRetrieval",
         dataset={
-            "path": "xlangai/BRIGHT",
-            "revision": "3066d29c9651a576c8aba4832d249807b181ecae",
+            "path": "mteb/BRIGHT",
+            "revision": "c26703e6600d97c579ee2985f16cf307db13ed85",
         },
         reference="https://huggingface.co/datasets/xlangai/BRIGHT",
         description="Part of the BRIGHT benchmark for reasoning-intensive retrieval. Retrieval of web documents cited in Stack Overflow answers.",
@@ -353,8 +353,8 @@ class BrightSustainableLivingRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="BrightSustainableLivingRetrieval",
         dataset={
-            "path": "xlangai/BRIGHT",
-            "revision": "3066d29c9651a576c8aba4832d249807b181ecae",
+            "path": "mteb/BRIGHT",
+            "revision": "c26703e6600d97c579ee2985f16cf307db13ed85",
         },
         reference="https://huggingface.co/datasets/xlangai/BRIGHT",
         description="Part of the BRIGHT benchmark for reasoning-intensive retrieval. Retrieval of web documents cited in Sustainable Living StackExchange answers.",
@@ -397,8 +397,8 @@ class BrightPonyRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="BrightPonyRetrieval",
         dataset={
-            "path": "xlangai/BRIGHT",
-            "revision": "3066d29c9651a576c8aba4832d249807b181ecae",
+            "path": "mteb/BRIGHT",
+            "revision": "c26703e6600d97c579ee2985f16cf307db13ed85",
         },
         reference="https://huggingface.co/datasets/xlangai/BRIGHT",
         description="Part of the BRIGHT benchmark for reasoning-intensive retrieval. Retrieval of Pony programming language syntax documentation.",
@@ -441,8 +441,8 @@ class BrightLeetcodeRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="BrightLeetcodeRetrieval",
         dataset={
-            "path": "xlangai/BRIGHT",
-            "revision": "3066d29c9651a576c8aba4832d249807b181ecae",
+            "path": "mteb/BRIGHT",
+            "revision": "c26703e6600d97c579ee2985f16cf307db13ed85",
         },
         reference="https://huggingface.co/datasets/xlangai/BRIGHT",
         description="Part of the BRIGHT benchmark for reasoning-intensive retrieval. Retrieval of similar algorithmic problems based on shared solution techniques.",
@@ -485,8 +485,8 @@ class BrightAopsRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="BrightAopsRetrieval",
         dataset={
-            "path": "xlangai/BRIGHT",
-            "revision": "3066d29c9651a576c8aba4832d249807b181ecae",
+            "path": "mteb/BRIGHT",
+            "revision": "c26703e6600d97c579ee2985f16cf307db13ed85",
         },
         reference="https://huggingface.co/datasets/xlangai/BRIGHT",
         description="Part of the BRIGHT benchmark for reasoning-intensive retrieval. Retrieval of similar Math Olympiad problems from Art of Problem Solving.",
@@ -529,8 +529,8 @@ class BrightTheoremQATheoremsRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="BrightTheoremQATheoremsRetrieval",
         dataset={
-            "path": "xlangai/BRIGHT",
-            "revision": "3066d29c9651a576c8aba4832d249807b181ecae",
+            "path": "mteb/BRIGHT",
+            "revision": "c26703e6600d97c579ee2985f16cf307db13ed85",
         },
         reference="https://huggingface.co/datasets/xlangai/BRIGHT",
         description="Part of the BRIGHT benchmark for reasoning-intensive retrieval. Retrieval of theorem definitions and proofs from ProofWiki.",
@@ -573,8 +573,8 @@ class BrightTheoremQAQuestionsRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="BrightTheoremQAQuestionsRetrieval",
         dataset={
-            "path": "xlangai/BRIGHT",
-            "revision": "3066d29c9651a576c8aba4832d249807b181ecae",
+            "path": "mteb/BRIGHT",
+            "revision": "c26703e6600d97c579ee2985f16cf307db13ed85",
         },
         reference="https://huggingface.co/datasets/xlangai/BRIGHT",
         description="Part of the BRIGHT benchmark for reasoning-intensive retrieval. Retrieval of theorem definitions from ProofWiki given questions rephrased as real-world scenarios.",
@@ -617,8 +617,8 @@ class BrightBiologyLongRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="BrightBiologyLongRetrieval",
         dataset={
-            "path": "xlangai/BRIGHT",
-            "revision": "3066d29c9651a576c8aba4832d249807b181ecae",
+            "path": "mteb/BRIGHT",
+            "revision": "c26703e6600d97c579ee2985f16cf307db13ed85",
         },
         reference="https://huggingface.co/datasets/xlangai/BRIGHT",
         description="Part of the BRIGHT benchmark for reasoning-intensive retrieval. Retrieval of web documents cited in Biology StackExchange answers with long documents.",
@@ -661,8 +661,8 @@ class BrightEarthScienceLongRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="BrightEarthScienceLongRetrieval",
         dataset={
-            "path": "xlangai/BRIGHT",
-            "revision": "3066d29c9651a576c8aba4832d249807b181ecae",
+            "path": "mteb/BRIGHT",
+            "revision": "c26703e6600d97c579ee2985f16cf307db13ed85",
         },
         reference="https://huggingface.co/datasets/xlangai/BRIGHT",
         description="Part of the BRIGHT benchmark for reasoning-intensive retrieval. Retrieval of web documents cited in Earth Science StackExchange answers with long documents.",
@@ -705,8 +705,8 @@ class BrightEconomicsLongRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="BrightEconomicsLongRetrieval",
         dataset={
-            "path": "xlangai/BRIGHT",
-            "revision": "3066d29c9651a576c8aba4832d249807b181ecae",
+            "path": "mteb/BRIGHT",
+            "revision": "c26703e6600d97c579ee2985f16cf307db13ed85",
         },
         reference="https://huggingface.co/datasets/xlangai/BRIGHT",
         description="Part of the BRIGHT benchmark for reasoning-intensive retrieval. Retrieval of web documents cited in Economics StackExchange answers with long documents.",
@@ -749,8 +749,8 @@ class BrightPsychologyLongRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="BrightPsychologyLongRetrieval",
         dataset={
-            "path": "xlangai/BRIGHT",
-            "revision": "3066d29c9651a576c8aba4832d249807b181ecae",
+            "path": "mteb/BRIGHT",
+            "revision": "c26703e6600d97c579ee2985f16cf307db13ed85",
         },
         reference="https://huggingface.co/datasets/xlangai/BRIGHT",
         description="Part of the BRIGHT benchmark for reasoning-intensive retrieval. Retrieval of web documents cited in Psychology StackExchange answers with long documents.",
@@ -793,8 +793,8 @@ class BrightRoboticsLongRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="BrightRoboticsLongRetrieval",
         dataset={
-            "path": "xlangai/BRIGHT",
-            "revision": "3066d29c9651a576c8aba4832d249807b181ecae",
+            "path": "mteb/BRIGHT",
+            "revision": "c26703e6600d97c579ee2985f16cf307db13ed85",
         },
         reference="https://huggingface.co/datasets/xlangai/BRIGHT",
         description="Part of the BRIGHT benchmark for reasoning-intensive retrieval. Retrieval of web documents cited in Robotics StackExchange answers with long documents.",
@@ -837,8 +837,8 @@ class BrightStackoverflowLongRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="BrightStackoverflowLongRetrieval",
         dataset={
-            "path": "xlangai/BRIGHT",
-            "revision": "3066d29c9651a576c8aba4832d249807b181ecae",
+            "path": "mteb/BRIGHT",
+            "revision": "c26703e6600d97c579ee2985f16cf307db13ed85",
         },
         reference="https://huggingface.co/datasets/xlangai/BRIGHT",
         description="Part of the BRIGHT benchmark for reasoning-intensive retrieval. Retrieval of web documents cited in Stack Overflow answers with long documents.",
@@ -881,8 +881,8 @@ class BrightSustainableLivingLongRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="BrightSustainableLivingLongRetrieval",
         dataset={
-            "path": "xlangai/BRIGHT",
-            "revision": "3066d29c9651a576c8aba4832d249807b181ecae",
+            "path": "mteb/BRIGHT",
+            "revision": "c26703e6600d97c579ee2985f16cf307db13ed85",
         },
         reference="https://huggingface.co/datasets/xlangai/BRIGHT",
         description="Part of the BRIGHT benchmark for reasoning-intensive retrieval. Retrieval of web documents cited in Sustainable Living StackExchange answers with long documents.",
@@ -925,8 +925,8 @@ class BrightPonyLongRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="BrightPonyLongRetrieval",
         dataset={
-            "path": "xlangai/BRIGHT",
-            "revision": "3066d29c9651a576c8aba4832d249807b181ecae",
+            "path": "mteb/BRIGHT",
+            "revision": "c26703e6600d97c579ee2985f16cf307db13ed85",
         },
         reference="https://huggingface.co/datasets/xlangai/BRIGHT",
         description="Part of the BRIGHT benchmark for reasoning-intensive retrieval. Retrieval of Pony programming language syntax documentation with long documents.",


### PR DESCRIPTION
Duplicated bright repo to mteb to make possible to create a benchmark from it. I didn't add this to `brightv1`, because this is not possible to choose revision from duplicated repo and scores are not the same as in paper, so I don't think we want to create a "benchmark" on huggingface from it