### PR TITLE
ci: add workflow to auto-update leaderboard model list

### DIFF
--- a/.github/workflows/update_leaderboard_models.yml
+++ b/.github/workflows/update_leaderboard_models.yml
@@ -1,0 +1,52 @@
+name: Update Leaderboard Model List
+
+on:
+  schedule:
+    # Weekly on Monday at 9 AM UTC
+    - cron: "0 9 * * 1"
+  push:
+    branches: [main]
+    paths:
+      - "mteb/models/**"
+  workflow_dispatch:
+
+concurrency:
+  group: update-leaderboard-models
+  cancel-in-progress: true
+
+jobs:
+  update-models:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout mteb
+        uses: actions/checkout@v6
+
+      - name: Install uv and set the Python version
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.10"
+          version: "0.10.12"
+
+      - name: Install mteb
+        run: uv sync
+
+      - name: Generate model list
+        run: uv run python scripts/generate_leaderboard_models.py > leaderboard_models.py
+
+      - name: Clone leaderboard space and update
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          git clone https://huggingface.co/spaces/mteb/leaderboard hf-leaderboard
+          cp leaderboard_models.py hf-leaderboard/models.py
+          cd hf-leaderboard
+          if git diff --quiet models.py; then
+            echo "No changes to models.py"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://mteb:${HF_TOKEN}@huggingface.co/spaces/mteb/leaderboard"
+          git add models.py
+          git commit -m "Update model list"
+          git push

--- a/scripts/generate_leaderboard_models.py
+++ b/scripts/generate_leaderboard_models.py
@@ -1,0 +1,29 @@
+"""Generate the model list for the HuggingFace leaderboard space.
+
+Outputs a Python file (to stdout) containing the complete list of model
+names registered in MTEB. The leaderboard space imports this to know
+which models are available.
+
+Usage:
+    python scripts/generate_leaderboard_models.py > models.py
+"""
+
+from __future__ import annotations
+
+import mteb
+
+
+def main():
+    model_metas = mteb.get_model_metas()
+    model_names = sorted({m.name for m in model_metas})
+
+    print('"""Auto-generated list of models registered in MTEB."""')
+    print()
+    print("MODEL_NAMES = [")
+    for name in model_names:
+        print(f'    "{name}",')
+    print("]")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add a GitHub Actions workflow that automatically updates the model list in the HuggingFace leaderboard space. Runs weekly, on model file changes to main, and via manual dispatch. 

Issue #4316
