### PR TITLE
[MVEB] Add MusicAVQACLS v2c and av2c zero-shot classification

### DIFF
--- a/mteb/tasks/zeroshot_classification/eng/__init__.py
+++ b/mteb/tasks/zeroshot_classification/eng/__init__.py
@@ -13,6 +13,10 @@ from .human_animal_cartoon import HumanAnimalCartoonZeroShotClassification
 from .imagenet1k import Imagenet1kZeroShotClassification
 from .kinetics400 import Kinetics400ZeroShotClassification
 from .mnist import MNISTZeroShotClassification
+from .music_avqa import (
+    MusicAVQACLSAudioVideoZeroShotClassification,
+    MusicAVQACLSVideoZeroShotClassification,
+)
 from .oxford_pets import OxfordPetsZeroShotClassification
 from .patch_camelyon import PatchCamelyonZeroShotClassification
 from .ravdess import RavdessZeroshotClassification
@@ -46,6 +50,8 @@ __all__ = [
     "Imagenet1kZeroShotClassification",
     "Kinetics400ZeroShotClassification",
     "MNISTZeroShotClassification",
+    "MusicAVQACLSAudioVideoZeroShotClassification",
+    "MusicAVQACLSVideoZeroShotClassification",
     "OxfordPetsZeroShotClassification",
     "PatchCamelyonZeroShotClassification",
     "RESISC45ZeroShotClassification",

--- a/mteb/tasks/zeroshot_classification/eng/music_avqa.py
+++ b/mteb/tasks/zeroshot_classification/eng/music_avqa.py
@@ -72,7 +72,7 @@ class MusicAVQACLSVideoZeroShotClassification(AbsTaskZeroShotClassification):
         license="gpl-3.0",
         annotations_creators="human-annotated",
         dialect=[],
-        modalities=["video"],
+        modalities=["video", "text"],
         sample_creation="found",
         bibtex_citation=CITATION,
         is_beta=True,

--- a/mteb/tasks/zeroshot_classification/eng/music_avqa.py
+++ b/mteb/tasks/zeroshot_classification/eng/music_avqa.py
@@ -36,7 +36,7 @@ class MusicAVQACLSAudioVideoZeroShotClassification(AbsTaskZeroShotClassification
         license="gpl-3.0",
         annotations_creators="human-annotated",
         dialect=[],
-        modalities=["video", "audio"],
+        modalities=["video", "audio", "text"],
         sample_creation="found",
         bibtex_citation=CITATION,
         is_beta=True,

--- a/mteb/tasks/zeroshot_classification/eng/music_avqa.py
+++ b/mteb/tasks/zeroshot_classification/eng/music_avqa.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from mteb.abstasks.task_metadata import TaskMetadata
+from mteb.abstasks.zeroshot_classification import (
+    AbsTaskZeroShotClassification,
+)
+
+CITATION = r"""
+@inproceedings{li2022learning,
+  author = {Li, Guangyao and Wei, Yake and Tian, Yapeng and Xu, Chenliang and Wen, Ji-Rong and Hu, Di},
+  booktitle = {Proceedings of the IEEE/CVF conference on computer vision and pattern recognition},
+  pages = {19108--19118},
+  title = {Learning to answer questions in dynamic audio-visual scenarios},
+  year = {2022},
+}
+"""
+
+
+class MusicAVQACLSAudioVideoZeroShotClassification(AbsTaskZeroShotClassification):
+    metadata = TaskMetadata(
+        name="MusicAVQACLSAudioVideoZeroShot",
+        description="MUSIC-AVQA classification dataset containing 22 instrument categories. Given a video and audio of someone playing an instrument, the goal is to predict the instrument type. This zero-shot variant uses both video and audio modalities.",
+        reference="https://arxiv.org/abs/2203.14072",
+        dataset={
+            "path": "mteb/MUSIC-AVQA_cls-preprocessed",
+            "revision": "29f50ae80ad4e8c1cfdbc0148aefe6fe050833dd",
+        },
+        type="VideoZeroshotClassification",
+        category="va2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2021-01-01", "2022-06-19"),
+        domains=["Music"],
+        task_subtypes=["Music Instrument Recognition"],
+        license="gpl-3.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video", "audio"],
+        sample_creation="found",
+        bibtex_citation=CITATION,
+        is_beta=True,
+    )
+
+    input_column_name = ("video", "audio")
+    label_column_name: str = "label"
+
+    def get_candidate_labels(self) -> list[str]:
+        return [
+            f"a video of someone playing {name.replace('_', ' ')}"
+            for name in self.dataset["test"].features[self.label_column_name].names
+        ]
+
+
+class MusicAVQACLSVideoZeroShotClassification(AbsTaskZeroShotClassification):
+    metadata = TaskMetadata(
+        name="MusicAVQACLSVideoZeroShot",
+        description="MUSIC-AVQA classification dataset containing 22 instrument categories. Given a video and audio of someone playing an instrument, the goal is to predict the instrument type. This zero-shot variant uses video only.",
+        reference="https://arxiv.org/abs/2203.14072",
+        dataset={
+            "path": "mteb/MUSIC-AVQA_cls-preprocessed",
+            "revision": "29f50ae80ad4e8c1cfdbc0148aefe6fe050833dd",
+        },
+        type="VideoZeroshotClassification",
+        category="v2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2021-01-01", "2022-06-19"),
+        domains=["Music"],
+        task_subtypes=["Music Instrument Recognition"],
+        license="gpl-3.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video"],
+        sample_creation="found",
+        bibtex_citation=CITATION,
+        is_beta=True,
+    )
+
+    input_column_name: str = "video"
+    label_column_name: str = "label"
+
+    def get_candidate_labels(self) -> list[str]:
+        return [
+            f"a video of someone playing {name.replace('_', ' ')}"
+            for name in self.dataset["test"].features[self.label_column_name].names
+        ]


### PR DESCRIPTION
MUSIC-AVQA has video classification setups for both `v2c` and `va2c`, but is missing the corresponding zero-shot variants. This PR adds `MusicAVQACLSVideoZeroShot` (v2c) and `MusicAVQACLSAudioVideoZeroShot` (va2c).

  - [x] I have outlined why this dataset is filling an existing gap in `mteb`
  - [x] I have tested that the dataset runs with the `mteb` package.
  - [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t
  {task_name}` command.
    - [x] `mteb/baseline-random-encoder`
    - [x] `facebook/pe-av-small-16-frame`
  - [x] I have checked that the performance is neither trivial (close to perfect scores) nor random.
  - [x] I have considered the size of the dataset and reduced it if it is too big (e.g. 2048 examples for binary classification)

  ### Results

  | Model | MusicAVQACLSAudioVideoZeroShot (va2c) | MusicAVQACLSVideoZeroShot (v2c) |
  |---|---:|---:|
  | mteb/baseline-random-encoder | 0.0416 | 0.0410 |
  | facebook/pe-av-small-16-frame | 0.5926 | 0.5903 |

[MusicAVQACLSAudioVideoZeroShot_baseline.json](https://github.com/user-attachments/files/27188590/MusicAVQACLSAudioVideoZeroShot.json)
[MusicAVQACLSVideoZeroShot_baseline.json](https://github.com/user-attachments/files/27188591/MusicAVQACLSVideoZeroShot.json)
[MusicAVQACLSAudioVideoZeroShot_facebook.json](https://github.com/user-attachments/files/27188592/MusicAVQACLSAudioVideoZeroShot.json)
[MusicAVQACLSVideoZeroShot_facebook.json](https://github.com/user-attachments/files/27188593/MusicAVQACLSVideoZeroShot.json)