### PR TITLE
ci: add .venv caching step to speed up dep install

### DIFF
--- a/.github/workflows/dataset_loading.yml
+++ b/.github/workflows/dataset_loading.yml
@@ -44,6 +44,12 @@ jobs:
       with:
         python-version: '3.11'
 
+    - name: Cache venv
+      uses: actions/cache@v5
+      with:
+        path: .venv
+        key: venv-${{ runner.os }}-${{ runner.arch }}-py3.11-install-${{ hashFiles('uv.lock') }}
+
     - name: Install dependencies
       run: |
         make install

--- a/.github/workflows/dataset_loading.yml
+++ b/.github/workflows/dataset_loading.yml
@@ -37,18 +37,13 @@ jobs:
       uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
+        prune-cache: false
         version: "0.10.12"
 
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
         python-version: '3.11'
-
-    - name: Cache venv
-      uses: actions/cache@v5
-      with:
-        path: .venv
-        key: venv-${{ runner.os }}-${{ runner.arch }}-py3.11-install-${{ hashFiles('uv.lock') }}
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -40,6 +40,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
+          prune-cache: false
           version: "0.10.12"
 
       - uses: actions/setup-python@v6
@@ -50,14 +51,8 @@ jobs:
         if: github.event_name == 'push'
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d
 
-      - name: Cache venv
-        uses: actions/cache@v5
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ runner.arch }}-py3.10-docs-${{ hashFiles('uv.lock') }}
-
       - name: Install dependencies
-        run: uv sync --group docs
+        run: uv sync --frozen --group docs
 
       - name: Build
         run: make build-docs

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -50,6 +50,12 @@ jobs:
         if: github.event_name == 'push'
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d
 
+      - name: Cache venv
+        uses: actions/cache@v5
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ runner.arch }}-py3.10-docs-${{ hashFiles('uv.lock') }}
+
       - name: Install dependencies
         run: uv sync --group docs
 

--- a/.github/workflows/leaderboard_build.yml
+++ b/.github/workflows/leaderboard_build.yml
@@ -44,6 +44,12 @@ jobs:
         with:
           python-version: '3.10'
 
+      - name: Cache venv
+        uses: actions/cache@v5
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ runner.arch }}-py3.10-leaderboard-${{ hashFiles('uv.lock') }}
+
       - name: Run leaderboard build test
         run: |
           make leaderboard-build-test

--- a/.github/workflows/leaderboard_build.yml
+++ b/.github/workflows/leaderboard_build.yml
@@ -37,18 +37,13 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
+          prune-cache: false
           version: "0.10.12"
 
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: '3.10'
-
-      - name: Cache venv
-        uses: actions/cache@v5
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ runner.arch }}-py3.10-leaderboard-${{ hashFiles('uv.lock') }}
 
       - name: Run leaderboard build test
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,17 +37,12 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
+          prune-cache: false
           version: "0.10.12"
 
       - uses: actions/setup-python@v6
         with:
           python-version: "3.10"
-
-      - name: Cache venv
-        uses: actions/cache@v5
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ runner.arch }}-py3.10-install-${{ hashFiles('uv.lock') }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,6 +43,12 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Cache venv
+        uses: actions/cache@v5
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ runner.arch }}-py3.10-install-${{ hashFiles('uv.lock') }}
+
       - name: Install dependencies
         run: |
           make install

--- a/.github/workflows/model_loading.yml
+++ b/.github/workflows/model_loading.yml
@@ -46,6 +46,12 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Cache venv
+        uses: actions/cache@v5
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ runner.arch }}-py3.10-model-loading-${{ hashFiles('uv.lock') }}
+
       - name: Install dependencies and run tests
         run: |
           make model-load-test BASE_BRANCH=${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/model_loading.yml
+++ b/.github/workflows/model_loading.yml
@@ -39,18 +39,13 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
+          prune-cache: false
           version: "0.10.12"
 
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: "3.10"
-
-      - name: Cache venv
-        uses: actions/cache@v5
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ runner.arch }}-py3.10-model-loading-${{ hashFiles('uv.lock') }}
 
       - name: Install dependencies and run tests
         run: |

--- a/.github/workflows/reference_models.yml
+++ b/.github/workflows/reference_models.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           python-version: '3.11'
           enable-cache: true
+          prune-cache: false
 
       - name: Install FFmpeg
         shell: bash
@@ -36,12 +37,6 @@ jobs:
           sudo add-apt-repository -y ppa:ubuntuhandbook1/ffmpeg8
           sudo apt-get update
           sudo apt-get install -y ffmpeg
-
-      - name: Cache venv
-        uses: actions/cache@v5
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ runner.arch }}-py3.11-install-for-tests-${{ hashFiles('uv.lock') }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/reference_models.yml
+++ b/.github/workflows/reference_models.yml
@@ -28,6 +28,12 @@ jobs:
           python-version: '3.11'
           enable-cache: true
 
+      - name: Cache venv
+        uses: actions/cache@v5
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ runner.arch }}-py3.11-install-for-tests-${{ hashFiles('uv.lock') }}
+
       - name: Install dependencies
         run: |
           make install-for-tests

--- a/.github/workflows/reference_models.yml
+++ b/.github/workflows/reference_models.yml
@@ -28,6 +28,15 @@ jobs:
           python-version: '3.11'
           enable-cache: true
 
+      - name: Install FFmpeg
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y software-properties-common
+          sudo add-apt-repository -y ppa:ubuntuhandbook1/ffmpeg8
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg
+
       - name: Cache venv
         uses: actions/cache@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,12 @@ jobs:
       - name: Check FFmpeg version
         run: ffmpeg -version
 
+      - name: Cache venv
+        uses: actions/cache@v5
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-install-for-tests-${{ hashFiles('uv.lock') }}
+
       - name: Install dependencies
         shell: bash
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,8 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
+          enable-cache: true
+          prune-cache: false
           version: "0.10.12"
 
       # required for evaluation the audio subset
@@ -90,12 +92,6 @@ jobs:
 
       - name: Check FFmpeg version
         run: ffmpeg -version
-
-      - name: Cache venv
-        uses: actions/cache@v5
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-install-for-tests-${{ hashFiles('uv.lock') }}
 
       - name: Install dependencies
         shell: bash

--- a/.github/workflows/typechecking.yml
+++ b/.github/workflows/typechecking.yml
@@ -36,17 +36,12 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
+          prune-cache: false
           version: "0.10.12"
 
       - uses: actions/setup-python@v6
         with:
           python-version: "3.10"
-
-      - name: Cache venv
-        uses: actions/cache@v5
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ runner.arch }}-py3.10-install-for-tests-${{ hashFiles('uv.lock') }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/typechecking.yml
+++ b/.github/workflows/typechecking.yml
@@ -42,6 +42,12 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Cache venv
+        uses: actions/cache@v5
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ runner.arch }}-py3.10-install-for-tests-${{ hashFiles('uv.lock') }}
+
       - name: Install dependencies
         run: |
           make install-for-tests

--- a/.github/workflows/update_leaderboard_models.yml
+++ b/.github/workflows/update_leaderboard_models.yml
@@ -27,6 +27,12 @@ jobs:
           python-version: "3.10"
           version: "0.10.12"
 
+      - name: Cache venv
+        uses: actions/cache@v5
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ runner.arch }}-py3.10-sync-${{ hashFiles('uv.lock') }}
+
       - name: Install mteb
         run: uv sync
 

--- a/.github/workflows/update_leaderboard_models.yml
+++ b/.github/workflows/update_leaderboard_models.yml
@@ -25,16 +25,12 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.10"
+          enable-cache: true
+          prune-cache: false
           version: "0.10.12"
 
-      - name: Cache venv
-        uses: actions/cache@v5
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ runner.arch }}-py3.10-sync-${{ hashFiles('uv.lock') }}
-
       - name: Install mteb
-        run: uv sync
+        run: uv sync --frozen
 
       - name: Generate model list
         run: uv run python scripts/generate_leaderboard_models.py > leaderboard_models.py

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 install:
 	@echo "--- 🚀 Installing project dependencies ---"
-	uv sync --extra image --group dev
+	uv sync --frozen --extra image --group dev
 
 install-for-tests:
 	@echo "--- 🚀 Installing project dependencies for test ---"
 	@echo "This ensures that the project is not installed in editable mode"
-	uv sync --extra bm25s --extra image --extra audio --extra leaderboard --extra faiss-cpu --extra github --group dev
+	uv sync --frozen --extra bm25s --extra image --extra audio --extra leaderboard --extra faiss-cpu --extra github --group dev
 
 lint:
 	@echo "--- 🧹 Running linters ---"
@@ -52,7 +52,7 @@ serve-docs:
 
 model-load-test:
 	@echo "--- 🚀 Running model load test ---"
-	uv sync --extra pylate --group dev
+	uv sync --frozen --extra pylate --group dev
 	uv run --no-sync python scripts/extract_model_names.py $(BASE_BRANCH) --return_one_model_name_per_file
 	uv run --no-sync python tests/test_models/model_loading.py --model_name_file scripts/model_names.txt
 

--- a/mteb/models/model_meta.py
+++ b/mteb/models/model_meta.py
@@ -30,6 +30,10 @@ from huggingface_hub.errors import (
 from packaging.requirements import Requirement
 from packaging.version import InvalidVersion, Version
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+from sentence_transformers import (
+    CrossEncoder,
+    SentenceTransformer,
+)
 from transformers import AutoConfig
 
 from mteb._helpful_enum import HelpfulStrEnum
@@ -54,9 +58,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from sentence_transformers import (
-        CrossEncoder,
         CrossEncoderModelCardData,
-        SentenceTransformer,
         SentenceTransformerModelCardData,
     )
     from typing_extensions import Self
@@ -745,8 +747,6 @@ class ModelMeta(BaseModel):  # noqa: PLR0904
         logger.info(
             "Calculating number of embedding parameters for SentenceTransformer model."
         )
-
-        from sentence_transformers import CrossEncoder, SentenceTransformer
 
         emb = None
         if isinstance(model, CrossEncoder) and hasattr(

--- a/mteb/models/model_meta.py
+++ b/mteb/models/model_meta.py
@@ -30,10 +30,6 @@ from huggingface_hub.errors import (
 from packaging.requirements import Requirement
 from packaging.version import InvalidVersion, Version
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator
-from sentence_transformers import (
-    CrossEncoder,
-    SentenceTransformer,
-)
 from transformers import AutoConfig
 
 from mteb._helpful_enum import HelpfulStrEnum
@@ -58,7 +54,9 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from sentence_transformers import (
+        CrossEncoder,
         CrossEncoderModelCardData,
+        SentenceTransformer,
         SentenceTransformerModelCardData,
     )
     from typing_extensions import Self
@@ -747,6 +745,8 @@ class ModelMeta(BaseModel):  # noqa: PLR0904
         logger.info(
             "Calculating number of embedding parameters for SentenceTransformer model."
         )
+
+        from sentence_transformers import CrossEncoder, SentenceTransformer
 
         emb = None
         if isinstance(model, CrossEncoder) and hasattr(


### PR DESCRIPTION
Currently a simple test like linting takes 14 minutes to run, in which 13 minutes were used to install dependencies: e.g. https://github.com/embeddings-benchmark/mteb/actions/runs/24953209689/job/73066896371?pr=4515

Fix: use `hashFiles('uv.lock')` and other params to form a cache key to cache `.venv` for applicable workflows.

The first CI run will take the same amount of time as before. The second run (given no changes to uv.lock) should be much faster with cache read.

<details>

  Workflow: dataset_loading                    
  Cache key suffix: py3.11-install
  Notes: make install                                                                        
  ────────────────────────────────────────
  Workflow: documentation                                                                    
  Cache key suffix: py3.10-docs                                                            
  Notes: uv sync --group docs
  ────────────────────────────────────────
  Workflow: lint
  Cache key suffix: py3.10-install
  Notes: make install
  ────────────────────────────────────────
  Workflow: model_loading
  Cache key suffix: py3.10-model-loading
  Notes: uv sync --extra pylate --group dev
  ────────────────────────────────────────
  Workflow: test
  Cache key suffix: py${{ matrix.python-version }}-install-for-tests
  Notes: Matrix across 3.10-3.14 + Windows
  ────────────────────────────────────────
  Workflow: typechecking
  Cache key suffix: py3.10-install-for-tests
  Notes: Shares cache with test py3.10/ubuntu
  ────────────────────────────────────────
  Workflow: reference_models
  Cache key suffix: py3.11-install-for-tests
  Notes: Shares cache with test py3.11/ubuntu
  ────────────────────────────────────────
  Workflow: leaderboard_build
  Cache key suffix: py3.10-leaderboard
  Notes: uv run --group test --extra leaderboard
  ────────────────────────────────────────
  Workflow: update_leaderboard_models
  Cache key suffix: py3.10-sync
  Notes: Bare uv sync

</details>

  Skipped: test_lowest (uses --resolution lowest-direct which deliberately ignores the
  lockfile — caching would defeat its purpose), release, leaderboard_docker,
  leaderboard_refresh, leaderboard_healthcheck, hf_space_docker, stale_pr (no Python deps
  installed on runner).
