### PR TITLE
fix: update dataset card with descriptive category and paper title reference

### DIFF
--- a/mteb/abstasks/task_metadata.py
+++ b/mteb/abstasks/task_metadata.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
@@ -272,6 +273,14 @@ TaskCategory = Literal[
 20. at2at: audio+text to audio+text
 21. v2t: video to text
 """
+
+_MODALITY_CODES: dict[str, str] = {
+    "t": "text",
+    "i": "image",
+    "a": "audio",
+    "v": "video",
+    "c": "category",
+}
 
 AnnotatorType = Literal[
     "expert-annotated",
@@ -627,20 +636,60 @@ class TaskMetadata(BaseModel):
             )
         )
 
+        # Format category as "{type} ({description})" e.g. "Retrieval (text-to-text)"
+        if self.category is not None:
+            category_desc = self._category_description(self.category)
+            formatted_category = f"{self.type} ({category_desc})"
+        else:
+            formatted_category = str(self.type)
+
+        # Format reference with paper title from BibTeX when available
+        formatted_reference = self._format_reference()
+
         return (
             DatasetCardData(**dataset_card_data_params),
             # parameters for readme generation
             dict(
                 citation=self.bibtex_citation,
                 dataset_description=self.description,
-                dataset_reference=self.reference,
+                dataset_reference=formatted_reference,
                 descriptive_stats=descriptive_stats,
                 dataset_task_name=self.name,
-                category=self.category,
+                category=formatted_category,
                 domains=", ".join(self.domains) if self.domains else None,
                 contributed_by=self.contributed_by,
             ),
         )
+
+    @staticmethod
+    def _category_description(category: str) -> str:
+        """Convert category code like 'it2t' to 'image+text-to-text'."""
+        parts = category.split("2", 1)
+        if len(parts) != 2:
+            return category
+        query = "+".join(_MODALITY_CODES.get(c, c) for c in parts[0])
+        doc = "+".join(_MODALITY_CODES.get(c, c) for c in parts[1])
+        return f"{query}-to-{doc}"
+
+    @staticmethod
+    def _extract_bibtex_title(bibtex_citation: str) -> str | None:
+        """Extract the title from a BibTeX citation string."""
+        match = re.search(r"title\s*=\s*\{([^}]+)\}", bibtex_citation)
+        if match:
+            return match.group(1).strip()
+        return None
+
+    def _format_reference(self) -> str | None:
+        """Format the reference as a markdown link with the paper title from BibTeX."""
+        title = None
+        if self.bibtex_citation:
+            title = self._extract_bibtex_title(self.bibtex_citation)
+
+        if title and self.reference:
+            return f"[{title}]({self.reference})"
+        if self.reference:
+            return str(self.reference)
+        return None
 
     def generate_dataset_card(
         self,


### PR DESCRIPTION
## Summary
- Format task category as `{type} ({description})` (e.g. `Retrieval (text-to-text)`) instead of raw codes like `t2t`
- Extract paper title from BibTeX citation and format reference as a markdown link (e.g. `[CoIR: A Comprehensive Benchmark...](url)`) instead of a plain URL

**Before** (CodeFeedbackST example):
| | |
|---|---|
| Task category | t2t |
| Reference | https://arxiv.org/abs/2407.02883 |

**After**:
| | |
|---|---|
| Task category | Retrieval (text-to-text) |
| Reference | [CoIR: A Comprehensive Benchmark for Code Information Retrieval Models](https://arxiv.org/abs/2407.02883) |

## Test plan
- [x] Verified with CodeFeedbackST task — category renders as `Retrieval (text-to-text)`, reference renders as markdown link with paper title
- [x] Tested edge cases: no BibTeX, no reference URL, no category — all degrade gracefully
- [x] All existing tests pass (1232+ metadata validation tests, card tests, citation tests)

Closes #2807