### PR TITLE
final reupload tasks from mmteb

### DIFF
--- a/mteb/tasks/bitext_mining/multilingual/bible_nlp_bitext_mining.py
+++ b/mteb/tasks/bitext_mining/multilingual/bible_nlp_bitext_mining.py
@@ -860,8 +860,8 @@ class BibleNLPBitextMining(AbsTaskBitextMining):
     metadata = TaskMetadata(
         name="BibleNLPBitextMining",
         dataset={
-            "path": "davidstap/biblenlp-corpus-mmteb",
-            "revision": "264a18480c529d9e922483839b4b9758e690b762",
+            "path": "mteb/biblenlp-corpus",
+            "revision": "94c4293ca75c04b908c6b8e30d15788fe20fb409",
             "split": f"train[:{_N}]",
         },
         description="Partial Bible translations in 829 languages, aligned by verse.",

--- a/mteb/tasks/instruction_reranking/eng/core17_instruction_retrieval.py
+++ b/mteb/tasks/instruction_reranking/eng/core17_instruction_retrieval.py
@@ -11,8 +11,8 @@ class Core17InstructionRetrieval(AbsTaskRetrieval):
         description="Measuring retrieval instruction following ability on Core17 narratives for the FollowIR benchmark.",
         reference="https://arxiv.org/abs/2403.15246",
         dataset={
-            "path": "jhu-clsp/core17-instructions-mteb",
-            "revision": "7030c7efc3585d9020f243b12862997889243b78",
+            "path": "mteb/Core17InstructionRetrieval",
+            "revision": "67d8733dd0691f08f34ed9dda5941578cba8d91c",
         },
         type="InstructionReranking",
         category="t2t",

--- a/mteb/tasks/instruction_reranking/eng/news21_instruction_retrieval.py
+++ b/mteb/tasks/instruction_reranking/eng/news21_instruction_retrieval.py
@@ -11,8 +11,8 @@ class News21InstructionRetrieval(AbsTaskRetrieval):
         description="Measuring retrieval instruction following ability on News21 narratives for the FollowIR benchmark.",
         reference="https://arxiv.org/abs/2403.15246",
         dataset={
-            "path": "jhu-clsp/news21-instructions-mteb",
-            "revision": "39db677749b3b783bb277d0e2d4712f5f133f52b",
+            "path": "mteb/News21InstructionRetrieval",
+            "revision": "c6fffeb9cdd95c1ffa81c62c687b48b56352872b",
         },
         type="InstructionReranking",
         category="t2t",

--- a/mteb/tasks/instruction_reranking/eng/robust04_instruction_retrieval.py
+++ b/mteb/tasks/instruction_reranking/eng/robust04_instruction_retrieval.py
@@ -11,8 +11,8 @@ class Robust04InstructionRetrieval(AbsTaskRetrieval):
         description="Measuring retrieval instruction following ability on Robust04 narratives for the FollowIR benchmark.",
         reference="https://arxiv.org/abs/2403.15246",
         dataset={
-            "path": "jhu-clsp/robust04-instructions-mteb",
-            "revision": "0a3efedfcac0a7f859c46cff3a0fac0f8747b28f",
+            "path": "mteb/Robust04InstructionRetrieval",
+            "revision": "0495a5cb69aa8fa5bca81bd56ac248911c19eeb6",
         },
         type="InstructionReranking",
         category="t2t",


### PR DESCRIPTION
Reupload last of MMTEB datasets. BibleNLPCorpus was duplicated and FollowIR datasets wehere reuload to mteb (verified that scores are matching) ref https://github.com/embeddings-benchmark/mteb/issues/4163