### PR TITLE
Fix Gradio style daataframe initalization error on LB

### DIFF
--- a/mteb/benchmarks/_create_table.py
+++ b/mteb/benchmarks/_create_table.py
@@ -158,7 +158,7 @@ def _create_summary_table_from_benchmark_results(
     joint_table.insert(
         1,
         "Embedding Dimensions",
-        model_metas.map(lambda m: _get_embedding_size),
+        model_metas.map(lambda m: _get_embedding_size(m.embed_dim)),
     )
     joint_table.insert(
         1,
@@ -399,7 +399,7 @@ def _create_summary_table_mean_public_private(
     joint_table.insert(
         1,
         "Embedding Dimensions",
-        model_metas.map(lambda m: _get_embedding_size),
+        model_metas.map(lambda m: _get_embedding_size(m.embed_dim)),
     )
     joint_table.insert(
         1,
@@ -518,7 +518,7 @@ def _create_summary_table_mean_subset(
     joint_table.insert(
         1,
         "Embedding Dimensions",
-        model_metas.map(lambda m: _get_embedding_size),
+        model_metas.map(lambda m: _get_embedding_size(m.embed_dim)),
     )
     joint_table.insert(
         1,
@@ -633,7 +633,7 @@ def _create_summary_table_mean_task_type(
     joint_table.insert(
         1,
         "Embedding Dimensions",
-        model_metas.map(lambda m: _get_embedding_size),
+        model_metas.map(lambda m: _get_embedding_size(m.embed_dim)),
     )
     joint_table.insert(
         1,


### PR DESCRIPTION
closes #4267 
I think the error was at line:

`joint_table.insert(
        1,
        "Embedding Dimensions",
        model_metas.map(lambda m: _get_embedding_size(m.embed_dim)),
    )`

the code was storing the `_get_embedding_size` function itself in the "Embedding Dimensions" column instead of calling it with m.embed_dim. When Gradio initializes the styled dataframe, pandas tries to apply "{:.0f}" to that cell and fails with ValueError. 

Though, I am not sure, was this the core problem, because when I checked before merging #3979, it was working perfectly.



Checked after this PR, LB is working: 

<img width="1482" height="749" alt="image" src="https://github.com/user-attachments/assets/f50ef3c7-4874-489d-92fc-57670ef38dbf" />
