### PR TITLE
fix: Change main score from accuracy to LRAP

### DIFF
--- a/mteb/tasks/multilabel_classification/eng/fsd2019_kaggle.py
+++ b/mteb/tasks/multilabel_classification/eng/fsd2019_kaggle.py
@@ -19,7 +19,7 @@ class FSD2019KaggleMultilingualClassification(AbsTaskMultilabelClassification):
         category="a2t",
         eval_splits=["test"],
         eval_langs={"curated": ["eng-Latn"], "noisy": ["eng-Latn"]},
-        main_score="accuracy",
+        main_score="lrap",
         date=(
             "2020-01-01",
             "2020-01-30",

--- a/mteb/tasks/multilabel_classification/eng/fsd50_hf.py
+++ b/mteb/tasks/multilabel_classification/eng/fsd50_hf.py
@@ -18,7 +18,7 @@ class FSD50HFMultilingualClassification(AbsTaskMultilabelClassification):
         category="a2t",
         eval_splits=["test"],
         eval_langs=["eng-Latn"],
-        main_score="accuracy",
+        main_score="lrap",
         date=(
             "2020-01-01",
             "2020-01-30",

--- a/mteb/tasks/multilabel_classification/zxx/bird_set.py
+++ b/mteb/tasks/multilabel_classification/zxx/bird_set.py
@@ -20,7 +20,7 @@ class BirdSetMultilabelClassification(AbsTaskMultilabelClassification):
         category="a2t",
         eval_splits=["test_5s"],
         eval_langs=["zxx-Zxxx"],
-        main_score="accuracy",
+        main_score="lrap",
         date=("2025-01-01", "2025-12-31"),  # Competition year
         domains=["Spoken", "Speech", "Bioacoustics"],
         task_subtypes=["Species Classification"],


### PR DESCRIPTION
For MAEB MultiLabelClassification tasks.

I suspect we also need to change the submitted results to match this change
