### PR TITLE
Update zeroshot classification template path for `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,7 +208,7 @@ namespaces = false
     "descriptive_stats/Image/*/*.json",  # for descriptive_stats image
 ]
 "mteb.abstasks" = ["dataset_card_template.md"]
-"mteb.tasks.ZeroShotClassification.eng.templates" = ["*.txt"]
+"mteb.tasks.zeroshot_classification.eng.templates" = ["*.txt"]
 
 [tool.ruff]
 target-version = "py310"


### PR DESCRIPTION
The current path for the zeroshot classification path does not reflect the new changes to the folder structure, thus the *.txt templates are not downloaded when installing the library.

Old: `"mteb.tasks.Image.ZeroShotClassification.eng.templates" = ["*.txt"]`
New: `"mteb.tasks.zeroshot_classification.eng.templates" = ["*.txt"]`
