### PR TITLE
fix: Don't specify hf_subsets for aggregated tasks

### DIFF
--- a/mteb/tasks/aggregated_tasks/eng/sts17_multilingual_visual_sts_eng.py
+++ b/mteb/tasks/aggregated_tasks/eng/sts17_multilingual_visual_sts_eng.py
@@ -22,9 +22,6 @@ class STS17MultilingualVisualSTSEng(AbsTaskAggregate):
         modalities=["image"],
         annotations_creators="human-annotated",
         dialect=[""],
-        eval_langs={
-            "en-en": ["eng-Latn"]
-        },  # rely on subsets to filter scores in TaskResults.get_score_fast().
         sample_creation="rendered",
         main_score="cosine_spearman",
         type="VisualSTS(eng)",

--- a/mteb/tasks/aggregated_tasks/eng/sts_benchmark_multilingual_visual_sts_eng.py
+++ b/mteb/tasks/aggregated_tasks/eng/sts_benchmark_multilingual_visual_sts_eng.py
@@ -26,7 +26,6 @@ class STSBenchmarkMultilingualVisualSTSEng(AbsTaskAggregate):
         main_score="cosine_spearman",
         type="VisualSTS(eng)",
         eval_splits=["test"],
-        eval_langs=["eng-Latn"],
         bibtex_citation=r"""
 @article{xiao2024pixel,
   author = {Xiao, Chenghao and Huang, Zhuoxu and Chen, Danlu and Hudson, G Thomas and Li, Yizhi and Duan, Haoran and Lin, Chenghua and Fu, Jie and Han, Jungong and Moubayed, Noura Al},

--- a/mteb/tasks/aggregated_tasks/multilingual/sts17_multilingual_vision_sts.py
+++ b/mteb/tasks/aggregated_tasks/multilingual/sts17_multilingual_vision_sts.py
@@ -38,18 +38,6 @@ class STS17MultilingualVisualSTSMultilingual(AbsTaskAggregate):
         main_score="cosine_spearman",
         type="VisualSTS(multi)",
         eval_splits=["test"],
-        eval_langs={  # rely on subsets to filter scores in TaskResults.get_score_fast().
-            "ko-ko": ["kor-Hang"],
-            "ar-ar": ["ara-Arab"],
-            "en-ar": ["eng-Latn", "ara-Arab"],
-            "en-de": ["eng-Latn", "deu-Latn"],
-            "en-tr": ["eng-Latn", "tur-Latn"],
-            "es-en": ["spa-Latn", "eng-Latn"],
-            "es-es": ["spa-Latn"],
-            "fr-en": ["fra-Latn", "eng-Latn"],
-            "it-en": ["ita-Latn", "eng-Latn"],
-            "nl-en": ["nld-Latn", "eng-Latn"],
-        },
         bibtex_citation=r"""
 @article{xiao2024pixel,
   author = {Xiao, Chenghao and Huang, Zhuoxu and Chen, Danlu and Hudson, G Thomas and Li, Yizhi and Duan, Haoran and Lin, Chenghua and Fu, Jie and Han, Jungong and Moubayed, Noura Al},

--- a/mteb/tasks/aggregated_tasks/multilingual/sts_benchmark_multilingual_visual_sts.py
+++ b/mteb/tasks/aggregated_tasks/multilingual/sts_benchmark_multilingual_visual_sts.py
@@ -47,17 +47,6 @@ class STSBenchmarkMultilingualVisualSTSMultilingual(AbsTaskAggregate):
         main_score="cosine_spearman",
         type="VisualSTS(multi)",
         eval_splits=["test"],
-        eval_langs=[
-            "deu-Latn",
-            "spa-Latn",
-            "fra-Latn",
-            "ita-Latn",
-            "nld-Latn",
-            "pol-Latn",
-            "por-Latn",
-            "rus-Cyrl",
-            "cmn-Hans",
-        ],
         bibtex_citation=r"""
 @article{xiao2024pixel,
   author = {Xiao, Chenghao and Huang, Zhuoxu and Chen, Danlu and Hudson, G Thomas and Li, Yizhi and Duan, Haoran and Lin, Chenghua and Fu, Jie and Han, Jungong and Moubayed, Noura Al},

--- a/mteb/tasks/aggregated_tasks/nld/cqadupstack_nl_retrieval.py
+++ b/mteb/tasks/aggregated_tasks/nld/cqadupstack_nl_retrieval.py
@@ -43,7 +43,6 @@ class CQADupstackNLRetrieval(AbsTaskAggregate):
         category="t2t",
         modalities=["text"],
         eval_splits=["test"],
-        eval_langs=["nld-Latn"],
         date=("2015-12-01", "2015-12-01"),  # best guess: based on publication date
         domains=["Written", "Non-fiction"],
         task_subtypes=[],

--- a/tests/test_tasks/test_metadata.py
+++ b/tests/test_tasks/test_metadata.py
@@ -117,6 +117,9 @@ def test_all_metadata_is_filled_and_valid(task: AbsTask):
 
     # --- Test is descriptive stats are present for all datasets ---
     if task.is_aggregate:  # aggregate tasks do not have descriptive stats
+        assert set(task.metadata.hf_subsets_to_langscripts.keys()) == {"default"}, (
+            f"Aggregate task {task.metadata.name} has incorrect eval_langs, only a default subset is allowed"
+        )
         return
 
     # TODO https://github.com/embeddings-benchmark/mteb/issues/3498


### PR DESCRIPTION
The eval_langs are computed by the object itself

Added tests to ensure this going forward.

Fixes #4473
