### PR TITLE
[MVEB] Adding UCF101 Task (Clustering)

### DIFF
--- a/mteb/tasks/clustering/eng/__init__.py
+++ b/mteb/tasks/clustering/eng/__init__.py
@@ -37,6 +37,7 @@ from .twenty_newsgroups_clustering import (
     TwentyNewsgroupsClustering,
     TwentyNewsgroupsClusteringFast,
 )
+from .ucf101_clustering import UCF101Clustering
 from .voice_gender import VoiceGenderClustering
 from .vox_celeb_clustering import VoxCelebClustering
 from .vox_populi_accent_clustering import VoxPopuliAccentClustering
@@ -89,6 +90,7 @@ __all__ = [
     "TinyImageNet",
     "TwentyNewsgroupsClustering",
     "TwentyNewsgroupsClusteringFast",
+    "UCF101Clustering",
     "VoiceGenderClustering",
     "VoxCelebClustering",
     "VoxPopuliAccentClustering",

--- a/mteb/tasks/clustering/eng/ucf101_clustering.py
+++ b/mteb/tasks/clustering/eng/ucf101_clustering.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from mteb.abstasks import AbsTaskClustering
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class UCF101Clustering(AbsTaskClustering):
+    metadata = TaskMetadata(
+        name="UCF101Clustering",
+        description=(
+            "Clustering of video clips with audio into 51 human "
+            "action categories from the UCF101 dataset."
+        ),
+        reference="https://arxiv.org/abs/1212.0402",
+        dataset={
+            "path": "mteb/UCF101-51VA",
+            "revision": "866b006d84629d66d9927646db89bd43381925e7",
+        },
+        type="VideoClustering",
+        category="va2c",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="v_measure",
+        date=("2012-01-01", "2012-12-03"),
+        domains=["Web", "Scene"],
+        task_subtypes=["Activity recognition"],
+        license="cc0-1.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video", "audio"],
+        sample_creation="found",
+        bibtex_citation=r"""
+@misc{Soomro2012UCF101,
+    title = {UCF101: A Dataset of 101 Human Actions Classes From Videos in The Wild},
+    author = {Soomro, Khurram and Zamir, Amir Roshan and Shah, Mubarak},
+    year = {2012},
+    eprint = {1212.0402},
+    archivePrefix = {arXiv},
+    primaryClass = {cs.CV},
+    url = {https://arxiv.org/abs/1212.0402},
+}
+""",
+        is_beta=True,
+    )
+    max_fraction_of_documents_to_embed = None
+    input_column_name = ("video", "audio")
+    label_column_name: str = "label"
+
+    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+        for split in self.metadata.eval_splits:
+            self.dataset[split] = self.dataset[split].select_columns(
+                ["video", "audio", "label"],
+            )


### PR DESCRIPTION
- [x] I have outlined why this dataset is filling an existing gap in the MVEB benchmark
- [x] I have tested that the dataset runs with the `mteb` package.
- [ ] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
  - [ ] `facebook/pe-av-small-16-frame`
  - [x] `mteb/baseline-random-encoder`
- [ ] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [x] I have considered the size of the dataset and reduced it if it is too big (2048 examples is typically large enough for most tasks)

Will merge after https://github.com/embeddings-benchmark/mteb/pull/4393
I produced the results for random and pe-av on the new datasets and the v measure looks alright.


Results for pe-av:
```json
...
```

Results for random baseline:
```json
{
  "dataset_revision": "866b006d84629d66d9927646db89bd43381925e7",
  "task_name": "UCF101Clustering",
  "mteb_version": "2.12.22",
  "scores": {
    "test": [
      {
        "v_measures": {
          "Level 0": [
            0.182471,
            0.184579,
            0.175821,
            0.184512,
            0.179718,
            0.183678,
            0.193383,
            0.188906,
            0.178862,
            0.181327
          ]
        },
        "v_measure": 0.183326,
        "v_measure_std": 0.004789,
        "main_score": 0.183326,
        "hf_subset": "default",
        "languages": [
          "eng-Latn"
        ]
      }
    ]
  },
  "evaluation_time": 54.74761390686035,
  "kg_co2_emissions": null,
  "date": 1776627162.279514
}
```