### PR TITLE
[MVEB] Add AV-SpeakerBench video-centric QA task

### DIFF
--- a/mteb/tasks/multichoice/eng/__init__.py
+++ b/mteb/tasks/multichoice/eng/__init__.py
@@ -1,3 +1,4 @@
+from .av_speaker_bench import AVSpeakerBenchVideoAudioCentricQA, AVSpeakerBenchVideoCentricQA
 from .avmeme_exam import AVMemeExamVideoAudioCentricQA, AVMemeExamVideoCentricQA
 from .avqa import AVQAVideoAudioCentricQA, AVQAVideoCentricQA
 from .blink_it2i_multi_choice import BLINKIT2IMultiChoice
@@ -14,6 +15,8 @@ from .video_mme import VideoMMEShortVideoAudioCentricQA, VideoMMEShortVideoCentr
 from .worldsense import WorldSense1MinVideoAudioCentricQA, WorldSense1MinVideoCentricQA
 
 __all__ = [
+    "AVSpeakerBenchVideoAudioCentricQA",
+    "AVSpeakerBenchVideoCentricQA",
     "AVMemeExamVideoAudioCentricQA",
     "AVMemeExamVideoCentricQA",
     "AVQAVideoAudioCentricQA",

--- a/mteb/tasks/multichoice/eng/__init__.py
+++ b/mteb/tasks/multichoice/eng/__init__.py
@@ -1,4 +1,7 @@
-from .av_speaker_bench import AVSpeakerBenchVideoAudioCentricQA, AVSpeakerBenchVideoCentricQA
+from .av_speaker_bench import (
+    AVSpeakerBenchVideoAudioCentricQA,
+    AVSpeakerBenchVideoCentricQA,
+)
 from .avmeme_exam import AVMemeExamVideoAudioCentricQA, AVMemeExamVideoCentricQA
 from .avqa import AVQAVideoAudioCentricQA, AVQAVideoCentricQA
 from .blink_it2i_multi_choice import BLINKIT2IMultiChoice
@@ -15,12 +18,12 @@ from .video_mme import VideoMMEShortVideoAudioCentricQA, VideoMMEShortVideoCentr
 from .worldsense import WorldSense1MinVideoAudioCentricQA, WorldSense1MinVideoCentricQA
 
 __all__ = [
-    "AVSpeakerBenchVideoAudioCentricQA",
-    "AVSpeakerBenchVideoCentricQA",
     "AVMemeExamVideoAudioCentricQA",
     "AVMemeExamVideoCentricQA",
     "AVQAVideoAudioCentricQA",
     "AVQAVideoCentricQA",
+    "AVSpeakerBenchVideoAudioCentricQA",
+    "AVSpeakerBenchVideoCentricQA",
     "BLINKIT2IMultiChoice",
     "BLINKIT2TMultiChoice",
     "CVBenchCount",

--- a/mteb/tasks/multichoice/eng/av_speaker_bench.py
+++ b/mteb/tasks/multichoice/eng/av_speaker_bench.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from datasets import Dataset, load_dataset
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.retrieval_dataset_loaders import RetrievalSplitData
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class AVSpeakerBenchVideoCentricQA(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="AVSpeakerBenchVideoCentricQA",
+        description="AV-SpeakerBench is an audio-visual benchmark for speaker-centric question answering in video, evaluating multimodal LLMs on human speech understanding. Each example pairs a video with a question about the speaker and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate.",
+        reference="https://arxiv.org/abs/2512.02231",
+        dataset={
+            "path": "mteb/AV-SpeakerBench",
+            "revision": "46da53344c6a968d30cd72e28862732adf747802",
+        },
+        type="VideoCentricQA",
+        category="vt2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2024-12-03", "2024-12-03"),
+        domains=["Web"],
+        task_subtypes=["Question answering"],
+        license="cc-by-nc-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video", "text"],
+        sample_creation="found",
+        is_beta=True,
+        bibtex_citation=r"""
+@article{nguyen2024seehearunderstand,
+  author = {Nguyen, Le Thien Phuc and Yu, Zhuoran and Hang, Samuel Low Yu and An, Subin and Lee, Jeongik and Ban, Yohan and Chung, SeungEun and Nguyen, Thanh-Huy and Maeng, JuWan and Lee, Soochahn and Lee, Yong Jae},
+  journal = {arXiv preprint arXiv:2512.02231},
+  title = {See, Hear, and Understand: Benchmarking Audiovisual Human Speech Understanding in Multimodal Large Language Models},
+  year = {2024},
+}
+""",
+    )
+
+    def load_data(self, **kwargs) -> None:
+        if self.data_loaded:
+            return
+        self.dataset = {"default": {}}
+        for split in self.metadata.eval_splits:
+            ds = load_dataset(
+                self.metadata.dataset["path"],
+                revision=self.metadata.dataset["revision"],
+                split=split,
+            )
+            ds = ds.add_column("id", [f"q{i}" for i in range(len(ds))])
+
+            queries = ds.select_columns(["id", "question", "video"]).rename_column(
+                "question", "text"
+            )
+
+            corpus_rows: list[dict] = []
+            relevant_docs: dict[str, dict[str, int]] = {}
+            top_ranked: dict[str, list[str]] = {}
+            for row in ds.select_columns(["id", "candidates", "answer"]):
+                qid = row["id"]
+                answer = row["answer"]
+                top_ranked[qid] = []
+                for j, candidate in enumerate(row["candidates"]):
+                    doc_id = f"{qid}_c{j}"
+                    corpus_rows.append({"id": doc_id, "text": candidate})
+                    top_ranked[qid].append(doc_id)
+                    if candidate == answer:
+                        relevant_docs[qid] = {doc_id: 1}
+
+            corpus = Dataset.from_list(corpus_rows)
+            self.dataset["default"][split] = RetrievalSplitData(
+                queries=queries,
+                corpus=corpus,
+                relevant_docs=relevant_docs,
+                top_ranked=top_ranked,
+            )
+        self.data_loaded = True
+
+
+class AVSpeakerBenchVideoAudioCentricQA(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="AVSpeakerBenchVideoAudioCentricQA",
+        description="AV-SpeakerBench is an audio-visual benchmark for speaker-centric question answering in video, evaluating multimodal LLMs on human speech understanding. Each example pairs a video with audio and a question about the speaker and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, audio, question) tuple, retrieve the correct candidate.",
+        reference="https://arxiv.org/abs/2512.02231",
+        dataset={
+            "path": "mteb/AV-SpeakerBench",
+            "revision": "46da53344c6a968d30cd72e28862732adf747802",
+        },
+        type="VideoCentricQA",
+        category="vat2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2024-12-03", "2024-12-03"),
+        domains=["Web"],
+        task_subtypes=["Question answering"],
+        license="cc-by-nc-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video", "audio", "text"],
+        sample_creation="found",
+        is_beta=True,
+        bibtex_citation=r"""
+@article{nguyen2024seehearunderstand,
+  author = {Nguyen, Le Thien Phuc and Yu, Zhuoran and Hang, Samuel Low Yu and An, Subin and Lee, Jeongik and Ban, Yohan and Chung, SeungEun and Nguyen, Thanh-Huy and Maeng, JuWan and Lee, Soochahn and Lee, Yong Jae},
+  journal = {arXiv preprint arXiv:2512.02231},
+  title = {See, Hear, and Understand: Benchmarking Audiovisual Human Speech Understanding in Multimodal Large Language Models},
+  year = {2024},
+}
+""",
+    )
+
+    def load_data(self, **kwargs) -> None:
+        if self.data_loaded:
+            return
+        self.dataset = {"default": {}}
+        for split in self.metadata.eval_splits:
+            ds = load_dataset(
+                self.metadata.dataset["path"],
+                revision=self.metadata.dataset["revision"],
+                split=split,
+            )
+            ds = ds.add_column("id", [f"q{i}" for i in range(len(ds))])
+
+            queries = ds.select_columns(
+                ["id", "question", "video", "audio"]
+            ).rename_column("question", "text")
+
+            corpus_rows: list[dict] = []
+            relevant_docs: dict[str, dict[str, int]] = {}
+            top_ranked: dict[str, list[str]] = {}
+            for row in ds.select_columns(["id", "candidates", "answer"]):
+                qid = row["id"]
+                answer = row["answer"]
+                top_ranked[qid] = []
+                for j, candidate in enumerate(row["candidates"]):
+                    doc_id = f"{qid}_c{j}"
+                    corpus_rows.append({"id": doc_id, "text": candidate})
+                    top_ranked[qid].append(doc_id)
+                    if candidate == answer:
+                        relevant_docs[qid] = {doc_id: 1}
+
+            corpus = Dataset.from_list(corpus_rows)
+            self.dataset["default"][split] = RetrievalSplitData(
+                queries=queries,
+                corpus=corpus,
+                relevant_docs=relevant_docs,
+                top_ranked=top_ranked,
+            )
+        self.data_loaded = True


### PR DESCRIPTION
[MVEB] Add AV-SpeakerBench video-centric QA task
                                                                                                                                                                                          
  Adds AVSpeakerBenchVideoCentricQA and AVSpeakerBenchVideoAudioCentricQA as part of the MVEB initiative (#4130).
                                                                                                                                                                                          
  Dataset: https://huggingface.co/datasets/mteb/AV-SpeakerBench                                                                                                                           
  Paper: https://arxiv.org/abs/2512.02231 (Nguyen et al., 2024)                                                                                                                           
                                                                                                                                                                                          
  Tasks added:                                                    
  - AVSpeakerBenchVideoCentricQA : vt2t, modalities: [video, text]                                                                                                                        
  - AVSpeakerBenchVideoAudioCentricQA : vat2t, modalities: [video, audio, text]                                                                                                           
                                                                               
Each example pairs a video with a speaker-centric question and multiple candidate answers. Formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate.                                                                                                                                                                      
                                                                                                                                                                                          
  Random baseline results (attached):                                                                                                                                                     
  - AVSpeakerBenchVideoCentricQA : accuracy: 0.238                
  - AVSpeakerBenchVideoAudioCentricQA : accuracy: 0.248                                                                                                                                   
                                                          


[AVSpeakerBenchVideoAudioCentricQA.json](https://github.com/user-attachments/files/27299847/AVSpeakerBenchVideoAudioCentricQA.json)
[AVSpeakerBenchVideoCentricQA.json](https://github.com/user-attachments/files/27299848/AVSpeakerBenchVideoCentricQA.json)
