### PR TITLE
feat: add required_dependencies field to ModelMeta

### DIFF
--- a/mteb/models/model_implementations/e5_v.py
+++ b/mteb/models/model_implementations/e5_v.py
@@ -187,4 +187,5 @@ e5_v = ModelMeta(
         # princeton-nlp/datasets-for-simcse
     ),
     citation=E5_V_CITATION,
+    required_dependencies=["transformers==4.44.2"],
 )

--- a/mteb/models/model_implementations/evaclip_models.py
+++ b/mteb/models/model_implementations/evaclip_models.py
@@ -163,6 +163,7 @@ EVA02_CLIP_B_16 = ModelMeta(
     use_instructions=False,
     training_datasets=training_datasets,
     citation=EVA_CLIP_CITATION,
+    required_dependencies=["eva_clip"],
 )
 
 EVA02_CLIP_L_14 = ModelMeta(
@@ -188,6 +189,7 @@ EVA02_CLIP_L_14 = ModelMeta(
     use_instructions=False,
     training_datasets=training_datasets,
     citation=EVA_CLIP_CITATION,
+    required_dependencies=["eva_clip"],
 )
 
 EVA02_CLIP_bigE_14 = ModelMeta(
@@ -213,6 +215,7 @@ EVA02_CLIP_bigE_14 = ModelMeta(
     use_instructions=False,
     training_datasets=laion_2b,
     citation=EVA_CLIP_CITATION,
+    required_dependencies=["eva_clip"],
 )
 
 
@@ -239,4 +242,5 @@ EVA02_CLIP_bigE_14_plus = ModelMeta(
     use_instructions=False,
     training_datasets=laion_2b,
     citation=EVA_CLIP_CITATION,
+    required_dependencies=["eva_clip"],
 )

--- a/mteb/models/model_implementations/lco_embedding_models.py
+++ b/mteb/models/model_implementations/lco_embedding_models.py
@@ -162,6 +162,7 @@ lco_3b = ModelMeta(
   primaryClass={cs.CL},
   url={https://arxiv.org/abs/2510.11693},
 }""",
+    required_dependencies=["qwen_omni_utils"],
 )
 
 lco_7b = ModelMeta(
@@ -197,4 +198,5 @@ lco_7b = ModelMeta(
   primaryClass={cs.CL},
   url={https://arxiv.org/abs/2510.11693},
 }""",
+    required_dependencies=["qwen_omni_utils"],
 )

--- a/mteb/models/model_implementations/nvidia_models.py
+++ b/mteb/models/model_implementations/nvidia_models.py
@@ -639,6 +639,7 @@ llama_embed_nemotron_8b = ModelMeta(
     public_training_data="https://huggingface.co/datasets/nvidia/embed-nemotron-dataset-v1",
     contacts=["ybabakhin"],
     citation=LlamaEmbedNemotron_CITATION,
+    required_dependencies=["transformers==4.51.0", "flash_attn"],
 )
 
 

--- a/mteb/models/model_implementations/opensearch_neural_sparse_models.py
+++ b/mteb/models/model_implementations/opensearch_neural_sparse_models.py
@@ -156,6 +156,7 @@ opensearch_neural_sparse_encoding_doc_v3_gte = ModelMeta(
     loader_kwargs=dict(
         trust_remote_code=True,
     ),
+    required_dependencies=["sentence-transformers>=5.0.0"],
 )
 
 
@@ -180,6 +181,7 @@ opensearch_neural_sparse_encoding_doc_v3_distill = ModelMeta(
     use_instructions=True,
     training_datasets=v3_training_data,
     loader=SparseEncoderWrapper,
+    required_dependencies=["sentence-transformers>=5.0.0"],
 )
 
 opensearch_neural_sparse_encoding_doc_v2_distill = ModelMeta(
@@ -203,6 +205,7 @@ opensearch_neural_sparse_encoding_doc_v2_distill = ModelMeta(
     use_instructions=True,
     training_datasets=v2_training_data,
     loader=SparseEncoderWrapper,
+    required_dependencies=["sentence-transformers>=5.0.0"],
 )
 
 
@@ -227,6 +230,7 @@ opensearch_neural_sparse_encoding_doc_v2_mini = ModelMeta(
     use_instructions=True,
     training_datasets=v2_training_data,
     loader=SparseEncoderWrapper,
+    required_dependencies=["sentence-transformers>=5.0.0"],
 )
 
 opensearch_neural_sparse_encoding_doc_v1 = ModelMeta(
@@ -252,4 +256,5 @@ opensearch_neural_sparse_encoding_doc_v1 = ModelMeta(
         "MSMARCO",
     },
     loader=SparseEncoderWrapper,
+    required_dependencies=["sentence-transformers>=5.0.0"],
 )

--- a/mteb/models/model_implementations/vista_models.py
+++ b/mteb/models/model_implementations/vista_models.py
@@ -272,6 +272,7 @@ visualized_bge_base = ModelMeta(
     use_instructions=False,
     training_datasets=vista_training_datasets,
     citation=VISTA_CITATION,
+    required_dependencies=["visual_bge"],
 )
 
 visualized_bge_m3 = ModelMeta(
@@ -301,4 +302,5 @@ visualized_bge_m3 = ModelMeta(
     use_instructions=False,
     training_datasets=vista_training_datasets,
     citation=VISTA_CITATION,
+    required_dependencies=["visual_bge"],
 )

--- a/mteb/models/model_meta.py
+++ b/mteb/models/model_meta.py
@@ -144,6 +144,8 @@ class ModelMeta(BaseModel):  # noqa: PLR0904
         contacts: The people to contact in case of a problem in the model, preferably a GitHub handle.
         experiment_kwargs: A dictionary of parameters used in the experiment that are not covered by other fields. This is used to create experiment names for ablation studies and similar experiments.
         output_dtypes: Output embedding data types (e.g. int8, binary, float) natively supported by the model. If None, it is assumed that the model only returns float embeddings.
+        required_dependencies: A list of required dependencies for the model. These are displayed in the error message if the model fails to load due
+            to an ImportError. E.g. ``["visual_bge"]`` or ``["transformers>=4.51.0"]``.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -178,6 +180,7 @@ class ModelMeta(BaseModel):  # noqa: PLR0904
     contacts: list[str] | None = None
     experiment_kwargs: Mapping[str, Any] | None = None
     output_dtypes: OutputDType | list[OutputDType] | None = None
+    required_dependencies: list[str] = field(default_factory=list)
 
     def __setattr__(self, name: str, value: Any) -> None:
         """Deprecation warning for direct attribute mutation. Use model_copy(update={...}) instead."""
@@ -390,11 +393,21 @@ class ModelMeta(BaseModel):  # noqa: PLR0904
 
         updates["loader_kwargs"] = _kwargs
         _self = _self.model_copy(update=updates)
-        model: MTEBModels = loader(
-            name,
-            revision=revision,
-            **_kwargs,
-        )
+        try:
+            model: MTEBModels = loader(
+                name,
+                revision=revision,
+                **_kwargs,
+            )
+        except ImportError as e:
+            if _self.required_dependencies:
+                deps = ", ".join(_self.required_dependencies)
+                raise ImportError(
+                    f"Failed to load model '{_self.name}'. "
+                    f"Required dependencies: {deps}. "
+                    f"Original error: {e}"
+                ) from e
+            raise
         model.mteb_model_meta = _self  # type: ignore[misc]
         return model
 

--- a/tests/test_models/test_model_meta.py
+++ b/tests/test_models/test_model_meta.py
@@ -365,6 +365,7 @@ def test_model_to_python():
     citation='@inproceedings{reimers-2019-sentence-bert,\\n    title = "Sentence-BERT: Sentence Embeddings using Siamese BERT-Networks",\\n    author = "Reimers, Nils and Gurevych, Iryna",\\n    booktitle = "Proceedings of the 2019 Conference on Empirical Methods in Natural Language Processing",\\n    month = "11",\\n    year = "2019",\\n    publisher = "Association for Computational Linguistics",\\n    url = "http://arxiv.org/abs/1908.10084",\\n}\\n',
     contacts=None,
     output_dtypes=None,
+    required_dependencies=[],
 )"""
     )
 
@@ -432,3 +433,102 @@ def test_get_model_metas_without_modality_filter_returns_more_models():
     text_models = mteb.get_model_metas(modalities=["text"])
 
     assert len(all_models) > len(text_models)
+
+
+def test_required_dependencies_default():
+    """Test that required_dependencies defaults to an empty list."""
+    meta = mteb.get_model_meta("sentence-transformers/all-MiniLM-L6-v2")
+    assert meta.required_dependencies == []
+
+
+def test_required_dependencies_set_on_model():
+    """Test that required_dependencies can be set on a model."""
+    meta = ModelMeta(
+        loader=None,
+        name="test/model",
+        revision="1",
+        release_date=None,
+        languages=None,
+        n_parameters=None,
+        memory_usage_mb=None,
+        max_tokens=None,
+        embed_dim=None,
+        license=None,
+        open_weights=True,
+        public_training_code=None,
+        public_training_data=None,
+        framework=[],
+        similarity_fn_name=None,
+        use_instructions=False,
+        training_datasets=None,
+        required_dependencies=["some-package>=1.0", "another-package"],
+    )
+    assert meta.required_dependencies == ["some-package>=1.0", "another-package"]
+
+
+def test_required_dependencies_in_import_error():
+    """Test that required_dependencies are shown in the ImportError message when loading fails."""
+
+    def failing_loader(name, **kwargs):
+        raise ImportError("No module named 'nonexistent_package'")
+
+    meta = ModelMeta(
+        loader=failing_loader,
+        name="test/model",
+        revision="1",
+        release_date=None,
+        languages=None,
+        n_parameters=None,
+        memory_usage_mb=None,
+        max_tokens=None,
+        embed_dim=None,
+        license=None,
+        open_weights=True,
+        public_training_code=None,
+        public_training_data=None,
+        framework=[],
+        similarity_fn_name=None,
+        use_instructions=False,
+        training_datasets=None,
+        required_dependencies=["nonexistent_package"],
+    )
+    with pytest.raises(ImportError, match="Required dependencies: nonexistent_package"):
+        meta.load_model()
+
+
+def test_required_dependencies_import_error_without_deps():
+    """Test that ImportError propagates unchanged when required_dependencies is empty."""
+
+    def failing_loader(name, **kwargs):
+        raise ImportError("No module named 'foo'")
+
+    meta = ModelMeta(
+        loader=failing_loader,
+        name="test/model",
+        revision="1",
+        release_date=None,
+        languages=None,
+        n_parameters=None,
+        memory_usage_mb=None,
+        max_tokens=None,
+        embed_dim=None,
+        license=None,
+        open_weights=True,
+        public_training_code=None,
+        public_training_data=None,
+        framework=[],
+        similarity_fn_name=None,
+        use_instructions=False,
+        training_datasets=None,
+    )
+    with pytest.raises(ImportError, match="No module named 'foo'"):
+        meta.load_model()
+
+
+def test_required_dependencies_accessible_without_loading():
+    """Test that required_dependencies can be inspected without loading the model."""
+    from mteb.models.model_implementations import MODEL_REGISTRY
+
+    vista_meta = MODEL_REGISTRY.get("BAAI/bge-visualized-base")
+    assert vista_meta is not None
+    assert "visual_bge" in vista_meta.required_dependencies


### PR DESCRIPTION
Add a `required_dependencies` field to `ModelMeta` that lists packages needed to load a model. When `load_model()` catches an ImportError, the error message now includes these dependencies so users know what to install.

Issue #4350
