### PR TITLE
add mteb/TUNA-Bench_1K dataset

### DIFF
--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -229,6 +229,8 @@ from .touche2020_retrieval import Touche2020, Touche2020v3Retrieval
 from .treccovid_retrieval import TRECCOVID
 from .trecdl_retrieval import TRECDL2019, TRECDL2020
 from .tu_berlin_t2i_retrieval import TUBerlinT2IRetrieval
+from .tuna_bench_t2v_retrieval import TUNABenchT2VRetrieval
+from .tuna_bench_v2t_retrieval import TUNABenchV2TRetrieval
 from .vidore_bench_retrieval import (
     VidoreArxivQARetrieval,
     VidoreDocVQARetrieval,
@@ -481,6 +483,8 @@ __all__ = [
     "SpokenSQuADT2ARetrieval",
     "StanfordCarsI2I",
     "TUBerlinT2IRetrieval",
+    "TUNABenchT2VRetrieval",
+    "TUNABenchV2TRetrieval",
     "TempReasonL1",
     "TempReasonL2Context",
     "TempReasonL2Fact",

--- a/mteb/tasks/retrieval/eng/tuna_bench_t2v_retrieval.py
+++ b/mteb/tasks/retrieval/eng/tuna_bench_t2v_retrieval.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from datasets import load_dataset
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.retrieval_dataset_loaders import RetrievalSplitData
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class TUNABenchT2VRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="TUNABenchT2VRetrieval",
+        description=(
+            "Retrieve the video clip that matches a given fine-grained English caption "
+            "from the TUNA-Bench dataset of dense dynamic videos with detailed "
+            "temporal descriptions."
+        ),
+        reference="https://arxiv.org/abs/2505.20124",
+        dataset={
+            "path": "mteb/TUNA-Bench_1K",
+            "revision": "0a2b6ec66a3f662f68ac0f0649020b3c37d8551c",
+        },
+        type="Any2AnyRetrieval",
+        category="t2v",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2025-01-01", "2025-12-31"),
+        domains=["Web", "Spoken"],
+        task_subtypes=["Caption Pairing"],
+        license="cc-by-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["text", "video"],
+        sample_creation="found",
+        bibtex_citation=r"""
+@inproceedings{ye2025tuna,
+  author = {Ye, Jinghao and Zhu, Yanbin and Liu, Jiaqi and Zhang, Yixin and Huang, Qianyu and Zhou, Jianfeng},
+  booktitle = {Proceedings of the 63rd Annual Meeting of the Association for Computational Linguistics (ACL)},
+  title = {TUNA: Comprehensive Fine-grained Temporal Understanding Evaluation on Dense Dynamic Videos},
+  year = {2025},
+}
+""",
+        prompt={
+            "query": "Find the video clip that matches the given caption.",
+        },
+        is_beta=True,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        """Load the TUNA-Bench dataset for text-to-video retrieval.
+
+        TODO: Reupload dataset in standard format and remove this custom load_data.
+        """
+        if self.data_loaded:
+            return
+        self.dataset = {"default": {}}
+        dataset = load_dataset(
+            self.metadata.dataset["path"],
+            revision=self.metadata.dataset["revision"],
+            split=self.metadata.eval_splits[0],
+        )
+        dataset = dataset.add_column("id", [str(i) for i in range(len(dataset))])
+
+        query = dataset.select_columns(["id", "caption"]).rename_column(
+            "caption", "text"
+        )
+        corpus = dataset.select_columns(["id", "video"])
+        qrels = {}
+        for i in range(len(dataset)):
+            key = str(i)
+            if key not in qrels:
+                qrels[key] = {}
+            qrels[key][key] = 1
+        self.dataset["default"]["test"] = RetrievalSplitData(
+            queries=query, corpus=corpus, relevant_docs=qrels, top_ranked=None
+        )
+        self.data_loaded = True

--- a/mteb/tasks/retrieval/eng/tuna_bench_v2t_retrieval.py
+++ b/mteb/tasks/retrieval/eng/tuna_bench_v2t_retrieval.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from datasets import load_dataset
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.retrieval_dataset_loaders import RetrievalSplitData
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class TUNABenchV2TRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="TUNABenchV2TRetrieval",
+        description=(
+            "Retrieve the fine-grained English caption that describes a given video "
+            "from the TUNA-Bench dataset of dense dynamic videos with detailed "
+            "temporal descriptions."
+        ),
+        reference="https://arxiv.org/abs/2505.20124",
+        dataset={
+            "path": "mteb/TUNA-Bench_1K",
+            "revision": "0a2b6ec66a3f662f68ac0f0649020b3c37d8551c",
+        },
+        type="Any2AnyRetrieval",
+        category="v2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2025-01-01", "2025-12-31"),
+        domains=["Web", "Spoken"],
+        task_subtypes=["Caption Pairing"],
+        license="cc-by-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video", "text"],
+        sample_creation="found",
+        bibtex_citation=r"""
+@inproceedings{ye2025tuna,
+  author = {Ye, Jinghao and Zhu, Yanbin and Liu, Jiaqi and Zhang, Yixin and Huang, Qianyu and Zhou, Jianfeng},
+  booktitle = {Proceedings of the 63rd Annual Meeting of the Association for Computational Linguistics (ACL)},
+  title = {TUNA: Comprehensive Fine-grained Temporal Understanding Evaluation on Dense Dynamic Videos},
+  year = {2025},
+}
+""",
+        prompt={
+            "query": "Find the caption that best describes the following video.",
+        },
+        is_beta=True,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        """Load the TUNA-Bench dataset for video-to-text retrieval.
+
+        TODO: Reupload dataset in standard format and remove this custom load_data.
+        """
+        if self.data_loaded:
+            return
+        self.dataset = {"default": {}}
+        dataset = load_dataset(
+            self.metadata.dataset["path"],
+            revision=self.metadata.dataset["revision"],
+            split=self.metadata.eval_splits[0],
+        )
+        dataset = dataset.add_column("id", [str(i) for i in range(len(dataset))])
+
+        query = dataset.select_columns(["id", "video"])
+        corpus = dataset.select_columns(["id", "caption"]).rename_column(
+            "caption", "text"
+        )
+        qrels = {}
+        for i in range(len(dataset)):
+            key = str(i)
+            if key not in qrels:
+                qrels[key] = {}
+            qrels[key][key] = 1
+        self.dataset["default"]["test"] = RetrievalSplitData(
+            queries=query, corpus=corpus, relevant_docs=qrels, top_ranked=None
+        )
+        self.data_loaded = True


### PR DESCRIPTION
- [x] I have outlined why this dataset is filling an existing gap in `mteb`
- [x] I have tested that the dataset runs with the `mteb` package.
- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
  - [ ] `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
  - [ ] `intfloat/multilingual-e5-small`
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [x] I have considered the size of the dataset and reduced it if it is too big (2048 examples is typically large enough for most tasks)

https://github.com/embeddings-benchmark/mteb/issues/4130
Ran the mteb/baseline-random-encoder model on 5 subsampled rows.
[tuna_bench_eval_results.json](https://github.com/user-attachments/files/26853719/tuna_bench_eval_results.json)

cc @Samoed 
