### PR TITLE
fix: drop unused modality columns in dataloader for cross-modal tasks

### DIFF
--- a/mteb/_create_dataloaders.py
+++ b/mteb/_create_dataloaders.py
@@ -75,13 +75,11 @@ def _corpus_to_dict(
 
 
 def _combine_queries_with_instruction_text(row: dict[str, str]) -> dict[str, str]:
+    row["text"] = row.get("text") or ""
     row["query"] = row["text"]
 
-    if row["text"] is not None:
-        if "instruction" in row and row["instruction"] is not None:
-            row["text"] = row["query"] + " " + row["instruction"]
-        else:
-            row["text"] = row["query"]
+    if "instruction" in row and row["instruction"] is not None:
+        row["text"] = row["query"] + " " + row["instruction"]
     return row
 
 
@@ -222,19 +220,17 @@ def _custom_collate_fn(batch: list[dict[str, Any]]) -> BatchedInput:
     """
     collated = {}
     for key in batch[0]:
-        values = [item[key] for item in batch]
         if key in (  # noqa: PLR6201
             "image",  # images can be with different sizes
             "conversation",  # conversations are lists of varying lengths
             "audio",  # audio can have different lengths
             "video",  # video can have different lengths
         ):
-            collated[key] = values
-        elif any(v is None for v in values):
-            # In multimodal tasks, text can be None for image-only items
-            collated[key] = values
+            collated[key] = [item[key] for item in batch]
         else:
-            collated[key] = default_collate(values)
+            if any(item[key] is None for item in batch):
+                raise ValueError(f"Found None in batch for key '{key}'")
+            collated[key] = default_collate([item[key] for item in batch])
     return cast("BatchedInput", collated)
 
 

--- a/mteb/_create_dataloaders.py
+++ b/mteb/_create_dataloaders.py
@@ -60,26 +60,29 @@ def _create_dataloader_from_texts(
 def _corpus_to_dict(
     row: dict[str, str],
 ) -> dict[str, str]:
-    raw_text = row.get("text") or ""
-    title = row.get("title") or ""
-    text = (title + " " + raw_text).strip() if title else raw_text.strip()
+    text = (
+        (row["title"] + " " + row["text"]).strip()
+        if "title" in row and len(row["title"]) > 0
+        else row["text"].strip()
+    )
     new_row = {
         "id": row["id"],
         "text": text,
-        "body": raw_text,
+        "body": row["text"],
     }
     # dataloaders can't handle None
-    if title:
-        new_row["title"] = title
+    if "title" in row and row["title"] is not None and len(row["title"]) > 0:
+        new_row["title"] = row["title"]
     return new_row
 
 
 def _combine_queries_with_instruction_text(row: dict[str, str]) -> dict[str, str]:
-    row["text"] = row.get("text") or ""
     row["query"] = row["text"]
 
     if "instruction" in row and row["instruction"] is not None:
         row["text"] = row["query"] + " " + row["instruction"]
+    else:
+        row["text"] = row["query"]
     return row
 
 
@@ -289,6 +292,13 @@ def _prepare_dataset(
                 and modality not in dataset.column_names
             ):
                 dataset = dataset.rename_column(input_column, modality)
+
+    # Drop modality columns not needed for this prompt type to avoid
+    # None values in the collate function (e.g. text=None in image-only corpus)
+    all_modality_columns = {"text", "image", "audio", "video"}
+    for col in all_modality_columns - set(modalities):
+        if col in dataset.column_names:
+            dataset = dataset.remove_columns(col)
 
     return dataset
 

--- a/mteb/_create_dataloaders.py
+++ b/mteb/_create_dataloaders.py
@@ -60,29 +60,28 @@ def _create_dataloader_from_texts(
 def _corpus_to_dict(
     row: dict[str, str],
 ) -> dict[str, str]:
-    text = (
-        (row["title"] + " " + row["text"]).strip()
-        if "title" in row and len(row["title"]) > 0
-        else row["text"].strip()
-    )
+    raw_text = row.get("text") or ""
+    title = row.get("title") or ""
+    text = (title + " " + raw_text).strip() if title else raw_text.strip()
     new_row = {
         "id": row["id"],
         "text": text,
-        "body": row["text"],
+        "body": raw_text,
     }
     # dataloaders can't handle None
-    if "title" in row and row["title"] is not None and len(row["title"]) > 0:
-        new_row["title"] = row["title"]
+    if title:
+        new_row["title"] = title
     return new_row
 
 
 def _combine_queries_with_instruction_text(row: dict[str, str]) -> dict[str, str]:
     row["query"] = row["text"]
 
-    if "instruction" in row and row["instruction"] is not None:
-        row["text"] = row["query"] + " " + row["instruction"]
-    else:
-        row["text"] = row["query"]
+    if row["text"] is not None:
+        if "instruction" in row and row["instruction"] is not None:
+            row["text"] = row["query"] + " " + row["instruction"]
+        else:
+            row["text"] = row["query"]
     return row
 
 
@@ -223,17 +222,19 @@ def _custom_collate_fn(batch: list[dict[str, Any]]) -> BatchedInput:
     """
     collated = {}
     for key in batch[0]:
+        values = [item[key] for item in batch]
         if key in (  # noqa: PLR6201
             "image",  # images can be with different sizes
             "conversation",  # conversations are lists of varying lengths
             "audio",  # audio can have different lengths
             "video",  # video can have different lengths
         ):
-            collated[key] = [item[key] for item in batch]
+            collated[key] = values
+        elif any(v is None for v in values):
+            # In multimodal tasks, text can be None for image-only items
+            collated[key] = values
         else:
-            if any(item[key] is None for item in batch):
-                raise ValueError(f"Found None in batch for key '{key}'")
-            collated[key] = default_collate([item[key] for item in batch])
+            collated[key] = default_collate(values)
     return cast("BatchedInput", collated)
 
 

--- a/mteb/models/model_implementations/random_baseline.py
+++ b/mteb/models/model_implementations/random_baseline.py
@@ -148,15 +148,21 @@ def _batch_to_embeddings(
 
         if "text" in batch:
             text_embeddings = [
-                _string_to_vector(txt, embedding_dim) for txt in batch["text"]
+                _string_to_vector(txt, embedding_dim)
+                for txt in batch["text"]
+                if txt is not None
             ]
         if "image" in batch:
             image_embeddings = [
-                _image_to_vector(img, embedding_dim) for img in batch["image"]
+                _image_to_vector(img, embedding_dim)
+                for img in batch["image"]
+                if img is not None
             ]
         if "audio" in batch:
             audio_embeddings = [
-                _audio_to_vector(audio, embedding_dim) for audio in batch["audio"]
+                _audio_to_vector(audio, embedding_dim)
+                for audio in batch["audio"]
+                if audio is not None
             ]
         if "video" in batch:
             video_embeddings = [
@@ -165,6 +171,7 @@ def _batch_to_embeddings(
                     embedding_dim,
                 )
                 for video in batch["video"]
+                if video is not None
             ]
 
         # Combine embeddings

--- a/mteb/models/model_implementations/random_baseline.py
+++ b/mteb/models/model_implementations/random_baseline.py
@@ -148,21 +148,15 @@ def _batch_to_embeddings(
 
         if "text" in batch:
             text_embeddings = [
-                _string_to_vector(txt, embedding_dim)
-                for txt in batch["text"]
-                if txt is not None
+                _string_to_vector(txt, embedding_dim) for txt in batch["text"]
             ]
         if "image" in batch:
             image_embeddings = [
-                _image_to_vector(img, embedding_dim)
-                for img in batch["image"]
-                if img is not None
+                _image_to_vector(img, embedding_dim) for img in batch["image"]
             ]
         if "audio" in batch:
             audio_embeddings = [
-                _audio_to_vector(audio, embedding_dim)
-                for audio in batch["audio"]
-                if audio is not None
+                _audio_to_vector(audio, embedding_dim) for audio in batch["audio"]
             ]
         if "video" in batch:
             video_embeddings = [
@@ -171,7 +165,6 @@ def _batch_to_embeddings(
                     embedding_dim,
                 )
                 for video in batch["video"]
-                if video is not None
             ]
 
         # Combine embeddings


### PR DESCRIPTION
Fixes #4436

Cross-modal retrieval tasks (e.g. `CIRRIT2IRetrieval`, `Fashion200kI2TRetrieval`, `VisualNewsI2TRetrieval`) have `None` values  for modalities not used by that side of the retrieval — for example, `text=None` in an image-only corpus (`it2i`), or `image=None` in  text-only queries (`i2t`).

### Changes
- Drop columns for modalities not needed for the current prompt type in `_prepare_dataset`, using the task category (e.g. `it2i`) to determine which modalities each side requires
- This prevents `None` values from reaching `_custom_collate_fn` or model encode functions, without needing defensive guards throughout the codebase

Tested with `mteb run -m mteb/baseline-random-encoder -t CIRRIT2IRetrieval NIGHTSI2IRetrieval Fashion200kI2TRetrieval VisualNewsI2TRetrieval` — all complete successfully