### PR TITLE
Add Zeroentropy models

### DIFF
--- a/mteb/models/model_implementations/zeroentropy_models.py
+++ b/mteb/models/model_implementations/zeroentropy_models.py
@@ -63,7 +63,7 @@ zeroentropy_zembed_1 = ModelMeta(
 
 zeroentropy_zerank_1 = ModelMeta(
     loader=CrossEncoderWrapper,
-    loader_kwargs={},
+    loader_kwargs={"trust_remote_code": True},
     name="zeroentropy/zerank-1",
     revision="9c848454a9a4561496c5130a9c27f22c6b2c5fc3",
     release_date="2025-07-01",
@@ -101,7 +101,7 @@ zeroentropy_zerank_1 = ModelMeta(
 
 zeroentropy_zerank_1_small = ModelMeta(
     loader=CrossEncoderWrapper,
-    loader_kwargs={},
+    loader_kwargs={"trust_remote_code": True},
     name="zeroentropy/zerank-1-small",
     revision="bfaf6a8852da288e60b7375e79943c7f417ad606",
     release_date="2025-07-01",
@@ -139,7 +139,7 @@ zeroentropy_zerank_1_small = ModelMeta(
 
 zeroentropy_zerank_2 = ModelMeta(
     loader=CrossEncoderWrapper,
-    loader_kwargs={},
+    loader_kwargs={"trust_remote_code": True},
     name="zeroentropy/zerank-2",
     revision="1b0a8f8c70348f5c553f8b534499fe7104ef9a4e",
     release_date="2025-11-19",


### PR DESCRIPTION
Added 3 reranker models from Zeroentropy: 

1. https://huggingface.co/zeroentropy/zerank-2
2. https://huggingface.co/zeroentropy/zerank-1-small
3. https://huggingface.co/zeroentropy/zerank-1

For each of the above model, I have done below checklist: 

- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [ ] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e., is available either as an API or the weights are publicly available to download
