### PR TITLE
Add model meta for nanovdr/NanoVDR-S-Multi

### DIFF
--- a/mteb/models/model_implementations/nanovdr_models.py
+++ b/mteb/models/model_implementations/nanovdr_models.py
@@ -18,6 +18,7 @@ nanovdr_s_multi = ModelMeta(
     release_date="2026-02-26",
     modalities=["text"],
     n_parameters=69_000_000,
+    n_embedding_parameters=1_572_864,
     memory_usage_mb=282,
     embed_dim=2048,
     license="apache-2.0",


### PR DESCRIPTION
Add model metadata for [nanovdr/NanoVDR-S-Multi](https://huggingface.co/nanovdr/NanoVDR-S-Multi), a 69M text-only query encoder for visual document retrieval.

- **Model**: NanoVDR-S-Multi (DistilBERT + MLP projector, 69M params)
- **Loader**: `sentence_transformers_loader` (standard Sentence Transformers model)
- **Paper**: [arXiv:2603.12824](https://arxiv.org/abs/2603.12824)
- **Modality**: text-only query encoder (documents indexed offline by a frozen VLM teacher)
- **Languages**: en, de, fr, es, it, pt
- **Benchmarks**: ViDoRe v1/v2/v3 (22 datasets)

Results PR: https://github.com/embeddings-benchmark/results/pull/447