### PR TITLE
fix: query filtering for audio

### DIFF
--- a/mteb/abstasks/retrieval.py
+++ b/mteb/abstasks/retrieval.py
@@ -114,9 +114,9 @@ def _filter_queries_without_positives(
             continue
         _relevant_docs[idx] = relevant_docs[idx]
 
-    queries = queries.filter(
-        lambda x: x["id"] in _relevant_docs.keys(), desc="Filtering queries by qrels"
-    )
+    ids_to_keep = set(_relevant_docs.keys())
+    indices = [i for i, id_ in enumerate(queries["id"]) if id_ in ids_to_keep]
+    queries = queries.select(indices)
 
     return _relevant_docs, queries
 

--- a/mteb/abstasks/retrieval_dataset_loaders.py
+++ b/mteb/abstasks/retrieval_dataset_loaders.py
@@ -94,9 +94,9 @@ class RetrievalDatasetLoader:
         corpus = self._load_corpus(num_proc)
         queries = self._load_queries(num_proc)
 
-        queries = queries.filter(
-            lambda x: x["id"] in qrels.keys(), desc="Filtering queries by qrels"
-        )
+        ids_to_keep = set(qrels.keys())
+        indices = [i for i, id_ in enumerate(queries["id"]) if id_ in ids_to_keep]
+        queries = queries.select(indices)
 
         if any(c.endswith("top_ranked") for c in self.dataset_configs):
             top_ranked = self._load_top_ranked(num_proc)


### PR DESCRIPTION
`Dataset.filter()` iterates rows and formats each one as a full Python dict, triggering HuggingFace's feature decoder for every column — including `Audio(decode=True)`. For audio retrieval tasks (e.g. JamAltArtistA2ARetrieval), this opened a torchcodec AudioDecoder for every query row just to check the id field, rapidly exhausting OS resources. 
```
  File "/mteb/mteb/abstasks/retrieval.py", line 115, in _filter_queries_without_positives
    queries = queries.filter(
        lambda x: x["id"] in _relevant_docs.keys(), desc="Filtering queries by qrels"
    )
...
  File "/mteb/.venv/lib/python3.14/site-packages/torchcodec/decoders/_audio_decoder.py", line 92, in __init__
    core.add_audio_stream(
    ~~~~~~~~~~~~~~~~~~~~~^
        self._decoder,
        ^^^^^^^^^^^^^^
    ...<2 lines>...
        num_channels=num_channels,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File /mteb/.venv/lib/python3.14/site-packages/torch/_ops.py", line 819, in __call__
    return self._op(*args, **kwargs)
           ~~~~~~~~^^^^^^^^^^^^^^^^^
RuntimeError: Resource temporarily unavailable
```

Found during testing https://github.com/embeddings-benchmark/mteb/pull/4427 on `JamAltArtistA2ARetrieval`