### PR TITLE
model: add Octen INT8 models and update HuggingFace org to Octen

### DIFF
--- a/mteb/models/model_implementations/octen_models.py
+++ b/mteb/models/model_implementations/octen_models.py
@@ -206,7 +206,7 @@ Octen_Embedding_0B6 = ModelMeta(
     public_training_data=None,
     training_datasets=training_data,
     citation=OCTEN_CITATION,
-    output_dtypes=[OutputDType.BF16],
+    output_dtypes=OutputDType.BF16,
     adapted_from="Qwen/Qwen3-Embedding-0.6B",
 )
 
@@ -238,7 +238,7 @@ Octen_Embedding_4B = ModelMeta(
     public_training_data=None,
     training_datasets=training_data,
     citation=OCTEN_CITATION,
-    output_dtypes=[OutputDType.BF16],
+    output_dtypes=OutputDType.BF16,
     adapted_from="Qwen/Qwen3-Embedding-4B",
 )
 
@@ -270,7 +270,7 @@ Octen_Embedding_8B = ModelMeta(
     public_training_data=None,
     training_datasets=training_data,
     citation=OCTEN_CITATION,
-    output_dtypes=[OutputDType.BF16],
+    output_dtypes=OutputDType.BF16,
     adapted_from="Qwen/Qwen3-Embedding-8B",
 )
 
@@ -302,7 +302,7 @@ Octen_Embedding_4B_INT8_dim_1024 = ModelMeta(
     public_training_data=None,
     training_datasets=training_data,
     citation=OCTEN_CITATION,
-    output_dtypes=[OutputDType.FLOAT16],
+    output_dtypes=OutputDType.FLOAT16,
     adapted_from="Qwen/Qwen3-Embedding-4B",
 )
 
@@ -334,6 +334,6 @@ Octen_Embedding_8B_INT8_dim_1024 = ModelMeta(
     public_training_data=None,
     training_datasets=training_data,
     citation=OCTEN_CITATION,
-    output_dtypes=[OutputDType.FLOAT16],
+    output_dtypes=OutputDType.FLOAT16,
     adapted_from="Qwen/Qwen3-Embedding-8B",
 )


### PR DESCRIPTION
- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [x] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e., is available either as an API or the weights are publicly available to download