### PR TITLE
[MVEB] Add Daily-Omni video-centric QA task

### DIFF
--- a/mteb/tasks/multichoice/eng/__init__.py
+++ b/mteb/tasks/multichoice/eng/__init__.py
@@ -3,6 +3,7 @@ from .avqa import AVQAVideoAudioCentricQA, AVQAVideoCentricQA
 from .blink_it2i_multi_choice import BLINKIT2IMultiChoice
 from .blink_it2t_multi_choice import BLINKIT2TMultiChoice
 from .cv_bench import CVBenchCount, CVBenchDepth, CVBenchDistance, CVBenchRelation
+from .daily_omni import DailyOmniVideoAudioCentricQA, DailyOmniVideoCentricQA
 from .egoschema import EgoSchemaVideoCentricQA
 from .nextqa import NExTQAVideoCentricQA
 from .perception_test import (
@@ -22,6 +23,8 @@ __all__ = [
     "CVBenchDepth",
     "CVBenchDistance",
     "CVBenchRelation",
+    "DailyOmniVideoAudioCentricQA",
+    "DailyOmniVideoCentricQA",
     "EgoSchemaVideoCentricQA",
     "NExTQAVideoCentricQA",
     "PerceptionTestVideoAudioCentricQA",

--- a/mteb/tasks/multichoice/eng/daily_omni.py
+++ b/mteb/tasks/multichoice/eng/daily_omni.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from datasets import Dataset, load_dataset
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.retrieval_dataset_loaders import RetrievalSplitData
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class DailyOmniVideoCentricQA(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="DailyOmniVideoCentricQA",
+        description="Daily-Omni is a video question answering benchmark covering everyday scenarios with audio-visual content. Each example pairs a video with a question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate.",
+        reference="https://arxiv.org/abs/2505.17862",
+        dataset={
+            "path": "mteb/Daily-Omni",
+            "revision": "1209825141184353b668f8c205765e313b3d2a26",
+        },
+        type="VideoCentricQA",
+        category="vt2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2025-05-23", "2025-05-23"),
+        domains=["Web"],
+        task_subtypes=["Question answering"],
+        license="cc-by-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video", "text"],
+        sample_creation="found",
+        is_beta=True,
+        bibtex_citation=r"""
+@article{zhou2025dailyomni,
+  author = {Zhou, Ziwei and Wang, Rui and Wu, Zuxuan and Jiang, Yu-Gang},
+  journal = {arXiv preprint arXiv:2505.17862},
+  title = {Daily-Omni: Towards Audio-Visual Reasoning with Temporal Alignment across Modalities},
+  year = {2025},
+}
+""",
+    )
+
+    def load_data(self, **kwargs) -> None:
+        if self.data_loaded:
+            return
+        self.dataset = {"default": {}}
+        for split in self.metadata.eval_splits:
+            ds = load_dataset(
+                self.metadata.dataset["path"],
+                revision=self.metadata.dataset["revision"],
+                split=split,
+            )
+            ds = ds.add_column("id", [f"q{i}" for i in range(len(ds))])
+
+            queries = ds.select_columns(["id", "question", "video"]).rename_column(
+                "question", "text"
+            )
+
+            corpus_rows: list[dict] = []
+            relevant_docs: dict[str, dict[str, int]] = {}
+            top_ranked: dict[str, list[str]] = {}
+            for row in ds.select_columns(["id", "candidates", "answer"]):
+                qid = row["id"]
+                answer = row["answer"]
+                top_ranked[qid] = []
+                for j, candidate in enumerate(row["candidates"]):
+                    doc_id = f"{qid}_c{j}"
+                    corpus_rows.append({"id": doc_id, "text": candidate})
+                    top_ranked[qid].append(doc_id)
+                    if candidate == answer:
+                        relevant_docs[qid] = {doc_id: 1}
+
+            corpus = Dataset.from_list(corpus_rows)
+            self.dataset["default"][split] = RetrievalSplitData(
+                queries=queries,
+                corpus=corpus,
+                relevant_docs=relevant_docs,
+                top_ranked=top_ranked,
+            )
+        self.data_loaded = True
+
+
+class DailyOmniVideoAudioCentricQA(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="DailyOmniVideoAudioCentricQA",
+        description="Daily-Omni is a video question answering benchmark covering everyday scenarios with audio-visual content. Each example pairs a video with audio and a question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, audio, question) tuple, retrieve the correct candidate.",
+        reference="https://arxiv.org/abs/2505.17862",
+        dataset={
+            "path": "mteb/Daily-Omni",
+            "revision": "1209825141184353b668f8c205765e313b3d2a26",
+        },
+        type="VideoCentricQA",
+        category="vat2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2025-05-23", "2025-05-23"),
+        domains=["Web"],
+        task_subtypes=["Question answering"],
+        license="cc-by-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video", "audio", "text"],
+        sample_creation="found",
+        is_beta=True,
+        bibtex_citation=r"""
+@article{zhou2025dailyomni,
+  author = {Zhou, Ziwei and Wang, Rui and Wu, Zuxuan and Jiang, Yu-Gang},
+  journal = {arXiv preprint arXiv:2505.17862},
+  title = {Daily-Omni: Towards Audio-Visual Reasoning with Temporal Alignment across Modalities},
+  year = {2025},
+}
+""",
+    )
+
+    def load_data(self, **kwargs) -> None:
+        if self.data_loaded:
+            return
+        self.dataset = {"default": {}}
+        for split in self.metadata.eval_splits:
+            ds = load_dataset(
+                self.metadata.dataset["path"],
+                revision=self.metadata.dataset["revision"],
+                split=split,
+            )
+            ds = ds.add_column("id", [f"q{i}" for i in range(len(ds))])
+
+            queries = ds.select_columns(
+                ["id", "question", "video", "audio"]
+            ).rename_column("question", "text")
+
+            corpus_rows: list[dict] = []
+            relevant_docs: dict[str, dict[str, int]] = {}
+            top_ranked: dict[str, list[str]] = {}
+            for row in ds.select_columns(["id", "candidates", "answer"]):
+                qid = row["id"]
+                answer = row["answer"]
+                top_ranked[qid] = []
+                for j, candidate in enumerate(row["candidates"]):
+                    doc_id = f"{qid}_c{j}"
+                    corpus_rows.append({"id": doc_id, "text": candidate})
+                    top_ranked[qid].append(doc_id)
+                    if candidate == answer:
+                        relevant_docs[qid] = {doc_id: 1}
+
+            corpus = Dataset.from_list(corpus_rows)
+            self.dataset["default"][split] = RetrievalSplitData(
+                queries=queries,
+                corpus=corpus,
+                relevant_docs=relevant_docs,
+                top_ranked=top_ranked,
+            )
+        self.data_loaded = True


### PR DESCRIPTION
Adds DailyOmniVideoCentricQA — a multiple-choice video QA task following the
AbsTaskRetrieval + RetrievalSplitData pattern established in NExT-QA (#4462).

Dataset: mteb/daily-omni-video-centric-qa
Category: vt2t
Modalities: video, audio, text
Metric: accuracy

Baseline results

> Random encoder baseline: 26.5% accuracy (test split)
[DailyOmniVideoCentricQA.json](https://github.com/user-attachments/files/27142454/DailyOmniVideoCentricQA.json)
