### PR TITLE
[MVEB] Add HMDB51ZeroShot for video zero-shot classification

### DIFF
--- a/mteb/tasks/zeroshot_classification/eng/__init__.py
+++ b/mteb/tasks/zeroshot_classification/eng/__init__.py
@@ -9,6 +9,7 @@ from .fer2013 import FER2013ZeroShotClassification
 from .fgvc_aircraft import FGVCAircraftZeroShotClassification
 from .food101 import Food101ZeroShotClassification
 from .gtsrb import GTSRBZeroShotClassification
+from .hmdb51 import HMDB51ZeroShotClassification
 from .human_animal_cartoon import HumanAnimalCartoonZeroShotClassification
 from .imagenet1k import Imagenet1kZeroShotClassification
 from .kinetics400 import Kinetics400ZeroShotClassification
@@ -42,6 +43,7 @@ __all__ = [
     "FGVCAircraftZeroShotClassification",
     "Food101ZeroShotClassification",
     "GTSRBZeroShotClassification",
+    "HMDB51ZeroShotClassification",
     "HumanAnimalCartoonZeroShotClassification",
     "Imagenet1kZeroShotClassification",
     "Kinetics400ZeroShotClassification",

--- a/mteb/tasks/zeroshot_classification/eng/hmdb51.py
+++ b/mteb/tasks/zeroshot_classification/eng/hmdb51.py
@@ -1,0 +1,54 @@
+from mteb.abstasks.task_metadata import TaskMetadata
+from mteb.abstasks.zeroshot_classification import (
+    AbsTaskZeroShotClassification,
+)
+
+
+class HMDB51ZeroShotClassification(AbsTaskZeroShotClassification):
+    metadata = TaskMetadata(
+        name="HMDB51ZeroShot",
+        description="HMDB51 is a large video database for human motion recognition with 51 action categories from digitized movies and online sources.",
+        reference="https://serre-lab.clps.brown.edu/resource/hmdb-a-large-human-motion-database/",
+        dataset={
+            "path": "mteb/HMDB51",
+            "revision": "73e5ac9cd9536c406d0046f3d6046785885f7ebe",
+        },
+        type="VideoZeroshotClassification",
+        category="v2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=(
+            "2011-01-01",
+            "2011-12-31",
+        ),
+        domains=["Scene"],
+        task_subtypes=["Activity recognition"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video"],
+        sample_creation="found",
+        bibtex_citation=r"""
+@inproceedings{6126543,
+  author = {Kuehne, H. and Jhuang, H. and Garrote, E. and Poggio, T. and Serre, T.},
+  booktitle = {2011 International Conference on Computer Vision},
+  doi = {10.1109/ICCV.2011.6126543},
+  keywords = {Cameras;YouTube;Databases;Training;Visualization;Humans;Motion pictures},
+  number = {},
+  pages = {2556-2563},
+  title = {HMDB: A large video database for human motion recognition},
+  volume = {},
+  year = {2011},
+}
+""",
+        is_beta=True,
+    )
+
+    input_column_name: str = "video"
+
+    def get_candidate_labels(self) -> list[str]:
+        return [
+            f"a video of {name.replace('_', ' ')}"
+            for name in self.dataset["test"].features[self.label_column_name].names
+        ]


### PR DESCRIPTION
  HMDB51 has a video classification setup but is missing a ZeroShot variant. This PR adds HMDB51ZeroShot.

  - [x] I have outlined why this dataset is filling an existing gap in `mteb`
  - [x] I have tested that the dataset runs with the `mteb` package.
  - [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t
  {task_name}` command.
    - [x] `mteb/baseline-random-encoder`
    - [x] `facebook/pe-av-small-16-frame`
  - [x] I have checked that the performance is neither trivial (close to perfect scores) nor random.
  - [x] I have considered the size of the dataset and reduced it if it is too big (e.g. 2048 examples for binary classification)

  ### Results
  | Model | Accuracy |
  |---|---:|
  | `mteb/baseline-random-encoder` | 0.0222 |
  | `facebook/pe-av-small-16-frame` | 0.747712 |

[HMDB51ZeroShot_mtebaseline.json](https://github.com/user-attachments/files/27145727/HMDB51ZeroShot.json)
[HMDB51ZeroShot_facebook.json](https://github.com/user-attachments/files/27146362/HMDB51ZeroShot.json)
