### PR TITLE
fix: pass prompt_type to create_dataloader in pair classification evaluator

### DIFF
--- a/mteb/_create_dataloaders.py
+++ b/mteb/_create_dataloaders.py
@@ -334,11 +334,7 @@ def create_dataloader(
     # Sequence means columns already match modality names, no renaming needed
     _input_column = input_column if isinstance(input_column, str) else None
 
-    if (
-        prompt_type is None
-        and task_metadata.modalities == ["text"]
-        and _input_column is not None
-    ):
+    if task_metadata.modalities == ["text"] and _input_column is not None:
         return _create_dataloader_from_texts(
             dataset[_input_column],
             batch_size=batch_size,

--- a/mteb/_evaluators/pair_classification_evaluator.py
+++ b/mteb/_evaluators/pair_classification_evaluator.py
@@ -95,12 +95,21 @@ class PairClassificationEvaluator(Evaluator):
         encode_kwargs: EncodeKwargs,
         num_proc: int | None = None,
     ) -> PairClassificationDistances:
+        def _columns_for(col_name: str) -> list[str]:
+            """Select the input column plus any auxiliary columns needed by text preprocessing."""
+            cols = [col_name]
+            for aux in ("id", "title"):
+                if aux != col_name and aux in self.dataset.column_names:
+                    cols.append(aux)
+            return cols
+
         logger.info("Running pair classification - Encoding samples (1/2)")
         embeddings1 = model.encode(
             create_dataloader(
-                self.dataset.select_columns(self.input1_column_name),
+                self.dataset.select_columns(_columns_for(self.input1_column_name)),
                 task_metadata=self.task_metadata,
                 input_column=self.input1_column_name,
+                prompt_type=self.input1_prompt_type,
                 num_proc=num_proc,
                 **encode_kwargs,
             ),
@@ -113,9 +122,10 @@ class PairClassificationEvaluator(Evaluator):
         logger.info("Running pair classification - Encoding samples (2/2)")
         embeddings2 = model.encode(
             create_dataloader(
-                self.dataset.select_columns(self.input2_column_name),
+                self.dataset.select_columns(_columns_for(self.input2_column_name)),
                 task_metadata=self.task_metadata,
                 input_column=self.input2_column_name,
+                prompt_type=self.input2_prompt_type,
                 num_proc=num_proc,
                 **encode_kwargs,
             ),


### PR DESCRIPTION
The pair classification evaluator never passes `prompt_type` to `create_dataloader()`. For text-only tasks this is fine because both sides get the same treatment, but for cross-modal tasks (e.g. v2t where input1=video, input2=text) the modality routing in `get_modalities()` is skipped entirely — both sides are treated as the same modality, which crashes.

Two fixes here:

**`pair_classification_evaluator.py`**:
- Actually pass `input1_prompt_type` / `input2_prompt_type` through to `create_dataloader()`
- Fix `select_columns` to keep `id` and `title` columns when present (otherwise `_corpus_to_dict` blows up with `KeyError`)

**`_create_dataloaders.py`**:
- Drop the `prompt_type is None` guard on the text fast-path. Without this, text-only tasks that set a `PromptType` (like `TERRaV2`) fall through to `_corpus_to_dict` instead of `_create_dataloader_from_texts`, which is wrong.

Tested: 19/19 evaluator tests pass, TERRaV2 still works, cross-modal VideoPairClassification tasks run correctly.

Ref: #4130