### PR TITLE
[MVEB] LCO Refactor: replace process_mm_info with direct processor calls

### DIFF
--- a/mteb/models/model_implementations/lco_embedding_models.py
+++ b/mteb/models/model_implementations/lco_embedding_models.py
@@ -70,9 +70,7 @@ class LCOEmbedding(AbsEncoder):
         return "\nSummarize the above text in one word:"
 
     @staticmethod
-    def _build_messages(
-        batch: BatchedInput, suffix: str
-    ) -> list[list[dict[str, Any]]]:
+    def _build_messages(batch: BatchedInput, suffix: str) -> list[list[dict[str, Any]]]:
         """Build chat messages for each item in the batch."""
         texts = batch.get("text", [])
         images = batch.get("image", [])

--- a/mteb/models/model_implementations/lco_embedding_models.py
+++ b/mteb/models/model_implementations/lco_embedding_models.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 import torch
 from tqdm.auto import tqdm
 
-from mteb._create_dataloaders import AudioCollator
+from mteb._create_dataloaders import AudioCollator, VideoCollator
 from mteb.models import ModelMeta
 from mteb.models.abs_encoder import AbsEncoder
 
@@ -24,7 +24,11 @@ class LCOEmbedding(AbsEncoder):
         self,
         model_name: str,
         revision: str | None = None,
-        device: str = "cuda" if torch.cuda.is_available() else "cpu",
+        device: str | None = None,
+        fps: float | None = 2.0,
+        max_frames: int | None = None,
+        num_frames: int | None = None,
+        max_audio_length: int | None = None,
         **kwargs: Any,
     ):
         from transformers import (
@@ -33,8 +37,17 @@ class LCOEmbedding(AbsEncoder):
         )
 
         self.model_name = model_name
-        self.device = device
-        self.max_audio_length_seconds = 10
+        self.device = device or (
+            "cuda"
+            if torch.cuda.is_available()
+            else "mps"
+            if torch.backends.mps.is_available()
+            else "cpu"
+        )
+        self.fps = fps
+        self.max_frames = max_frames
+        self.num_frames = num_frames
+        self.max_audio_length = max_audio_length
 
         self.processor = Qwen2_5OmniProcessor.from_pretrained(
             model_name, revision=revision
@@ -46,10 +59,7 @@ class LCOEmbedding(AbsEncoder):
         ).to(self.device)
         self.model.eval()
 
-        # Audio sampling rate target
         self.sampling_rate = self.processor.feature_extractor.sampling_rate
-        # Pre-calculate max samples once
-        self.max_samples = int(self.max_audio_length_seconds * self.sampling_rate)
 
     @staticmethod
     def _prompt_suffix(batch: BatchedInput) -> str:
@@ -59,49 +69,33 @@ class LCOEmbedding(AbsEncoder):
                 return f"\nSummarize the above {modality} in one word:"
         return "\nSummarize the above text in one word:"
 
-    def _build_messages(self, batch: BatchedInput) -> list[list[dict]]:
+    @staticmethod
+    def _build_messages(
+        batch: BatchedInput, suffix: str
+    ) -> list[list[dict[str, Any]]]:
         """Build chat messages for each item in the batch."""
-        audio_list = batch.get("audio", [])
-        text_list = batch.get("text", [])
-        video_list = batch.get("video", [])
-        image_list = batch.get("image", [])
-        batch_size = max(
-            len(audio_list), len(text_list), len(video_list), len(image_list)
-        )
-        suffix = self._prompt_suffix(batch)
+        texts = batch.get("text", [])
+        images = batch.get("image", [])
+        audios = batch.get("audio", [])
+        videos = batch.get("video", [])
+        batch_size = max(len(texts), len(images), len(audios), len(videos))
 
-        messages_batch = []
+        messages = []
         for i in range(batch_size):
-            content: list[dict] = []
-
-            # Audio
-            audio_row = audio_list[i] if i < len(audio_list) else None
-            if audio_row is not None:
-                array = AudioCollator.resample_audio(
-                    {"audio": audio_row}, self.sampling_rate, self.max_samples
-                )
-                content.append({"type": "audio", "audio": array})
-
-            # Video
-            video_row = video_list[i] if i < len(video_list) else None
-            if video_row is not None:
-                content.append({"type": "video", "video": video_row})
-
-            # Image
-            image_row = image_list[i] if i < len(image_list) else None
-            if image_row is not None:
-                content.append({"type": "image", "image": image_row})
-
-            # Text
-            text_row = text_list[i] if i < len(text_list) else None
-            if text_row is not None:
-                content.append({"type": "text", "text": text_row})
-
+            content: list[dict[str, Any]] = []
+            if i < len(videos) and videos[i] is not None:
+                content.append({"type": "video", "video": "placeholder"})
+            if i < len(audios) and audios[i] is not None:
+                content.append({"type": "audio", "audio": "placeholder"})
+            if i < len(images) and images[i] is not None:
+                content.append({"type": "image", "image": "placeholder"})
+            if i < len(texts) and texts[i] is not None:
+                content.append({"type": "text", "text": texts[i]})
             content.append({"type": "text", "text": suffix})
-            messages_batch.append([{"role": "user", "content": content}])
+            messages.append([{"role": "user", "content": content}])
+        return messages
 
-        return messages_batch
-
+    @torch.no_grad()
     def encode(
         self,
         inputs: DataLoader[BatchedInput],
@@ -110,49 +104,68 @@ class LCOEmbedding(AbsEncoder):
         hf_split: str,
         hf_subset: str,
         prompt_type: PromptType | None = None,
-        show_progress_bar: bool = True,
         **kwargs: Any,
     ) -> Array:
-        """Encode batches of text, audio, image, or video inputs.
-
-        Follows the batch encoding examples from
-        https://huggingface.co/LCO-Embedding/LCO-Embedding-Omni-7B
-        """
-        from qwen_omni_utils import process_mm_info
-
-        all_embeddings = []
-
-        for batch in tqdm(inputs, disable=not show_progress_bar):
-            messages_batch = self._build_messages(batch)
-
-            text_prompts = self.processor.apply_chat_template(
-                messages_batch, tokenize=False, add_generation_prompt=True
+        has_video = "video" in inputs.dataset.features
+        has_audio = "audio" in inputs.dataset.features
+        if has_video:
+            inputs.collate_fn = VideoCollator(
+                target_sampling_rate=self.sampling_rate,
+                fps=self.fps,
+                max_frames=self.max_frames,
+                num_frames=self.num_frames,
+                max_samples=self.max_audio_length,
+            )
+        elif has_audio:
+            inputs.collate_fn = AudioCollator(
+                target_sampling_rate=self.sampling_rate,
+                max_samples=self.max_audio_length,
             )
 
-            audio_inputs, image_inputs, video_inputs = process_mm_info(
-                messages_batch, use_audio_in_video=False
-            )
+        all_embeddings: list[torch.Tensor] = []
 
-            processor_inputs = self.processor(
-                text=text_prompts,
-                audio=audio_inputs,
-                images=image_inputs,
-                videos=video_inputs,
+        for batch in tqdm(inputs, desc="Encoding"):
+            suffix = self._prompt_suffix(batch)
+            messages = self._build_messages(batch, suffix)
+
+            texts = [
+                self.processor.apply_chat_template(
+                    msg, tokenize=False, add_generation_prompt=True
+                )
+                for msg in messages
+            ]
+
+            videos = batch.get("video")
+            images = batch.get("image")
+            audios = batch.get("audio")
+            if audios:
+                audios = [
+                    a["array"] if isinstance(a, dict) and "array" in a else a
+                    for a in audios
+                ]
+
+            model_inputs = self.processor(
+                text=texts,
+                audio=audios or None,
+                images=images or None,
+                videos=videos or None,
                 padding=True,
                 return_tensors="pt",
+                videos_kwargs={
+                    "do_sample_frames": False,
+                    "use_audio_in_video": False,
+                },
+                audio_kwargs={"max_length": self.max_audio_length},
             ).to(self.device)
 
-            with torch.no_grad():
-                outputs = self.model(
-                    **processor_inputs, output_hidden_states=True, return_dict=True
-                )
-                embeddings = outputs.hidden_states[-1][:, -1, :]
-                all_embeddings.append(embeddings.cpu().to(torch.float32))
+            outputs = self.model(
+                **model_inputs, output_hidden_states=True, return_dict=True
+            )
+            embeddings = outputs.hidden_states[-1][:, -1, :]
+            embeddings = torch.nn.functional.normalize(embeddings, p=2, dim=-1)
+            all_embeddings.append(embeddings.cpu())
 
-            del processor_inputs, outputs
-            torch.cuda.empty_cache()
-
-        return torch.cat(all_embeddings, dim=0).numpy()
+        return torch.cat(all_embeddings, dim=0).float()
 
 
 lco_3b = ModelMeta(
@@ -188,7 +201,6 @@ lco_3b = ModelMeta(
   primaryClass={cs.CL},
   url={https://arxiv.org/abs/2510.11693},
 }""",
-    extra_requirements_groups=["qwen_omni_utils"],
 )
 
 lco_7b = ModelMeta(
@@ -224,5 +236,4 @@ lco_7b = ModelMeta(
   primaryClass={cs.CL},
   url={https://arxiv.org/abs/2510.11693},
 }""",
-    extra_requirements_groups=["qwen_omni_utils"],
 )


### PR DESCRIPTION
Add VideoCollator/AudioCollator for proper video/audio support, remove qwen_omni_utils dependency, add L2 normalization, and expose fps/max_frames/num_frames/max_audio_length params.

Related to:
https://github.com/embeddings-benchmark/mteb/pull/4384

If you add a model or a dataset, please add the corresponding checklist:

* [dataset checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_dataset/#submit-a-pull-request)
* [model checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_model/#submitting-your-model-as-a-pr)
