### PR TITLE
fix: Revert gradio version bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ audio = [
 ]
 codecarbon = ["codecarbon>=2.0.0,<3.0.0"]
 leaderboard = [
-    "gradio==6.9.0",
+    "gradio==6.0.1",
     "plotly>=5.24.0,<6.0.0",
     "cachetools>=5.2.0",
     "matplotlib>=3.9.4",


### PR DESCRIPTION
After a lot of local testing this seems to resolve the issue

intends to fix: #4273

