### PR TITLE
add mteb/Shot2Story20K dataset

### DIFF
--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -209,6 +209,12 @@ from .sci_fact_retrieval import SciFact
 from .sci_mmir_i2t_retrieval import SciMMIRI2TRetrieval
 from .sci_mmir_t2i_retrieval import SciMMIRT2IRetrieval
 from .scidocs_retrieval import SCIDOCS
+from .shot2story_retrieval import (
+    Shot2Story20KT2VARetrieval,
+    Shot2Story20KT2VRetrieval,
+    Shot2Story20KV2TRetrieval,
+    Shot2Story20KVA2TRetrieval,
+)
 from .siqa_retrieval import SIQA
 from .sketchy_i2i_retrieval import SketchyI2IRetrieval
 from .sop_i2i_retrieval import SOPI2IRetrieval
@@ -472,6 +478,10 @@ __all__ = [
     "SciFact",
     "SciMMIRI2TRetrieval",
     "SciMMIRT2IRetrieval",
+    "Shot2Story20KT2VARetrieval",
+    "Shot2Story20KT2VRetrieval",
+    "Shot2Story20KV2TRetrieval",
+    "Shot2Story20KVA2TRetrieval",
     "SketchyI2IRetrieval",
     "SpartQA",
     "SpokenSQuADT2ARetrieval",

--- a/mteb/tasks/retrieval/eng/shot2story_retrieval.py
+++ b/mteb/tasks/retrieval/eng/shot2story_retrieval.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from datasets import load_dataset
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.retrieval_dataset_loaders import RetrievalSplitData
+from mteb.abstasks.task_metadata import TaskMetadata
+
+_DATASET_PATH = "mteb/Shot2Story20K_test"
+_DATASET_REVISION = "1957723c0ad97993f3807df271e2660b869c3ea2"
+_BIBTEX = r"""
+@article{han2023shot2story,
+  author = {Han, Mingfei and Zhang, Linjie and Du, Yali and Luo, Junbin and Wang, Xiaodan},
+  title = {Shot2Story: A New Benchmark for Comprehensive Understanding of Multi-shot Videos},
+  journal = {arXiv preprint arXiv:2312.10300},
+  year = {2023},
+}
+"""
+
+
+def _load_shot2story(
+    task: AbsTaskRetrieval,
+    query_columns: list[str],
+    corpus_columns: list[str],
+) -> None:
+    """Shared loader for all Shot2Story20K retrieval directions.
+
+    TODO: Reupload dataset in standard format and remove this custom load_data.
+    """
+    if task.data_loaded:
+        return
+    task.dataset = {"default": {}}
+    dataset = load_dataset(
+        task.metadata.dataset["path"],
+        revision=task.metadata.dataset["revision"],
+        split=task.metadata.eval_splits[0],
+    )
+    dataset = dataset.add_column("id", [str(i) for i in range(len(dataset))])
+
+    query = dataset.select_columns(["id"] + query_columns)
+    corpus = dataset.select_columns(["id"] + corpus_columns)
+    if "caption" in query_columns:
+        query = query.rename_column("caption", "text")
+    if "caption" in corpus_columns:
+        corpus = corpus.rename_column("caption", "text")
+
+    qrels = {str(i): {str(i): 1} for i in range(len(dataset))}
+    task.dataset["default"]["test"] = RetrievalSplitData(
+        queries=query, corpus=corpus, relevant_docs=qrels, top_ranked=None
+    )
+    task.data_loaded = True
+
+
+class Shot2Story20KV2TRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="Shot2Story20KV2TRetrieval",
+        description=(
+            "Retrieve the detailed summary caption that describes a given video "
+            "clip (video only) from the Shot2Story20K benchmark of multi-shot videos."
+        ),
+        reference="https://arxiv.org/abs/2312.10300",
+        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        type="Any2AnyRetrieval",
+        category="v2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        modalities=["video", "text"],
+        date=("2023-12-01", "2023-12-31"),
+        domains=["Web", "Spoken"],
+        task_subtypes=["Caption Pairing"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find the caption that describes the following video."},
+        is_beta=True,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_shot2story(self, query_columns=["video"], corpus_columns=["caption"])
+
+
+class Shot2Story20KT2VRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="Shot2Story20KT2VRetrieval",
+        description=(
+            "Retrieve the video clip (video only) that matches a given detailed "
+            "summary caption from the Shot2Story20K benchmark of multi-shot videos."
+        ),
+        reference="https://arxiv.org/abs/2312.10300",
+        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        type="Any2AnyRetrieval",
+        category="t2v",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        modalities=["text", "video"],
+        date=("2023-12-01", "2023-12-31"),
+        domains=["Web", "Spoken"],
+        task_subtypes=["Caption Pairing"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find the video clip that matches the given caption."},
+        is_beta=True,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_shot2story(self, query_columns=["caption"], corpus_columns=["video"])
+
+
+class Shot2Story20KVA2TRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="Shot2Story20KVA2TRetrieval",
+        description=(
+            "Retrieve the detailed summary caption that describes a given video "
+            "clip from the Shot2Story20K benchmark of multi-shot videos."
+        ),
+        reference="https://arxiv.org/abs/2312.10300",
+        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        type="Any2AnyRetrieval",
+        category="va2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        modalities=["audio", "video", "text"],
+        date=("2023-12-01", "2023-12-31"),
+        domains=["Web", "Spoken"],
+        task_subtypes=["Caption Pairing"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find the caption that describes the following video."},
+        is_beta=True,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_shot2story(
+            self, query_columns=["video", "audio"], corpus_columns=["caption"]
+        )
+
+
+class Shot2Story20KT2VARetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="Shot2Story20KT2VARetrieval",
+        description=(
+            "Retrieve the video clip that matches a given detailed summary caption "
+            "from the Shot2Story20K benchmark of multi-shot videos."
+        ),
+        reference="https://arxiv.org/abs/2312.10300",
+        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        type="Any2AnyRetrieval",
+        category="t2va",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        modalities=["text", "audio", "video"],
+        date=("2023-12-01", "2023-12-31"),
+        domains=["Web", "Spoken"],
+        task_subtypes=["Caption Pairing"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find the video clip that matches the given caption."},
+        is_beta=True,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_shot2story(
+            self, query_columns=["caption"], corpus_columns=["video", "audio"]
+        )


### PR DESCRIPTION
- [x] I have outlined why this dataset is filling an existing gap in `mteb`
- [x] I have tested that the dataset runs with the `mteb` package.
- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
  - [ ] `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
  - [ ] `intfloat/multilingual-e5-small`
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [x] I have considered the size of the dataset and reduced it if it is too big (2048 examples is typically large enough for most tasks)

https://github.com/embeddings-benchmark/mteb/issues/4130
Ran the mteb/baseline-random-encoder model.



cc @Samoed 
