### PR TITLE
model: Add NanoVDR-S-Multi with custom AbsEncoder for asymmetric VDR

### DIFF
--- a/mteb/models/model_implementations/nanovdr_models.py
+++ b/mteb/models/model_implementations/nanovdr_models.py
@@ -252,7 +252,10 @@ class NanoVDRWrapper(AbsEncoder):
 
         # Validate: reject tasks where queries contain images.
         # NanoVDR only supports text-query → image-document retrieval.
-        if prompt_type in (PromptType.query, None) and "image" in inputs.dataset.features:
+        if (
+            prompt_type in (PromptType.query, None)
+            and "image" in inputs.dataset.features
+        ):
             raise ValueError(
                 f"NanoVDR only supports text queries, but task "
                 f"'{task_metadata.name}' provides image inputs for queries. "


### PR DESCRIPTION
Implements `NanoVDRWrapper`, a custom `AbsEncoder` subclass for [nanovdr/NanoVDR-S-Multi](https://huggingface.co/nanovdr/NanoVDR-S-Multi) — an asymmetric visual document retrieval model.

**How it works:**
- **Query encoding**: routes to the lightweight NanoVDR-S-Multi student (69M, text-only, SentenceTransformer)
- **Document encoding**: routes to the frozen Qwen3-VL-Embedding-2B teacher (2B, VLM) for page image encoding
- Teacher is lazy-loaded only when document encoding is needed

This follows the custom `AbsEncoder` pattern used by `Qwen3VLEmbeddingWrapper` and addresses the feedback from #4240 — using a custom wrapper instead of the standard Router/SentenceTransformer loader to support asymmetric multimodal routing.

- **Paper**: [arXiv:2603.12824](https://arxiv.org/abs/2603.12824)
- **Results PR**: https://github.com/embeddings-benchmark/results/pull/447 (will reopen after this merges)