### PR TITLE
fix: handle empty sim_scores in confidence_scores

### DIFF
--- a/mteb/_evaluators/retrieval_metrics.py
+++ b/mteb/_evaluators/retrieval_metrics.py
@@ -268,6 +268,9 @@ def confidence_scores(sim_scores: list[float]) -> dict[str, float]:
             - `std`: Standard deviation of similarity scores
             - `diff1`: Difference between highest and second highest similarity scores
     """
+    if not sim_scores:
+        return {"max": 0.0, "std": 0.0, "diff1": 0.0}
+
     sim_scores_sorted = sorted(sim_scores)[::-1]
 
     cs_max = sim_scores_sorted[0]


### PR DESCRIPTION
## Summary
- Handle empty `sim_scores` list in `confidence_scores()` by returning zeros instead of crashing with `IndexError: list index out of range`
- This occurs when BM25 returns no results for a query in reranking tasks

## Test plan
- Ran BM25 evaluation on all 8 reranking tasks that previously failed with this error — all succeed now