### PR TITLE
fix: pylate reranking

### DIFF
--- a/mteb/models/model_implementations/pylate_models.py
+++ b/mteb/models/model_implementations/pylate_models.py
@@ -7,8 +7,6 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-import torch
-
 from mteb._create_dataloaders import (
     create_dataloader,
 )
@@ -257,8 +255,8 @@ class PylateSearchEncoder:
             if not ranked_ids:
                 continue
 
-            doc_indices = torch.tensor([doc_id_to_idx[doc_id] for doc_id in ranked_ids])
-            query_doc_embeddings = torch.as_tensor(all_doc_embeddings[doc_indices])
+            doc_indices = [doc_id_to_idx[doc_id] for doc_id in ranked_ids]
+            query_doc_embeddings = [all_doc_embeddings[idx] for idx in doc_indices]
 
             q_emb = query_embeddings[q_idx]
             reranked = rank.rerank(


### PR DESCRIPTION
Pylate `encode` returns `list[np.ndarray]`, but because we take indices with `[1, 2, 3]` https://github.com/embeddings-benchmark/mteb/blob/d37253042e23d5047cdd187d84f2b39e77b9c1a6/mteb/models/model_implementations/pylate_models.py#L260-L261 this would fail, because lists don't support index by list. Previously this was working because we pad all embeddings, but we removed this in https://github.com/embeddings-benchmark/mteb/pull/3711