### PR TITLE
leaderboard: reduce pandas future warnings

### DIFF
--- a/mteb/results/model_result.py
+++ b/mteb/results/model_result.py
@@ -66,21 +66,21 @@ def _aggregate_and_pivot(
         )  # each language in its own row before aggregation
 
     # perform aggregation
-    if aggregation_fn is None:
-        aggregation_fn = np.mean
+    # Pass "mean" string rather than np.mean to avoid a pandas FutureWarning:
+    aggregation_fn_pandas = "mean" if aggregation_fn is None else aggregation_fn
 
     if format == "wide":
         return df.pivot_table(
             index=index_columns,
             columns=columns,
             values="score",
-            aggfunc=aggregation_fn,  # type: ignore[arg-type]
+            aggfunc=aggregation_fn_pandas,  # type: ignore[arg-type]
             observed=True,
         ).reset_index()
     elif format == "long":
         return (
             df.groupby(columns + index_columns, observed=True)
-            .agg(score=("score", aggregation_fn))
+            .agg(score=("score", aggregation_fn_pandas))
             .reset_index()
         )
 


### PR DESCRIPTION
There was 600+ warnings in the logs

e.g.

```
/mteb/mteb/results/model_result.py:83: FutureWarning:

The provided callable <function mean at 0x7fd3b8744680> is currently using SeriesGroupBy.mean. In a future version of pandas, the provided callable will be used directly. To keep current behavior pass the string "mean" instead.
```