### PR TITLE
Fix floating-point non-determinism in GPU operations

### DIFF
--- a/mteb/__init__.py
+++ b/mteb/__init__.py
@@ -1,5 +1,11 @@
 from importlib.metadata import version
 
+import torch
+
+# Set GPU deterministic mode for reproducibility
+torch.backends.cudnn.deterministic = True
+torch.backends.cudnn.benchmark = False
+
 from mteb import types
 from mteb.abstasks import AbsTask
 from mteb.abstasks.task_metadata import TaskMetadata


### PR DESCRIPTION
Good day

This PR fixes floating-point non-determinism in GPU operations (issue #2789).

## Problem
GPU operations in PyTorch can produce non-deterministic results across runs due to non-deterministic cuDNN algorithms. This causes tests to be flaky and benchmarks to be unreproducible.

## Fix
At the torch import site (mteb/__init__.py), set:
- torch.backends.cudnn.deterministic = True
- torch.backends.cudnn.benchmark = False

This ensures that cuDNN uses deterministic algorithms, making GPU operations reproducible across runs.

## Changes
- Added torch import and cudnn configuration in mteb/__init__.py, right after version import and before any other mteb imports.

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust。

Warmly, RoomWithRoof