### PR TITLE
dataset: add HumanConceptsClustering (Shani et al. 2025)

### DIFF
--- a/mteb/descriptive_stats/Clustering/HumanConceptsClustering.json
+++ b/mteb/descriptive_stats/Clustering/HumanConceptsClustering.json
@@ -1,0 +1,173 @@
+{
+    "Rosch1973": {
+        "num_samples": 48,
+        "text_statistics": {
+            "total_text_length": 335,
+            "min_text_length": 3,
+            "average_text_length": 6.979166666666667,
+            "max_text_length": 18,
+            "unique_texts": 48
+        },
+        "image_statistics": null,
+        "audio_statistics": null,
+        "video_statistics": null,
+        "labels_statistics": {
+            "min_labels_per_text": 1,
+            "average_label_per_text": 1.0,
+            "max_labels_per_text": 1,
+            "unique_labels": 8,
+            "labels": {
+                "Fruit": {
+                    "count": 6
+                },
+                "Science": {
+                    "count": 6
+                },
+                "Sport": {
+                    "count": 6
+                },
+                "Bird": {
+                    "count": 6
+                },
+                "Vehicle": {
+                    "count": 6
+                },
+                "Crime": {
+                    "count": 6
+                },
+                "Disease": {
+                    "count": 6
+                },
+                "Vegetable": {
+                    "count": 6
+                }
+            }
+        }
+    },
+    "Rosch1975": {
+        "num_samples": 565,
+        "text_statistics": {
+            "total_text_length": 3915,
+            "min_text_length": 3,
+            "average_text_length": 6.929203539823009,
+            "max_text_length": 16,
+            "unique_texts": 552
+        },
+        "image_statistics": null,
+        "audio_statistics": null,
+        "video_statistics": null,
+        "labels_statistics": {
+            "min_labels_per_text": 1,
+            "average_label_per_text": 1.0,
+            "max_labels_per_text": 1,
+            "unique_labels": 10,
+            "labels": {
+                "Furniture": {
+                    "count": 60
+                },
+                "Fruit": {
+                    "count": 51
+                },
+                "Vehicle": {
+                    "count": 50
+                },
+                "Weapon": {
+                    "count": 60
+                },
+                "Vegetable": {
+                    "count": 56
+                },
+                "Carpenter's tool": {
+                    "count": 60
+                },
+                "Birds": {
+                    "count": 54
+                },
+                "Sports": {
+                    "count": 59
+                },
+                "Toys": {
+                    "count": 60
+                },
+                "Clothing": {
+                    "count": 55
+                }
+            }
+        }
+    },
+    "McCloskey1978": {
+        "num_samples": 492,
+        "text_statistics": {
+            "total_text_length": 3697,
+            "min_text_length": 3,
+            "average_text_length": 7.514227642276423,
+            "max_text_length": 19,
+            "unique_texts": 449
+        },
+        "image_statistics": null,
+        "audio_statistics": null,
+        "video_statistics": null,
+        "labels_statistics": {
+            "min_labels_per_text": 1,
+            "average_label_per_text": 1.0,
+            "max_labels_per_text": 1,
+            "unique_labels": 18,
+            "labels": {
+                "Animal": {
+                    "count": 30
+                },
+                "Bird": {
+                    "count": 29
+                },
+                "Carpenter's Tool": {
+                    "count": 10
+                },
+                "Clothing": {
+                    "count": 29
+                },
+                "Disease": {
+                    "count": 28
+                },
+                "Fish": {
+                    "count": 30
+                },
+                "Fruit": {
+                    "count": 30
+                },
+                "Furniture": {
+                    "count": 24
+                },
+                "Insect": {
+                    "count": 30
+                },
+                "Kitchen Utensil": {
+                    "count": 25
+                },
+                "Natural Earth Formation": {
+                    "count": 29
+                },
+                "Precious Stone": {
+                    "count": 26
+                },
+                "Science": {
+                    "count": 30
+                },
+                "Ship": {
+                    "count": 28
+                },
+                "Sport": {
+                    "count": 27
+                },
+                "Vegetable": {
+                    "count": 30
+                },
+                "Vehicle": {
+                    "count": 28
+                },
+                "Weather Phenomenon": {
+                    "count": 29
+                }
+            }
+        }
+    }
+}

--- a/mteb/tasks/clustering/eng/__init__.py
+++ b/mteb/tasks/clustering/eng/__init__.py
@@ -18,10 +18,10 @@ from .cifar import CIFAR10Clustering, CIFAR100Clustering
 from .clus_trec_covid import ClusTrecCovid
 from .crema_d_clustering import CREMADClustering
 from .hmdb51_clustering import HMDB51Clustering
+from .human_concepts_clustering import HumanConceptsClustering
 from .hume_arxiv_clustering_p2p import HUMEArxivClusteringP2P
 from .hume_reddit_clustering_p2p import HUMERedditClusteringP2P
 from .hume_wiki_cities_clustering import HUMEWikiCitiesClustering
-from .human_concepts_clustering import HumanConceptsClustering
 from .image_net import ImageNet10Clustering, ImageNetDog15Clustering
 from .medrxiv_clustering_p2p import MedrxivClusteringP2P, MedrxivClusteringP2PFast
 from .medrxiv_clustering_s2s import MedrxivClusteringS2S, MedrxivClusteringS2SFast

--- a/mteb/tasks/clustering/eng/__init__.py
+++ b/mteb/tasks/clustering/eng/__init__.py
@@ -21,6 +21,7 @@ from .hmdb51_clustering import HMDB51Clustering
 from .hume_arxiv_clustering_p2p import HUMEArxivClusteringP2P
 from .hume_reddit_clustering_p2p import HUMERedditClusteringP2P
 from .hume_wiki_cities_clustering import HUMEWikiCitiesClustering
+from .human_concepts_clustering import HumanConceptsClustering
 from .image_net import ImageNet10Clustering, ImageNetDog15Clustering
 from .medrxiv_clustering_p2p import MedrxivClusteringP2P, MedrxivClusteringP2PFast
 from .medrxiv_clustering_s2s import MedrxivClusteringS2S, MedrxivClusteringS2SFast
@@ -89,6 +90,7 @@ __all__ = [
     "HUMEArxivClusteringP2P",
     "HUMERedditClusteringP2P",
     "HUMEWikiCitiesClustering",
+    "HumanConceptsClustering",
     "ImageNet10Clustering",
     "ImageNetDog15Clustering",
     "MELDEmotionAudioVideoClustering",

--- a/mteb/tasks/clustering/eng/human_concepts_clustering.py
+++ b/mteb/tasks/clustering/eng/human_concepts_clustering.py
@@ -55,10 +55,12 @@ class HumanConceptsClustering(AbsTaskClustering):
     label_column_name = "category"
 
     def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
-        self.dataset = DatasetDict({
-            sub: self.dataset["train"].filter(
-                lambda x, s=sub: x["subdataset"] == s,
-                num_proc=num_proc,
-            )
-            for sub in _SUBDATASETS
-        })
+        self.dataset = DatasetDict(
+            {
+                sub: self.dataset["train"].filter(
+                    lambda x, s=sub: x["subdataset"] == s,
+                    num_proc=num_proc,
+                )
+                for sub in _SUBDATASETS
+            }
+        )

--- a/mteb/tasks/clustering/eng/human_concepts_clustering.py
+++ b/mteb/tasks/clustering/eng/human_concepts_clustering.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from datasets import DatasetDict
+
+from mteb.abstasks.clustering import AbsTaskClustering
+from mteb.abstasks.task_metadata import TaskMetadata
+
+CITATION = r"""
+@article{shani2025tokens,
+  author = {Shani, Chen and Soffer, Liron and Jurafsky, Dan and LeCun, Yann and Shwartz-Ziv, Ravid},
+  journal = {arXiv preprint arXiv:2505.17117},
+  title = {From Tokens to Thoughts: How LLMs and Humans Trade Compression for Meaning},
+  year = {2025},
+}
+"""
+
+_SUBDATASETS = ["Rosch1973", "Rosch1975", "McCloskey1978"]
+
+
+class HumanConceptsClustering(AbsTaskClustering):
+    metadata = TaskMetadata(
+        name="HumanConceptsClustering",
+        description=(
+            "Semantic concept clustering benchmark drawn from three classic cognitive psychology "
+            "typicality studies: Rosch (1973, 48 items, 8 categories), Rosch (1975, 565 items, "
+            "10 categories), and McCloskey & Glucksberg (1978, 492 items, 18 categories). "
+            "Each item is an everyday concept (e.g. 'robin', 'chair') annotated with a "
+            "human-assigned semantic category. The task measures how well embeddings recover "
+            "human conceptual organisation. Evaluated separately per study."
+        ),
+        reference="https://arxiv.org/abs/2505.17117",
+        dataset={
+            "path": "CShani/human-concepts",
+            "revision": "99f1715a5945341896ed3cbe4a3f1d3b7b913cf2",
+        },
+        type="Clustering",
+        category="t2c",
+        modalities=["text"],
+        eval_splits=_SUBDATASETS,
+        eval_langs=["eng-Latn"],
+        main_score="v_measure",
+        date=("1973-01-01", "2025-05-22"),
+        domains=["Academic"],
+        task_subtypes=["Thematic clustering"],
+        license="http://www.wtfpl.net/about/",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=CITATION,
+        prompt="Identify the semantic category of the concept",
+    )
+
+    max_fraction_of_documents_to_embed = None
+    input_column_name = "item"
+    label_column_name = "category"
+
+    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+        self.dataset = DatasetDict({
+            sub: self.dataset["train"].filter(
+                lambda x, s=sub: x["subdataset"] == s,
+                num_proc=num_proc,
+            )
+            for sub in _SUBDATASETS
+        })

--- a/mteb/tasks/clustering/eng/human_concepts_clustering.py
+++ b/mteb/tasks/clustering/eng/human_concepts_clustering.py
@@ -38,7 +38,7 @@ class HumanConceptsClustering(AbsTaskClustering):
         modalities=["text"],
         eval_splits=_SUBDATASETS,
         eval_langs=["eng-Latn"],
-        main_score="v_measure",
+        main_score="ami",
         date=("1973-01-01", "2025-05-22"),
         domains=["Academic"],
         task_subtypes=["Thematic clustering"],

--- a/tests/test_tasks/test_task_quality.py
+++ b/tests/test_tasks/test_task_quality.py
@@ -278,6 +278,7 @@ KNOWN_ISSUES = {
     "RuSciBenchYearPublRegression",
     # Add new datasets below with an explanation of why it is added
     # "name" # explanation
+    "HumanConceptsClustering",  # single-word concept items (e.g. "Bat", "Cat") are intentionally short by design
 }
 
 


### PR DESCRIPTION
## Description

Adds `HumanConceptsClustering`, a new clustering benchmark based on the cognitive psychology typicality datasets compiled in:

> Shani, C., Soffer, L., Jurafsky, D., LeCun, Y., & Shwartz-Ziv, R. (2025). *From Tokens to Thoughts: How LLMs and Humans Trade Compression for Meaning.* arXiv:2505.17117

Closes #4497

## Dataset

**HuggingFace:** `CShani/human-concepts`  
**Source studies:**
- Rosch (1973) — 48 items, 8 categories
- Rosch (1975) — 565 items, 10 categories
- McCloskey & Glucksberg (1978) — 492 items, 18 categories

Each item is an everyday concept (e.g. "robin", "chair") annotated with a human-assigned semantic category. The task measures how well embeddings recover human conceptual organisation.

## Implementation

- Task type: `Clustering` (`t2c`), `AbsTaskClustering`
- Metric: V-measure
- The three studies are evaluated as separate splits (`Rosch1973`, `Rosch1975`, `McCloskey1978`) within a single task class, using `dataset_transform` to filter on the `subdataset` column
- Full dataset is embedded (no downsampling — largest split is 565 items)

## Test plan

- [x] `mteb.get_task('HumanConceptsClustering')` resolves correctly
- [x] `task.load_data()` produces three splits with correct item counts and categories
- [x] Task registered in `mteb/tasks/clustering/eng/__init__.py`

## Notes

- The dataset is currently licensed as WTFPL (`http://www.wtfpl.net/about/`). The underlying typicality ratings are factual measurements and likely not copyrightable (cf. *Feist v. Rural Telephone*, 1991). Updating the dataset card to `cc0-1.0` would be more appropriate for a research dataset — this can be done by the dataset owner separately.