### PR TITLE
Expand reference models (#4448) 

### DIFF
--- a/tests/test_benchmarks/test_reference_models.py
+++ b/tests/test_benchmarks/test_reference_models.py
@@ -12,14 +12,22 @@ from mteb.models.get_model_meta import get_model_meta
 logging.basicConfig(level=logging.INFO)
 
 REFERENCE_MODELS = [
+    # text models
     "intfloat/multilingual-e5-small",
     "sentence-transformers/static-similarity-mrl-multilingual-v1",
     "minishlab/potion-multilingual-128M",
     "mteb/baseline-bm25s",
+    "mteb/baseline-random-encoder",
+    "sentence-transformers/LaBSE",
+    "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
+    # image models
+    "vidore/colSmol-256M",
+    # audio models
+    "facebook/wav2vec2-base",
 ]
 
 # Models that implement SearchProtocol only (retrieval/reranking tasks)
-RETRIEVAL_ONLY_MODELS = {"mteb/baseline-bm25s"}
+RETRIEVAL_ONLY_MODELS = {"mteb/baseline-bm25s", "vidore/colSmol-256M"}
 
 
 def _get_expected_task_names(benchmark, model_name):

--- a/tests/test_benchmarks/test_reference_models.py
+++ b/tests/test_benchmarks/test_reference_models.py
@@ -17,17 +17,12 @@ REFERENCE_MODELS = [
     "sentence-transformers/static-similarity-mrl-multilingual-v1",
     "minishlab/potion-multilingual-128M",
     "mteb/baseline-bm25s",
-    "mteb/baseline-random-encoder",
     "sentence-transformers/LaBSE",
     "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
-    # image models
-    "vidore/colSmol-256M",
-    # audio models
-    "facebook/wav2vec2-base",
 ]
 
 # Models that implement SearchProtocol only (retrieval/reranking tasks)
-RETRIEVAL_ONLY_MODELS = {"mteb/baseline-bm25s", "vidore/colSmol-256M"}
+RETRIEVAL_ONLY_MODELS = {"mteb/baseline-bm25s"}
 
 
 def _get_expected_task_names(benchmark, model_name):


### PR DESCRIPTION
Closes #4448
              
  Expands `REFERENCE_MODELS` per the issue guidelines:                                                                  
                                                      
  **Text models added:**                                                                                                
  - `mteb/baseline-random-encoder` — random baseline for comparison
  - `sentence-transformers/LaBSE` — widely-used multilingual model 
  - `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2` — small, efficient multilingual model
                                                                                                       
  **Image model added:**                                                                                                
  - `vidore/colSmol-256M` — small 256M late-interaction model for image modality (added to `RETRIEVAL_ONLY_MODELS`)
                                                                                                                        
  **Audio model added:**                                                                                                
  - `facebook/wav2vec2-base` — small 95M audio model
                                                                                                                        
  All added models satisfy the criteria: minimal dependencies, relatively small size, and represent their respective
  categories. 