### PR TITLE
model: Add missing required dependencies to jina models

### DIFF
--- a/mteb/models/model_implementations/jina_models.py
+++ b/mteb/models/model_implementations/jina_models.py
@@ -812,6 +812,7 @@ jina_embeddings_v5_text_small = ModelMeta(
       primaryClass={cs.CL},
       url={https://arxiv.org/abs/2602.15547},
 }""",
+    extra_requirements_groups=["peft"],
 )
 
 
@@ -867,6 +868,7 @@ jina_embeddings_v5_text_nano = ModelMeta(
       primaryClass={cs.CL},
       url={https://arxiv.org/abs/2602.15547},
 }""",
+    extra_requirements_groups=["peft"],
 )
 
 jina_reranker_v3 = ModelMeta(


### PR DESCRIPTION
get the following when running
````
ImportError: This modeling file requires the following packages that were not found in your environment: peft. Run `pip install peft`

