### PR TITLE
Add Zero shot classification for breakfast classification

### DIFF
--- a/mteb/tasks/zeroshot_classification/eng/__init__.py
+++ b/mteb/tasks/zeroshot_classification/eng/__init__.py
@@ -1,4 +1,5 @@
 from .birdsnap import BirdsnapZeroShotClassification
+from .breakfast_classification import BreakfastZeroShotClassification
 from .caltech101 import Caltech101ZeroShotClassification
 from .cifar import CIFAR10ZeroShotClassification, CIFAR100ZeroShotClassification
 from .clevr import CLEVR, CLEVRCount
@@ -31,6 +32,7 @@ from .ucf101 import UCF101ZeroShotClassification
 __all__ = [
     "CLEVR",
     "BirdsnapZeroShotClassification",
+    "BreakfastZeroShotClassification",
     "CIFAR10ZeroShotClassification",
     "CIFAR100ZeroShotClassification",
     "CLEVRCount",

--- a/mteb/tasks/zeroshot_classification/eng/breakfast_classification.py
+++ b/mteb/tasks/zeroshot_classification/eng/breakfast_classification.py
@@ -14,7 +14,7 @@ class BreakfastZeroShotClassification(AbsTaskZeroShotClassification):
             "revision": "59a874899eb241993794a3454c37829727c3b559",
         },
         type="VideoZeroshotClassification",
-        category="v2t", 
+        category="v2t",
         eval_splits=["test"],
         eval_langs=["eng-Latn"],
         main_score="accuracy",

--- a/mteb/tasks/zeroshot_classification/eng/breakfast_classification.py
+++ b/mteb/tasks/zeroshot_classification/eng/breakfast_classification.py
@@ -1,0 +1,51 @@
+from mteb.abstasks.task_metadata import TaskMetadata
+from mteb.abstasks.zeroshot_classification import (
+    AbsTaskZeroShotClassification,
+)
+
+
+class BreakfastZeroShotClassification(AbsTaskZeroShotClassification):
+    metadata = TaskMetadata(
+        name="BreakfastZeroShot",
+        description="The Breakfast Actions dataset contains 433 videos of 10 breakfast-related activities (e.g. making coffee, preparing cereal, frying eggs) recorded in 18 different kitchens. The task is to classify each video into the correct activity.",
+        reference="https://ieeexplore.ieee.org/document/6909500",
+        dataset={
+            "path": "mteb/Breakfast",
+            "revision": "59a874899eb241993794a3454c37829727c3b559",
+        },
+        type="VideoZeroshotClassification",
+        category="v2t", 
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=(
+            "2014-06-23",
+            "2014-06-28",
+        ),
+        domains=["Scene"],
+        task_subtypes=["Activity recognition"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video"],
+        sample_creation="found",
+        is_beta=True,
+        bibtex_citation=r"""
+@inproceedings{kuehne2014language,
+  author = {Kuehne, Hilde and Arslan, Ali and Serre, Thomas},
+  booktitle = {2014 IEEE Conference on Computer Vision and Pattern Recognition},
+  doi = {10.1109/CVPR.2014.338},
+  pages = {3325-3332},
+  title = {The Language of Actions: Recovering the Syntax and Semantics of Goal-Directed Human Activities},
+  year = {2014},
+}
+""",
+    )
+
+    input_column_name = "video"
+
+    def get_candidate_labels(self) -> list[str]:
+        return [
+            f"a video of {name}"
+            for name in self.dataset["test"].features[self.label_column_name].names
+        ]


### PR DESCRIPTION
- [x] I have outlined why this dataset is filling an existing gap in `mteb`
- [x] I have tested that the dataset runs with the `mteb` package.
- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
  - [x] `mteb/baseline-random encoder`
  - [ ] `facebook/pe-av-small-16-frame` or another small model
- [x] I have checked that the performance is neither trivial (close to perfect scores) nor random.
- [x] I have considered the size of the dataset and reduced it if it is too big (e.g. 2048 examples for binary classification)

[mteb__baseline_random_encoder.json](https://github.com/user-attachments/files/27151243/mteb__baseline_random_encoder.json)
