### PR TITLE
fix: Corrected incorrect model rename

### DIFF
--- a/mteb/models/get_model_meta.py
+++ b/mteb/models/get_model_meta.py
@@ -135,7 +135,7 @@ _MODEL_RENAMES: dict[str, str] = {
     # to store model's eval results to display on benchmark
     "baseline/bm25s": "mteb/baseline-bm25s",
     "baseline/random-cross-encoder-baseline": "mteb/baseline-random-cross-encoder",
-    "mteb/baseline-random-encoder": "mteb/baseline-random-encoder",
+    "baseline/random-encoder": "mteb/baseline-random-encoder",
     "baseline/bb25": "mteb/baseline-bb25",
 }
 


### PR DESCRIPTION
This gave the following incorrect warning:

```
DeprecationWarning: The model 'mteb/baseline-random-encoder' has been renamed to 'mteb/baseline-random-encoder'. To prevent this warning use the new name.
  model = mteb.get_model_meta("mteb/baseline-random-encoder")

If you add a model or a dataset, please add the corresponding checklist:

* [dataset checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_dataset/#submit-a-pr)
* [model checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_model/#submitting-your-model-as-a-pr)
