### PR TITLE
fix: Code leaderboard is failing

### DIFF
--- a/mteb/languages/check_language_code.py
+++ b/mteb/languages/check_language_code.py
@@ -29,7 +29,11 @@ def check_language_code(code: str) -> None:
             raise ValueError(
                 f"Programming language {lang} is not a valid programming language."
             )
-    if lang is not None and lang not in ISO_TO_LANGUAGE:
+    if (
+        lang is not None
+        and lang not in ISO_TO_LANGUAGE
+        and lang not in PROGRAMMING_LANGS
+    ):
         raise ValueError(
             f"Invalid language code: {lang}, you can find valid ISO 639-3 codes in {path_to_lang_codes}"
         )


### PR DESCRIPTION
Currently, this is not possible to view code leaderboard, because there is an error in getting language code. Probably after https://github.com/embeddings-benchmark/mteb/pull/4145
<img width="4080" height="2476" alt="image" src="https://github.com/user-attachments/assets/491eee3b-6af5-438a-8dea-202ee98358d4" />

CC @NohTow 