### PR TITLE
model: Add ModelMeta for serhiiseletskyi/intelli-embed-v3

### DIFF
--- a/mteb/models/model_implementations/intelli_embed_models.py
+++ b/mteb/models/model_implementations/intelli_embed_models.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from mteb.models.model_meta import ModelMeta, ScoringFunction
+from mteb.models.sentence_transformer_wrapper import sentence_transformers_loader
+
+intelli_embed_v3 = ModelMeta(
+    loader=sentence_transformers_loader,
+    name="serhiiseletskyi/intelli-embed-v3",
+    model_type=["dense"],
+    revision="d63e20fa8dcc133d21c5d63da921c2df73bca1ad",
+    release_date="2025-02-21",
+    languages=["eng-Latn"],
+    open_weights=True,
+    framework=["Sentence Transformers", "PyTorch", "ONNX", "safetensors"],
+    n_parameters=567_754_752,
+    n_embedding_parameters=256_002_048,
+    memory_usage_mb=2166,
+    max_tokens=8194,
+    embed_dim=1024,
+    license="apache-2.0",
+    reference="https://huggingface.co/serhiiseletskyi/intelli-embed-v3",
+    similarity_fn_name=ScoringFunction.COSINE,
+    use_instructions=False,
+    adapted_from="Snowflake/snowflake-arctic-embed-l-v2.0",
+    superseded_by=None,
+    public_training_code=None,
+    public_training_data=None,
+    training_datasets={
+        "NQ",
+        "NQHardNegatives",
+        "HotPotQA",
+        "HotpotQAHardNegatives",
+        "FEVER",
+        "FEVERHardNegatives",
+    },
+)


### PR DESCRIPTION
## Add ModelMeta for serhiiseletskyi/intelli-embed-v3

### Model Information
- **Model**: [serhiiseletskyi/intelli-embed-v3](https://huggingface.co/serhiiseletskyi/intelli-embed-v3)
- **Base model**: Snowflake/snowflake-arctic-embed-l-v2.0 (fine-tuned)
- **Architecture**: XLM-RoBERTa-large, 567M parameters
- **Embedding dim**: 1024
- **Max tokens**: 8194
- **Pooling**: CLS
- **License**: Apache-2.0

### MTEB(eng, v2) Results
Overall score: **0.5654** (avg of type averages across 41 tasks)

| Category | Score | Tasks |
|---|---|---|
| Classification | 0.7650 | 8 |
| Clustering | 0.4228 | 8 |
| PairClassification | 0.7976 | 4 |
| Reranking | 0.3001 | 1 |
| Retrieval | 0.4931 | 10 |
| STS | 0.8341 | 9 |
| Summarization | 0.3452 | 1 |

Results PR: https://github.com/embeddings-benchmark/results/pull/422

### Checklist
- [x] `ModelMeta` object with all required fields
- [x] Model loads with `sentence_transformers_loader`
- [x] Model publicly available on HuggingFace
- [x] MTEB(eng, v2) results submitted to results repo
