### PR TITLE
fix tolerate off-by-one frame metadata in compute_video_hashes

### DIFF
--- a/mteb/abstasks/_statistics_calculation.py
+++ b/mteb/abstasks/_statistics_calculation.py
@@ -57,7 +57,9 @@ def compute_video_hashes(videos: list[VideoDecoder]) -> list[str]:
     hashes = []
     for video in videos:
         meta = video.metadata
-        num_frames = meta.num_frames
+        # Drop the last frame index because some container metadata over-counts
+        # by one (the final claimed frame fails to decode).
+        num_frames = meta.num_frames - 1 if meta.num_frames else meta.num_frames
         avg_fps = meta.average_fps
 
         if num_frames is not None and avg_fps is not None and avg_fps > 0:


### PR DESCRIPTION
@Samoed 
Some videos' container metadata over-counts frames by one, it claims num_frames = N but only N-1 frames are actually decodable. compute_video_hashes samples at indices range(0, num_frames, round(avg_fps)), which lands on the imaginary last index when (N-1) is divisible by round(fps) and crashes.

Example (MSVD video 184): metadata says num_frames=226, avg_fps=25 → samples include index 225, but the file only has frames 0–224. Eval doesn't hit this because its stride (num_frames // target) doesn't align with N-1.


If you add a model or a dataset, please add the corresponding checklist:

* [dataset checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_dataset/#submit-a-pull-request)
* [model checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_model/#submitting-your-model-as-a-pr)
