### PR TITLE
fix: add contributed_by field to TaskMetadata

### DIFF
--- a/docs/overview/create_available_tasks.py
+++ b/docs/overview/create_available_tasks.py
@@ -114,6 +114,8 @@ def create_aggregate_table(task: AbsTaskAggregate) -> str:
 
 def format_task_entry(task: mteb.AbsTask) -> str:
     description = task.metadata.description
+    if task.metadata.contributed_by:
+        description += f" Contributed by {task.metadata.contributed_by}."
     license = task.metadata.license or "not specified"
     reference = task.metadata.reference
     dataset_name = task.metadata.dataset["path"]

--- a/mteb/abstasks/dataset_card_template.md
+++ b/mteb/abstasks/dataset_card_template.md
@@ -18,6 +18,9 @@
 | Task category | {{ category }}                              |
 | Domains       | {{ domains }}                               |
 | Reference     | {{ dataset_reference | default("", true) }} |
+{%- if contributed_by %}
+| Contributed by| {{ contributed_by }}                        |
+{%- endif %}
 
 Source datasets:
 {%- for dataset in source_datasets %}

--- a/mteb/abstasks/task_metadata.py
+++ b/mteb/abstasks/task_metadata.py
@@ -386,13 +386,6 @@ class TaskMetadata(BaseModel):
     contributed_by: str | None = None
     superseded_by: str | None = None
 
-    @property
-    def full_description(self) -> str:
-        """Returns the description with contributor info appended if available."""
-        if self.contributed_by:
-            return f"{self.description} This dataset was contributed by {self.contributed_by}."
-        return self.description
-
     def _validate_metadata(self) -> None:
         self._eval_langs_are_valid(self.eval_langs)
 
@@ -639,12 +632,13 @@ class TaskMetadata(BaseModel):
             # parameters for readme generation
             dict(
                 citation=self.bibtex_citation,
-                dataset_description=self.full_description,
+                dataset_description=self.description,
                 dataset_reference=self.reference,
                 descriptive_stats=descriptive_stats,
                 dataset_task_name=self.name,
                 category=self.category,
                 domains=", ".join(self.domains) if self.domains else None,
+                contributed_by=self.contributed_by,
             ),
         )
 

--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -127,7 +127,6 @@ def _update_task_info(task_names: str) -> pd.DataFrame:
             "main_score",
             "modalities",
             "is_public",
-            "contributed_by",
         ]
     )
     df["languages"] = df["languages"].map(_format_list)
@@ -147,7 +146,6 @@ def _update_task_info(task_names: str) -> pd.DataFrame:
             "main_score": "Metric",
             "modalities": "Modality",
             "is_public": "Public",
-            "contributed_by": "Contributed By",
         }
     )
     df = df.drop(columns="reference")

--- a/mteb/tasks/retrieval/code/code1_retrieval.py
+++ b/mteb/tasks/retrieval/code/code1_retrieval.py
@@ -26,4 +26,5 @@ class Code1Retrieval(AbsTaskRetrieval):
         sample_creation="found",
         bibtex_citation="",
         is_public=False,
+        contributed_by="Voyage AI",
     )

--- a/mteb/tasks/retrieval/code/japanese_code1_retrieval.py
+++ b/mteb/tasks/retrieval/code/japanese_code1_retrieval.py
@@ -26,4 +26,5 @@ class JapaneseCode1Retrieval(AbsTaskRetrieval):
         sample_creation="found",
         bibtex_citation="",
         is_public=False,
+        contributed_by="Voyage AI",
     )

--- a/mteb/tasks/retrieval/deu/german1_retrieval.py
+++ b/mteb/tasks/retrieval/deu/german1_retrieval.py
@@ -26,4 +26,5 @@ class German1Retrieval(AbsTaskRetrieval):
         sample_creation="found",
         bibtex_citation="",
         is_public=False,
+        contributed_by="Voyage AI",
     )

--- a/mteb/tasks/retrieval/deu/german_healthcare1_retrieval.py
+++ b/mteb/tasks/retrieval/deu/german_healthcare1_retrieval.py
@@ -26,4 +26,5 @@ class GermanHealthcare1Retrieval(AbsTaskRetrieval):
         sample_creation="found",
         bibtex_citation="",
         is_public=False,
+        contributed_by="Voyage AI",
     )

--- a/mteb/tasks/retrieval/deu/german_legal1_retrieval.py
+++ b/mteb/tasks/retrieval/deu/german_legal1_retrieval.py
@@ -26,4 +26,5 @@ class GermanLegal1Retrieval(AbsTaskRetrieval):
         sample_creation="found",
         bibtex_citation="",
         is_public=False,
+        contributed_by="Voyage AI",
     )

--- a/mteb/tasks/retrieval/eng/english_finance1_retrieval.py
+++ b/mteb/tasks/retrieval/eng/english_finance1_retrieval.py
@@ -26,4 +26,5 @@ class EnglishFinance1Retrieval(AbsTaskRetrieval):
         sample_creation="found",
         bibtex_citation="",
         is_public=False,
+        contributed_by="Voyage AI",
     )

--- a/mteb/tasks/retrieval/eng/english_finance2_retrieval.py
+++ b/mteb/tasks/retrieval/eng/english_finance2_retrieval.py
@@ -26,4 +26,5 @@ class EnglishFinance2Retrieval(AbsTaskRetrieval):
         sample_creation="found",
         bibtex_citation="",
         is_public=False,
+        contributed_by="Voyage AI",
     )

--- a/mteb/tasks/retrieval/eng/english_finance3_retrieval.py
+++ b/mteb/tasks/retrieval/eng/english_finance3_retrieval.py
@@ -26,4 +26,5 @@ class EnglishFinance3Retrieval(AbsTaskRetrieval):
         sample_creation="found",
         bibtex_citation="",
         is_public=False,
+        contributed_by="Voyage AI",
     )

--- a/mteb/tasks/retrieval/eng/english_finance4_retrieval.py
+++ b/mteb/tasks/retrieval/eng/english_finance4_retrieval.py
@@ -26,4 +26,5 @@ class EnglishFinance4Retrieval(AbsTaskRetrieval):
         sample_creation="found",
         bibtex_citation="",
         is_public=False,
+        contributed_by="Voyage AI",
     )

--- a/mteb/tasks/retrieval/eng/english_healthcare1_retrieval.py
+++ b/mteb/tasks/retrieval/eng/english_healthcare1_retrieval.py
@@ -26,4 +26,5 @@ class EnglishHealthcare1Retrieval(AbsTaskRetrieval):
         sample_creation="found",
         bibtex_citation="",
         is_public=False,
+        contributed_by="Voyage AI",
     )

--- a/mteb/tasks/retrieval/fra/french1_retrieval.py
+++ b/mteb/tasks/retrieval/fra/french1_retrieval.py
@@ -26,4 +26,5 @@ class French1Retrieval(AbsTaskRetrieval):
         sample_creation="found",
         bibtex_citation="",
         is_public=False,
+        contributed_by="Voyage AI",
     )

--- a/mteb/tasks/retrieval/fra/french_legal1_retrieval.py
+++ b/mteb/tasks/retrieval/fra/french_legal1_retrieval.py
@@ -26,4 +26,5 @@ class FrenchLegal1Retrieval(AbsTaskRetrieval):
         sample_creation="found",
         bibtex_citation="",
         is_public=False,
+        contributed_by="Voyage AI",
     )

--- a/mteb/tasks/retrieval/jpn/japanese_legal1_retrieval.py
+++ b/mteb/tasks/retrieval/jpn/japanese_legal1_retrieval.py
@@ -26,4 +26,5 @@ class JapaneseLegal1Retrieval(AbsTaskRetrieval):
         sample_creation="found",
         bibtex_citation="",
         is_public=False,
+        contributed_by="Voyage AI",
     )

--- a/mteb/tasks/retrieval/multilingual/vidore3_bench_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/vidore3_bench_retrieval.py
@@ -46,6 +46,7 @@ class Vidore3FinanceEnRetrieval(AbsTaskRetrieval):
 """,
         prompt={"query": "Find a screenshot that is relevant to the user's question."},
         is_public=True,
+        contributed_by="Illuin Technology",
         superseded_by="Vidore3FinanceEnRetrieval.v2",
     )
 
@@ -86,6 +87,7 @@ class Vidore3FinanceEnRetrievalv2(AbsTaskRetrieval):
 """,
         prompt={"query": "Find a screenshot that is relevant to the user's question."},
         adapted_from=["Vidore3FinanceEnRetrieval"],
+        contributed_by="Illuin Technology",
     )
 
 
@@ -124,6 +126,7 @@ class Vidore3FinanceFrRetrieval(AbsTaskRetrieval):
 """,
         prompt={"query": "Find a screenshot that is relevant to the user's question."},
         is_public=True,
+        contributed_by="Illuin Technology",
         superseded_by="Vidore3FinanceFrRetrieval.v2",
     )
 
@@ -164,6 +167,7 @@ class Vidore3FinanceFrRetrievalv2(AbsTaskRetrieval):
 """,
         prompt={"query": "Find a screenshot that is relevant to the user's question."},
         is_public=True,
+        contributed_by="Illuin Technology",
         adapted_from=["Vidore3FinanceFrRetrieval"],
     )
 
@@ -203,6 +207,7 @@ class Vidore3IndustrialRetrieval(AbsTaskRetrieval):
 """,
         prompt={"query": "Find a screenshot that is relevant to the user's question."},
         is_public=True,
+        contributed_by="Illuin Technology",
         superseded_by="Vidore3IndustrialRetrieval.v2",
     )
 
@@ -243,6 +248,7 @@ class Vidore3IndustrialRetrievalv2(AbsTaskRetrieval):
 """,
         prompt={"query": "Find a screenshot that is relevant to the user's question."},
         is_public=True,
+        contributed_by="Illuin Technology",
         adapted_from=["Vidore3IndustrialRetrieval"],
     )
 
@@ -282,6 +288,7 @@ class Vidore3PharmaceuticalsRetrieval(AbsTaskRetrieval):
 """,
         prompt={"query": "Find a screenshot that is relevant to the user's question."},
         is_public=True,
+        contributed_by="Illuin Technology",
         superseded_by="Vidore3PharmaceuticalsRetrieval.v2",
     )
 
@@ -322,6 +329,7 @@ class Vidore3PharmaceuticalsRetrievalv2(AbsTaskRetrieval):
 """,
         prompt={"query": "Find a screenshot that is relevant to the user's question."},
         is_public=True,
+        contributed_by="Illuin Technology",
         adapted_from=["Vidore3PharmaceuticalsRetrieval"],
     )
 
@@ -361,6 +369,7 @@ class Vidore3ComputerScienceRetrieval(AbsTaskRetrieval):
 """,
         prompt={"query": "Find a screenshot that is relevant to the user's question."},
         is_public=True,
+        contributed_by="Illuin Technology",
         superseded_by="Vidore3ComputerScienceRetrieval.v2",
     )
 
@@ -401,6 +410,7 @@ class Vidore3ComputerScienceRetrievalv2(AbsTaskRetrieval):
 """,
         prompt={"query": "Find a screenshot that is relevant to the user's question."},
         is_public=True,
+        contributed_by="Illuin Technology",
         adapted_from=["Vidore3ComputerScienceRetrieval"],
     )
 
@@ -440,6 +450,7 @@ class Vidore3HrRetrieval(AbsTaskRetrieval):
 """,
         prompt={"query": "Find a screenshot that is relevant to the user's question."},
         is_public=True,
+        contributed_by="Illuin Technology",
         superseded_by="Vidore3HrRetrieval.v2",
     )
 
@@ -480,6 +491,7 @@ class Vidore3HrRetrievalv2(AbsTaskRetrieval):
 """,
         prompt={"query": "Find a screenshot that is relevant to the user's question."},
         is_public=True,
+        contributed_by="Illuin Technology",
         adapted_from=["Vidore3HrRetrieval"],
     )
 
@@ -519,6 +531,7 @@ class Vidore3EnergyRetrieval(AbsTaskRetrieval):
 """,
         prompt={"query": "Find a screenshot that is relevant to the user's question."},
         is_public=True,
+        contributed_by="Illuin Technology",
         superseded_by="Vidore3EnergyRetrieval.v2",
     )
 
@@ -559,6 +572,7 @@ class Vidore3EnergyRetrievalv2(AbsTaskRetrieval):
 """,
         prompt={"query": "Find a screenshot that is relevant to the user's question."},
         is_public=True,
+        contributed_by="Illuin Technology",
         adapted_from=["Vidore3EnergyRetrieval"],
     )
 
@@ -598,6 +612,7 @@ class Vidore3PhysicsRetrieval(AbsTaskRetrieval):
 """,
         prompt={"query": "Find a screenshot that is relevant to the user's question."},
         is_public=True,
+        contributed_by="Illuin Technology",
         superseded_by="Vidore3PhysicsRetrieval.v2",
     )
 
@@ -638,6 +653,7 @@ class Vidore3PhysicsRetrievalv2(AbsTaskRetrieval):
 """,
         prompt={"query": "Find a screenshot that is relevant to the user's question."},
         is_public=True,
+        contributed_by="Illuin Technology",
         adapted_from=["Vidore3PhysicsRetrieval"],
     )
 
@@ -677,6 +693,7 @@ class Vidore3NuclearRetrieval(AbsTaskRetrieval):
 """,
         prompt={"query": "Find a screenshot that is relevant to the user's question."},
         is_public=False,
+        contributed_by="Illuin Technology",
         superseded_by="Vidore3NuclearRetrieval.v2",
     )
 
@@ -716,6 +733,7 @@ class Vidore3TelecomRetrieval(AbsTaskRetrieval):
 """,
         prompt={"query": "Find a screenshot that is relevant to the user's question."},
         is_public=False,
+        contributed_by="Illuin Technology",
         superseded_by="Vidore3TelecomRetrieval.v2",
     )
 
@@ -756,6 +774,7 @@ class Vidore3TelecomRetrievalv2(AbsTaskRetrieval):
 """,
         prompt={"query": "Find a screenshot that is relevant to the user's question."},
         is_public=False,
+        contributed_by="Illuin Technology",
         adapted_from=["Vidore3TelecomRetrieval"],
     )
 
@@ -796,5 +815,6 @@ class Vidore3NuclearRetrievalv2(AbsTaskRetrieval):
 """,
         prompt={"query": "Find a screenshot that is relevant to the user's question."},
         is_public=False,
+        contributed_by="Illuin Technology",
         adapted_from=["Vidore3NuclearRetrieval"],
     )

--- a/tests/test_abstasks/test_task_metadata.py
+++ b/tests/test_abstasks/test_task_metadata.py
@@ -201,31 +201,7 @@ def test_filled_metadata_is_filled():
     )
 
 
-def test_full_description_without_contributor():
-    my_task = TaskMetadata(
-        name="MyTask",
-        dataset={"path": "test/dataset", "revision": "1.0"},
-        description="A test dataset.",
-        reference=None,
-        type="Classification",
-        category="t2t",
-        modalities=["text"],
-        eval_splits=["test"],
-        eval_langs=["eng-Latn"],
-        main_score="map_at_1000",
-        date=None,
-        domains=None,
-        license=None,
-        task_subtypes=None,
-        annotations_creators=None,
-        dialect=None,
-        sample_creation=None,
-        bibtex_citation="",
-    )
-    assert my_task.full_description == "A test dataset."
-
-
-def test_full_description_with_contributor():
+def test_contributed_by_field():
     my_task = TaskMetadata(
         name="MyTask",
         dataset={"path": "test/dataset", "revision": "1.0"},
@@ -247,10 +223,7 @@ def test_full_description_with_contributor():
         bibtex_citation="",
         contributed_by="Acme Corp",
     )
-    assert (
-        my_task.full_description
-        == "A test dataset. This dataset was contributed by Acme Corp."
-    )
+    assert my_task.contributed_by == "Acme Corp"
 
 
 def test_task_hf_config():


### PR DESCRIPTION
## Summary

Closes #3920

- Adds an optional `contributed_by: str | None` field to `TaskMetadata` to specify who provided a dataset
- Adds a `full_description` property that appends `"This dataset was contributed by {company}."` when set
- Surfaces contributor info in HuggingFace dataset cards and the leaderboard task info table
- Adds unit tests for the new `full_description` property

## Usage

```python
metadata = TaskMetadata(
    name="MyDataset",
    description="A dataset for testing.",
    contributed_by="Acme Corp",
    ...
)
# metadata.full_description → "A dataset for testing. This dataset was contributed by Acme Corp."
```

## Test plan

- [x] `test_full_description_without_contributor` — description unchanged when no contributor
- [x] `test_full_description_with_contributor` — contributor info appended correctly
- [x] All existing metadata tests pass (1510 tests in `test_metadata.py`, 55 in `test_task_metadata.py`)