### PR TITLE
Add Zeroshot classification for Worldsense classification datatset

### DIFF
--- a/mteb/tasks/zeroshot_classification/eng/__init__.py
+++ b/mteb/tasks/zeroshot_classification/eng/__init__.py
@@ -27,6 +27,10 @@ from .stanford_cars import StanfordCarsZeroShotClassification
 from .stl10 import STL10ZeroShotClassification
 from .sun397 import SUN397ZeroShotClassification
 from .ucf101 import UCF101ZeroShotClassification
+from .worldsense_classification import (
+    WorldSenseAudioVideoZeroShotClassification,
+    WorldSenseVideoZeroShotClassification,
+)
 
 __all__ = [
     "CLEVR",
@@ -58,4 +62,6 @@ __all__ = [
     "SpeechCommandsZeroshotClassificationv02",
     "StanfordCarsZeroShotClassification",
     "UCF101ZeroShotClassification",
+    "WorldSenseAudioVideoZeroShotClassification",
+    "WorldSenseVideoZeroShotClassification",
 ]

--- a/mteb/tasks/zeroshot_classification/eng/worldsense_classification.py
+++ b/mteb/tasks/zeroshot_classification/eng/worldsense_classification.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from mteb.abstasks.task_metadata import TaskMetadata
+from mteb.abstasks.zeroshot_classification import AbsTaskZeroShotClassification
+
+CITATION = r"""
+@inproceedings{hong2025worldsense,
+  author = {Hong, Jack and Yan, Shilin and Cai, Jiayin and Jiang, Xiaolong and Hu, Yao and Xie, Weidi},
+  journal = {arXiv preprint arXiv:2502.04326},
+  title = {Worldsense: Evaluating real-world omnimodal understanding for multimodal llms},
+  year = {2025},
+}
+"""
+
+
+class WorldSenseAudioVideoZeroShotClassification(AbsTaskZeroShotClassification):
+    metadata = TaskMetadata(
+        name="WorldSenseAudioVideoZeroShot",
+        description="WorldSense is a multimodal video understanding benchmark encompassing visual, audio, and text inputs. Videos are categorized into 8 primary domains across 67 fine-grained subcategories. This zero-shot classification task predicts the domain category of a video clip",
+        reference="https://arxiv.org/abs/2502.04326",
+        dataset={
+            "path": "mteb/WorldSense_1min",
+            "revision": "10c7ce0eb32d620f1f685bfedde2724066068a1c",
+        },
+        type="VideoZeroshotClassification",
+        category="va2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2025-02-06", "2026-03-01"),
+        domains=["Scene", "AudioScene", "Music", "Entertainment"],
+        task_subtypes=["Scene recognition"],
+        license="not specified",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        modalities=["video", "audio"],
+        sample_creation="found",
+        bibtex_citation=CITATION,
+        is_beta=True,
+    )
+
+    input_column_name = ("video", "audio")
+    label_column_name: str = "domain"
+
+    def get_candidate_labels(self) -> list[str]:
+        return [
+            name for name in self.dataset["test"].features[self.label_column_name].names
+        ]
+
+
+class WorldSenseVideoZeroShotClassification(AbsTaskZeroShotClassification):
+    metadata = TaskMetadata(
+        name="WorldSenseVideoZeroShot",
+        description="WorldSense is a multimodal video understanding benchmark encompassing visual, audio, and text inputs. Videos are categorized into 8 primary domains across 67 fine-grained subcategories. This zero-shot classification task predicts the domain category of a video clip",
+        reference="https://arxiv.org/abs/2502.04326",
+        dataset={
+            "path": "mteb/WorldSense_1min",
+            "revision": "10c7ce0eb32d620f1f685bfedde2724066068a1c",
+        },
+        type="VideoZeroshotClassification",
+        category="v2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2025-02-06", "2026-03-01"),
+        domains=["Scene", "AudioScene", "Music", "Entertainment"],
+        task_subtypes=["Scene recognition"],
+        license="not specified",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        modalities=["video"],
+        sample_creation="found",
+        bibtex_citation=CITATION,
+        is_beta=True,
+    )
+
+    input_column_name = "video"
+    label_column_name: str = "domain"
+
+    def get_candidate_labels(self) -> list[str]:
+        return [
+            name for name in self.dataset["test"].features[self.label_column_name].names
+        ]

--- a/mteb/tasks/zeroshot_classification/eng/worldsense_classification.py
+++ b/mteb/tasks/zeroshot_classification/eng/worldsense_classification.py
@@ -43,9 +43,7 @@ class WorldSenseAudioVideoZeroShotClassification(AbsTaskZeroShotClassification):
     label_column_name: str = "domain"
 
     def get_candidate_labels(self) -> list[str]:
-        return [
-            name for name in self.dataset["test"].features[self.label_column_name].names
-        ]
+        return self.dataset["test"].features[self.label_column_name].names
 
 
 class WorldSenseVideoZeroShotClassification(AbsTaskZeroShotClassification):
@@ -78,6 +76,4 @@ class WorldSenseVideoZeroShotClassification(AbsTaskZeroShotClassification):
     label_column_name: str = "domain"
 
     def get_candidate_labels(self) -> list[str]:
-        return [
-            name for name in self.dataset["test"].features[self.label_column_name].names
-        ]
+        return self.dataset["test"].features[self.label_column_name].names


### PR DESCRIPTION
- [x] I have outlined why this dataset is filling an existing gap in `mteb`
- [x] I have tested that the dataset runs with the `mteb` package.
- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
  - [x] `mteb/baseline-random encoder` 
  - [ ] `facebook/pe-av-small-16-frame` or another small model (Takes too long, maybe a day)
- [x] I have checked that the performance is neither trivial (close to perfect scores) nor random.
- [x] I have considered the size of the dataset and reduced it if it is too big (e.g. 2048 examples for binary classification)

| | mteb/baseline-random encoder | facebook/pe-av-small-16-frame |
| :--- | :---: | :---: |
| ** WorldSenseAudioVideoZeroShotClassification** | 0.123209 | |
| ** WorldSenseVideoZeroShotClassification** | 0.106972 | |



[WorldSenseVideoZeroShotClassification x random encoder](https://github.com/user-attachments/files/27155599/AVMemeVideoZeroShot.json)
[WorldSenseAudioVideoZeroShotClassification x random encoder](https://github.com/user-attachments/files/27155600/AVMemeAudioVideoZeroShot.json)