### PR TITLE
Make corpus_chunk_size tunable via the public evaluate() API

### DIFF
--- a/docs/get_started/usage/running_the_evaluation.md
+++ b/docs/get_started/usage/running_the_evaluation.md
@@ -169,6 +169,21 @@ sentence_trf_model.half() # half precision
 A last option is to make a [custom implementation](defining_the_model.md#using-a-custom-model) of the model. This way you have full flexibility of how the model handles the input.
 
 
+### Reduce Memory During Evaluation
+
+For large retrieval corpora, MTEB encodes the corpus in chunks to avoid running out of memory. The default chunk size is 50,000 documents. You can lower it to reduce peak memory usage:
+
+```python
+import mteb
+
+model = mteb.get_model("sentence-transformers/all-MiniLM-L6-v2")
+task = mteb.get_task("NFCorpus")
+
+results = mteb.evaluate(model, task, encode_kwargs={"corpus_chunk_size": 10_000})
+```
+
+Passing a smaller value increases the number of encoding passes over the corpus but keeps GPU/CPU memory usage lower. This works for both retrieval tasks (via `SearchEncoderWrapper`) and bitext mining tasks (via `BitextMiningEvaluator`) and has no effect on other task types.
+
 ### Speeding Download
 
 The simplest way to speed up downloads is by using Huggingface's [`xet`](https://huggingface.co/blog/xet-on-the-hub). You can use this simply using:

--- a/mteb/_evaluators/text/bitext_mining_evaluator.py
+++ b/mteb/_evaluators/text/bitext_mining_evaluator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 import torch
 from datasets import Dataset
@@ -42,8 +42,11 @@ class BitextMiningEvaluator(Evaluator):
         *,
         encode_kwargs: EncodeKwargs,
         num_proc: int | None = None,
-        corpus_chunk_size: int | None = None,
     ) -> dict[str, list[dict[str, float]]]:
+        _encode_kwargs: dict[str, Any] = dict(encode_kwargs)
+        corpus_chunk_size: int = _encode_kwargs.pop("corpus_chunk_size", 500_000)
+        encode_kwargs = cast("EncodeKwargs", _encode_kwargs)
+
         pair_elements = {p for pair in self.pairs for p in pair}
         if isinstance(self.sentences, Dataset):
             subsets = [
@@ -70,15 +73,11 @@ class BitextMiningEvaluator(Evaluator):
             )
 
         logger.info("Finding nearest neighbors...")
-        search_kwargs = (
-            {"corpus_chunk_size": corpus_chunk_size}
-            if corpus_chunk_size is not None
-            else {}
-        )
         neighbours = {}
         for i, (key1, key2) in enumerate(tqdm(self.pairs, desc="Matching sentences")):
             neighbours[f"{key1}-{key2}"] = self._similarity_search(
-                embeddings[key1], embeddings[key2], model, **search_kwargs
+                embeddings[key1], embeddings[key2], model,
+                corpus_chunk_size=corpus_chunk_size,
             )
         return neighbours
 

--- a/mteb/_evaluators/text/bitext_mining_evaluator.py
+++ b/mteb/_evaluators/text/bitext_mining_evaluator.py
@@ -42,6 +42,7 @@ class BitextMiningEvaluator(Evaluator):
         *,
         encode_kwargs: EncodeKwargs,
         num_proc: int | None = None,
+        corpus_chunk_size: int | None = None,
     ) -> dict[str, list[dict[str, float]]]:
         pair_elements = {p for pair in self.pairs for p in pair}
         if isinstance(self.sentences, Dataset):
@@ -69,10 +70,15 @@ class BitextMiningEvaluator(Evaluator):
             )
 
         logger.info("Finding nearest neighbors...")
+        search_kwargs = (
+            {"corpus_chunk_size": corpus_chunk_size}
+            if corpus_chunk_size is not None
+            else {}
+        )
         neighbours = {}
         for i, (key1, key2) in enumerate(tqdm(self.pairs, desc="Matching sentences")):
             neighbours[f"{key1}-{key2}"] = self._similarity_search(
-                embeddings[key1], embeddings[key2], model
+                embeddings[key1], embeddings[key2], model, **search_kwargs
             )
         return neighbours
 

--- a/mteb/abstasks/retrieval.py
+++ b/mteb/abstasks/retrieval.py
@@ -359,6 +359,7 @@ class AbsTaskRetrieval(AbsTask):
         hf_subset: str,
         prediction_folder: Path | None = None,
         num_proc: int | None = None,
+        corpus_chunk_size: int | None = None,
         **kwargs,
     ) -> ScoresDict:
         """Evaluate a model on a specific subset of the data.
@@ -371,6 +372,7 @@ class AbsTaskRetrieval(AbsTask):
             hf_subset: Subset to evaluate on
             prediction_folder: Folder with results prediction
             num_proc: Number of processes to use
+            corpus_chunk_size: Number of corpus entries to encode at once. Reduces memory usage for large corpora.
             **kwargs: Additional keyword arguments passed to the evaluator
 
         Returns:
@@ -396,7 +398,12 @@ class AbsTaskRetrieval(AbsTask):
         search_model: SearchProtocol
 
         if isinstance(model, EncoderProtocol) and not isinstance(model, SearchProtocol):
-            search_model = SearchEncoderWrapper(model)
+            wrapper_kwargs = (
+                {"corpus_chunk_size": corpus_chunk_size}
+                if corpus_chunk_size is not None
+                else {}
+            )
+            search_model = SearchEncoderWrapper(model, **wrapper_kwargs)
         elif isinstance(model, CrossEncoderProtocol):
             search_model = SearchCrossEncoderWrapper(model)
         elif isinstance(model, SearchProtocol):

--- a/mteb/abstasks/retrieval.py
+++ b/mteb/abstasks/retrieval.py
@@ -352,6 +352,7 @@ class AbsTaskRetrieval(AbsTask):
         hf_subset: str,
         prediction_folder: Path | None = None,
         num_proc: int | None = None,
+        corpus_chunk_size: int | None = None,
         **kwargs,
     ) -> ScoresDict:
         """Evaluate a model on a specific subset of the data.
@@ -364,6 +365,7 @@ class AbsTaskRetrieval(AbsTask):
             hf_subset: Subset to evaluate on
             prediction_folder: Folder with results prediction
             num_proc: Number of processes to use
+            corpus_chunk_size: Number of corpus entries to encode at once. Reduces memory usage for large corpora.
             **kwargs: Additional keyword arguments passed to the evaluator
 
         Returns:
@@ -389,7 +391,12 @@ class AbsTaskRetrieval(AbsTask):
         search_model: SearchProtocol
 
         if isinstance(model, EncoderProtocol) and not isinstance(model, SearchProtocol):
-            search_model = SearchEncoderWrapper(model)
+            wrapper_kwargs = (
+                {"corpus_chunk_size": corpus_chunk_size}
+                if corpus_chunk_size is not None
+                else {}
+            )
+            search_model = SearchEncoderWrapper(model, **wrapper_kwargs)
         elif isinstance(model, CrossEncoderProtocol):
             search_model = SearchCrossEncoderWrapper(model)
         elif isinstance(model, SearchProtocol):

--- a/mteb/abstasks/text/bitext_mining.py
+++ b/mteb/abstasks/text/bitext_mining.py
@@ -156,6 +156,7 @@ class AbsTaskBitextMining(AbsTask):
         prediction_folder: Path | None = None,
         parallel: bool = False,
         num_proc: int | None = None,
+        corpus_chunk_size: int | None = None,
         **kwargs,
     ) -> BitextMiningMetrics | dict[str, BitextMiningMetrics]:
         pairs = self._get_pairs(parallel)
@@ -175,7 +176,12 @@ class AbsTaskBitextMining(AbsTask):
             else data_split["gold"]
         )
 
-        neighbours = evaluator(model, encode_kwargs=encode_kwargs, num_proc=num_proc)
+        neighbours = evaluator(
+            model,
+            encode_kwargs=encode_kwargs,
+            num_proc=num_proc,
+            corpus_chunk_size=corpus_chunk_size,
+        )
 
         if prediction_folder:
             self._save_task_predictions(

--- a/mteb/evaluate.py
+++ b/mteb/evaluate.py
@@ -93,6 +93,7 @@ def _evaluate_task(
     prediction_folder: Path | None,
     public_only: bool | None,
     num_proc: int | None = None,
+    corpus_chunk_size: int | None = None,
 ) -> TaskResult | TaskError:
     """The core logic to run a model on a given task. See `evaluate` for more details.
 
@@ -127,6 +128,7 @@ def _evaluate_task(
                 prediction_folder=prediction_folder,
                 public_only=public_only,
                 num_proc=num_proc,
+                corpus_chunk_size=corpus_chunk_size,
             )
         if isinstance(result, TaskResult):
             result.kg_co2_emissions = tracker.final_emissions
@@ -166,6 +168,7 @@ def _evaluate_task(
             encode_kwargs=encode_kwargs,
             prediction_folder=prediction_folder,
             num_proc=num_proc,
+            corpus_chunk_size=corpus_chunk_size,
         )
         tock = time()
 
@@ -285,6 +288,7 @@ def evaluate(  # noqa: PLR0913, PLR0914
     show_progress_bar: bool = True,
     public_only: bool | None = None,
     num_proc: int | None = None,
+    corpus_chunk_size: int | None = None,
 ) -> ModelResult:
     """This function runs a model on a given task and returns the results.
 
@@ -310,6 +314,7 @@ def evaluate(  # noqa: PLR0913, PLR0914
             `encode_kwargs['show_progress_bar']` to False if encode_kwargs is unspecified.
         public_only: Run only public tasks. If None, it will attempt to run the private task.
         num_proc: Number of processes to use during data loading and transformation. Defaults to 1.
+        corpus_chunk_size: Number of corpus entries to encode at a time in retrieval and bitext mining tasks. Reduces memory usage for large corpora. Defaults to 50,000 for retrieval and 500,000 for bitext mining.
 
     Returns:
         The results of the evaluation.
@@ -479,6 +484,7 @@ def evaluate(  # noqa: PLR0913, PLR0914
                 prediction_folder=prediction_folder,
                 public_only=public_only,
                 num_proc=num_proc,
+                corpus_chunk_size=corpus_chunk_size,
             )
         except Exception as e:
             logger.error(
@@ -495,6 +501,7 @@ def evaluate(  # noqa: PLR0913, PLR0914
             prediction_folder=prediction_folder,
             public_only=public_only,
             num_proc=num_proc,
+            corpus_chunk_size=corpus_chunk_size,
         )
     logger.info(f"✓ Finished evaluation for {task.metadata.name}")
 

--- a/mteb/evaluate.py
+++ b/mteb/evaluate.py
@@ -93,6 +93,7 @@ def _evaluate_task(
     prediction_folder: Path | None,
     public_only: bool | None,
     num_proc: int | None = None,
+    corpus_chunk_size: int | None = None,
 ) -> TaskResult | TaskError:
     """The core logic to run a model on a given task. See `evaluate` for more details.
 
@@ -127,6 +128,7 @@ def _evaluate_task(
                 prediction_folder=prediction_folder,
                 public_only=public_only,
                 num_proc=num_proc,
+                corpus_chunk_size=corpus_chunk_size,
             )
         if isinstance(result, TaskResult):
             result.kg_co2_emissions = tracker.final_emissions
@@ -166,6 +168,7 @@ def _evaluate_task(
             encode_kwargs=encode_kwargs,
             prediction_folder=prediction_folder,
             num_proc=num_proc,
+            corpus_chunk_size=corpus_chunk_size,
         )
         tock = time()
 
@@ -285,6 +288,7 @@ def evaluate(  # noqa: PLR0913, PLR0914
     show_progress_bar: bool = True,
     public_only: bool | None = None,
     num_proc: int | None = None,
+    corpus_chunk_size: int | None = None,
 ) -> ModelResult:
     """This function runs a model on a given task and returns the results.
 
@@ -310,6 +314,7 @@ def evaluate(  # noqa: PLR0913, PLR0914
             `encode_kwargs['show_progress_bar']` to False if encode_kwargs is unspecified.
         public_only: Run only public tasks. If None, it will attempt to run the private task.
         num_proc: Number of processes to use during data loading and transformation. Defaults to 1.
+        corpus_chunk_size: Number of corpus entries to encode at a time in retrieval and bitext mining tasks. Reduces memory usage for large corpora. Defaults to 50,000 for retrieval and 500,000 for bitext mining.
 
     Returns:
         The results of the evaluation.
@@ -483,6 +488,7 @@ def evaluate(  # noqa: PLR0913, PLR0914
                 prediction_folder=prediction_folder,
                 public_only=public_only,
                 num_proc=num_proc,
+                corpus_chunk_size=corpus_chunk_size,
             )
         except Exception as e:
             logger.error(
@@ -499,6 +505,7 @@ def evaluate(  # noqa: PLR0913, PLR0914
             prediction_folder=prediction_folder,
             public_only=public_only,
             num_proc=num_proc,
+            corpus_chunk_size=corpus_chunk_size,
         )
     logger.info(f"✓ Finished evaluation for {task.metadata.name}")
 

--- a/mteb/models/search_wrappers.py
+++ b/mteb/models/search_wrappers.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import heapq
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import torch
 from datasets import Dataset
@@ -73,6 +73,9 @@ class SearchEncoderWrapper:
         """
         # Always retain corpus for potential reranking or fallback flows
         self.task_corpus = corpus
+        _encode_kwargs: dict[str, Any] = dict(encode_kwargs)
+        _encode_kwargs.pop("corpus_chunk_size", None)
+        encode_kwargs = cast("EncodeKwargs", _encode_kwargs)
         if self.index_backend is not None:
             all_doc_embeddings = self.model.encode(
                 create_dataloader(
@@ -121,6 +124,12 @@ class SearchEncoderWrapper:
         """
         if self.task_corpus is None:
             raise ValueError("Corpus must be indexed before searching.")
+
+        _encode_kwargs: dict[str, Any] = dict(encode_kwargs)
+        corpus_chunk_size: int = _encode_kwargs.pop(
+            "corpus_chunk_size", self.corpus_chunk_size
+        )
+        encode_kwargs = cast("EncodeKwargs", _encode_kwargs)
 
         queries_dataloader = create_dataloader(
             queries,
@@ -188,6 +197,7 @@ class SearchEncoderWrapper:
                     hf_split=hf_split,
                     top_k=top_k,
                     encode_kwargs=encode_kwargs,
+                    corpus_chunk_size=corpus_chunk_size,
                 )
             else:
                 cos_scores_top_k_values, cos_scores_top_k_idx = (
@@ -231,12 +241,14 @@ class SearchEncoderWrapper:
         hf_split: str,
         top_k: int,
         encode_kwargs: EncodeKwargs,
+        corpus_chunk_size: int | None = None,
     ) -> dict[str, list[tuple[float, str]]]:
         logger.info("Encoding Corpus in batches (this might take a while)...")
         if self.task_corpus is None:
             raise ValueError("Corpus must be indexed before searching.")
 
-        itr = range(0, len(self.task_corpus), self.corpus_chunk_size)
+        chunk_size = corpus_chunk_size if corpus_chunk_size is not None else self.corpus_chunk_size
+        itr = range(0, len(self.task_corpus), chunk_size)
 
         result_heaps: dict[str, list[tuple[float, str]]] = {
             qid: [] for qid in query_idx_to_id.values()
@@ -244,7 +256,7 @@ class SearchEncoderWrapper:
         for batch_num, corpus_start_idx in enumerate(itr):
             logger.info(f"Encoding Batch {batch_num + 1}/{len(itr)}...")
             corpus_end_idx = min(
-                corpus_start_idx + self.corpus_chunk_size,
+                corpus_start_idx + chunk_size,
                 len(self.task_corpus),
             )
             sub_corpus = self.task_corpus.select(
@@ -443,7 +455,8 @@ class SearchEncoderWrapper:
         prompt_type: PromptType | None = None,
         **kwargs: Any,
     ) -> Array:
-        """Encode inputs using the model' s encode."""
+        """Encode inputs using the model's encode."""
+        kwargs.pop("corpus_chunk_size", None)
         return self.model.encode(
             inputs,
             task_metadata=task_metadata,

--- a/mteb/types/_encoder_io.py
+++ b/mteb/types/_encoder_io.py
@@ -22,10 +22,15 @@ class EncodeKwargs(TypedDict):
     Attributes:
         batch_size: The batch size to use for encoding.
         show_progress_bar: Whether to show a progress bar during encoding.
+        corpus_chunk_size: Number of corpus documents to encode and score at once during retrieval.
+            Intercepted by :class:`~mteb.models.SearchEncoderWrapper` and
+            :class:`~mteb.BitextMiningEvaluator` before reaching the underlying encoder.
+            Reducing this value lowers peak memory at the cost of more passes over the corpus.
     """
 
     batch_size: NotRequired[int]
     show_progress_bar: NotRequired[bool]
+    corpus_chunk_size: NotRequired[int]
 
 
 # --- Output types ---


### PR DESCRIPTION
Fixes #4450
             
  ## Problem
  `corpus_chunk_size` was hardcoded inside `SearchEncoderWrapper` (default 50,000) and
  `BitextMiningEvaluator._similarity_search` (default 500,000) with no way to override them from the public
  `mteb.evaluate()` API.                                                                                                
                        
  ## Changes                                                                                                            
  - Added `corpus_chunk_size: int | None = None` to `evaluate()` and `_evaluate_task()` in `evaluate.py`
  - Threaded it through to `SearchEncoderWrapper` in `abstasks/retrieval.py`                            
  - Added `corpus_chunk_size` to `BitextMiningEvaluator.__call__()` and passed to `_similarity_search()`                
  - Threaded it through `AbsTaskBitextMining._evaluate_subset()`                                                        
                                                                                                                        
  ## Usage                                                                                                              
  ```python                                                                                                             
  # Reduce memory on large retrieval corpora                                                                            
  mteb.evaluate(model, task, corpus_chunk_size=10_000)