### PR TITLE
[MVEB] Adding MUSIC-AVQA Task (Clustering)

### DIFF
--- a/mteb/tasks/clustering/eng/__init__.py
+++ b/mteb/tasks/clustering/eng/__init__.py
@@ -20,6 +20,7 @@ from .hume_wiki_cities_clustering import HUMEWikiCitiesClustering
 from .image_net import ImageNet10Clustering, ImageNetDog15Clustering
 from .medrxiv_clustering_p2p import MedrxivClusteringP2P, MedrxivClusteringP2PFast
 from .medrxiv_clustering_s2s import MedrxivClusteringS2S, MedrxivClusteringS2SFast
+from .music_avqa_clustering import MusicAVQAClustering
 from .ravdess_av_clustering import RAVDESSAVClustering
 from .reddit_clustering import RedditClustering, RedditFastClusteringS2S
 from .reddit_clustering_p2p import RedditClusteringP2P, RedditFastClusteringP2P
@@ -75,6 +76,7 @@ __all__ = [
     "MedrxivClusteringP2PFast",
     "MedrxivClusteringS2S",
     "MedrxivClusteringS2SFast",
+    "MusicAVQAClustering",
     "RAVDESSAVClustering",
     "RedditClustering",
     "RedditClusteringP2P",

--- a/mteb/tasks/clustering/eng/music_avqa_clustering.py
+++ b/mteb/tasks/clustering/eng/music_avqa_clustering.py
@@ -8,9 +8,9 @@ class MusicAVQAClustering(AbsTaskClustering):
     metadata = TaskMetadata(
         name="MusicAVQAClustering",
         description=(
-            "Clustering of synchronized video and audio clips into 22 musical "
-            "instrument categories from a MUSIC-AVQA classification subset "
-            "(Li et al., CVPR 2022)."
+            "Clustering of video clips with audio into 22 musical "
+            "instrument categories. Extracted from the MUSIC-AVQA "
+            "dataset."
         ),
         reference="https://gewu-lab.github.io/MUSIC-AVQA/",
         dataset={

--- a/mteb/tasks/clustering/eng/music_avqa_clustering.py
+++ b/mteb/tasks/clustering/eng/music_avqa_clustering.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from mteb.abstasks import AbsTaskClustering
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class MusicAVQAClustering(AbsTaskClustering):
+    metadata = TaskMetadata(
+        name="MusicAVQAClustering",
+        description=(
+            "Clustering of synchronized video and audio clips into 22 musical "
+            "instrument categories from a MUSIC-AVQA classification subset "
+            "(Li et al., CVPR 2022)."
+        ),
+        reference="https://gewu-lab.github.io/MUSIC-AVQA/",
+        dataset={
+            "path": "mteb/MUSIC-AVQA_cls-preprocessed",
+            "revision": "29f50ae80ad4e8c1cfdbc0148aefe6fe050833dd",
+        },
+        type="VideoClustering",
+        category="va2c",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="v_measure",
+        date=("2022-06-01", "2022-06-30"),
+        domains=["Music"],
+        task_subtypes=["Thematic clustering"],
+        license="mit",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video", "audio"],
+        sample_creation="found",
+        bibtex_citation=r"""
+@ARTICLE{Li2022Learning,
+    title	= {Learning to Answer Questions in Dynamic Audio-Visual Scenarios},
+    author	= {Guangyao li, Yake Wei, Yapeng Tian, Chenliang Xu, Ji-Rong Wen, Di Hu},
+    journal	= {IEEE Conference on Computer Vision and Pattern Recognition (CVPR)},
+    year	= {2022},
+}
+""",
+        is_beta=True,
+    )
+    max_fraction_of_documents_to_embed = None
+    input_column_name = ("video", "audio")
+    label_column_name: str = "label"
+
+    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+        for split in self.metadata.eval_splits:
+            self.dataset[split] = self.dataset[split].select_columns(
+                ["video", "audio", "label"],
+            )


### PR DESCRIPTION
- [x] I have outlined why this dataset is filling an existing gap in the MVEB benchmark
- [x] I have tested that the dataset runs with the `mteb` package.
- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
  - [x] `facebook/pe-av-small-16-frame`
  - [x] `mteb/baseline-random-encoder`
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [x] I have considered the size of the dataset and reduced it if it is too big (2048 examples is typically large enough for most tasks)

V measures from random and pe-av on the new dataset look alright (see below).

Results for pe-av:
```json
{
  "dataset_revision": "29f50ae80ad4e8c1cfdbc0148aefe6fe050833dd",
  "task_name": "MusicAVQAClustering",
  "mteb_version": "2.12.20",
  "scores": {
    "test": [
      {
        "v_measures": {
          "Level 0": [
            0.477977,
            0.457592,
            0.441274,
            0.469966,
            0.448949,
            0.456659,
            0.433751,
            0.466858,
            0.458299,
            0.458914
          ]
        },
        "v_measure": 0.457024,
        "v_measure_std": 0.012505,
        "main_score": 0.457024,
        "hf_subset": "default",
        "languages": [
          "eng-Latn"
        ]
      }
    ]
  },
  "evaluation_time": 10296.616286993027,
  "kg_co2_emissions": null,
  "date": 1776468723.255704
}
```

Results for random baseline:
```json
{
  "dataset_revision": "29f50ae80ad4e8c1cfdbc0148aefe6fe050833dd",
  "task_name": "MusicAVQAClustering",
  "mteb_version": "2.12.20",
  "scores": {
    "test": [
      {
        "v_measures": {
          "Level 0": [
            0.049974,
            0.048426,
            0.046523,
            0.048457,
            0.049037,
            0.052755,
            0.050626,
            0.049021,
            0.052621,
            0.052527
          ]
        },
        "v_measure": 0.049997,
        "v_measure_std": 0.002002,
        "main_score": 0.049997,
        "hf_subset": "default",
        "languages": [
          "eng-Latn"
        ]
      }
    ]
  },
  "evaluation_time": 852.0752861499786,
  "kg_co2_emissions": null,
  "date": 1776458364.539883
}
```