### PR TITLE
fix: KeyError on aggregated tasks with eval_langs

### DIFF
--- a/mteb/results/task_result.py
+++ b/mteb/results/task_result.py
@@ -197,7 +197,18 @@ class TaskResult(BaseModel):  # noqa: PLR0904
         flat_scores = defaultdict(list)
         for split, hf_subset_scores in scores.items():
             for hf_subset, hf_scores in hf_subset_scores.items():
-                eval_langs = subset2langscripts[hf_subset]
+                if hf_subset in subset2langscripts:
+                    eval_langs = subset2langscripts[hf_subset]
+                else:
+                    # For aggregated tasks, scores may use "default" subset
+                    # which isn't in the per-subset langscript mapping.
+                    # Collect all languages from the mapping.
+                    all_langs: list[str] = []
+                    for langs in subset2langscripts.values():
+                        all_langs.extend(
+                            lang for lang in langs if lang not in all_langs
+                        )
+                    eval_langs = all_langs
                 _scores = {
                     **hf_scores,
                     "hf_subset": hf_subset,


### PR DESCRIPTION
Fixes #4437

- Fixes `KeyError: 'default'` when running aggregated tasks (e.g. `VisualSTS17Multilingual`) that define `eval_langs` as a dict
- `task_results_to_scores` produces a `"default"` subset key, but `hf_subsets_to_langscripts` only contains the specific subset keys — causing a KeyError in `TaskResult.from_task_results`
- Falls back to collecting all languages from the mapping when the subset key is missing
- Tested with `mteb run -m mteb/baseline-random-encoder -t VisualSTS17Multilingual` — completes successfully
- running on STS12VisualSTS (not an aggregate task) also passes.

Also ran `mteb run -m openai/clip-vit-base-patch32 -t VisualSTS17Multilingual` which matches [existing results](https://github.com/embeddings-benchmark/results/blob/main/results/openai__clip-vit-base-patch32/3d74acf9a28c67741b2f4f2ea7635f0aaf6f0268/STS17MultilingualVisualSTS.json):

<details>

```
{
  "dataset_revision": "2e31b4b459551a51e1ab54fd7266b40f3fe510d4",
  "task_name": "STS17MultilingualVisualSTS",
  "mteb_version": "2.12.21",
  "scores": {
    "test": [
      {
        "pearson": 0.049867,
        "spearman": 0.180619,
        "cosine_pearson": 0.049867,
        "cosine_spearman": 0.18062,
        "manhattan_pearson": 0.108083,
        "manhattan_spearman": 0.182232,
        "euclidean_pearson": 0.106255,
        "euclidean_spearman": 0.181127,
        "main_score": 0.18062,
        "hf_subset": "ko-ko",
        "languages": [
          "kor-Hang"
        ]
      },
      {
        "pearson": 0.234638,
        "spearman": 0.285756,
        "cosine_pearson": 0.234637,
        "cosine_spearman": 0.285769,
        "manhattan_pearson": 0.307702,
        "manhattan_spearman": 0.278535,
        "euclidean_pearson": 0.318468,
        "euclidean_spearman": 0.288376,
        "main_score": 0.285769,
        "hf_subset": "ar-ar",
        "languages": [
          "ara-Arab"
        ]
      },
      {
        "pearson": 0.096468,
        "spearman": 0.083195,
        "cosine_pearson": 0.096468,
        "cosine_spearman": 0.083195,
        "manhattan_pearson": 0.075004,
        "manhattan_spearman": 0.072824,
        "euclidean_pearson": 0.087377,
        "euclidean_spearman": 0.078044,
        "main_score": 0.083195,
        "hf_subset": "en-ar",
        "languages": [
          "eng-Latn",
          "ara-Arab"
        ]
      },
      {
        "pearson": 0.248886,
        "spearman": 0.221803,
        "cosine_pearson": 0.248886,
        "cosine_spearman": 0.221803,
        "manhattan_pearson": 0.259022,
        "manhattan_spearman": 0.213672,
        "euclidean_pearson": 0.252801,
        "euclidean_spearman": 0.207503,
        "main_score": 0.221803,
        "hf_subset": "en-de",
        "languages": [
          "eng-Latn",
          "deu-Latn"
        ]
      },
      {
        "pearson": 0.205419,
        "spearman": 0.180008,
        "cosine_pearson": 0.205419,
        "cosine_spearman": 0.180008,
        "manhattan_pearson": 0.159234,
        "manhattan_spearman": 0.13008,
        "euclidean_pearson": 0.154743,
        "euclidean_spearman": 0.119599,
        "main_score": 0.180008,
        "hf_subset": "en-tr",
        "languages": [
          "eng-Latn",
          "tur-Latn"
        ]
      },
      {
        "pearson": 0.121523,
        "spearman": 0.123428,
        "cosine_pearson": 0.121523,
        "cosine_spearman": 0.123428,
        "manhattan_pearson": 0.139312,
        "manhattan_spearman": 0.146203,
        "euclidean_pearson": 0.119997,
        "euclidean_spearman": 0.124758,
        "main_score": 0.123428,
        "hf_subset": "es-en",
        "languages": [
          "spa-Latn",
          "eng-Latn"
        ]
      },
      {
        "pearson": 0.444354,
        "spearman": 0.476492,
        "cosine_pearson": 0.444354,
        "cosine_spearman": 0.476474,
        "manhattan_pearson": 0.539168,
        "manhattan_spearman": 0.5014,
        "euclidean_pearson": 0.532253,
        "euclidean_spearman": 0.493756,
        "main_score": 0.476474,
        "hf_subset": "es-es",
        "languages": [
          "spa-Latn"
        ]
      },
      {
        "pearson": 0.206366,
        "spearman": 0.195645,
        "cosine_pearson": 0.206366,
        "cosine_spearman": 0.195645,
        "manhattan_pearson": 0.2886,
        "manhattan_spearman": 0.274789,
        "euclidean_pearson": 0.283905,
        "euclidean_spearman": 0.266433,
        "main_score": 0.195645,
        "hf_subset": "fr-en",
        "languages": [
          "fra-Latn",
          "eng-Latn"
        ]
      },
      {
        "pearson": 0.231033,
        "spearman": 0.226661,
        "cosine_pearson": 0.231032,
        "cosine_spearman": 0.226661,
        "manhattan_pearson": 0.315327,
        "manhattan_spearman": 0.293202,
        "euclidean_pearson": 0.315797,
        "euclidean_spearman": 0.294259,
        "main_score": 0.226661,
        "hf_subset": "it-en",
        "languages": [
          "ita-Latn",
          "eng-Latn"
        ]
      },
      {
        "pearson": 0.245403,
        "spearman": 0.249146,
        "cosine_pearson": 0.245403,
        "cosine_spearman": 0.249146,
        "manhattan_pearson": 0.306539,
        "manhattan_spearman": 0.295649,
        "euclidean_pearson": 0.279828,
        "euclidean_spearman": 0.259283,
        "main_score": 0.249146,
        "hf_subset": "nl-en",
        "languages": [
          "nld-Latn",
          "eng-Latn"
        ]
      }
    ]
  },
  "evaluation_time": 35.045138359069824,
  "kg_co2_emissions": null,
  "date": 1776552308.753423
}
```

</details>
