### PR TITLE
Add MELD zero shot classification task

### DIFF
--- a/mteb/tasks/zeroshot_classification/eng/__init__.py
+++ b/mteb/tasks/zeroshot_classification/eng/__init__.py
@@ -12,6 +12,10 @@ from .gtsrb import GTSRBZeroShotClassification
 from .human_animal_cartoon import HumanAnimalCartoonZeroShotClassification
 from .imagenet1k import Imagenet1kZeroShotClassification
 from .kinetics400 import Kinetics400ZeroShotClassification
+from .meld_classification import (
+    MELDAudioVideoZeroShotClassification,
+    MELDVideoZeroShotClassification,
+)
 from .mnist import MNISTZeroShotClassification
 from .oxford_pets import OxfordPetsZeroShotClassification
 from .patch_camelyon import PatchCamelyonZeroShotClassification
@@ -45,6 +49,8 @@ __all__ = [
     "HumanAnimalCartoonZeroShotClassification",
     "Imagenet1kZeroShotClassification",
     "Kinetics400ZeroShotClassification",
+    "MELDAudioVideoZeroShotClassification",
+    "MELDVideoZeroShotClassification",
     "MNISTZeroShotClassification",
     "OxfordPetsZeroShotClassification",
     "PatchCamelyonZeroShotClassification",

--- a/mteb/tasks/zeroshot_classification/eng/meld_classification.py
+++ b/mteb/tasks/zeroshot_classification/eng/meld_classification.py
@@ -44,13 +44,15 @@ class MELDAudioVideoZeroShotClassification(AbsTaskZeroShotClassification):
 
     def dataset_transform(self, num_proc=None, **kwargs) -> None:
         self.dataset = self.stratified_subsampling(
-            self.dataset, seed=self.seed, splits=["test"], label=self.label_column_name, n_samples=2048
+            self.dataset,
+            seed=self.seed,
+            splits=["test"],
+            label=self.label_column_name,
+            n_samples=2048,
         )
 
     def get_candidate_labels(self) -> list[str]:
-        return [
-            name for name in self.dataset["test"].features[self.label_column_name].names
-        ]
+        return self.dataset["test"].features[self.label_column_name].names
 
 
 class MELDVideoZeroShotClassification(AbsTaskZeroShotClassification):
@@ -83,10 +85,12 @@ class MELDVideoZeroShotClassification(AbsTaskZeroShotClassification):
 
     def dataset_transform(self, num_proc=None, **kwargs) -> None:
         self.dataset = self.stratified_subsampling(
-            self.dataset, seed=self.seed, splits=["test"], label=self.label_column_name, n_samples=2048
+            self.dataset,
+            seed=self.seed,
+            splits=["test"],
+            label=self.label_column_name,
+            n_samples=2048,
         )
 
     def get_candidate_labels(self) -> list[str]:
-        return [
-            name for name in self.dataset["test"].features[self.label_column_name].names
-        ]
+        return self.dataset["test"].features[self.label_column_name].names

--- a/mteb/tasks/zeroshot_classification/eng/meld_classification.py
+++ b/mteb/tasks/zeroshot_classification/eng/meld_classification.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from mteb.abstasks.task_metadata import TaskMetadata
+from mteb.abstasks.zeroshot_classification import AbsTaskZeroShotClassification
+
+CITATION = r"""
+@inproceedings{poria2019meld,
+  author = {Poria, Soujanya and Hazarika, Devamanyu and Majumder, Navonil and Naik, Gautam and Cambria, Erik and Mihalcea, Rada},
+  booktitle = {Proceedings of the 57th annual meeting of the association for computational linguistics},
+  pages = {527--536},
+  title = {Meld: A multimodal multi-party dataset for emotion recognition in conversations},
+  year = {2019},
+}
+"""
+
+
+class MELDAudioVideoZeroShotClassification(AbsTaskZeroShotClassification):
+    metadata = TaskMetadata(
+        name="MELDAudioVideoZeroShot",
+        description="MELD (Multimodal EmotionLines Dataset) is a multimodal emotion recognition dataset containing over 13,000 utterances from the Friends TV series, labeled with 7 emotion categories: Anger, Disgust, Sadness, Joy, Neutral, Surprise, and Fear",
+        reference="https://aclanthology.org/P19-1050.pdf",
+        dataset={
+            "path": "mteb/MELD",
+            "revision": "6c0bf58845b1acccefc450b131c304378c1e38d5",
+        },
+        type="VideoZeroshotClassification",
+        category="va2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2019-01-01", "2019-07-28"),
+        domains=["Entertainment"],
+        task_subtypes=["Emotion classification"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video", "audio", "text"],
+        sample_creation="found",
+        is_beta=True,
+        bibtex_citation=CITATION,
+    )
+    input_column_name = ("video", "audio")
+    label_column_name: str = "emotion"
+
+    def dataset_transform(self, num_proc=None, **kwargs) -> None:
+        self.dataset = self.stratified_subsampling(
+            self.dataset, seed=self.seed, splits=["test"], label=self.label_column_name, n_samples=2048
+        )
+
+    def get_candidate_labels(self) -> list[str]:
+        return [
+            name for name in self.dataset["test"].features[self.label_column_name].names
+        ]
+
+
+class MELDVideoZeroShotClassification(AbsTaskZeroShotClassification):
+    metadata = TaskMetadata(
+        name="MELDVideoZeroShot",
+        description="MELD (Multimodal EmotionLines Dataset) is a multimodal emotion recognition dataset containing over 13,000 utterances from the Friends TV series, labeled with 7 emotion categories: Anger, Disgust, Sadness, Joy, Neutral, Surprise, and Fear",
+        reference="https://aclanthology.org/P19-1050.pdf",
+        dataset={
+            "path": "mteb/MELD",
+            "revision": "6c0bf58845b1acccefc450b131c304378c1e38d5",
+        },
+        type="VideoZeroshotClassification",
+        category="v2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2019-01-01", "2019-07-28"),
+        domains=["Entertainment"],
+        task_subtypes=["Emotion classification"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video", "text"],
+        sample_creation="found",
+        is_beta=True,
+        bibtex_citation=CITATION,
+    )
+    input_column_name = "video"
+    label_column_name: str = "emotion"
+
+    def dataset_transform(self, num_proc=None, **kwargs) -> None:
+        self.dataset = self.stratified_subsampling(
+            self.dataset, seed=self.seed, splits=["test"], label=self.label_column_name, n_samples=2048
+        )
+
+    def get_candidate_labels(self) -> list[str]:
+        return [
+            name for name in self.dataset["test"].features[self.label_column_name].names
+        ]


### PR DESCRIPTION

[MELDAudioVideoZeroShot.json](https://github.com/user-attachments/files/27155735/MELDAudioVideoZeroShot.json)
- [x] I have outlined why this dataset is filling an existing gap in `mteb`
- [x] I have tested that the dataset runs with the `mteb` package.
- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
  - [x] `mteb/baseline-random encoder` 
  - [ ] `facebook/pe-av-small-16-frame` or another small model (Takes too long, maybe a day)
- [x] I have checked that the performance is neither trivial (close to perfect scores) nor random.
- [x] I have considered the size of the dataset and reduced it if it is too big (e.g. 2048 examples for binary classification)

| | mteb/baseline-random encoder | facebook/pe-av-small-16-frame |
| :--- | :---: | :---: |
| ** MELDAudioVideoZeroShotClassification** | 0.149414 | |
| ** MELDVideoZeroShotClassification** | 0.15625 | |


[MELDVideoZeroShotClassification x random encoder](https://github.com/user-attachments/files/27155732/MELDVideoZeroShot.json)
[MELDAudioVideoZeroShotClassification x random encoder](https://github.com/user-attachments/files/27155754/MELDAudioVideoZeroShot.json)