### PR TITLE
fix: remove button from Gradio event handler inputs in benchmark selector

### DIFF
--- a/mteb/leaderboard/benchmark_selector.py
+++ b/mteb/leaderboard/benchmark_selector.py
@@ -34,17 +34,17 @@ def _create_button(
         **kwargs,
     )
 
-    def _update_variant(state: str, label: str) -> gr.Button:
+    def _update_variant(state: str) -> gr.Button:
         if state == label_to_value[label]:
             return gr.Button(variant="primary")
         else:
             return gr.Button(variant="secondary")
 
-    def _update_value(label: str) -> str:
+    def _update_value() -> str:
         return label_to_value[label]
 
-    state.change(_update_variant, inputs=[state, button], outputs=[button])
-    button.click(_update_value, inputs=[button], outputs=[state])
+    state.change(_update_variant, inputs=[state], outputs=[button])
+    button.click(_update_value, inputs=[], outputs=[state])
     return button
 
 

--- a/mteb/leaderboard/benchmark_selector.py
+++ b/mteb/leaderboard/benchmark_selector.py
@@ -44,7 +44,7 @@ def _create_button(
         return label_to_value[label]
 
     state.change(_update_variant, inputs=[state], outputs=[button])
-    button.click(_update_value, inputs=[], outputs=[state])
+    button.click(_update_value, outputs=[state])
     return button
 
 


### PR DESCRIPTION
`_update_value` and `_update_variant` used gr.Button as an input to read its label, but Gradio doesn't reliably pass button values causing "didn't receive enough input values" errors (~340 occurrences in logs).

Seems like label is already in scope so no input is needed. Tested locally and everything worked fine (and couldn't get it to re-appear), but I am not 100% sure on this change.

If you add a model or a dataset, please add the corresponding checklist:

* [dataset checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_dataset/#submit-a-pull-request)
* [model checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_model/#submitting-your-model-as-a-pr)
