### PR TITLE
[MVEB] Add AVEDataset v2c and va2c zero-shot classification

### DIFF
--- a/mteb/tasks/zeroshot_classification/eng/__init__.py
+++ b/mteb/tasks/zeroshot_classification/eng/__init__.py
@@ -1,3 +1,7 @@
+from .ave_dataset import (
+    AVEDatasetVideoZeroShotClassification,
+    AVEDatasetZeroShotClassification,
+)
 from .birdsnap import BirdsnapZeroShotClassification
 from .caltech101 import Caltech101ZeroShotClassification
 from .cifar import CIFAR10ZeroShotClassification, CIFAR100ZeroShotClassification
@@ -30,6 +34,8 @@ from .ucf101 import UCF101ZeroShotClassification
 
 __all__ = [
     "CLEVR",
+    "AVEDatasetVideoZeroShotClassification",
+    "AVEDatasetZeroShotClassification",
     "BirdsnapZeroShotClassification",
     "CIFAR10ZeroShotClassification",
     "CIFAR100ZeroShotClassification",

--- a/mteb/tasks/zeroshot_classification/eng/ave_dataset.py
+++ b/mteb/tasks/zeroshot_classification/eng/ave_dataset.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from mteb.abstasks.task_metadata import TaskMetadata
+from mteb.abstasks.zeroshot_classification import (
+    AbsTaskZeroShotClassification,
+)
+
+CITATION = r"""
+@inproceedings{tian2018audio,
+  author = {Tian, Yapeng and Shi, Jing and Li, Bochen and Duan, Zhiyao and Xu, Chenliang},
+  booktitle = {Proceedings of the European conference on computer vision (ECCV)},
+  pages = {247--263},
+  title = {Audio-visual event localization in unconstrained videos},
+  year = {2018},
+}
+"""
+
+
+class AVEDatasetZeroShotClassification(AbsTaskZeroShotClassification):
+    metadata = TaskMetadata(
+        name="AVEDatasetZeroShot",
+        description="Audio-Visual Event (AVE) classification dataset containing 28 event categories such as church bell, truck, dog barking, and other everyday sounds sourced from YouTube videos. The goal is to predict the sound event category from synchronized video and audio. This variant uses both video and audio modalities.",
+        reference="https://openaccess.thecvf.com/content_ECCV_2018/papers/Yapeng_Tian_Audio-Visual_Event_Localization_ECCV_2018_paper.pdf",
+        dataset={
+            "path": "mteb/AVE-Dataset",
+            "revision": "f6eb93b4e89456277a242583b5565b801bc1981d",
+        },
+        type="VideoZeroshotClassification",
+        category="va2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2018-01-01", "2018-09-01"),
+        domains=["Web", "AudioScene"],
+        task_subtypes=["Environment Sound Classification"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video", "audio"],
+        sample_creation="found",
+        bibtex_citation=CITATION,
+        is_beta=True,
+    )
+
+    input_column_name = ("video", "audio")
+    label_column_name: str = "label"
+
+    def get_candidate_labels(self) -> list[str]:
+        return [
+            f"a video of {name.replace('_', ' ')}"
+            for name in self.dataset["test"].features[self.label_column_name].names
+        ]
+
+
+class AVEDatasetVideoZeroShotClassification(AbsTaskZeroShotClassification):
+    metadata = TaskMetadata(
+        name="AVEDatasetVideoZeroShot",
+        description="Audio-Visual Event (AVE) classification dataset containing 28 event categories such as church bell, truck, dog barking, and other everyday sounds sourced from YouTube videos. The goal is to predict the sound event category from video only.",
+        reference="https://openaccess.thecvf.com/content_ECCV_2018/papers/Yapeng_Tian_Audio-Visual_Event_Localization_ECCV_2018_paper.pdf",
+        dataset={
+            "path": "mteb/AVE-Dataset",
+            "revision": "f6eb93b4e89456277a242583b5565b801bc1981d",
+        },
+        type="VideoZeroshotClassification",
+        category="v2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2018-01-01", "2018-09-01"),
+        domains=["Web", "AudioScene"],
+        task_subtypes=["Environment Sound Classification"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video"],
+        sample_creation="found",
+        bibtex_citation=CITATION,
+        is_beta=True,
+    )
+
+    input_column_name: str = "video"
+    label_column_name: str = "label"
+
+    def get_candidate_labels(self) -> list[str]:
+        return [
+            f"a video of {name.replace('_', ' ')}"
+            for name in self.dataset["test"].features[self.label_column_name].names
+        ]


### PR DESCRIPTION
AVE-Dataset has video classification setups for both `v2c` and `va2c`, but is missing the corresponding zero-shot variants. This PR adds`AVEDatasetVideoZeroShot` (v2c) and `AVEDatasetZeroShot` (va2c).

  - [x] I have outlined why this dataset is filling an existing gap in `mteb`
  - [x] I have tested that the dataset runs with the `mteb` package.
  - [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
    - [x] `mteb/baseline-random-encoder`
    - [x] `facebook/pe-av-small-16-frame`
  - [x] I have checked that the performance is neither trivial (close to perfect scores) nor random.
  - [x] I have considered the size of the dataset and reduced it if it is too big (e.g. 2048 examples for binary classification)

  ### Results

  | Model | AVEDatasetZeroShot (va2c) | AVEDatasetVideoZeroShot (v2c) |
  |---|---:|---:|
  | mteb/baseline-random-encoder | 0.0348 | 0.0299 |
  | facebook/pe-av-small-16-frame | 0.9254 | 0.9104 |

[AVEDatasetVideoZeroShot_facebook.json](https://github.com/user-attachments/files/27187041/AVEDatasetVideoZeroShot.json)
[AVEDatasetZeroShot_facebook.json](https://github.com/user-attachments/files/27187042/AVEDatasetZeroShot.json)
[AVEDatasetVideoZeroShot_baseline.json](https://github.com/user-attachments/files/27187050/AVEDatasetVideoZeroShot.json)
[AVEDatasetZeroShot_baseline.json](https://github.com/user-attachments/files/27187051/AVEDatasetZeroShot.json)