### PR TITLE
add mteb/AVMeme-Exam dataset

### DIFF
--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -8,6 +8,12 @@ from .alpha_nli_retrieval import AlphaNLI
 from .arc_challenge_retrieval import ARCChallenge
 from .argu_ana_retrieval import ArguAna
 from .audio_set_strong import AudioSetStrongA2TRetrieval, AudioSetStrongT2ARetrieval
+from .avmeme_exam_retrieval import (
+    AVMemeExamT2VARetrieval,
+    AVMemeExamT2VRetrieval,
+    AVMemeExamV2TRetrieval,
+    AVMemeExamVA2TRetrieval,
+)
 from .bar_exam_qa_retrieval import BarExamQARetrieval
 from .bill_sum_ca_retrieval import BillSumCARetrieval
 from .bill_sum_us_retrieval import BillSumUSRetrieval
@@ -311,6 +317,10 @@ __all__ = [
     "AILACasedocs",
     "AILAStatutes",
     "ARCChallenge",
+    "AVMemeExamT2VARetrieval",
+    "AVMemeExamT2VRetrieval",
+    "AVMemeExamV2TRetrieval",
+    "AVMemeExamVA2TRetrieval",
     "ActivityNetCaptionsT2VRetrieval",
     "ActivityNetCaptionsV2TRetrieval",
     "AlphaNLI",

--- a/mteb/tasks/retrieval/eng/avmeme_exam_retrieval.py
+++ b/mteb/tasks/retrieval/eng/avmeme_exam_retrieval.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from datasets import load_dataset
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.retrieval_dataset_loaders import RetrievalSplitData
+from mteb.abstasks.task_metadata import TaskMetadata
+
+_DATASET_PATH = "mteb/AVMeme-Exam"
+_DATASET_REVISION = "7070d1979d9a4943dd49b2e72858eb1e54f6bd5b"
+_BIBTEX = r"""
+@article{avmeme2025,
+  title = {AVMeme: A Benchmark for Audio-Visual Meme Understanding},
+  year = {2025},
+}
+"""
+
+
+def _load_avmeme_exam(
+    task: AbsTaskRetrieval,
+    query_columns: list[str],
+    corpus_columns: list[str],
+) -> None:
+    """Shared loader for all AVMeme-Exam retrieval directions.
+
+    TODO: Reupload dataset in standard format and remove this custom load_data.
+    """
+    if task.data_loaded:
+        return
+    task.dataset = {"default": {}}
+    dataset = load_dataset(
+        task.metadata.dataset["path"],
+        revision=task.metadata.dataset["revision"],
+        split=task.metadata.eval_splits[0],
+    )
+    dataset = dataset.add_column("id", [str(i) for i in range(len(dataset))])
+
+    query = dataset.select_columns(["id"] + query_columns)
+    corpus = dataset.select_columns(["id"] + corpus_columns)
+    if "summary" in query_columns:
+        query = query.rename_column("summary", "text")
+    if "summary" in corpus_columns:
+        corpus = corpus.rename_column("summary", "text")
+
+    qrels = {str(i): {str(i): 1} for i in range(len(dataset))}
+    task.dataset["default"]["test"] = RetrievalSplitData(
+        queries=query, corpus=corpus, relevant_docs=qrels, top_ranked=None
+    )
+    task.data_loaded = True
+
+
+class AVMemeExamV2TRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="AVMemeExamV2TRetrieval",
+        description=(
+            "Retrieve the summary that describes a given meme video clip (video "
+            "only) from AVMeme-Exam, a multilingual audio-visual meme understanding "
+            "benchmark."
+        ),
+        reference="https://huggingface.co/datasets/mteb/AVMeme-Exam",
+        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        type="Any2AnyRetrieval",
+        category="v2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        modalities=["video", "text"],
+        date=("2025-01-01", "2025-12-31"),
+        domains=["Web", "Social"],
+        task_subtypes=["Caption Pairing"],
+        license="cc-by-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find the summary that describes the following meme video."},
+        is_beta=True,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_avmeme_exam(self, query_columns=["video"], corpus_columns=["summary"])
+
+
+class AVMemeExamT2VRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="AVMemeExamT2VRetrieval",
+        description=(
+            "Retrieve the meme video clip (video only) that matches a given summary "
+            "from AVMeme-Exam, a multilingual audio-visual meme understanding "
+            "benchmark."
+        ),
+        reference="https://huggingface.co/datasets/mteb/AVMeme-Exam",
+        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        type="Any2AnyRetrieval",
+        category="t2v",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        modalities=["text", "video"],
+        date=("2025-01-01", "2025-12-31"),
+        domains=["Web", "Social"],
+        task_subtypes=["Caption Pairing"],
+        license="cc-by-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find the meme video clip that matches the given summary."},
+        is_beta=True,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_avmeme_exam(self, query_columns=["summary"], corpus_columns=["video"])
+
+
+class AVMemeExamVA2TRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="AVMemeExamVA2TRetrieval",
+        description=(
+            "Retrieve the summary that describes a given meme video+audio clip "
+            "from AVMeme-Exam, a multilingual audio-visual meme understanding "
+            "benchmark."
+        ),
+        reference="https://huggingface.co/datasets/mteb/AVMeme-Exam",
+        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        type="Any2AnyRetrieval",
+        category="va2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        modalities=["audio", "video", "text"],
+        date=("2025-01-01", "2025-12-31"),
+        domains=["Web", "Social"],
+        task_subtypes=["Caption Pairing"],
+        license="cc-by-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find the summary that describes the following meme video."},
+        is_beta=True,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_avmeme_exam(
+            self, query_columns=["video", "audio"], corpus_columns=["summary"]
+        )
+
+
+class AVMemeExamT2VARetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="AVMemeExamT2VARetrieval",
+        description=(
+            "Retrieve the meme video+audio clip that matches a given summary "
+            "from AVMeme-Exam, a multilingual audio-visual meme understanding "
+            "benchmark."
+        ),
+        reference="https://huggingface.co/datasets/mteb/AVMeme-Exam",
+        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        type="Any2AnyRetrieval",
+        category="t2va",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        modalities=["text", "audio", "video"],
+        date=("2025-01-01", "2025-12-31"),
+        domains=["Web", "Social"],
+        task_subtypes=["Caption Pairing"],
+        license="cc-by-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find the meme video clip that matches the given summary."},
+        is_beta=True,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_avmeme_exam(
+            self, query_columns=["summary"], corpus_columns=["video", "audio"]
+        )


### PR DESCRIPTION
- [x] I have outlined why this dataset is filling an existing gap in `mteb`
- [x] I have tested that the dataset runs with the `mteb` package.
- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
  - [ ] `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
  - [ ] `intfloat/multilingual-e5-small`
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [x] I have considered the size of the dataset and reduced it if it is too big (2048 examples is typically large enough for most tasks)

https://github.com/embeddings-benchmark/mteb/issues/4130
Ran the mteb/baseline-random-encoder model.

cc @Samoed @AdnanElAssadi56 