### PR TITLE
fix: ensure that get_model_metas raise an error if model name is incorrect

### DIFF
--- a/mteb/models/get_model_meta.py
+++ b/mteb/models/get_model_meta.py
@@ -58,7 +58,11 @@ def get_model_metas(  # noqa: PLR0913, PLR0917
     model_types_set = set(model_types) if model_types is not None else None
     modalities_set = set(modalities) if modalities is not None else None
 
-    for model_meta in MODEL_REGISTRY.values():
+    model_metas = MODEL_REGISTRY.values()
+    if model_names is not None:
+        model_metas = [get_model_meta(name) for name in model_names]
+
+    for model_meta in model_metas:
         if (model_names is not None) and (model_meta.name not in model_names):
             continue
         if languages is not None:

--- a/mteb/models/get_model_meta.py
+++ b/mteb/models/get_model_meta.py
@@ -58,7 +58,7 @@ def get_model_metas(  # noqa: PLR0913, PLR0917
     model_types_set = set(model_types) if model_types is not None else None
     modalities_set = set(modalities) if modalities is not None else None
 
-    model_metas = MODEL_REGISTRY.values()
+    model_metas: Iterable[ModelMeta] = MODEL_REGISTRY.values()
     if model_names is not None:
         model_metas = [get_model_meta(name) for name in model_names]
 

--- a/tests/test_models/test_model_meta.py
+++ b/tests/test_models/test_model_meta.py
@@ -319,7 +319,9 @@ def test_fill_missing_parameter():
 def test_raise_on_invalid_model_name():
     """Test that an error is raised for invalid model names."""
     with pytest.raises(KeyError):
-        mteb.get_model_metas(["mteb/baseline-bm25"]) # invalid (but plausible user input)
+        mteb.get_model_metas(
+            ["mteb/baseline-bm25"]
+        )  # invalid (but plausible user input)
     mdls = mteb.get_model_metas(["mteb/baseline-bm25s"])  # valid
     assert len(mdls) == 1
 

--- a/tests/test_models/test_model_meta.py
+++ b/tests/test_models/test_model_meta.py
@@ -316,6 +316,14 @@ def test_fill_missing_parameter():
     assert meta_with_compute.memory_usage_mb is not None
 
 
+def test_raise_on_invalid_model_name():
+    """Test that an error is raised for invalid model names."""
+    with pytest.raises(KeyError):
+        mteb.get_model_metas(["mteb/baseline-bm25"]) # invalid (but plausible user input)
+    mdls = mteb.get_model_metas(["mteb/baseline-bm25s"])  # valid
+    assert len(mdls) == 1
+
+
 @pytest.mark.parametrize(
     "model_meta",
     [m for m in mteb.get_model_metas(open_weights=True) if "text" in m.modalities],


### PR DESCRIPTION
Currently it will just silently drop the model. Discovered when trying to get "mteb/baseline-bm25".

Added test and fixes the issue. This should in practice also speed up the function quite a bit. It also has the added benefit of sorting the models in the specified user order
