### PR TITLE
fix: remove `n_jobs-1` from logistic regression

### DIFF
--- a/mteb/abstasks/classification.py
+++ b/mteb/abstasks/classification.py
@@ -133,7 +133,6 @@ class AbsTaskClassification(AbsTask):
 
     evaluator: type[SklearnEvaluator] = SklearnEvaluator
     evaluator_model: SklearnModelProtocol = LogisticRegression(
-        n_jobs=-1,
         max_iter=100,
     )
 

--- a/mteb/abstasks/regression.py
+++ b/mteb/abstasks/regression.py
@@ -100,7 +100,7 @@ class AbsTaskRegression(AbsTaskClassification):
     """
 
     evaluator: type[SklearnEvaluator] = SklearnEvaluator
-    evaluator_model: SklearnModelProtocol = LinearRegression(n_jobs=-1)
+    evaluator_model: SklearnModelProtocol = LinearRegression()
 
     train_split: str = "train"
     label_column_name: str = "value"

--- a/tests/mock_tasks.py
+++ b/tests/mock_tasks.py
@@ -146,7 +146,7 @@ def create_mock_audio(
 
 
 class MockClassificationTask(AbsTaskClassification):
-    classifier = LogisticRegression(n_jobs=1, max_iter=10)
+    classifier = LogisticRegression(max_iter=10)
 
     expected_stats = {
         "test": {
@@ -224,7 +224,7 @@ class MockClassificationTask(AbsTaskClassification):
 
 
 class MockMultilingualClassificationTask(AbsTaskClassification):
-    classifier = LogisticRegression(n_jobs=1, max_iter=10)
+    classifier = LogisticRegression(max_iter=10)
 
     expected_stats = {
         "test": {

--- a/tests/test_evaluators/test_ClassificationEvaluator.py
+++ b/tests/test_evaluators/test_ClassificationEvaluator.py
@@ -33,10 +33,7 @@ def test_expected_scores(model, mock_task):
         mock_task.metadata,
         hf_split="test",
         hf_subset="default",
-        evaluator_model=LogisticRegression(
-            n_jobs=-1,
-            max_iter=10,
-        ),
+        evaluator_model=LogisticRegression(max_iter=10),
     )
     y_pred, test_cache = evaluator(model, encode_kwargs={"batch_size": 32})
 
@@ -77,10 +74,7 @@ def test_cache_usage_binary(model):
         mock_task.metadata,
         hf_split="test",
         hf_subset="default",
-        evaluator_model=LogisticRegression(
-            n_jobs=-1,
-            max_iter=10,
-        ),
+        evaluator_model=LogisticRegression(max_iter=10),
     )
     _, test_cache_initial = evaluator_initial(model, encode_kwargs={"batch_size": 32})
 
@@ -93,10 +87,7 @@ def test_cache_usage_binary(model):
         mock_task.metadata,
         hf_split="test",
         hf_subset="default",
-        evaluator_model=LogisticRegression(
-            n_jobs=-1,
-            max_iter=10,
-        ),
+        evaluator_model=LogisticRegression(max_iter=10),
     )
     y_pred, test_cache_after_cache_usage = evaluator_with_cache(
         model, encode_kwargs={"batch_size": 32}, test_cache=test_cache_initial


### PR DESCRIPTION
It is currently ignored and gives a future warning.

closes #4210
