### PR TITLE
dataset: add MrTyDiKoreanReranking task

### DIFF
--- a/mteb/descriptive_stats/Reranking/MrTyDiKoreanReranking.json
+++ b/mteb/descriptive_stats/Reranking/MrTyDiKoreanReranking.json
@@ -1,0 +1,64 @@
+{
+  "test": {
+    "num_samples": 1496547,
+    "number_of_characters": 262146362,
+    "documents_text_statistics": {
+      "total_text_length": 262136771,
+      "min_text_length": 4,
+      "average_text_length": 175.21035728274222,
+      "max_text_length": 25247,
+      "unique_texts": 1490526
+    },
+    "documents_image_statistics": null,
+    "documents_audio_statistics": null,
+    "queries_text_statistics": {
+      "total_text_length": 9591,
+      "min_text_length": 6,
+      "average_text_length": 22.78147268408551,
+      "max_text_length": 122,
+      "unique_texts": 421
+    },
+    "queries_image_statistics": null,
+    "queries_audio_statistics": null,
+    "relevant_docs_statistics": {
+      "num_relevant_docs": 492,
+      "min_relevant_docs_per_query": 1,
+      "average_relevant_docs_per_query": 1.168646080760095,
+      "max_relevant_docs_per_query": 3,
+      "unique_relevant_docs": 397
+    },
+    "top_ranked_statistics": null,
+    "hf_subset_descriptive_stats": {
+      "korean": {
+        "num_samples": 1496547,
+        "number_of_characters": 262146362,
+        "documents_text_statistics": {
+          "total_text_length": 262136771,
+          "min_text_length": 4,
+          "average_text_length": 175.21035728274222,
+          "max_text_length": 25247,
+          "unique_texts": 1490526
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "queries_text_statistics": {
+          "total_text_length": 9591,
+          "min_text_length": 6,
+          "average_text_length": 22.78147268408551,
+          "max_text_length": 122,
+          "unique_texts": 421
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "relevant_docs_statistics": {
+          "num_relevant_docs": 492,
+          "min_relevant_docs_per_query": 1,
+          "average_relevant_docs_per_query": 1.168646080760095,
+          "max_relevant_docs_per_query": 3,
+          "unique_relevant_docs": 397
+        },
+        "top_ranked_statistics": null
+      }
+    }
+  }
+}

--- a/mteb/tasks/reranking/__init__.py
+++ b/mteb/tasks/reranking/__init__.py
@@ -2,6 +2,7 @@ from .ara import *
 from .eng import *
 from .fra import *
 from .jpn import *
+from .kor import *
 from .multilingual import *
 from .rus import *
 from .vie import *

--- a/mteb/tasks/reranking/kor/__init__.py
+++ b/mteb/tasks/reranking/kor/__init__.py
@@ -1,0 +1,3 @@
+from .mr_tydi_korean_reranking import MrTyDiKoreanReranking
+
+__all__ = ["MrTyDiKoreanReranking"]

--- a/mteb/tasks/reranking/kor/mr_tydi_korean_reranking.py
+++ b/mteb/tasks/reranking/kor/mr_tydi_korean_reranking.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import logging
+
+import datasets
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.task_metadata import TaskMetadata
+
+logger = logging.getLogger(__name__)
+
+_EVAL_SPLIT = "test"
+
+
+def _load_mr_tydi_korean(
+    path: str, splits: list[str], revision: str | None = None
+) -> tuple[dict, dict, dict]:
+    lang = "korean"
+    corpus = {lang: {split: {} for split in splits}}
+    queries = {lang: {split: {} for split in splits}}
+    relevant_docs = {lang: {split: {} for split in splits}}
+
+    split = _EVAL_SPLIT
+
+    qrels_data = datasets.load_dataset(
+        path,
+        name=f"{lang}-qrels",
+        revision=revision,
+    )[split]
+    for row in qrels_data:
+        qid = row["query-id"]
+        did = row["corpus-id"]
+        score = row["score"]
+        if qid not in relevant_docs[lang][split]:
+            relevant_docs[lang][split][qid] = {}
+        relevant_docs[lang][split][qid][did] = score
+
+    corpus_data = datasets.load_dataset(
+        path,
+        name=f"{lang}-corpus",
+        revision=revision,
+    )["train"]
+    for row in corpus_data:
+        corpus[lang][split][row["_id"]] = {
+            "title": row["title"],
+            "text": row["text"],
+        }
+
+    queries_data = datasets.load_dataset(
+        path,
+        name=f"{lang}-queries",
+        revision=revision,
+    )[split]
+    for row in queries_data:
+        queries[lang][split][row["_id"]] = row["text"]
+
+    logger.info("Loaded %d Korean queries.", len(queries[lang][split]))
+    return corpus, queries, relevant_docs
+
+
+class MrTyDiKoreanReranking(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="MrTyDiKoreanReranking",
+        description=(
+            "Mr. TyDi is a multi-lingual benchmark dataset built on TyDi, covering eleven "
+            "typologically diverse languages. It is designed for monolingual retrieval, "
+            "specifically to evaluate ranking with learned dense representations. "
+            "This task adapts the Korean test split for reranking evaluation."
+        ),
+        reference="https://huggingface.co/datasets/castorini/mr-tydi",
+        dataset={
+            "path": "mteb/mrtidy",
+            "revision": "fc24a3ce8f09746410daee3d5cd823ff7a0675b7",
+        },
+        type="Reranking",
+        category="t2t",
+        modalities=["text"],
+        eval_splits=[_EVAL_SPLIT],
+        eval_langs={"korean": ["kor-Kore"]},
+        main_score="ndcg_at_10",
+        date=("2021-01-01", "2021-08-31"),
+        domains=["Encyclopaedic", "Written"],
+        task_subtypes=[],
+        license="cc-by-sa-3.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        adapted_from=["MrTidyRetrieval"],
+        bibtex_citation=r"""
+@article{mrtydi,
+  author = {Xinyu Zhang and Xueguang Ma and Peng Shi and Jimmy Lin},
+  journal = {arXiv:2108.08787},
+  title = {{Mr. TyDi}: A Multi-lingual Benchmark for Dense Retrieval},
+  year = {2021},
+}
+""",
+        prompt="Given a Korean question, retrieve Wikipedia passages that answer the question",
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        if self.data_loaded:
+            return
+
+        self.corpus, self.queries, self.relevant_docs = _load_mr_tydi_korean(
+            path=self.metadata.dataset["path"],
+            splits=self.metadata.eval_splits,
+            revision=self.metadata.dataset["revision"],
+        )
+        self.data_loaded = True


### PR DESCRIPTION
## Summary

This PR adds `MrTyDiKoreanReranking`, a Korean-language reranking task based on the [Mr. TyDi](https://huggingface.co/datasets/castorini/mr-tydi) dataset.

## Gap being filled

MTEB currently has no reranking task with Korean (`kor`) as the primary language. The existing `MIRACLReranking` and `MrTidyRetrieval` cover Korean as part of multilingual benchmarks, but there is no Korean-dedicated entry under `reranking/kor/`. This mirrors the pattern already established for Arabic (`NamaaMrTydiReranking`) and Japanese (`VoyageMMarcoReranking`).

## Implementation

- Subclasses `AbsTaskRetrieval` with `type="Reranking"`, following the same pattern as `MIRACLReranking`
- Uses the existing `mteb/mrtidy` dataset (Korean subset), avoiding any new data hosting
- Sets `adapted_from=["MrTidyRetrieval"]` to make the relationship explicit

## Model Results

| Model | ndcg_at_10 |
|---|---|
| `mteb/baseline-random-encoder` | 0.0000 |
| `intfloat/multilingual-e5-small` | 0.5597 |

> Random encoder score of 0.0 is expected — the corpus has 1.5M documents and random retrieval has near-zero probability of hitting the ~1.17 relevant docs per query. The multilingual-e5-small score of 0.56 is well within a meaningful range (neither trivial nor random).

## Checklist

- [x] I have outlined why this dataset is filling an existing gap in `mteb`
- [x] I have tested that the dataset runs with the `mteb` package
- [x] I have run the following models on the task
  - [x] `mteb/baseline-random-encoder` — ndcg_at_10: 0.0000
  - [x] `intfloat/multilingual-e5-small` — ndcg_at_10: 0.5597
- [x] I have checked that the performance is neither trivial nor random
- [x] Descriptive statistics added to `mteb/descriptive_stats/Reranking/MrTyDiKoreanReranking.json`

## Descriptive Statistics (test split, Korean)

| Metric | Value |
|---|---|
| Corpus size | 1,496,126 documents |
| Queries | 421 |
| Avg. document length | 175.2 chars |
| Avg. query length | 22.8 chars |
| Relevant docs per query (avg) | 1.17 |
| Unique documents | 1,490,526 |