### PR TITLE
fix: remove unused dataset transform for CzechProductReviewSentimentClassification

### DIFF
--- a/mteb/tasks/classification/ces/czech_product_review_sentiment_classification.py
+++ b/mteb/tasks/classification/ces/czech_product_review_sentiment_classification.py
@@ -46,14 +46,6 @@ Montoyo, Andres},
     )
     samples_per_label = 16
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
-        self.dataset = self.dataset.rename_columns(
-            {"comment": "text", "rating_str": "label"}
-        )
-        self.dataset = self.stratified_subsampling(
-            self.dataset, seed=self.seed, splits=["test"]
-        )
-
 
 class CzechProductReviewSentimentClassificationV2(AbsTaskClassification):
     metadata = TaskMetadata(


### PR DESCRIPTION
was not removed in: https://github.com/embeddings-benchmark/mteb/pull/4172

leads to this error:
```
ValueError: Original column names {'rating_str', 'comment'} not in the dataset. Current columns in the dataset: ['text', 'label']
```

cc @Samoed