### PR TITLE
Add F2LLM-v2-80M as a reference model

### DIFF
--- a/tests/test_benchmarks/test_reference_models.py
+++ b/tests/test_benchmarks/test_reference_models.py
@@ -16,6 +16,7 @@ REFERENCE_MODELS = [
     "sentence-transformers/static-similarity-mrl-multilingual-v1",
     "minishlab/potion-multilingual-128M",
     "mteb/baseline-bm25s",
+    "codefuse-ai/F2LLM-v2-80M",
 ]
 
 # Models that implement SearchProtocol only (retrieval/reranking tasks)


### PR DESCRIPTION
## Summary
- Adds `codefuse-ai/F2LLM-v2-80M` to the `REFERENCE_MODELS` list in the reference model coverage test
- F2LLM-v2-80M is a small (80M params), multilingual, open-source model with public training data and code
- Results were uploaded in https://github.com/embeddings-benchmark/results/pull/438

Issue #4321
