### PR TITLE
[MVEB] Add Kinetics400VAZeroShot for video+audio zero-shot classification

### DIFF
--- a/mteb/tasks/zeroshot_classification/eng/__init__.py
+++ b/mteb/tasks/zeroshot_classification/eng/__init__.py
@@ -11,7 +11,10 @@ from .food101 import Food101ZeroShotClassification
 from .gtsrb import GTSRBZeroShotClassification
 from .human_animal_cartoon import HumanAnimalCartoonZeroShotClassification
 from .imagenet1k import Imagenet1kZeroShotClassification
-from .kinetics400 import Kinetics400ZeroShotClassification
+from .kinetics400 import (
+    Kinetics400VAZeroShotClassification,
+    Kinetics400ZeroShotClassification,
+)
 from .mnist import MNISTZeroShotClassification
 from .oxford_pets import OxfordPetsZeroShotClassification
 from .patch_camelyon import PatchCamelyonZeroShotClassification
@@ -44,6 +47,7 @@ __all__ = [
     "GTSRBZeroShotClassification",
     "HumanAnimalCartoonZeroShotClassification",
     "Imagenet1kZeroShotClassification",
+    "Kinetics400VAZeroShotClassification",
     "Kinetics400ZeroShotClassification",
     "MNISTZeroShotClassification",
     "OxfordPetsZeroShotClassification",

--- a/mteb/tasks/zeroshot_classification/eng/kinetics400.py
+++ b/mteb/tasks/zeroshot_classification/eng/kinetics400.py
@@ -48,3 +48,51 @@ class Kinetics400ZeroShotClassification(AbsTaskZeroShotClassification):
             {name}
             for name in self.dataset["test"].features[self.label_column_name].names
         ]
+
+
+class Kinetics400VAZeroShotClassification(AbsTaskZeroShotClassification):
+    metadata = TaskMetadata(
+        name="Kinetics400VAZeroShot",
+        description="Kinetics-400 is a large-scale action recognition dataset containing 400 human action classes from YouTube videos. Each clip is approximately 10 seconds long. This variant uses both video and audio modalities.",
+        reference="https://arxiv.org/abs/1705.06950",
+        dataset={
+            "path": "mteb/kinetics-400",
+            "revision": "e5b93b6eae80b8c9e9c88a381baae84d29b34fd2",
+        },
+        type="VideoZeroshotClassification",
+        category="va2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=(
+            "2017-05-19",
+            "2017-05-19",
+        ),
+        domains=["Web", "Scene"],
+        task_subtypes=["Activity recognition"],
+        license="cc-by-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video", "audio"],
+        sample_creation="found",
+        bibtex_citation=r"""
+@misc{kay2017kineticshumanactionvideo,
+  archiveprefix = {arXiv},
+  author = {Will Kay and Joao Carreira and Karen Simonyan and Brian Zhang and Chloe Hillier and Sudheendra Vijayanarasimhan and Fabio Viola and Tim Green and Trevor Back and Paul Natsev and Mustafa Suleyman and Andrew Zisserman},
+  eprint = {1705.06950},
+  primaryclass = {cs.CV},
+  title = {The Kinetics Human Action Video Dataset},
+  url = {https://arxiv.org/abs/1705.06950},
+  year = {2017},
+}
+""",
+        is_beta=True,
+    )
+
+    input_column_name = ("video", "audio")
+
+    def get_candidate_labels(self) -> list[str]:
+        return [
+            f"a video of {name}"
+            for name in self.dataset["test"].features[self.label_column_name].names
+        ]


### PR DESCRIPTION
Kinetics400 currently has a ZeroShot classification setup for video, but is missing the setup for video + audio. This PR adds Kinetics400VAZeroShot.

- [x] I have outlined why this dataset is filling an existing gap in `mteb`
- [x] I have tested that the dataset runs with the `mteb` package.
- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
  - [x] `mteb/baseline-random encoder`
  - [x] `facebook/pe-av-small-16-frame`
- [x] I have checked that the performance is neither trivial (close to perfect scores) nor random.
- [x] I have considered the size of the dataset and reduced it if it is too big (e.g. 2048 examples for binary classification)

### Results
  | Model | Accuracy |
  |---|---:|
  | `mteb/baseline-random-encoder` | 0.0025 |
  | `facebook/pe-av-small-16-frame` | 0.7592 |

[Kinetics400VAZeroShot_facebook.json](https://github.com/user-attachments/files/27145552/Kinetics400VAZeroShot.json)
[Kinetics400VAZeroShot_mtebbaseline.json](https://github.com/user-attachments/files/27145566/Kinetics400VAZeroShot.json)
