### PR TITLE
Fix: apply skip_first_result when computing hit_rate metric

### DIFF
--- a/mteb/_evaluators/retrieval_metrics.py
+++ b/mteb/_evaluators/retrieval_metrics.py
@@ -569,6 +569,14 @@ def calculate_retrieval_scores(  # noqa: PLR0914
     k_values: list[int],
     skip_first_result: bool = False,
 ) -> RetrievalEvaluationResult:
+    if skip_first_result:
+        results = {
+            qid: dict(
+                sorted(doc_scores.items(), key=lambda x: x[1], reverse=True)[1:]
+            )
+            for qid, doc_scores in results.items()
+        }
+
     map_string = "map_cut." + ",".join([str(k) for k in k_values])
     ndcg_string = "ndcg_cut." + ",".join([str(k) for k in k_values])
     recall_string = "recall." + ",".join([str(k) for k in k_values])

--- a/mteb/_evaluators/retrieval_metrics.py
+++ b/mteb/_evaluators/retrieval_metrics.py
@@ -571,9 +571,7 @@ def calculate_retrieval_scores(  # noqa: PLR0914
 ) -> RetrievalEvaluationResult:
     if skip_first_result:
         results = {
-            qid: dict(
-                sorted(doc_scores.items(), key=lambda x: x[1], reverse=True)[1:]
-            )
+            qid: dict(sorted(doc_scores.items(), key=lambda x: x[1], reverse=True)[1:])
             for qid, doc_scores in results.items()
         }
 


### PR DESCRIPTION
## Description
                                                                                                                        
  Fixes #4423.                                              
                                                                                                                        
  In #4142, `cv_recall` was replaced with `hit_rate`, but the `skip_first_result` logic was not carried over. The
  parameter was accepted by `calculate_retrieval_scores` but silently ignored, results were passed to pytrec_eval      
  unmodified.                                                                                                      
                                                                                                                        
  Tasks like `CUB200I2IRetrieval`, `METRetrieval`, and `SOPRetrieval` set `skip_first_result = True` because the query 
  exists in the corpus, so the top-ranked result is always the query itself. Without skipping it, all hit_rate scores  
  for these tasks are inflated.                                                                                         
                               
  ## Fix                                                                                                                
                                                            
  Before evaluation, when `skip_first_result=True`, sort each query's results by score descending and drop the top
  entry:                                                                                                                
        
  ```python                                                                                                             
  if skip_first_result:                                     
      results = {      
          qid: dict(sorted(doc_scores.items(), key=lambda x: x[1], reverse=True)[1:])
          for qid, doc_scores in results.items()                                                                        
      } 
 ```
                                
                                                                                                                        
  Files changed                                             
                                                                                                                        
  - mteb/_evaluators/retrieval_metrics.py — 7 lines added                                                               
                                                           