### PR TITLE
Fix ColQwen3.5-4.5B - ColPaliEngineWrapper.encode() for multimodal datasets

### DIFF
--- a/mteb/models/model_implementations/colqwen_models.py
+++ b/mteb/models/model_implementations/colqwen_models.py
@@ -189,7 +189,7 @@ class ColQwen3_5Wrapper(AbsEncoder):  # noqa: N801
                     imgs = [img.convert("RGB") for img in imgs]
                     inputs = self.processor.process_images(imgs)
                 else:
-                    inputs = self.processor.process_texts(texts)
+                    inputs = self.processor.process_queries(texts)
                 inputs = {k: v.to(self.device) for k, v in inputs.items()}
                 outs = self._encode_inputs(inputs)
                 all_embeds.extend(outs.cpu().to(torch.float32))


### PR DESCRIPTION
### Changes

- Override `encode()` in `ColQwen3_5Wrapper` to route by `prompt_type`: queries use text, documents use images when available.
- Override `encode_input()` in `ColQwen3_5Wrapper` to clear stale `rope_deltas` cache before forward passes.