### PR TITLE
ci: raise leaderboard docker workflow timeout to 12min

### DIFF
--- a/.github/workflows/leaderboard_docker.yml
+++ b/.github/workflows/leaderboard_docker.yml
@@ -72,7 +72,7 @@ jobs:
         docker tag ghcr.io/${{ github.repository }}/leaderboard:${{ github.sha }} mteb-leaderboard:test
 
     - name: Test container can start and run
-      timeout-minutes: 9
+      timeout-minutes: 12
       run: |
         # Start the container in background
         docker run -d --name mteb-test -p 7860:7860 mteb-leaderboard:test
@@ -88,8 +88,8 @@ jobs:
           CURRENT_TIME=$(date +%s)
           ELAPSED=$((CURRENT_TIME - START_TIME))
 
-          # Maximum timeout: 8 minutes - always fail at timeout
-          if [ $ELAPSED -gt 480 ]; then
+          # Maximum timeout: 12 minutes - always fail at timeout
+          if [ $ELAPSED -gt 720 ]; then
             echo "❌ Timeout reached after ${ELAPSED}s - container failed to complete initialization"
             docker logs --tail 20 mteb-test
             docker stop mteb-test


### PR DESCRIPTION
Fixes #4136.

Note: Cache download failed due to Pydantic validation errors (458 validation errors). Once we can start specifying the results loading using ModelMeta instead of model name, we can unlock the speed up here from using git clone (4+min) to loading the pre-computed results cache (1min).
