### PR TITLE
fix: default PE-AV max_samples to 1,440,000 (30s @ 48kHz)

### DIFF
--- a/mteb/models/model_implementations/pe_av_models.py
+++ b/mteb/models/model_implementations/pe_av_models.py
@@ -35,7 +35,7 @@ class PEAudioVisualWrapper(AbsEncoder):
         fps: float | None = 2.0,
         max_frames: int | None = 64,
         num_frames: int | None = None,
-        max_samples: int | None = None,
+        max_samples: int | None = 1_440_000,
         **kwargs: Any,
     ):
         from transformers import PeAudioVideoModel, PeAudioVideoProcessor

--- a/mteb/models/model_implementations/pe_av_models.py
+++ b/mteb/models/model_implementations/pe_av_models.py
@@ -35,7 +35,7 @@ class PEAudioVisualWrapper(AbsEncoder):
         fps: float | None = 2.0,
         max_frames: int | None = 64,
         num_frames: int | None = None,
-        max_samples: int | None = 1_440_000,
+        max_samples: int | None = 30 * 48000,  # 30s * sampling rate
         **kwargs: Any,
     ):
         from transformers import PeAudioVideoModel, PeAudioVideoProcessor


### PR DESCRIPTION
PE-AV is trained and evaluated on 30-second audio-video clips with audio at 48 kHz (preprocessor_config.json: sampling_rate=48000), so a suitable truncation is 30 * 48000 = 1,440,000 samples. 

The paper (arXiv:2512.19687) states evals/training are chunked at 30-second intervals.

If you add a model or a dataset, please add the corresponding checklist:

* [dataset checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_dataset/#submit-a-pull-request)
* [model checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_model/#submitting-your-model-as-a-pr)
