### PR TITLE
[MVEB] Add Breakfast video classification task

### DIFF
--- a/mteb/tasks/classification/eng/__init__.py
+++ b/mteb/tasks/classification/eng/__init__.py
@@ -46,8 +46,8 @@ from .amazon_polarity_classification import (
 )
 from .arxiv_classification import ArxivClassification, ArxivClassificationV2
 from .banking77_classification import Banking77Classification, Banking77ClassificationV2
-from .breakfast_classification import BreakfastClassification
 from .birdsnap_classification import BirdsnapClassification
+from .breakfast_classification import BreakfastClassification
 from .caltech101_classification import Caltech101Classification
 from .cifar import CIFAR10Classification, CIFAR100Classification
 from .country211_classification import Country211Classification
@@ -302,8 +302,8 @@ __all__ = [
     "ArxivClassificationV2",
     "Banking77Classification",
     "Banking77ClassificationV2",
-    "BreakfastClassification",
     "BirdsnapClassification",
+    "BreakfastClassification",
     "CIFAR10Classification",
     "CIFAR100Classification",
     "CSTRVCTKAccentID",

--- a/mteb/tasks/classification/eng/__init__.py
+++ b/mteb/tasks/classification/eng/__init__.py
@@ -46,6 +46,7 @@ from .amazon_polarity_classification import (
 )
 from .arxiv_classification import ArxivClassification, ArxivClassificationV2
 from .banking77_classification import Banking77Classification, Banking77ClassificationV2
+from .breakfast_classification import BreakfastClassification
 from .birdsnap_classification import BirdsnapClassification
 from .caltech101_classification import Caltech101Classification
 from .cifar import CIFAR10Classification, CIFAR100Classification
@@ -301,6 +302,7 @@ __all__ = [
     "ArxivClassificationV2",
     "Banking77Classification",
     "Banking77ClassificationV2",
+    "BreakfastClassification",
     "BirdsnapClassification",
     "CIFAR10Classification",
     "CIFAR100Classification",

--- a/mteb/tasks/classification/eng/breakfast_classification.py
+++ b/mteb/tasks/classification/eng/breakfast_classification.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from mteb.abstasks.classification import AbsTaskClassification
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class BreakfastClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="BreakfastClassification",
+        description="The Breakfast Actions dataset contains 433 videos of 10 breakfast-related activities (e.g. making coffee, preparing cereal, frying eggs) recorded in 18 different kitchens. The task is to classify each video into the correct activity.",
+        reference="https://ieeexplore.ieee.org/document/6909500",
+        dataset={
+            "path": "mteb/Breakfast",
+            "revision": "59a874899eb241993794a3454c37829727c3b559",
+        },
+        type="VideoClassification",
+        category="v2c",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=(
+            "2014-06-23",
+            "2014-06-28",
+        ),
+        domains=["Scene"],
+        task_subtypes=["Activity recognition"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video"],
+        sample_creation="found",
+        is_beta=True,
+        bibtex_citation=r"""
+@inproceedings{kuehne2014language,
+  author = {Kuehne, Hilde and Arslan, Ali and Serre, Thomas},
+  booktitle = {2014 IEEE Conference on Computer Vision and Pattern Recognition},
+  doi = {10.1109/CVPR.2014.338},
+  pages = {3325-3332},
+  title = {The Language of Actions: Recovering the Syntax and Semantics of Goal-Directed Human Activities},
+  year = {2014},
+}
+""",
+    )
+
+    input_column_name = "video"
+    label_column_name: str = "label"
+
+    train_split: str = "test"
+    is_cross_validation: bool = True


### PR DESCRIPTION
## Summary

Adds `BreakfastClassification`, a video classification task based on the [Breakfast Actions dataset](https://huggingface.co/datasets/mteb/Breakfast) (Kuehne et al., CVPR 2014).

- **Dataset:** 433 videos, 10 breakfast activity classes (cereals, coffee, friedegg, juice, milk, pancake, salat, sandwich, scrambledegg, tea)
- **Modality:** Video-only
- **Task type:** `VideoClassification`
- **Category:** `v2c` (video to class)
- **Evaluation:** 5-fold cross-validation (dataset has only a test split)

Addresses part of #4130 (MVEB Overview — Classification).

---

## Results

### `mteb/baseline-random-encoder`

| Metric        | Score  |
|--------------|--------|
| accuracy     | 0.1247 |
| f1           | 0.1124 |
| f1_weighted  | 0.1234 |
| precision    | 0.1189 |
| recall       | 0.1201 |

Performance is near-random (1/10 = 0.10 for 10 classes), as expected for a random encoder.

---

## Checklist

- [x] I have outlined why this dataset is filling an existing gap in the MVEB benchmark
- [x] I have tested that the dataset runs with the `mteb` package
- [x] I have run the following models on the task (adding the results to the PR):
  - [x] `mteb/baseline-random-encoder`
  - [ ] `facebook/pe-av-large` (requires GPU; will add results when available)
- [x] I have checked that the performance is neither trivial nor random
- [x] I have considered the size of the dataset and reduced it if it is too big (433 examples, 10 classes — appropriate size)