### PR TITLE
docs: update links in README for task and usage sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ mteb run \
     --output-folder results
 ```
 
-For more on how to use the CLI check out the [related documentation](https://embeddings-benchmark.github.io/mteb/usage/cli/).
+For more on how to use the CLI check out the [related documentation](https://embeddings-benchmark.github.io/mteb/get_started/usage/cli/).
 
 ## Overview
 
@@ -88,23 +88,23 @@ For more on how to use the CLI check out the [related documentation](https://emb
 | 🏭 [Running Evaluation]        | How to run the evaluations, including cache management, speeding up evaluations etc. |
 | 📊 [Loading Results]           | How to load and work with existing model results                                     |
 | **Overview**.                  |                                                                                      |
+| 📋 [Tasks]                     | Overview of available tasks                                                          |
 | 📐 [Benchmarks]                | Overview of available benchmarks                                                     |
 | 🤖 [Models]                    | Overview of available Models                                                         |
-| 📋 [Tasks]                     | Overview of available tasks                                                          |
 | **Contributing**               |                                                                                      |
 | 🤖 [Adding a model]            | How to submit a model to MTEB and to the leaderboard                                 |
 | 👩‍💻 [Adding a dataset]          | How to add a new task/dataset to MTEB                                                |
 | 👩‍💻 [Adding a benchmark]        | How to add a new benchmark to MTEB and to the leaderboard                            |
 | 🤝 [Contributing]              | How to contribute to MTEB and set it up for development                              |
 
-[Get Started]: https://embeddings-benchmark.github.io/mteb/get_started/usage/get_started/
+[Get Started]: https://embeddings-benchmark.github.io/mteb/
 [Defining Models]: https://embeddings-benchmark.github.io/mteb/get_started/usage/defining_the_model/
 [Selecting tasks]: https://embeddings-benchmark.github.io/mteb/get_started/usage/selecting_tasks/
 [Running Evaluation]: https://embeddings-benchmark.github.io/mteb/get_started/usage/running_the_evaluation/
 [Loading Results]: https://embeddings-benchmark.github.io/mteb/get_started/usage/loading_results/
+[Tasks]: https://embeddings-benchmark.github.io/mteb/overview/available_tasks/retrieval/
 [Benchmarks]: https://embeddings-benchmark.github.io/mteb/overview/available_benchmarks/
 [Models]: https://embeddings-benchmark.github.io/mteb/overview/available_models/text/
-[Tasks]: https://embeddings-benchmark.github.io/mteb/overview/available_tasks/retrieval/
 [Contributing]: https://embeddings-benchmark.github.io/mteb/CONTRIBUTING/
 [Adding a model]: https://embeddings-benchmark.github.io/mteb/contributing/adding_a_model/
 [Adding a dataset]: https://embeddings-benchmark.github.io/mteb/contributing/adding_a_dataset/


### PR DESCRIPTION
Resolves #4341

This pull request updates the broken link present in the README.md file.
It fixes the link present under **Get Started** and tasks.
