### PR TITLE
[MVEB] expand clustering tasks with video-only mode

### DIFF
--- a/mteb/tasks/clustering/eng/__init__.py
+++ b/mteb/tasks/clustering/eng/__init__.py
@@ -5,7 +5,10 @@ from .arxiv_hierarchical_clustering import (
     ArXivHierarchicalClusteringP2P,
     ArXivHierarchicalClusteringS2S,
 )
-from .ave_dataset_clustering import AVEDatasetClustering
+from .ave_dataset_clustering import (
+    AVEDatasetAudioVideoClustering,
+    AVEDatasetVideoClustering,
+)
 from .big_patent_clustering import BigPatentClustering, BigPatentClusteringFast
 from .biorxiv_clustering_p2p import BiorxivClusteringP2P, BiorxivClusteringP2PFast
 from .biorxiv_clustering_s2s import BiorxivClusteringS2S, BiorxivClusteringS2SFast
@@ -27,7 +30,10 @@ from .meld_clustering import (
     MELDSpeakerAudioVideoClustering,
     MELDSpeakerVideoClustering,
 )
-from .music_avqa_clustering import MusicAVQAClustering
+from .music_avqa_clustering import (
+    MusicAVQACLSAudioVideoClustering,
+    MusicAVQACLSVideoClustering,
+)
 from .ravdess_av_clustering import RAVDESSAVClustering
 from .reddit_clustering import RedditClustering, RedditFastClusteringS2S
 from .reddit_clustering_p2p import RedditClusteringP2P, RedditFastClusteringP2P
@@ -44,7 +50,7 @@ from .twenty_newsgroups_clustering import (
     TwentyNewsgroupsClustering,
     TwentyNewsgroupsClusteringFast,
 )
-from .ucf101_clustering import UCF101Clustering
+from .ucf101_clustering import UCF101AudioVideoClustering, UCF101VideoClustering
 from .voice_gender import VoiceGenderClustering
 from .vox_celeb_clustering import VoxCelebClustering
 from .vox_populi_accent_clustering import VoxPopuliAccentClustering
@@ -53,10 +59,14 @@ from .wikipedia_chemistry_specialties_clustering import (
     WikipediaChemistrySpecialtiesClustering,
 )
 from .wikipedia_chemistry_topics_clustering import WikipediaChemistryTopicsClustering
-from .worldsense_1min_domain_clustering import WorldSense1MinDomainClustering
+from .worldsense_1min_domain_clustering import (
+    WorldSense1MinDomainAudioVideoClustering,
+    WorldSense1MinDomainVideoClustering,
+)
 
 __all__ = [
-    "AVEDatasetClustering",
+    "AVEDatasetAudioVideoClustering",
+    "AVEDatasetVideoClustering",
     "AmbientAcousticContextClustering",
     "ArXivHierarchicalClusteringP2P",
     "ArXivHierarchicalClusteringS2S",
@@ -89,7 +99,8 @@ __all__ = [
     "MedrxivClusteringP2PFast",
     "MedrxivClusteringS2S",
     "MedrxivClusteringS2SFast",
-    "MusicAVQAClustering",
+    "MusicAVQACLSAudioVideoClustering",
+    "MusicAVQACLSVideoClustering",
     "RAVDESSAVClustering",
     "RedditClustering",
     "RedditClusteringP2P",
@@ -102,12 +113,14 @@ __all__ = [
     "TinyImageNet",
     "TwentyNewsgroupsClustering",
     "TwentyNewsgroupsClusteringFast",
-    "UCF101Clustering",
+    "UCF101AudioVideoClustering",
+    "UCF101VideoClustering",
     "VoiceGenderClustering",
     "VoxCelebClustering",
     "VoxPopuliAccentClustering",
     "WikiCitiesClustering",
     "WikipediaChemistrySpecialtiesClustering",
     "WikipediaChemistryTopicsClustering",
-    "WorldSense1MinDomainClustering",
+    "WorldSense1MinDomainAudioVideoClustering",
+    "WorldSense1MinDomainVideoClustering",
 ]

--- a/mteb/tasks/clustering/eng/ave_dataset_clustering.py
+++ b/mteb/tasks/clustering/eng/ave_dataset_clustering.py
@@ -3,20 +3,34 @@ from __future__ import annotations
 from mteb.abstasks import AbsTaskClustering
 from mteb.abstasks.task_metadata import TaskMetadata
 
+BIBTEX = r"""
+@inproceedings{Tian_2018_ECCV,
+  author = {Tian, Yapeng and Shi, Jing and Li, Bochen and Duan, Zhiyao and Xu, Chenliang},
+  booktitle = {The European Conference on Computer Vision (ECCV)},
+  month = {September},
+  title = {Audio-Visual Event Localization in Unconstrained Videos},
+  year = {2018},
+}
+"""
 
-class AVEDatasetClustering(AbsTaskClustering):
+DATASET = {
+    "path": "mteb/AVE-Dataset",
+    "revision": "f6eb93b4e89456277a242583b5565b801bc1981d",
+}
+
+DESCRIPTION_BASE = (
+    "Clustering of short synchronized video and audio clips into 28 "
+    "sound-event categories from the Audio-Visual Event (AVE) dataset "
+    "(Tian et al., ECCV 2018)."
+)
+
+
+class AVEDatasetAudioVideoClustering(AbsTaskClustering):
     metadata = TaskMetadata(
-        name="AVEDatasetClustering",
-        description=(
-            "Clustering of short synchronized video and audio clips into 28 "
-            "sound-event categories from the Audio-Visual Event (AVE) dataset "
-            "(Tian et al., ECCV 2018)."
-        ),
+        name="AVEDatasetAudioVideoClustering",
+        description=DESCRIPTION_BASE + " Uses synchronized video and audio.",
         reference="https://openaccess.thecvf.com/content_ECCV_2018/html/Yapeng_Tian_Audio-Visual_Event_Localization_ECCV_2018_paper.html",
-        dataset={
-            "path": "mteb/AVE-Dataset",
-            "revision": "f6eb93b4e89456277a242583b5565b801bc1981d",
-        },
+        dataset=DATASET,
         type="VideoClustering",
         category="va2c",
         eval_splits=["test"],
@@ -30,15 +44,7 @@ class AVEDatasetClustering(AbsTaskClustering):
         dialect=[],
         modalities=["video", "audio"],
         sample_creation="found",
-        bibtex_citation=r"""
-@inproceedings{Tian_2018_ECCV,
-  author = {Tian, Yapeng and Shi, Jing and Li, Bochen and Duan, Zhiyao and Xu, Chenliang},
-  booktitle = {The European Conference on Computer Vision (ECCV)},
-  month = {September},
-  title = {Audio-Visual Event Localization in Unconstrained Videos},
-  year = {2018},
-}
-""",
+        bibtex_citation=BIBTEX,
         is_beta=True,
     )
     max_fraction_of_documents_to_embed = None
@@ -49,4 +55,37 @@ class AVEDatasetClustering(AbsTaskClustering):
         for split in self.metadata.eval_splits:
             self.dataset[split] = self.dataset[split].select_columns(
                 ["video", "audio", "label"],
+            )
+
+
+class AVEDatasetVideoClustering(AbsTaskClustering):
+    metadata = TaskMetadata(
+        name="AVEDatasetVideoClustering",
+        description=DESCRIPTION_BASE + " Uses video only.",
+        reference="https://openaccess.thecvf.com/content_ECCV_2018/html/Yapeng_Tian_Audio-Visual_Event_Localization_ECCV_2018_paper.html",
+        dataset=DATASET,
+        type="VideoClustering",
+        category="v2c",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="v_measure",
+        date=("2018-01-01", "2018-09-01"),
+        domains=["Spoken", "Scene", "Music"],
+        task_subtypes=["Thematic clustering"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video"],
+        sample_creation="found",
+        bibtex_citation=BIBTEX,
+        is_beta=True,
+    )
+    max_fraction_of_documents_to_embed = None
+    input_column_name: str = "video"
+    label_column_name: str = "label"
+
+    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+        for split in self.metadata.eval_splits:
+            self.dataset[split] = self.dataset[split].select_columns(
+                ["video", "label"],
             )

--- a/mteb/tasks/clustering/eng/music_avqa_clustering.py
+++ b/mteb/tasks/clustering/eng/music_avqa_clustering.py
@@ -3,20 +3,32 @@ from __future__ import annotations
 from mteb.abstasks import AbsTaskClustering
 from mteb.abstasks.task_metadata import TaskMetadata
 
+BIBTEX = r"""
+@article{Li2022Learning,
+  author = {Guangyao li, Yake Wei, Yapeng Tian, Chenliang Xu, Ji-Rong Wen, Di Hu},
+  journal = {IEEE Conference on Computer Vision and Pattern Recognition (CVPR)},
+  title = {Learning to Answer Questions in Dynamic Audio-Visual Scenarios},
+  year = {2022},
+}
+"""
 
-class MusicAVQAClustering(AbsTaskClustering):
+DATASET = {
+    "path": "mteb/MUSIC-AVQA_cls-preprocessed",
+    "revision": "29f50ae80ad4e8c1cfdbc0148aefe6fe050833dd",
+}
+
+DESCRIPTION_BASE = (
+    "Clustering of video clips into 22 musical instrument categories. "
+    "Extracted from the MUSIC-AVQA dataset."
+)
+
+
+class MusicAVQACLSAudioVideoClustering(AbsTaskClustering):
     metadata = TaskMetadata(
-        name="MusicAVQAClustering",
-        description=(
-            "Clustering of video clips with audio into 22 musical "
-            "instrument categories. Extracted from the MUSIC-AVQA "
-            "dataset."
-        ),
+        name="MusicAVQACLSAudioVideoClustering",
+        description=DESCRIPTION_BASE + " Uses synchronized video and audio.",
         reference="https://gewu-lab.github.io/MUSIC-AVQA/",
-        dataset={
-            "path": "mteb/MUSIC-AVQA_cls-preprocessed",
-            "revision": "29f50ae80ad4e8c1cfdbc0148aefe6fe050833dd",
-        },
+        dataset=DATASET,
         type="VideoClustering",
         category="va2c",
         eval_splits=["test"],
@@ -30,14 +42,7 @@ class MusicAVQAClustering(AbsTaskClustering):
         dialect=[],
         modalities=["video", "audio"],
         sample_creation="found",
-        bibtex_citation=r"""
-@article{Li2022Learning,
-  author = {Guangyao li, Yake Wei, Yapeng Tian, Chenliang Xu, Ji-Rong Wen, Di Hu},
-  journal = {IEEE Conference on Computer Vision and Pattern Recognition (CVPR)},
-  title = {Learning to Answer Questions in Dynamic Audio-Visual Scenarios},
-  year = {2022},
-}
-""",
+        bibtex_citation=BIBTEX,
         is_beta=True,
     )
     max_fraction_of_documents_to_embed = None
@@ -48,4 +53,37 @@ class MusicAVQAClustering(AbsTaskClustering):
         for split in self.metadata.eval_splits:
             self.dataset[split] = self.dataset[split].select_columns(
                 ["video", "audio", "label"],
+            )
+
+
+class MusicAVQACLSVideoClustering(AbsTaskClustering):
+    metadata = TaskMetadata(
+        name="MusicAVQACLSVideoClustering",
+        description=DESCRIPTION_BASE + " Uses video only.",
+        reference="https://gewu-lab.github.io/MUSIC-AVQA/",
+        dataset=DATASET,
+        type="VideoClustering",
+        category="v2c",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="v_measure",
+        date=("2022-06-01", "2022-06-30"),
+        domains=["Music"],
+        task_subtypes=["Thematic clustering"],
+        license="mit",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video"],
+        sample_creation="found",
+        bibtex_citation=BIBTEX,
+        is_beta=True,
+    )
+    max_fraction_of_documents_to_embed = None
+    input_column_name: str = "video"
+    label_column_name: str = "label"
+
+    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+        for split in self.metadata.eval_splits:
+            self.dataset[split] = self.dataset[split].select_columns(
+                ["video", "label"],
             )

--- a/mteb/tasks/clustering/eng/ucf101_clustering.py
+++ b/mteb/tasks/clustering/eng/ucf101_clustering.py
@@ -3,19 +3,34 @@ from __future__ import annotations
 from mteb.abstasks import AbsTaskClustering
 from mteb.abstasks.task_metadata import TaskMetadata
 
+BIBTEX = r"""
+@misc{Soomro2012UCF101,
+  archiveprefix = {arXiv},
+  author = {Soomro, Khurram and Zamir, Amir Roshan and Shah, Mubarak},
+  eprint = {1212.0402},
+  primaryclass = {cs.CV},
+  title = {UCF101: A Dataset of 101 Human Actions Classes From Videos in The Wild},
+  url = {https://arxiv.org/abs/1212.0402},
+  year = {2012},
+}
+"""
 
-class UCF101Clustering(AbsTaskClustering):
+DATASET = {
+    "path": "mteb/UCF101-51VA",
+    "revision": "866b006d84629d66d9927646db89bd43381925e7",
+}
+
+DESCRIPTION_BASE = (
+    "Clustering of video clips into 51 human action categories from the UCF101 dataset."
+)
+
+
+class UCF101AudioVideoClustering(AbsTaskClustering):
     metadata = TaskMetadata(
-        name="UCF101Clustering",
-        description=(
-            "Clustering of video clips with audio into 51 human "
-            "action categories from the UCF101 dataset."
-        ),
+        name="UCF101AudioVideoClustering",
+        description=DESCRIPTION_BASE + " Uses synchronized video and audio.",
         reference="https://arxiv.org/abs/1212.0402",
-        dataset={
-            "path": "mteb/UCF101-51VA",
-            "revision": "866b006d84629d66d9927646db89bd43381925e7",
-        },
+        dataset=DATASET,
         type="VideoClustering",
         category="va2c",
         eval_splits=["test"],
@@ -29,17 +44,7 @@ class UCF101Clustering(AbsTaskClustering):
         dialect=[],
         modalities=["video", "audio"],
         sample_creation="found",
-        bibtex_citation=r"""
-@misc{Soomro2012UCF101,
-  archiveprefix = {arXiv},
-  author = {Soomro, Khurram and Zamir, Amir Roshan and Shah, Mubarak},
-  eprint = {1212.0402},
-  primaryclass = {cs.CV},
-  title = {UCF101: A Dataset of 101 Human Actions Classes From Videos in The Wild},
-  url = {https://arxiv.org/abs/1212.0402},
-  year = {2012},
-}
-""",
+        bibtex_citation=BIBTEX,
         is_beta=True,
     )
     max_fraction_of_documents_to_embed = None
@@ -50,4 +55,37 @@ class UCF101Clustering(AbsTaskClustering):
         for split in self.metadata.eval_splits:
             self.dataset[split] = self.dataset[split].select_columns(
                 ["video", "audio", "label"],
+            )
+
+
+class UCF101VideoClustering(AbsTaskClustering):
+    metadata = TaskMetadata(
+        name="UCF101VideoClustering",
+        description=DESCRIPTION_BASE + " Uses video only.",
+        reference="https://arxiv.org/abs/1212.0402",
+        dataset=DATASET,
+        type="VideoClustering",
+        category="v2c",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="v_measure",
+        date=("2012-01-01", "2012-12-03"),
+        domains=["Web", "Scene"],
+        task_subtypes=["Activity recognition"],
+        license="cc0-1.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video"],
+        sample_creation="found",
+        bibtex_citation=BIBTEX,
+        is_beta=True,
+    )
+    max_fraction_of_documents_to_embed = None
+    input_column_name: str = "video"
+    label_column_name: str = "label"
+
+    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+        for split in self.metadata.eval_splits:
+            self.dataset[split] = self.dataset[split].select_columns(
+                ["video", "label"],
             )

--- a/mteb/tasks/clustering/eng/worldsense_1min_domain_clustering.py
+++ b/mteb/tasks/clustering/eng/worldsense_1min_domain_clustering.py
@@ -1,22 +1,50 @@
 from __future__ import annotations
 
-from mteb.abstasks.clustering import AbsTaskClustering
+from mteb.abstasks import AbsTaskClustering
 from mteb.abstasks.task_metadata import TaskMetadata
+from datasets import Dataset
+
+BIBTEX = r"""
+@misc{hong2025worldsense,
+  archiveprefix = {arXiv},
+  author = {Jack Hong and Shilin Yan and Jiayin Cai and Xiaolong Jiang and Yao Hu and Weidi Xie},
+  eprint = {2502.04326},
+  primaryclass = {cs.CV},
+  title = {WorldSense: Evaluating Real-world Omnimodal Understanding for Multimodal LLMs},
+  url = {https://arxiv.org/abs/2502.04326},
+  year = {2025},
+}
+"""
+
+DATASET = {
+    "path": "mteb/WorldSense_1min",
+    "revision": "10c7ce0eb32d620f1f685bfedde2724066068a1c",
+}
+
+DESCRIPTION_BASE = (
+    "Clustering of one-minute real-world clips into eight coarse domains "
+    "(e.g. daily life, music, sports), from the WorldSense benchmark "
+    "(deduplicated to one sample per video_id)."
+)
 
 
-class WorldSense1MinDomainClustering(AbsTaskClustering):
+def _dedupe_one_per_video_id(ds: Dataset) -> Dataset:
+    video_ids = ds.select_columns(["video_id"])["video_id"]
+    seen: set[str] = set()
+    keep_indices: list[int] = []
+    for i, vid in enumerate(video_ids):
+        if vid not in seen:
+            seen.add(vid)
+            keep_indices.append(i)
+    return ds.select(keep_indices)
+
+
+class WorldSense1MinDomainAudioVideoClustering(AbsTaskClustering):
     metadata = TaskMetadata(
-        name="WorldSense1MinDomainClustering",
-        description=(
-            "Clustering of one-minute real-world clips into eight coarse domains "
-            "(e.g. daily life, music, sports) using synchronized video and audio, "
-            "from the WorldSense benchmark (deduplicated to one sample per video_id)."
-        ),
+        name="WorldSense1MinDomainAudioVideoClustering",
+        description=DESCRIPTION_BASE + " Uses synchronized video and audio.",
         reference="https://arxiv.org/abs/2502.04326",
-        dataset={
-            "path": "mteb/WorldSense_1min",
-            "revision": "10c7ce0eb32d620f1f685bfedde2724066068a1c",
-        },
+        dataset=DATASET,
         type="VideoClustering",
         category="va2c",
         eval_splits=["test"],
@@ -30,17 +58,7 @@ class WorldSense1MinDomainClustering(AbsTaskClustering):
         dialect=[],
         modalities=["video", "audio"],
         sample_creation="found",
-        bibtex_citation=r"""
-@misc{hong2025worldsense,
-  archiveprefix = {arXiv},
-  author = {Jack Hong and Shilin Yan and Jiayin Cai and Xiaolong Jiang and Yao Hu and Weidi Xie},
-  eprint = {2502.04326},
-  primaryclass = {cs.CV},
-  title = {WorldSense: Evaluating Real-world Omnimodal Understanding for Multimodal LLMs},
-  url = {https://arxiv.org/abs/2502.04326},
-  year = {2025},
-}
-""",
+        bibtex_citation=BIBTEX,
         is_beta=True,
     )
     max_fraction_of_documents_to_embed = None
@@ -50,16 +68,42 @@ class WorldSense1MinDomainClustering(AbsTaskClustering):
     def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
         for split in self.metadata.eval_splits:
             ds = self.dataset[split]
-            # Read only video_id first so parquet column pruning avoids decoding video/audio
-            # for the full 1k+ QA rows while deduplicating.
-            video_ids = ds.select_columns(["video_id"])["video_id"]
-            seen: set[str] = set()
-            keep_indices: list[int] = []
-            for i, vid in enumerate(video_ids):
-                if vid not in seen:
-                    seen.add(vid)
-                    keep_indices.append(i)
-            ds = ds.select(keep_indices)
+            ds = _dedupe_one_per_video_id(ds)
             self.dataset[split] = ds.select_columns(
                 ["video", "audio", "domain"],
+            )
+
+
+class WorldSense1MinDomainVideoClustering(AbsTaskClustering):
+    metadata = TaskMetadata(
+        name="WorldSense1MinDomainVideoClustering",
+        description=DESCRIPTION_BASE + " Uses video only.",
+        reference="https://arxiv.org/abs/2502.04326",
+        dataset=DATASET,
+        type="VideoClustering",
+        category="v2c",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="v_measure",
+        date=("2025-01-01", "2025-12-31"),
+        domains=["Scene", "Web", "Entertainment"],
+        task_subtypes=["Thematic clustering"],
+        license="cc-by-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video"],
+        sample_creation="found",
+        bibtex_citation=BIBTEX,
+        is_beta=True,
+    )
+    max_fraction_of_documents_to_embed = None
+    input_column_name: str = "video"
+    label_column_name: str = "domain"
+
+    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+        for split in self.metadata.eval_splits:
+            ds = self.dataset[split]
+            ds = _dedupe_one_per_video_id(ds)
+            self.dataset[split] = ds.select_columns(
+                ["video", "domain"],
             )

--- a/mteb/tasks/clustering/eng/worldsense_1min_domain_clustering.py
+++ b/mteb/tasks/clustering/eng/worldsense_1min_domain_clustering.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from mteb.abstasks import AbsTaskClustering
 from mteb.abstasks.task_metadata import TaskMetadata
-from datasets import Dataset
+
+if TYPE_CHECKING:
+    from datasets import Dataset
 
 BIBTEX = r"""
 @misc{hong2025worldsense,


### PR DESCRIPTION
Adding the video only variant to 4 clustering tasks: AVE, MusicAVQA, UCF101, Worldsense1m

Sanity checked that the performance on AVE is slightly lower with video-only than video+audio with pe-small, and still way higher than random.

pe-small on AVE video-only:
```
{
  "dataset_revision": "f6eb93b4e89456277a242583b5565b801bc1981d",
  "task_name": "AVEDatasetVideoClustering",
  "mteb_version": "2.12.27",
  "scores": {
    "test": [
      {
        "v_measures": {
          "Level 0": [
            0.809333,
            0.790997,
            0.799447,
            0.815854,
            0.806778,
            0.765388,
            0.770982,
            0.790052,
            0.796937,
            0.812964
          ]
        },
        "v_measure": 0.795873,
        "v_measure_std": 0.016161,
        "main_score": 0.795873,
        "hf_subset": "default",
        "languages": [
          "eng-Latn"
        ]
      }
    ]
  },
  "evaluation_time": 834.8202481269836,
  "kg_co2_emissions": null,
  "date": 1777553809.080736
}
```

pe-small on AVE video+audio:
```
{
  "dataset_revision": "f6eb93b4e89456277a242583b5565b801bc1981d",
  "task_name": "AVEDatasetAudioVideoClustering",
  "mteb_version": "2.12.20",
  "scores": {
    "test": [
      {
        "v_measures": {
          "Level 0": [
            0.843561,
            0.845619,
            0.821078,
            0.817044,
            0.851698,
            0.811084,
            0.794674,
            0.835047,
            0.836217,
            0.799749
          ]
        },
        "v_measure": 0.825577,
        "v_measure_std": 0.018803,
        "main_score": 0.825577,
        "hf_subset": "default",
        "languages": [
          "eng-Latn"
        ]
      }
    ]
  },
  "evaluation_time": 998.563282251358,
  "kg_co2_emissions": null,
  "date": 1776375070.518382
}
```

random-encoder on AVE:
```
{
  "dataset_revision": "f6eb93b4e89456277a242583b5565b801bc1981d",
  "task_name": "AVEDatasetVideoClustering",
  "mteb_version": "2.12.27",
  "scores": {
    "test": [
      {
        "v_measures": {
          "Level 0": [
            0.266354,
            0.268215,
            0.26598,
            0.264718,
            0.268655,
            0.281173,
            0.28195,
            0.26157,
            0.264052,
            0.277191
          ]
        },
        "v_measure": 0.269986,
        "v_measure_std": 0.006987,
        "main_score": 0.269986,
        "hf_subset": "default",
        "languages": [
          "eng-Latn"
        ]
      }
    ]
  },
  "evaluation_time": 95.49934387207031,
  "kg_co2_emissions": null,
  "date": 1777557583.715391
}
```