### PR TITLE
fix: bump HMDB51 revision to cleaned snapshot

### DIFF
--- a/mteb/tasks/classification/eng/hmdb51_classification.py
+++ b/mteb/tasks/classification/eng/hmdb51_classification.py
@@ -11,7 +11,7 @@ class HMDB51Classification(AbsTaskClassification):
         reference="https://serre-lab.clps.brown.edu/resource/hmdb-a-large-human-motion-database/",
         dataset={
             "path": "mteb/HMDB51",
-            "revision": "73e5ac9cd9536c406d0046f3d6046785885f7ebe",
+            "revision": "7f9af5438a855e9348fb23ecb5ec740a9c21daf3",
         },
         type="VideoClassification",
         category="v2c",

--- a/mteb/tasks/clustering/eng/hmdb51_clustering.py
+++ b/mteb/tasks/clustering/eng/hmdb51_clustering.py
@@ -14,7 +14,7 @@ class HMDB51Clustering(AbsTaskClustering):
         reference="https://serre-lab.clps.brown.edu/resource/hmdb-a-large-human-motion-database/",
         dataset={
             "path": "mteb/HMDB51",
-            "revision": "73e5ac9cd9536c406d0046f3d6046785885f7ebe",
+            "revision": "7f9af5438a855e9348fb23ecb5ec740a9c21daf3",
         },
         type="VideoClustering",
         category="v2c",

--- a/mteb/tasks/zeroshot_classification/eng/hmdb51.py
+++ b/mteb/tasks/zeroshot_classification/eng/hmdb51.py
@@ -11,7 +11,7 @@ class HMDB51ZeroShotClassification(AbsTaskZeroShotClassification):
         reference="https://serre-lab.clps.brown.edu/resource/hmdb-a-large-human-motion-database/",
         dataset={
             "path": "mteb/HMDB51",
-            "revision": "73e5ac9cd9536c406d0046f3d6046785885f7ebe",
+            "revision": "7f9af5438a855e9348fb23ecb5ec740a9c21daf3",
         },
         type="VideoZeroshotClassification",
         category="v2t",


### PR DESCRIPTION
The previous HMDB51 revision contained ae corrupted video clip that crashed the descriptive-stats compute (no per-row error handling in the video stats path). The new revision drops the corrupted clip(s) so HMDB51Classification, HMDB51Clustering, and HMDB51ZeroShot can run end to end. Bump pinned revision in all three task classes.

If you add a model or a dataset, please add the corresponding checklist:

* [dataset checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_dataset/#submit-a-pull-request)
* [model checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_model/#submitting-your-model-as-a-pr)
