### PR TITLE
[MVEB] Adding HMDB51 Task (Clustering)

### DIFF
--- a/mteb/tasks/clustering/eng/__init__.py
+++ b/mteb/tasks/clustering/eng/__init__.py
@@ -14,6 +14,7 @@ from .built_bench_clustering_s2s import BuiltBenchClusteringS2S
 from .cifar import CIFAR10Clustering, CIFAR100Clustering
 from .clus_trec_covid import ClusTrecCovid
 from .crema_d_clustering import CREMADClustering
+from .hmdb51_clustering import HMDB51Clustering
 from .hume_arxiv_clustering_p2p import HUMEArxivClusteringP2P
 from .hume_reddit_clustering_p2p import HUMERedditClusteringP2P
 from .hume_wiki_cities_clustering import HUMEWikiCitiesClustering
@@ -68,6 +69,7 @@ __all__ = [
     "CIFAR100Clustering",
     "CREMADClustering",
     "ClusTrecCovid",
+    "HMDB51Clustering",
     "HUMEArxivClusteringP2P",
     "HUMERedditClusteringP2P",
     "HUMEWikiCitiesClustering",

--- a/mteb/tasks/clustering/eng/hmdb51_clustering.py
+++ b/mteb/tasks/clustering/eng/hmdb51_clustering.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from mteb.abstasks import AbsTaskClustering
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class HMDB51Clustering(AbsTaskClustering):
+    metadata = TaskMetadata(
+        name="HMDB51Clustering",
+        description=(
+            "Clustering of video clips into 51 human action categories from "
+            "HMDB51, a large video database for human motion recognition."
+        ),
+        reference="https://serre-lab.clps.brown.edu/resource/hmdb-a-large-human-motion-database/",
+        dataset={
+            "path": "mteb/HMDB51",
+            "revision": "73e5ac9cd9536c406d0046f3d6046785885f7ebe",
+        },
+        type="VideoClustering",
+        category="v2c",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="v_measure",
+        date=("2011-01-01", "2011-12-31"),
+        domains=["Scene"],
+        task_subtypes=["Activity recognition"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video"],
+        sample_creation="found",
+        bibtex_citation=r"""
+@inproceedings{kuehne2011hmdb,
+    title = {HMDB: a large video database for human motion recognition},
+    author = {Kuehne, Hildegard and Jhuang, Hueihan and Garrote, Est{\'\i}baliz and Poggio, Tomaso and Serre, Thomas},
+    booktitle = {2011 International Conference on Computer Vision},
+    pages = {2556--2563},
+    year = {2011},
+    organization = {IEEE},
+}
+""",
+        is_beta=True,
+    )
+    max_fraction_of_documents_to_embed = None
+    input_column_name: str = "video"
+    label_column_name: str = "label"
+
+    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+        for split in self.metadata.eval_splits:
+            self.dataset[split] = self.dataset[split].select_columns(
+                ["video", "label"],
+            )


### PR DESCRIPTION
- [x] I have outlined why this dataset is filling an existing gap in the MVEB benchmark
- [x] I have tested that the dataset runs with the `mteb` package.
- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
  - [x] `facebook/pe-av-small-16-frame`
  - [x] `mteb/baseline-random-encoder`
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [x] I have considered the size of the dataset and reduced it if it is too big (2048 examples is typically large enough for most tasks)

Will merge after https://github.com/embeddings-benchmark/mteb/pull/4393
I produced the results for random and pe-av on the new datasets and the v measure looks alright.


Results for pe-av:
```json
{
  "dataset_revision": "73e5ac9cd9536c406d0046f3d6046785885f7ebe",
  "task_name": "HMDB51Clustering",
  "mteb_version": "2.12.25",
  "scores": {
    "test": [
      {
        "v_measures": {
          "Level 0": [
            0.731515,
            0.735975,
            0.730294,
            0.743478,
            0.740408,
            0.730578,
            0.713356,
            0.74402,
            0.745802,
            0.742438
          ]
        },
        "v_measure": 0.735786,
        "v_measure_std": 0.009336,
        "main_score": 0.735786,
        "hf_subset": "default",
        "languages": [
          "eng-Latn"
        ]
      }
    ]
  },
  "evaluation_time": 2846.5528161525726,
  "kg_co2_emissions": null,
  "date": 1776959815.842988
}
```

Results for random baseline:
```json
{
  "dataset_revision": "73e5ac9cd9536c406d0046f3d6046785885f7ebe",
  "task_name": "HMDB51Clustering",
  "mteb_version": "2.12.25",
  "scores": {
    "test": [
      {
        "v_measures": {
          "Level 0": [
            0.21967,
            0.222382,
            0.214713,
            0.221613,
            0.221743,
            0.217871,
            0.22101,
            0.224004,
            0.215594,
            0.231021
          ]
        },
        "v_measure": 0.220962,
        "v_measure_std": 0.004388,
        "main_score": 0.220962,
        "hf_subset": "default",
        "languages": [
          "eng-Latn"
        ]
      }
    ]
  },
  "evaluation_time": 27.47688317298889,
  "kg_co2_emissions": null,
  "date": 1776956573.463896
}
```