### PR TITLE
add mteb/MSVD dataset

### DIFF
--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -154,6 +154,7 @@ from .mscoco_i2t_retrieval import MSCOCOI2TRetrieval
 from .mscoco_t2i_retrieval import MSCOCOT2IRetrieval
 from .msmarc_ov2_retrieval import MSMARCOv2
 from .msmarco_retrieval import MSMARCO, MSMARCOHardNegatives
+from .msvd_v2t_retrieval import MSVDV2TRetrieval
 from .nano_argu_ana_retrieval import NanoArguAnaRetrieval
 from .nano_climate_fever_retrieval import NanoClimateFeverRetrieval
 from .nano_db_pedia_retrieval import NanoDBPediaRetrieval
@@ -423,6 +424,7 @@ __all__ = [
     "MSCOCOT2IRetrieval",
     "MSMARCOHardNegatives",
     "MSMARCOv2",
+    "MSVDV2TRetrieval",
     "MedicalQARetrieval",
     "MemotionI2TRetrieval",
     "MemotionT2IRetrieval",

--- a/mteb/tasks/retrieval/eng/msvd_v2t_retrieval.py
+++ b/mteb/tasks/retrieval/eng/msvd_v2t_retrieval.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from datasets import load_dataset
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.retrieval_dataset_loaders import RetrievalSplitData
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class MSVDV2TRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="MSVDV2TRetrieval",
+        description=(
+            "Retrieve the English caption that describes a given short video clip. "
+            "Each example pairs one video with one reference sentence (1:1 retrieval)."
+        ),
+        reference="https://huggingface.co/datasets/mteb/MSVD",
+        dataset={
+            "path": "mteb/MSVD",
+            "revision": "177cefe5957363d1617f0427fcfa00ff0b0d7da8",
+        },
+        type="Any2AnyRetrieval",
+        category="v2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2010-01-01", "2012-12-31"),
+        domains=["Web", "Spoken"],
+        task_subtypes=["Caption Pairing"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video", "text"],
+        sample_creation="found",
+        bibtex_citation=r"""
+@misc{microsoft2011msvd,
+  author = {{Microsoft Research}},
+  title = {Microsoft Research Video Description Corpus},
+  year = {2011},
+  url = {https://www.microsoft.com/en-us/research/publication/microsoft-research-video-description-corpus/},
+}
+""",
+        prompt={
+            "query": "Find the caption that best describes the following video.",
+        },
+        is_beta=True,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        """Load the MSVD dataset.
+
+        TODO: Reupload dataset in standard format and remove this custom load_data.
+        """
+        if self.data_loaded:
+            return
+        self.dataset = {"default": {}}
+        dataset = load_dataset(
+            self.metadata.dataset["path"],
+            revision=self.metadata.dataset["revision"],
+            split=self.metadata.eval_splits[0],
+        )
+        dataset = dataset.add_column("id", [str(i) for i in range(len(dataset))])
+
+        query = dataset.select_columns(["id", "video"])
+        corpus = dataset.select_columns(["id", "caption"]).rename_column(
+            "caption", "text"
+        )
+        qrels = {}
+        for i in range(len(dataset)):
+            key = str(i)
+            if key not in qrels:
+                qrels[key] = {}
+            qrels[key][key] = 1
+        self.dataset["default"]["test"] = RetrievalSplitData(
+            queries=query, corpus=corpus, relevant_docs=qrels, top_ranked=None
+        )
+        self.data_loaded = True


### PR DESCRIPTION
- [x] I have outlined why this dataset is filling an existing gap in `mteb`
- [x] I have tested that the dataset runs with the `mteb` package.
- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
  - [ ] `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
  - [ ] `intfloat/multilingual-e5-small`
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [x] I have considered the size of the dataset and reduced it if it is too big (2048 examples is typically large enough for most tasks)
#4130 
Ran the `mteb/baseline-random-encoder` model. 
[MSVDV2TRetrieval_results.json](https://github.com/user-attachments/files/26806707/MSVDV2TRetrieval_results.json)

cc @Samoed 
