### PR TITLE
fix: pad short videos and bump cleaned AudioCapsAV/YouCook2 revisions

### DIFF
--- a/mteb/models/modality_collators.py
+++ b/mteb/models/modality_collators.py
@@ -206,9 +206,7 @@ class FramesCollator:
 
         if num_frames is None and fps is None:
             # No resampling: return all frames
-            return video.get_frames_at(
-                torch.tensor(list(range(num_source_frames)), dtype=torch.long)
-            ).data
+            return video.get_frames_at(list(range(num_source_frames))).data
 
         if num_frames is not None:
             # Fixed-sample mode: always select exactly num_frames
@@ -228,7 +226,7 @@ class FramesCollator:
         else:
             frame_step = max(1, num_source_frames // target)
             selected_frames = list(range(0, num_source_frames, frame_step))[:target]
-        return video.get_frames_at(torch.tensor(selected_frames, dtype=torch.long)).data
+        return video.get_frames_at(selected_frames).data
 
 
 class VideoCollator:

--- a/mteb/models/modality_collators.py
+++ b/mteb/models/modality_collators.py
@@ -228,9 +228,7 @@ class FramesCollator:
         else:
             frame_step = max(1, num_source_frames // target)
             selected_frames = list(range(0, num_source_frames, frame_step))[:target]
-        return video.get_frames_at(
-            torch.tensor(selected_frames, dtype=torch.long)
-        ).data
+        return video.get_frames_at(torch.tensor(selected_frames, dtype=torch.long)).data
 
 
 class VideoCollator:

--- a/mteb/models/modality_collators.py
+++ b/mteb/models/modality_collators.py
@@ -206,7 +206,9 @@ class FramesCollator:
 
         if num_frames is None and fps is None:
             # No resampling: return all frames
-            return video.get_frames_at(list(range(num_source_frames))).data
+            return video.get_frames_at(
+                torch.tensor(list(range(num_source_frames)), dtype=torch.long)
+            ).data
 
         if num_frames is not None:
             # Fixed-sample mode: always select exactly num_frames
@@ -218,9 +220,17 @@ class FramesCollator:
             if max_frames is not None:
                 target = min(target, max_frames)
 
-        frame_step = max(1, num_source_frames // target)
-        selected_frames = list(range(0, num_source_frames, frame_step))[:target]
-        return video.get_frames_at(selected_frames).data
+        if num_source_frames < target:
+            # Repeat frames to reach exactly ``target`` (fixed-count models break on shorter input).
+            selected_frames = (
+                list(range(num_source_frames)) * ((target // num_source_frames) + 1)
+            )[:target]
+        else:
+            frame_step = max(1, num_source_frames // target)
+            selected_frames = list(range(0, num_source_frames, frame_step))[:target]
+        return video.get_frames_at(
+            torch.tensor(selected_frames, dtype=torch.long)
+        ).data
 
 
 class VideoCollator:

--- a/mteb/models/modality_collators.py
+++ b/mteb/models/modality_collators.py
@@ -218,8 +218,8 @@ class FramesCollator:
             if max_frames is not None:
                 target = min(target, max_frames)
 
-        if num_source_frames < target:
-            # Repeat frames to reach exactly ``target`` (fixed-count models break on shorter input).
+        if num_frames is not None and num_source_frames < target:
+            # Repeat frames to reach exactly ``num_frames``.
             selected_frames = (
                 list(range(num_source_frames)) * ((target // num_source_frames) + 1)
             )[:target]

--- a/mteb/tasks/retrieval/eng/audiocaps_av_retrieval.py
+++ b/mteb/tasks/retrieval/eng/audiocaps_av_retrieval.py
@@ -7,7 +7,7 @@ from mteb.abstasks.retrieval_dataset_loaders import RetrievalSplitData
 from mteb.abstasks.task_metadata import TaskMetadata
 
 _DATASET_PATH = "mteb/AudioCaps_AV"
-_DATASET_REVISION = "dd2fe8cc347f590957ddf061ce3d3f179196ff03"
+_DATASET_REVISION = "5fd062d13a1ea8cdf36923faaacc32c43e6de14e"
 _BIBTEX = r"""
 @inproceedings{kim2019audiocaps,
   author = {Kim, Chris Dongjoo and Kim, Byeongchang and Lee, Hyunmin and Kim, Gunhee},

--- a/mteb/tasks/retrieval/eng/youcook2_retrieval.py
+++ b/mteb/tasks/retrieval/eng/youcook2_retrieval.py
@@ -7,7 +7,7 @@ from mteb.abstasks.retrieval_dataset_loaders import RetrievalSplitData
 from mteb.abstasks.task_metadata import TaskMetadata
 
 _DATASET_PATH = "mteb/YouCook2_val"
-_DATASET_REVISION = "a23c8bb74b0a8bce0f83eb33978fdd5cf1b21867"
+_DATASET_REVISION = "be654b591daef1382364d563f6d3d66f61f79b35"
 _BIBTEX = r"""
 @inproceedings{zhou2018towards,
   author = {Zhou, Luowei and Xu, Chenliang and Corso, Jason J.},


### PR DESCRIPTION
- FramesCollator.resample_video: when source has fewer frames than target, repeat frames to reach the target count. Previously returned a shorter tensor, causing fixed-frame models (e.g. EBind) to fail on short clips with mixed-shape batch errors. 

- FramesCollator.resample_video: pass torch.tensor(..., dtype=torch.long) to video.get_frames_at(). torchcodec's dispatcher converts list inputs via torch.tensor(...) without specifying dtype, occasionally producing Float instead of Long.

- AudioCapsAV: bump _DATASET_REVISION to drop a corrupt row (truncated mp4 bytes, torchcodec buffer overrun on decode).

- YouCook2_val: bump _DATASET_REVISION to drop a corrupt row (zero-frame video + audio decode failure).
