### PR TITLE
ci: remove inline comments from Makefile for Windows compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,12 @@ install-for-tests:
 
 lint:
 	@echo "--- 🧹 Running linters ---"
-	uv run --no-sync ruff format . 			# running ruff formatting
-	uv run --no-sync ruff check . --fix --exit-non-zero-on-fix  	# running ruff linting # --exit-non-zero-on-fix is used for the pre-commit hook to work
+	uv run --no-sync ruff format .
+	uv run --no-sync ruff check . --fix --exit-non-zero-on-fix
 	uv run --no-sync typos
 
 lint-check:
 	@echo "--- 🧹 Check is project is linted ---"
-	# Required for CI to work, otherwise it will just pass
 	uv run --no-sync ruff format . --check
 	uv run --no-sync ruff check .
 	uv run --no-sync typos --diff


### PR DESCRIPTION
## Summary
- Removes inline `#` comments from Makefile recipe lines that break on Windows (`cmd.exe` doesn't treat `#` as a comment character)
- Removes a standalone recipe-line comment (`# Required for CI to work`) that has the same issue
- The `@echo` headers already describe each target's purpose, so no information is lost

Closes #2300

## Test plan
- [x] Verified the Makefile still has correct syntax
- [x] Pre-commit hooks pass
- [ ] `make lint` works on Windows