### PR TITLE
fix: Display main score in task results

### DIFF
--- a/mteb/results/model_result.py
+++ b/mteb/results/model_result.py
@@ -103,9 +103,9 @@ class ModelResult(BaseModel):
     def __repr__(self) -> str:
         n_entries = len(self.task_results)
         return (
-            f"ModelResult(model_name={self.model_name}, model_revision={self.model_revision}, "
+            f"ModelResult(model_name='{self.model_name}', model_revision='{self.model_revision}', "
             f"{'experiment_name=' + self.experiment_name + ', ' if self.experiment_name else ''}"
-            f"task_results=[...](#{n_entries}))"
+            f"task_results=[...](#{n_entries}), ...)"
         )
 
     @classmethod

--- a/mteb/results/task_result.py
+++ b/mteb/results/task_result.py
@@ -278,6 +278,11 @@ class TaskResult(BaseModel):
         return self.task.metadata.is_public
 
     @property
+    def main_score(self) -> float:
+        """Get the main score of the result."""
+        return self.get_score()
+
+    @property
     def hf_subsets(self) -> list[str]:
         """Get the hf_subsets present in the scores."""
         hf_subsets = set()
@@ -608,7 +613,7 @@ class TaskResult(BaseModel):
         return cls.model_construct(**data)
 
     def __repr__(self) -> str:
-        return f"TaskResult(task_name={self.task_name}, scores=...)"
+        return f"TaskResult(task_name={self.task_name}, main_score={self.main_score:.2f}, scores=..., ...)"
 
     def only_main_score(self) -> TaskResult:
         """Return a new TaskResult object with only the main score.


### PR DESCRIPTION
Now diplay main score in task results. As well as the `task_res.main_score` property.

Also added "..." to indicate that there are more attributed than what is being shown.

```
res = mteb.evaluate(model, task)
res
res[0]
# currently displays:
# ModelResult(model_name=mteb/baseline-random-encoder, model_revision=1, task_results=[...](#1))
# TaskResult(task_name=LccSentimentClassification, scores=...)

# with PR:
# ModelResult(model_name=mteb/baseline-random-encoder, model_revision=1, task_results=[...](#1), ...)
# TaskResult(task_name=LccSentimentClassification, main_score=0.32, scores=...)
```
