### PR TITLE
fix: Allow `get_tasks` to filter out a tasks

### DIFF
--- a/mteb/_log_once.py
+++ b/mteb/_log_once.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import ClassVar
 
 
@@ -18,8 +19,10 @@ class LogOnce:
             self._seen[self.logger.name].add(msg)
 
     def warning(self, msg):
+        """Log and emit a warnings.warn exactly once per unique message."""
         if msg not in self._seen[self.logger.name]:
             self.logger.warning(msg)
+            warnings.warn(msg, stacklevel=2)
             self._seen[self.logger.name].add(msg)
 
     def error(self, msg):

--- a/mteb/get_tasks.py
+++ b/mteb/get_tasks.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 
+from mteb._log_once import LogOnce
 from mteb.abstasks import (
     AbsTask,
 )
@@ -22,6 +23,7 @@ if TYPE_CHECKING:
     from mteb.types import Modalities
 
 logger = logging.getLogger(__name__)
+log_once = LogOnce(logger)
 
 
 # Create task registry
@@ -281,16 +283,22 @@ def get_tasks(  # noqa: PLR0913, PLR0917
                 "When `tasks` is provided, other filters like domains, task_types, and categories are ignored. "
                 + "If you want to filter a list of tasks, please use `mteb.filter_tasks` instead."
             )
-        _tasks = [
-            get_task(
-                task,
-                languages=languages,
-                script=script,
-                eval_splits=eval_splits,
-                exclusive_language_filter=exclusive_language_filter,
-            )
-            for task in tasks
-        ]
+        _tasks = []
+        for task in tasks:
+            try:
+                _tasks.append(
+                    get_task(
+                        task,
+                        languages=languages,
+                        script=script,
+                        eval_splits=eval_splits,
+                        exclusive_language_filter=exclusive_language_filter,
+                    )
+                )
+            except ValueError:
+                log_once.warning(
+                    f"Skipping task '{task}': no subsets match the language filter {languages}."
+                )
         return MTEBTasks(_tasks)
 
     tasks_: Sequence[type[AbsTask]] = filter_tasks(

--- a/mteb/leaderboard/benchmark_selector.py
+++ b/mteb/leaderboard/benchmark_selector.py
@@ -34,17 +34,17 @@ def _create_button(
         **kwargs,
     )
 
-    def _update_variant(state: str, label: str) -> gr.Button:
+    def _update_variant(state: str) -> gr.Button:
         if state == label_to_value[label]:
             return gr.Button(variant="primary")
         else:
             return gr.Button(variant="secondary")
 
-    def _update_value(label: str) -> str:
+    def _update_value() -> str:
         return label_to_value[label]
 
-    state.change(_update_variant, inputs=[state, button], outputs=[button])
-    button.click(_update_value, inputs=[button], outputs=[state])
+    state.change(_update_variant, inputs=[state], outputs=[button])
+    button.click(_update_value, outputs=[state])
     return button
 
 

--- a/mteb/results/task_result.py
+++ b/mteb/results/task_result.py
@@ -15,13 +15,13 @@ from pydantic import BaseModel, field_validator
 from typing_extensions import deprecated
 
 from mteb._helpful_enum import HelpfulStrEnum
-from mteb._log_once import LogOnce
 from mteb._hf_integration.eval_result_model import (
     HFEvalResult,
     HFEvalResultDataset,
     HFEvalResults,
     HFEvalResultSource,
 )
+from mteb._log_once import LogOnce
 from mteb.abstasks import AbsTaskClassification
 from mteb.abstasks.abstask import AbsTask
 from mteb.abstasks.task_metadata import TaskMetadata

--- a/mteb/results/task_result.py
+++ b/mteb/results/task_result.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import datetime
 import json
 import logging
-import warnings
 from collections import defaultdict
 from functools import cached_property
 from importlib.metadata import version
@@ -16,6 +15,7 @@ from pydantic import BaseModel, field_validator
 from typing_extensions import deprecated
 
 from mteb._helpful_enum import HelpfulStrEnum
+from mteb._log_once import LogOnce
 from mteb._hf_integration.eval_result_model import (
     HFEvalResult,
     HFEvalResultDataset,
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
     )
 
 logger = logging.getLogger(__name__)
+log_once = LogOnce(logger)
 
 
 class Criteria(HelpfulStrEnum):
@@ -493,9 +494,7 @@ class TaskResult(BaseModel):  # noqa: PLR0904
                     if main_score in hf_subset_scores:
                         hf_subset_scores["main_score"] = hf_subset_scores[main_score]
                     else:
-                        msg = f"Main score {main_score} not found in scores"
-                        logger.warning(msg)
-                        warnings.warn(msg)
+                        log_once.warning(f"Main score {main_score} not found in scores")
                         hf_subset_scores["main_score"] = None
 
         # specific fixes:
@@ -703,9 +702,9 @@ class TaskResult(BaseModel):  # noqa: PLR0904
                 else:
                     missing_subsets_str = str(missing_subsets)
 
-                msg = f"{task.metadata.name}: Missing subsets {missing_subsets_str} for split {split}"
-                logger.warning(msg)
-                warnings.warn(msg)
+                log_once.warning(
+                    f"{task.metadata.name}: Missing subsets {missing_subsets_str} for split {split}"
+                )
                 for missing_subset in missing_subsets:
                     new_scores[split].append(
                         {
@@ -718,9 +717,9 @@ class TaskResult(BaseModel):  # noqa: PLR0904
                     )
             seen_splits.add(split)
         if seen_splits != set(splits):
-            msg = f"{task.metadata.name}: Missing splits {set(splits) - seen_splits}"
-            logger.warning(msg)
-            warnings.warn(msg)
+            log_once.warning(
+                f"{task.metadata.name}: Missing splits {set(splits) - seen_splits}"
+            )
             for missing_split in set(splits) - seen_splits:
                 new_scores[missing_split] = []
                 for missing_subset in hf_subsets:


### PR DESCRIPTION
Currently:

```
tasks = mteb.get_tasks(["AILAStatutes"], languages=["dan"])
```

would raise an ValueError, now it will raise a warning, but only once.

Currently in the leadboard this produces the following error:

```
  File "/mteb/mteb/abstasks/abstask.py", line 535, in filter_languages
    raise ValueError(
ValueError: No subsets were found for AILAStatutes with filters: language code ['dan', 'swe', 'nno', 'nob'], script None, hf subsets None.
```

