### PR TITLE
fix: Only log missing subset once

### DIFF
--- a/mteb/_log_once.py
+++ b/mteb/_log_once.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import ClassVar
 
 
@@ -18,8 +19,10 @@ class LogOnce:
             self._seen[self.logger.name].add(msg)
 
     def warning(self, msg):
+        """Log and emit a warnings.warn exactly once per unique message."""
         if msg not in self._seen[self.logger.name]:
             self.logger.warning(msg)
+            warnings.warn(msg, stacklevel=2)
             self._seen[self.logger.name].add(msg)
 
     def error(self, msg):

--- a/mteb/results/task_result.py
+++ b/mteb/results/task_result.py
@@ -15,13 +15,13 @@ from pydantic import BaseModel, field_validator
 from typing_extensions import deprecated
 
 from mteb._helpful_enum import HelpfulStrEnum
-from mteb._log_once import LogOnce
 from mteb._hf_integration.eval_result_model import (
     HFEvalResult,
     HFEvalResultDataset,
     HFEvalResults,
     HFEvalResultSource,
 )
+from mteb._log_once import LogOnce
 from mteb.abstasks import AbsTaskClassification
 from mteb.abstasks.abstask import AbsTask
 from mteb.abstasks.task_metadata import TaskMetadata

--- a/mteb/results/task_result.py
+++ b/mteb/results/task_result.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import datetime
 import json
 import logging
-import warnings
 from collections import defaultdict
 from functools import cached_property
 from importlib.metadata import version
@@ -16,6 +15,7 @@ from pydantic import BaseModel, field_validator
 from typing_extensions import deprecated
 
 from mteb._helpful_enum import HelpfulStrEnum
+from mteb._log_once import LogOnce
 from mteb._hf_integration.eval_result_model import (
     HFEvalResult,
     HFEvalResultDataset,
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
     )
 
 logger = logging.getLogger(__name__)
+log_once = LogOnce(logger)
 
 
 class Criteria(HelpfulStrEnum):
@@ -493,9 +494,7 @@ class TaskResult(BaseModel):  # noqa: PLR0904
                     if main_score in hf_subset_scores:
                         hf_subset_scores["main_score"] = hf_subset_scores[main_score]
                     else:
-                        msg = f"Main score {main_score} not found in scores"
-                        logger.warning(msg)
-                        warnings.warn(msg)
+                        log_once.warning(f"Main score {main_score} not found in scores")
                         hf_subset_scores["main_score"] = None
 
         # specific fixes:
@@ -703,9 +702,9 @@ class TaskResult(BaseModel):  # noqa: PLR0904
                 else:
                     missing_subsets_str = str(missing_subsets)
 
-                msg = f"{task.metadata.name}: Missing subsets {missing_subsets_str} for split {split}"
-                logger.warning(msg)
-                warnings.warn(msg)
+                log_once.warning(
+                    f"{task.metadata.name}: Missing subsets {missing_subsets_str} for split {split}"
+                )
                 for missing_subset in missing_subsets:
                     new_scores[split].append(
                         {
@@ -718,9 +717,9 @@ class TaskResult(BaseModel):  # noqa: PLR0904
                     )
             seen_splits.add(split)
         if seen_splits != set(splits):
-            msg = f"{task.metadata.name}: Missing splits {set(splits) - seen_splits}"
-            logger.warning(msg)
-            warnings.warn(msg)
+            log_once.warning(
+                f"{task.metadata.name}: Missing splits {set(splits) - seen_splits}"
+            )
             for missing_split in set(splits) - seen_splits:
                 new_scores[missing_split] = []
                 for missing_subset in hf_subsets:


### PR DESCRIPTION
Missing subset appears more than 14k times in the leaderboard. It is probably enough just to raise this warning once.
