### PR TITLE
fix: Update error message on evaluate when only-cache is set

### DIFF
--- a/mteb/evaluate.py
+++ b/mteb/evaluate.py
@@ -451,6 +451,10 @@ def evaluate(  # noqa: PLR0913, PLR0914
         OverwriteStrategy.NEVER,
         OverwriteStrategy.ONLY_CACHE,
     ]:
+        if existing_results is None:
+            raise ValueError(
+                f"overwrite_strategy is set to '{overwrite_strategy.value}' but no results found in cache for task {task.metadata.name}."
+            )
         raise ValueError(
             f"overwrite_strategy is set to '{overwrite_strategy.value}' and the results file exists for task {task.metadata.name}. "
             + f"However there are the following missing splits (and subsets): {missing_eval}. To rerun these set overwrite_strategy to 'only-missing'."

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -146,7 +146,7 @@ def test_cache_hit(task: AbsTask):
     model = mteb.get_model("mteb/baseline-random-encoder")
     with pytest.raises(
         ValueError,
-        match="overwrite_strategy is set to 'only-cache' and the results file exists",
+        match="overwrite_strategy is set to 'only-cache'",
     ):
         mteb.evaluate(model, task, overwrite_strategy="only-cache")
 


### PR DESCRIPTION
Currently it would state that:

````
overwrite_strategy is set to '{overwrite_strategy.value}' and the results file exists for task {task.metadata.name}. However there are the following missing splits (and subsets): {missing_eval}. To rerun these set overwrite_strategy to 'only-missing'.
```

even if the results does not exist. Fixed it my raising a more appropriate error.
