### PR TITLE
model: Add nomic-ai/nomic-embed-multimodal-7b dense embedding model

### DIFF
--- a/mteb/models/model_implementations/nomic_multimodal.py
+++ b/mteb/models/model_implementations/nomic_multimodal.py
@@ -39,7 +39,7 @@ CITATION = """
 }"""
 
 # https://huggingface.co/datasets/nomic-ai/colpali-queries-mined-20250321-by-source
-TRAINING_DATA = COLPALI_TRAINING_DATA
+TRAINING_DATA = COLPALI_TRAINING_DATA | {"VDRMultilingualRetrieval"}
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Add BiQwen2_5Wrapper and ModelMeta for nomic-embed-multimodal-7b, a dense (single-vector) multimodal embedding model for visual document retrieval using cosine similarity. Fixes #4168

- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [ ] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e., is available either as an API or the weights are publicly available to download

-> Need help running this to compare results. Tried on Colab TPU but no luck, timed out.
```
uv run --no-sync mteb run -m nomic-ai/nomic-embed-multimodal-7b -t Vidore2ESGReportsHLRetrieval --batch-size 8
```