### PR TITLE
fix: Add Thai to leaderboard language selector

### DIFF
--- a/mteb/leaderboard/benchmark_selector.py
+++ b/mteb/leaderboard/benchmark_selector.py
@@ -85,6 +85,7 @@ GP_BENCHMARK_ENTRIES = [
                         "MTEB(nld, v1)",
                         "MTEB(pol, v1)",
                         "MTEB(rus, v1.1)",
+                        "MTEB(tha, v1)",
                         "MTEB(fas, v2)",
                         "VN-MTEB (vie, v1)",
                     ]


### PR DESCRIPTION
## Summary

Add `MTEB(tha, v1)` to the Language-specific section of the benchmark selector so it appears in the HuggingFace leaderboard UI.

The benchmark definition was merged in #4213. This PR just adds it to the UI selector.

## Changes

- `mteb/leaderboard/benchmark_selector.py`: Add `"MTEB(tha, v1)"` to the Language-specific benchmark list

## Test plan

- [ ] Verify `MTEB(tha, v1)` appears under Language-specific dropdown on the leaderboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)