### PR TITLE
fix: remove unused calculate_probs method from model wrappers

### DIFF
--- a/mteb/models/model_implementations/colpali_models.py
+++ b/mteb/models/model_implementations/colpali_models.py
@@ -157,10 +157,6 @@ class ColPaliEngineWrapper(AbsEncoder):
             "Fused embeddings are not supported yet. Please use get_text_embeddings or get_image_embeddings."
         )
 
-    def calculate_probs(self, text_embeddings, image_embeddings):
-        scores = self.similarity(text_embeddings, image_embeddings).T
-        return scores.softmax(dim=-1)
-
     def similarity(self, a, b):
         return self.processor.score(a, b, device=self.device)
 

--- a/mteb/models/model_implementations/granite_vision_embedding_models.py
+++ b/mteb/models/model_implementations/granite_vision_embedding_models.py
@@ -153,10 +153,6 @@ class GraniteVisionEmbeddingWrapper:
             return image_embeddings
         raise ValueError
 
-    def calculate_probs(self, text_embeddings, image_embeddings):
-        scores = self.similarity(text_embeddings, image_embeddings)
-        return (scores * 100).softmax(dim=-1)
-
     def similarity(self, a, b):
         return self.processor.score_multi_vector(a, b)
 

--- a/mteb/models/model_implementations/nvidia_nemotron_vl_models.py
+++ b/mteb/models/model_implementations/nvidia_nemotron_vl_models.py
@@ -134,10 +134,6 @@ class NemotronColEmbedVL(AbsEncoder):
 
         return self.model.forward_images(all_images, batch_size=batch_size)
 
-    def calculate_probs(self, text_embeddings, image_embeddings):
-        scores = self.similarity(text_embeddings, image_embeddings)
-        return (scores * 100).softmax(dim=-1)
-
     def similarity(self, a, b):
         return self.model.get_scores(a, b)
 

--- a/mteb/models/model_implementations/slm_models.py
+++ b/mteb/models/model_implementations/slm_models.py
@@ -174,14 +174,6 @@ class SLMBaseWrapper(AbsEncoder):
         )
         return padded
 
-    def calculate_probs(
-        self,
-        text_embeddings: torch.Tensor,
-        image_embeddings: torch.Tensor,
-    ) -> torch.Tensor:
-        scores = self.similarity(text_embeddings, image_embeddings).T
-        return scores.softmax(dim=-1)
-
     def similarity(
         self,
         a: torch.Tensor | list,


### PR DESCRIPTION
## Summary
- Removes the unused `calculate_probs` method from 4 model wrapper classes: `ColPaliEngineWrapper`, `NemotronVLWrapper`, `GraniteVisionEmbeddingWrapper`, and `SLMBaseWrapper`
- This method was previously used by the old `ZeroshotClassificationEvaluator` but the evaluator was refactored to use `model.similarity()` directly instead

Closes #4201

## Test plan
- [x] Verified `calculate_probs` has zero callers in the entire codebase
- [x] Confirmed `similarity()` methods on the same classes are still used and preserved
- [x] No protocol/base class defines `calculate_probs`