### PR TITLE
add mteb/VGGSound_AV_RETRIEVAL dataset

### DIFF
--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -260,6 +260,12 @@ from .vatex_retrieval import (
     VATEXV2TRetrieval,
     VATEXVA2TRetrieval,
 )
+from .vggsound_av_retrieval import (
+    VGGSoundAVT2VARetrieval,
+    VGGSoundAVT2VRetrieval,
+    VGGSoundAVV2TRetrieval,
+    VGGSoundAVVA2TRetrieval,
+)
 from .vidore_bench_retrieval import (
     VidoreArxivQARetrieval,
     VidoreDocVQARetrieval,
@@ -553,6 +559,10 @@ __all__ = [
     "VATEXT2VRetrieval",
     "VATEXV2TRetrieval",
     "VATEXVA2TRetrieval",
+    "VGGSoundAVT2VARetrieval",
+    "VGGSoundAVT2VRetrieval",
+    "VGGSoundAVV2TRetrieval",
+    "VGGSoundAVVA2TRetrieval",
     "VQA2IT2TRetrieval",
     "VidoreArxivQARetrieval",
     "VidoreDocVQARetrieval",

--- a/mteb/tasks/retrieval/eng/vggsound_av_retrieval.py
+++ b/mteb/tasks/retrieval/eng/vggsound_av_retrieval.py
@@ -128,7 +128,7 @@ class VGGSoundAVVA2TRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="VGGSoundAVVA2TRetrieval",
         description=(
-            "Retrieve the audio caption that describes a given video+audio clip "
+            "Retrieve the visual caption that describes a given video+audio clip "
             "from the VGGSound-AV dataset, a large-scale audio-visual dataset "
             "sourced from YouTube."
         ),
@@ -154,7 +154,7 @@ class VGGSoundAVVA2TRetrieval(AbsTaskRetrieval):
 
     def load_data(self, num_proc: int | None = None, **kwargs) -> None:
         _load_vggsound_av(
-            self, query_columns=["video", "audio"], corpus_columns=["audio_caption"]
+            self, query_columns=["video", "audio"], corpus_columns=["video_caption"]
         )
 
 
@@ -162,7 +162,7 @@ class VGGSoundAVT2VARetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="VGGSoundAVT2VARetrieval",
         description=(
-            "Retrieve the video+audio clip that matches a given audio caption "
+            "Retrieve the video+audio clip that matches a given visual caption "
             "from the VGGSound-AV dataset, a large-scale audio-visual dataset "
             "sourced from YouTube."
         ),
@@ -188,5 +188,5 @@ class VGGSoundAVT2VARetrieval(AbsTaskRetrieval):
 
     def load_data(self, num_proc: int | None = None, **kwargs) -> None:
         _load_vggsound_av(
-            self, query_columns=["audio_caption"], corpus_columns=["video", "audio"]
+            self, query_columns=["video_caption"], corpus_columns=["video", "audio"]
         )

--- a/mteb/tasks/retrieval/eng/vggsound_av_retrieval.py
+++ b/mteb/tasks/retrieval/eng/vggsound_av_retrieval.py
@@ -26,6 +26,9 @@ def _load_vggsound_av(
 ) -> None:
     """Shared loader for all VGGSound-AV retrieval directions.
 
+    The 'av_caption' column is video_caption followed by audio_caption, matching
+    the natural order of describing a scene: what is seen, then what is heard.
+
     TODO: Reupload dataset in standard format and remove this custom load_data.
     """
     if task.data_loaded:
@@ -37,17 +40,22 @@ def _load_vggsound_av(
         split=task.metadata.eval_splits[0],
     )
     dataset = dataset.add_column("id", [str(i) for i in range(len(dataset))])
+    if "av_caption" in query_columns or "av_caption" in corpus_columns:
+        dataset = dataset.map(
+            lambda ex: {"av_caption": ex["video_caption"] + " " + ex["audio_caption"]}
+        )
 
     query = dataset.select_columns(["id"] + query_columns)
     corpus = dataset.select_columns(["id"] + corpus_columns)
+
     if "video_caption" in query_columns:
         query = query.rename_column("video_caption", "text")
     if "video_caption" in corpus_columns:
         corpus = corpus.rename_column("video_caption", "text")
-    if "audio_caption" in query_columns:
-        query = query.rename_column("audio_caption", "text")
-    if "audio_caption" in corpus_columns:
-        corpus = corpus.rename_column("audio_caption", "text")
+    if "av_caption" in query_columns:
+        query = query.rename_column("av_caption", "text")
+    if "av_caption" in corpus_columns:
+        corpus = corpus.rename_column("av_caption", "text")
 
     qrels = {str(i): {str(i): 1} for i in range(len(dataset))}
     task.dataset["default"]["test"] = RetrievalSplitData(
@@ -60,8 +68,8 @@ class VGGSoundAVV2TRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="VGGSoundAVV2TRetrieval",
         description=(
-            "Retrieve the visual caption that describes a given video clip (video "
-            "only) from the VGGSound-AV dataset, a large-scale audio-visual dataset "
+            "Retrieve the caption that describes the visual content of a given video "
+            "clip from the VGGSound-AV dataset, a large-scale audio-visual dataset "
             "sourced from YouTube."
         ),
         reference="https://www.robots.ox.ac.uk/~vgg/data/vggsound/",
@@ -94,9 +102,9 @@ class VGGSoundAVT2VRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="VGGSoundAVT2VRetrieval",
         description=(
-            "Retrieve the video clip (video only) that matches a given visual caption "
-            "from the VGGSound-AV dataset, a large-scale audio-visual dataset "
-            "sourced from YouTube."
+            "Retrieve the video clip that matches a given caption describing its "
+            "visual content, from the VGGSound-AV dataset, a large-scale "
+            "audio-visual dataset sourced from YouTube."
         ),
         reference="https://www.robots.ox.ac.uk/~vgg/data/vggsound/",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -128,9 +136,9 @@ class VGGSoundAVVA2TRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="VGGSoundAVVA2TRetrieval",
         description=(
-            "Retrieve the visual caption that describes a given video+audio clip "
-            "from the VGGSound-AV dataset, a large-scale audio-visual dataset "
-            "sourced from YouTube."
+            "Retrieve the caption covering both what is seen and what is heard in a "
+            "given video+audio clip from the VGGSound-AV dataset, a large-scale "
+            "audio-visual dataset sourced from YouTube."
         ),
         reference="https://www.robots.ox.ac.uk/~vgg/data/vggsound/",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -148,13 +156,15 @@ class VGGSoundAVVA2TRetrieval(AbsTaskRetrieval):
         dialect=[],
         sample_creation="found",
         bibtex_citation=_BIBTEX,
-        prompt={"query": "Find the caption that describes the following video."},
+        prompt={
+            "query": "Find the caption that describes what is seen and heard in the following video."
+        },
         is_beta=True,
     )
 
     def load_data(self, num_proc: int | None = None, **kwargs) -> None:
         _load_vggsound_av(
-            self, query_columns=["video", "audio"], corpus_columns=["video_caption"]
+            self, query_columns=["video", "audio"], corpus_columns=["av_caption"]
         )
 
 
@@ -162,9 +172,9 @@ class VGGSoundAVT2VARetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="VGGSoundAVT2VARetrieval",
         description=(
-            "Retrieve the video+audio clip that matches a given visual caption "
-            "from the VGGSound-AV dataset, a large-scale audio-visual dataset "
-            "sourced from YouTube."
+            "Retrieve the video+audio clip that matches a given caption covering "
+            "both what is seen and what is heard, from the VGGSound-AV dataset, a "
+            "large-scale audio-visual dataset sourced from YouTube."
         ),
         reference="https://www.robots.ox.ac.uk/~vgg/data/vggsound/",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -182,11 +192,13 @@ class VGGSoundAVT2VARetrieval(AbsTaskRetrieval):
         dialect=[],
         sample_creation="found",
         bibtex_citation=_BIBTEX,
-        prompt={"query": "Find the video clip that matches the given caption."},
+        prompt={
+            "query": "Find the video clip that matches the given description of what is seen and heard."
+        },
         is_beta=True,
     )
 
     def load_data(self, num_proc: int | None = None, **kwargs) -> None:
         _load_vggsound_av(
-            self, query_columns=["video_caption"], corpus_columns=["video", "audio"]
+            self, query_columns=["av_caption"], corpus_columns=["video", "audio"]
         )

--- a/mteb/tasks/retrieval/eng/vggsound_av_retrieval.py
+++ b/mteb/tasks/retrieval/eng/vggsound_av_retrieval.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from datasets import load_dataset
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.retrieval_dataset_loaders import RetrievalSplitData
+from mteb.abstasks.task_metadata import TaskMetadata
+
+_DATASET_PATH = "mteb/VGGSound_AV_RETRIEVAL"
+_DATASET_REVISION = "5bfb8eb997282004d1c3b322fd081b03e2011344"
+_BIBTEX = r"""
+@inproceedings{chen2020vggsound,
+  author = {Chen, Honglie and Xie, Weidi and Vedaldi, Andrea and Zisserman, Andrew},
+  booktitle = {ICASSP 2020-2020 IEEE International Conference on Acoustics, Speech and Signal Processing (ICASSP)},
+  organization = {IEEE},
+  title = {Vggsound: A Large-Scale Audio-Visual Dataset},
+  year = {2020},
+}
+"""
+
+
+def _load_vggsound_av(
+    task: AbsTaskRetrieval,
+    query_columns: list[str],
+    corpus_columns: list[str],
+) -> None:
+    """Shared loader for all VGGSound-AV retrieval directions.
+
+    TODO: Reupload dataset in standard format and remove this custom load_data.
+    """
+    if task.data_loaded:
+        return
+    task.dataset = {"default": {}}
+    dataset = load_dataset(
+        task.metadata.dataset["path"],
+        revision=task.metadata.dataset["revision"],
+        split=task.metadata.eval_splits[0],
+    )
+    dataset = dataset.add_column("id", [str(i) for i in range(len(dataset))])
+
+    query = dataset.select_columns(["id"] + query_columns)
+    corpus = dataset.select_columns(["id"] + corpus_columns)
+    if "video_caption" in query_columns:
+        query = query.rename_column("video_caption", "text")
+    if "video_caption" in corpus_columns:
+        corpus = corpus.rename_column("video_caption", "text")
+    if "audio_caption" in query_columns:
+        query = query.rename_column("audio_caption", "text")
+    if "audio_caption" in corpus_columns:
+        corpus = corpus.rename_column("audio_caption", "text")
+
+    qrels = {str(i): {str(i): 1} for i in range(len(dataset))}
+    task.dataset["default"]["test"] = RetrievalSplitData(
+        queries=query, corpus=corpus, relevant_docs=qrels, top_ranked=None
+    )
+    task.data_loaded = True
+
+
+class VGGSoundAVV2TRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="VGGSoundAVV2TRetrieval",
+        description=(
+            "Retrieve the visual caption that describes a given video clip (video "
+            "only) from the VGGSound-AV dataset, a large-scale audio-visual dataset "
+            "sourced from YouTube."
+        ),
+        reference="https://www.robots.ox.ac.uk/~vgg/data/vggsound/",
+        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        type="Any2AnyRetrieval",
+        category="v2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        modalities=["video", "text"],
+        date=("2020-01-01", "2020-12-31"),
+        domains=["Web", "Spoken"],
+        task_subtypes=["Caption Pairing"],
+        license="cc-by-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find the caption that describes the following video."},
+        is_beta=True,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_vggsound_av(
+            self, query_columns=["video"], corpus_columns=["video_caption"]
+        )
+
+
+class VGGSoundAVT2VRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="VGGSoundAVT2VRetrieval",
+        description=(
+            "Retrieve the video clip (video only) that matches a given visual caption "
+            "from the VGGSound-AV dataset, a large-scale audio-visual dataset "
+            "sourced from YouTube."
+        ),
+        reference="https://www.robots.ox.ac.uk/~vgg/data/vggsound/",
+        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        type="Any2AnyRetrieval",
+        category="t2v",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        modalities=["text", "video"],
+        date=("2020-01-01", "2020-12-31"),
+        domains=["Web", "Spoken"],
+        task_subtypes=["Caption Pairing"],
+        license="cc-by-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find the video clip that matches the given caption."},
+        is_beta=True,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_vggsound_av(
+            self, query_columns=["video_caption"], corpus_columns=["video"]
+        )
+
+
+class VGGSoundAVVA2TRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="VGGSoundAVVA2TRetrieval",
+        description=(
+            "Retrieve the audio caption that describes a given video+audio clip "
+            "from the VGGSound-AV dataset, a large-scale audio-visual dataset "
+            "sourced from YouTube."
+        ),
+        reference="https://www.robots.ox.ac.uk/~vgg/data/vggsound/",
+        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        type="Any2AnyRetrieval",
+        category="va2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        modalities=["audio", "video", "text"],
+        date=("2020-01-01", "2020-12-31"),
+        domains=["Web", "Spoken"],
+        task_subtypes=["Caption Pairing"],
+        license="cc-by-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find the caption that describes the following video."},
+        is_beta=True,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_vggsound_av(
+            self, query_columns=["video", "audio"], corpus_columns=["audio_caption"]
+        )
+
+
+class VGGSoundAVT2VARetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="VGGSoundAVT2VARetrieval",
+        description=(
+            "Retrieve the video+audio clip that matches a given audio caption "
+            "from the VGGSound-AV dataset, a large-scale audio-visual dataset "
+            "sourced from YouTube."
+        ),
+        reference="https://www.robots.ox.ac.uk/~vgg/data/vggsound/",
+        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        type="Any2AnyRetrieval",
+        category="t2va",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        modalities=["text", "audio", "video"],
+        date=("2020-01-01", "2020-12-31"),
+        domains=["Web", "Spoken"],
+        task_subtypes=["Caption Pairing"],
+        license="cc-by-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find the video clip that matches the given caption."},
+        is_beta=True,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_vggsound_av(
+            self, query_columns=["audio_caption"], corpus_columns=["video", "audio"]
+        )


### PR DESCRIPTION
- [x] I have outlined why this dataset is filling an existing gap in `mteb`
- [x] I have tested that the dataset runs with the `mteb` package.
- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
  - [ ] `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
  - [ ] `intfloat/multilingual-e5-small`
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [x] I have considered the size of the dataset and reduced it if it is too big (2048 examples is typically large enough for most tasks)

https://github.com/embeddings-benchmark/mteb/issues/4130
Ran the mteb/baseline-random-encoder model.

cc @Samoed @AdnanElAssadi56 