### PR TITLE
add v2a and a2v tasks for valid video retrieval datasets

### DIFF
--- a/mteb/abstasks/task_metadata.py
+++ b/mteb/abstasks/task_metadata.py
@@ -119,6 +119,7 @@ TaskSubtype = Literal[
     "Question Answering Retrieval",
     "Reading Comprehension",
     "Intent Classification",
+    "Cross-Modal Retrieval",
 ]
 """The subtypes of the task. E.g. includes "Sentiment/Hate speech", "Thematic Clustering". This list can be updated as needed."""
 

--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -271,8 +271,10 @@ from .tu_berlin_t2i_retrieval import TUBerlinT2IRetrieval
 from .tuna_bench_t2v_retrieval import TUNABenchT2VRetrieval
 from .tuna_bench_v2t_retrieval import TUNABenchV2TRetrieval
 from .valor_32k_retrieval import (
+    VALOR32KA2VRetrieval,
     VALOR32KT2VARetrieval,
     VALOR32KT2VRetrieval,
+    VALOR32KV2ARetrieval,
     VALOR32KV2TRetrieval,
     VALOR32KVA2TRetrieval,
 )
@@ -593,8 +595,10 @@ __all__ = [
     "TopiOCQARetrievalHardNegatives",
     "Touche2020",
     "Touche2020v3Retrieval",
+    "VALOR32KA2VRetrieval",
     "VALOR32KT2VARetrieval",
     "VALOR32KT2VRetrieval",
+    "VALOR32KV2ARetrieval",
     "VALOR32KV2TRetrieval",
     "VALOR32KVA2TRetrieval",
     "VATEXT2VARetrieval",

--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -243,8 +243,10 @@ from .sci_mmir_i2t_retrieval import SciMMIRI2TRetrieval
 from .sci_mmir_t2i_retrieval import SciMMIRT2IRetrieval
 from .scidocs_retrieval import SCIDOCS
 from .shot2story_retrieval import (
+    Shot2Story20KA2VRetrieval,
     Shot2Story20KT2VARetrieval,
     Shot2Story20KT2VRetrieval,
+    Shot2Story20KV2ARetrieval,
     Shot2Story20KV2TRetrieval,
     Shot2Story20KVA2TRetrieval,
 )
@@ -567,8 +569,10 @@ __all__ = [
     "SciFact",
     "SciMMIRI2TRetrieval",
     "SciMMIRT2IRetrieval",
+    "Shot2Story20KA2VRetrieval",
     "Shot2Story20KT2VARetrieval",
     "Shot2Story20KT2VRetrieval",
+    "Shot2Story20KV2ARetrieval",
     "Shot2Story20KV2TRetrieval",
     "Shot2Story20KVA2TRetrieval",
     "SketchyI2IRetrieval",

--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -176,7 +176,7 @@ from .mscoco_i2t_retrieval import MSCOCOI2TRetrieval
 from .mscoco_t2i_retrieval import MSCOCOT2IRetrieval
 from .msmarc_ov2_retrieval import MSMARCOv2
 from .msmarco_retrieval import MSMARCO, MSMARCOHardNegatives
-from .msr_vtt import MSRVTTT2V, MSRVTTT2VA, MSRVTTV2T, MSRVTTVA2T
+from .msr_vtt import MSRVTTA2V, MSRVTTT2V, MSRVTTT2VA, MSRVTTV2A, MSRVTTV2T, MSRVTTVA2T
 from .msvd_t2v_retrieval import MSVDT2VRetrieval
 from .msvd_v2t_retrieval import MSVDV2TRetrieval
 from .nano_argu_ana_retrieval import NanoArguAnaRetrieval
@@ -321,8 +321,10 @@ __all__ = [
     "FEVER",
     "FORBI2I",
     "MSMARCO",
+    "MSRVTTA2V",
     "MSRVTTT2V",
     "MSRVTTT2VA",
+    "MSRVTTV2A",
     "MSRVTTV2T",
     "MSRVTTVA2T",
     "NQ",

--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -279,8 +279,10 @@ from .valor_32k_retrieval import (
     VALOR32KVA2TRetrieval,
 )
 from .vatex_retrieval import (
+    VATEXA2VRetrieval,
     VATEXT2VARetrieval,
     VATEXT2VRetrieval,
+    VATEXV2ARetrieval,
     VATEXV2TRetrieval,
     VATEXVA2TRetrieval,
 )
@@ -601,8 +603,10 @@ __all__ = [
     "VALOR32KV2ARetrieval",
     "VALOR32KV2TRetrieval",
     "VALOR32KVA2TRetrieval",
+    "VATEXA2VRetrieval",
     "VATEXT2VARetrieval",
     "VATEXT2VRetrieval",
+    "VATEXV2ARetrieval",
     "VATEXV2TRetrieval",
     "VATEXVA2TRetrieval",
     "VGGSoundAVT2VARetrieval",

--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -312,8 +312,10 @@ from .web_qa_t2it_retrieval import WebQAT2ITRetrieval
 from .web_qa_t2t_retrieval import WebQAT2TRetrieval
 from .wino_grande_retrieval import WinoGrande
 from .youcook2_retrieval import (
+    YouCook2A2VRetrieval,
     YouCook2T2VARetrieval,
     YouCook2T2VRetrieval,
+    YouCook2V2ARetrieval,
     YouCook2V2TRetrieval,
     YouCook2VA2TRetrieval,
 )
@@ -622,8 +624,10 @@ __all__ = [
     "WebQAT2ITRetrieval",
     "WebQAT2TRetrieval",
     "WinoGrande",
+    "YouCook2A2VRetrieval",
     "YouCook2T2VARetrieval",
     "YouCook2T2VRetrieval",
+    "YouCook2V2ARetrieval",
     "YouCook2V2TRetrieval",
     "YouCook2VA2TRetrieval",
 ]

--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -103,8 +103,10 @@ from .dapfam_patent_retrieval import (
 )
 from .dbpedia_retrieval import DBPedia, DBPediaHardNegatives, DBPediaHardNegativesV2
 from .didemo_retrieval import (
+    DiDeMoA2VRetrieval,
     DiDeMoT2VARetrieval,
     DiDeMoT2VRetrieval,
+    DiDeMoV2ARetrieval,
     DiDeMoV2TRetrieval,
     DiDeMoVA2TRetrieval,
 )
@@ -431,8 +433,10 @@ __all__ = [
     "DBPedia",
     "DBPediaHardNegatives",
     "DBPediaHardNegativesV2",
+    "DiDeMoA2VRetrieval",
     "DiDeMoT2VARetrieval",
     "DiDeMoT2VRetrieval",
+    "DiDeMoV2ARetrieval",
     "DiDeMoV2TRetrieval",
     "DiDeMoVA2TRetrieval",
     "EDIST2ITRetrieval",

--- a/mteb/tasks/retrieval/eng/didemo_retrieval.py
+++ b/mteb/tasks/retrieval/eng/didemo_retrieval.py
@@ -177,3 +177,65 @@ class DiDeMoT2VARetrieval(AbsTaskRetrieval):
 
     def load_data(self, num_proc: int | None = None, **kwargs) -> None:
         _load_didemo(self, query_columns=["caption"], corpus_columns=["video", "audio"])
+
+
+class DiDeMoV2ARetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="DiDeMoV2ARetrieval",
+        description=(
+            "Retrieve the audio track that matches a given video clip from the "
+            "DiDeMo dataset. Tests cross-modal alignment between video frames and audio."
+        ),
+        reference="https://arxiv.org/abs/1708.01355",
+        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        type="Any2AnyRetrieval",
+        category="v2a",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        modalities=["video", "audio"],
+        date=("2017-01-01", "2017-12-31"),
+        domains=["Web", "Spoken"],
+        task_subtypes=["Cross-Modal Retrieval"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find the audio that corresponds to the following video."},
+        is_beta=True,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_didemo(self, query_columns=["video"], corpus_columns=["audio"])
+
+
+class DiDeMoA2VRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="DiDeMoA2VRetrieval",
+        description=(
+            "Retrieve the video clip that matches a given audio track from the "
+            "DiDeMo dataset. Tests cross-modal alignment between audio and video frames."
+        ),
+        reference="https://arxiv.org/abs/1708.01355",
+        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        type="Any2AnyRetrieval",
+        category="a2v",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        modalities=["audio", "video"],
+        date=("2017-01-01", "2017-12-31"),
+        domains=["Web", "Spoken"],
+        task_subtypes=["Cross-Modal Retrieval"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find the video that corresponds to the following audio."},
+        is_beta=True,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_didemo(self, query_columns=["audio"], corpus_columns=["video"])

--- a/mteb/tasks/retrieval/eng/msr_vtt.py
+++ b/mteb/tasks/retrieval/eng/msr_vtt.py
@@ -165,3 +165,65 @@ class MSRVTTT2VA(AbsTaskRetrieval):
         _load_msr_vtt(
             self, query_columns=["caption"], corpus_columns=["video", "audio"]
         )
+
+
+class MSRVTTV2A(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="MSRVTTV2A",
+        description=(
+            "Retrieve the audio track that matches a given video clip from MSR-VTT. "
+            "Tests cross-modal alignment between video frames and audio."
+        ),
+        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        type="Any2AnyRetrieval",
+        eval_langs=["eng-Latn"],
+        eval_splits=["test"],
+        main_score="ndcg_at_10",
+        reference="https://openaccess.thecvf.com/content_cvpr_2016/papers/Xu_MSR-VTT_A_Large_CVPR_2016_paper.pdf",
+        category="v2a",
+        modalities=["video", "audio"],
+        date=("2016-01-01", "2016-12-31"),
+        domains=[],
+        task_subtypes=["Cross-Modal Retrieval"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="created",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find the audio that corresponds to the following video."},
+        is_beta=True,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_msr_vtt(self, query_columns=["video"], corpus_columns=["audio"])
+
+
+class MSRVTTA2V(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="MSRVTTA2V",
+        description=(
+            "Retrieve the video clip that matches a given audio track from MSR-VTT. "
+            "Tests cross-modal alignment between audio and video frames."
+        ),
+        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        type="Any2AnyRetrieval",
+        eval_langs=["eng-Latn"],
+        eval_splits=["test"],
+        main_score="ndcg_at_10",
+        reference="https://openaccess.thecvf.com/content_cvpr_2016/papers/Xu_MSR-VTT_A_Large_CVPR_2016_paper.pdf",
+        category="a2v",
+        modalities=["audio", "video"],
+        date=("2016-01-01", "2016-12-31"),
+        domains=[],
+        task_subtypes=["Cross-Modal Retrieval"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="created",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find the video that corresponds to the following audio."},
+        is_beta=True,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_msr_vtt(self, query_columns=["audio"], corpus_columns=["video"])

--- a/mteb/tasks/retrieval/eng/shot2story_retrieval.py
+++ b/mteb/tasks/retrieval/eng/shot2story_retrieval.py
@@ -177,3 +177,67 @@ class Shot2Story20KT2VARetrieval(AbsTaskRetrieval):
         _load_shot2story(
             self, query_columns=["caption"], corpus_columns=["video", "audio"]
         )
+
+
+class Shot2Story20KV2ARetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="Shot2Story20KV2ARetrieval",
+        description=(
+            "Retrieve the audio track that matches a given video clip from the "
+            "Shot2Story dataset. Tests cross-modal alignment between video frames "
+            "and audio."
+        ),
+        reference="https://arxiv.org/abs/2312.10300",
+        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        type="Any2AnyRetrieval",
+        category="v2a",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        modalities=["video", "audio"],
+        date=("2023-12-01", "2023-12-31"),
+        domains=["Web", "Spoken"],
+        task_subtypes=["Cross-Modal Retrieval"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find the audio that corresponds to the following video."},
+        is_beta=True,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_shot2story(self, query_columns=["video"], corpus_columns=["audio"])
+
+
+class Shot2Story20KA2VRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="Shot2Story20KA2VRetrieval",
+        description=(
+            "Retrieve the video clip that matches a given audio track from the "
+            "Shot2Story dataset. Tests cross-modal alignment between audio and "
+            "video frames."
+        ),
+        reference="https://arxiv.org/abs/2312.10300",
+        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        type="Any2AnyRetrieval",
+        category="a2v",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        modalities=["audio", "video"],
+        date=("2023-12-01", "2023-12-31"),
+        domains=["Web", "Spoken"],
+        task_subtypes=["Cross-Modal Retrieval"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find the video that corresponds to the following audio."},
+        is_beta=True,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_shot2story(self, query_columns=["audio"], corpus_columns=["video"])

--- a/mteb/tasks/retrieval/eng/valor_32k_retrieval.py
+++ b/mteb/tasks/retrieval/eng/valor_32k_retrieval.py
@@ -173,3 +173,65 @@ class VALOR32KT2VARetrieval(AbsTaskRetrieval):
         _load_valor(
             self, query_columns=["description"], corpus_columns=["video", "audio"]
         )
+
+
+class VALOR32KV2ARetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="VALOR32KV2ARetrieval",
+        description=(
+            "Retrieve the audio track that matches a given video clip from the "
+            "VALOR-32K benchmark of vision-audio-language understanding. Tests "
+            "cross-modal alignment between video frames and audio."
+        ),
+        reference="https://arxiv.org/abs/2304.08345",
+        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        type="Any2AnyRetrieval",
+        category="v2a",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        modalities=["video", "audio"],
+        date=("2023-04-01", "2023-04-30"),
+        domains=["Web", "Spoken"],
+        task_subtypes=["Cross-Modal Retrieval"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find the audio that corresponds to the following video."},
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_valor(self, query_columns=["video"], corpus_columns=["audio"])
+
+
+class VALOR32KA2VRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="VALOR32KA2VRetrieval",
+        description=(
+            "Retrieve the video clip that matches a given audio track from the "
+            "VALOR-32K benchmark of vision-audio-language understanding. Tests "
+            "cross-modal alignment between audio and video frames."
+        ),
+        reference="https://arxiv.org/abs/2304.08345",
+        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        type="Any2AnyRetrieval",
+        category="a2v",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        modalities=["audio", "video"],
+        date=("2023-04-01", "2023-04-30"),
+        domains=["Web", "Spoken"],
+        task_subtypes=["Cross-Modal Retrieval"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find the video that corresponds to the following audio."},
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_valor(self, query_columns=["audio"], corpus_columns=["video"])

--- a/mteb/tasks/retrieval/eng/vatex_retrieval.py
+++ b/mteb/tasks/retrieval/eng/vatex_retrieval.py
@@ -173,3 +173,65 @@ class VATEXT2VARetrieval(AbsTaskRetrieval):
 
     def load_data(self, num_proc: int | None = None, **kwargs) -> None:
         _load_vatex(self, query_columns=["caption"], corpus_columns=["video", "audio"])
+
+
+class VATEXV2ARetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="VATEXV2ARetrieval",
+        description=(
+            "Retrieve the audio track that matches a given video clip from the "
+            "VATEX dataset. Tests cross-modal alignment between video frames and audio."
+        ),
+        reference="https://arxiv.org/abs/1904.03493",
+        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        type="Any2AnyRetrieval",
+        category="v2a",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        modalities=["video", "audio"],
+        date=("2019-01-01", "2019-12-31"),
+        domains=["Web", "Spoken"],
+        task_subtypes=["Cross-Modal Retrieval"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find the audio that corresponds to the following video."},
+        is_beta=True,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_vatex(self, query_columns=["video"], corpus_columns=["audio"])
+
+
+class VATEXA2VRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="VATEXA2VRetrieval",
+        description=(
+            "Retrieve the video clip that matches a given audio track from the "
+            "VATEX dataset. Tests cross-modal alignment between audio and video frames."
+        ),
+        reference="https://arxiv.org/abs/1904.03493",
+        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        type="Any2AnyRetrieval",
+        category="a2v",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        modalities=["audio", "video"],
+        date=("2019-01-01", "2019-12-31"),
+        domains=["Web", "Spoken"],
+        task_subtypes=["Cross-Modal Retrieval"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find the video that corresponds to the following audio."},
+        is_beta=True,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_vatex(self, query_columns=["audio"], corpus_columns=["video"])

--- a/mteb/tasks/retrieval/eng/youcook2_retrieval.py
+++ b/mteb/tasks/retrieval/eng/youcook2_retrieval.py
@@ -179,3 +179,67 @@ class YouCook2T2VARetrieval(AbsTaskRetrieval):
         _load_youcook2(
             self, query_columns=["sentence"], corpus_columns=["video", "audio"]
         )
+
+
+class YouCook2V2ARetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="YouCook2V2ARetrieval",
+        description=(
+            "Retrieve the audio track that matches a given video clip from the "
+            "YouCook2 dataset of instructional cooking videos. Tests cross-modal "
+            "alignment between video frames and audio narration."
+        ),
+        reference="https://arxiv.org/abs/1703.09788",
+        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        type="Any2AnyRetrieval",
+        category="v2a",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        modalities=["video", "audio"],
+        date=("2018-01-01", "2018-12-31"),
+        domains=["Web", "Spoken"],
+        task_subtypes=["Cross-Modal Retrieval"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find the audio that corresponds to the following video."},
+        is_beta=True,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_youcook2(self, query_columns=["video"], corpus_columns=["audio"])
+
+
+class YouCook2A2VRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="YouCook2A2VRetrieval",
+        description=(
+            "Retrieve the video clip that matches a given audio track from the "
+            "YouCook2 dataset of instructional cooking videos. Tests cross-modal "
+            "alignment between audio narration and video frames."
+        ),
+        reference="https://arxiv.org/abs/1703.09788",
+        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        type="Any2AnyRetrieval",
+        category="a2v",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        modalities=["audio", "video"],
+        date=("2018-01-01", "2018-12-31"),
+        domains=["Web", "Spoken"],
+        task_subtypes=["Cross-Modal Retrieval"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find the video that corresponds to the following audio."},
+        is_beta=True,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_youcook2(self, query_columns=["audio"], corpus_columns=["video"])


### PR DESCRIPTION
- [x] I have outlined why this dataset is filling an existing gap in `mteb`
- [x] I have tested that the dataset runs with the `mteb` package.
- [ ] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
  - [ ] `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
  - [ ] `intfloat/multilingual-e5-small`
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [x] I have considered the size of the dataset and reduced it if it is too big (2048 examples is typically large enough for most tasks)

https://github.com/embeddings-benchmark/mteb/issues/4130

cc @Samoed @AdnanElAssadi56 