### PR TITLE
leaderboard: add MTEB(spa, v1) to Language-specific section

### DIFF
--- a/mteb/benchmarks/_leaderboard_menu.py
+++ b/mteb/benchmarks/_leaderboard_menu.py
@@ -88,6 +88,7 @@ GP_BENCHMARK_ENTRIES = [
                         "MTEB(tha, v1)",
                         "MTEB(fas, v2)",
                         "VN-MTEB (vie, v1)",
+                        "MTEB(spa, v1)",
                     ]
                 )
                 + [


### PR DESCRIPTION
Adds the Spanish benchmark to the Language-specific section of the leaderboard UI.

Benchmark definition: #4053
Results: embeddings-benchmark/results#420