### PR TITLE
fix: normalize package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ mteb run \
 
 For more on how to use the CLI check out the [related documentation](https://embeddings-benchmark.github.io/mteb/get_started/usage/cli/).
 
+
 ## Overview
 
 | Overview                       |                                                                                      |


### PR DESCRIPTION
Apparently pipy normalizes package name  which gives a probleM that only appear when install from pipy:

```
ValueError: Unknown extras group(s) for mteb: ['google_genai']. Available: ['ark', 'audio', 'blip2', 'bm25s', 'codecarbon', 'cohere', 'colpali-engine', 'colqwen3', 'eager-embed', 'embeddinggemma', 'faiss-cpu', 'flagembedding', 'flash-attention', 'google-genai', 'gritlm', 'image', 'jina', 'jina-clip', 'jina-v4', 'leaderboard', 'llama-embed-nemotron', 'llama-nemotron-colembed-vl', 'llama-nemotron-embed-vl-1b-v2', 'llm2vec', 'mctct', 'model2vec', 'msclap', 'muq', 'nemotron-colembed-vl-v2', 'nomic', 'open-clip-torch', 'openai', 'peft', 'pylate', 'qwen-omni-utils', 'qwen-vl', 'sauerkrautlm-colpali', 'siglip', 'speechbrain', 'timm', 'torch-vggish-yamnet', 'vertexai', 'video', 'vllm', 'voyage-v', 'voyageai', 'wav2clip', 'xet', 'xformers', 'youtu']
```

pep: https://peps.python.org/pep-0685/

initially proposed a fix here, but discovered that it was added: https://github.com/embeddings-benchmark/mteb/pull/4384

in this commit: https://github.com/embeddings-benchmark/mteb/pull/4384/changes/45f1419b6516ab0aa4114696a1acb6d1919ffcec

This PR just bumps the version to release the fix.

(cc @isaac-chung)