### PR TITLE
docs: Don't display license links in the documentation

### DIFF
--- a/docs/overview/create_available_models.py
+++ b/docs/overview/create_available_models.py
@@ -122,7 +122,11 @@ def required_memory_string(mem_in_mb: int | None) -> str:
 
 def format_model_entry(meta: ModelMeta) -> str:
     revision = meta.revision or "not specified"
-    license = meta.license or "not specified"
+    raw_license = meta.license or "not specified"
+    if raw_license.startswith("http://") or raw_license.startswith("https://"):
+        license = f"[custom]({raw_license})"
+    else:
+        license = raw_license
     max_tokens = (
         human_readable_number(meta.max_tokens)
         if meta.max_tokens is not None

--- a/docs/overview/create_available_tasks.py
+++ b/docs/overview/create_available_tasks.py
@@ -102,7 +102,11 @@ def format_task_entry(task: mteb.AbsTask) -> str:  # noqa: PLR0914
     description = task.metadata.description
     if task.metadata.contributed_by:
         description += f" Contributed by {task.metadata.contributed_by}."
-    license = task.metadata.license or "not specified"
+    raw_license = task.metadata.license or "not specified"
+    if raw_license.startswith("http://") or raw_license.startswith("https://"):
+        license = f"[custom]({raw_license})"
+    else:
+        license = raw_license
     reference = task.metadata.reference
     dataset_name = task.metadata.dataset["path"]
     if not reference and not isinstance(task, AbsTaskAggregate):


### PR DESCRIPTION
Fixes #4461

Now looks like so:
<img width="782" height="284" alt="Screenshot 2026-04-21 at 13 31 58" src="https://github.com/user-attachments/assets/676719b8-7f2c-42c5-b730-a799c0d18c8d" />

