### PR TITLE
task: add RAVDESSVideoClustering (V-only emotion clustering)

### DIFF
--- a/mteb/tasks/clustering/eng/__init__.py
+++ b/mteb/tasks/clustering/eng/__init__.py
@@ -34,7 +34,7 @@ from .music_avqa_clustering import (
     MusicAVQACLSAudioVideoClustering,
     MusicAVQACLSVideoClustering,
 )
-from .ravdess_av_clustering import RAVDESSAVClustering
+from .ravdess_av_clustering import RAVDESSAVClustering, RAVDESSVideoClustering
 from .reddit_clustering import RedditClustering, RedditFastClusteringS2S
 from .reddit_clustering_p2p import RedditClusteringP2P, RedditFastClusteringP2P
 from .stack_exchange_clustering import (
@@ -102,6 +102,7 @@ __all__ = [
     "MusicAVQACLSAudioVideoClustering",
     "MusicAVQACLSVideoClustering",
     "RAVDESSAVClustering",
+    "RAVDESSVideoClustering",
     "RedditClustering",
     "RedditClusteringP2P",
     "RedditFastClusteringP2P",

--- a/mteb/tasks/clustering/eng/ravdess_av_clustering.py
+++ b/mteb/tasks/clustering/eng/ravdess_av_clustering.py
@@ -46,3 +46,47 @@ class RAVDESSAVClustering(AbsTaskClustering):
     max_fraction_of_documents_to_embed = None
     input_column_name = ("video", "audio")
     label_column_name: str = "emotion"
+
+
+class RAVDESSVideoClustering(AbsTaskClustering):
+    metadata = TaskMetadata(
+        name="RAVDESSVideoClustering",
+        description="Emotion clustering task with video data only for 8 emotions: neutral, calm, happy, sad, angry, fearful, surprise, and disgust expressions.",
+        reference="https://doi.org/10.1371/journal.pone.0196391",
+        dataset={
+            "path": "mteb/RAVDESS_AV",
+            "revision": "13af08387c3ce5e86c179a3718eb158669268d65",
+        },
+        type="VideoClustering",
+        category="v2c",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="v_measure",
+        date=("2018-05-16", "2018-05-16"),
+        domains=["Spoken"],
+        task_subtypes=["Emotion Clustering"],
+        license="cc-by-4.0",
+        annotations_creators="human-annotated",
+        dialect=["eng-US", "eng-CA"],
+        modalities=["video"],
+        sample_creation="found",
+        bibtex_citation=r"""
+@article{10.1371/journal.pone.0196391,
+  author = {Livingstone, Steven R. AND Russo, Frank A.},
+  doi = {10.1371/journal.pone.0196391},
+  journal = {PLOS ONE},
+  month = {05},
+  number = {5},
+  pages = {1-35},
+  publisher = {Public Library of Science},
+  title = {The Ryerson Audio-Visual Database of Emotional Speech and Song (RAVDESS): A dynamic, multimodal set of facial and vocal expressions in North American English},
+  url = {https://doi.org/10.1371/journal.pone.0196391},
+  volume = {13},
+  year = {2018},
+}
+""",
+        is_beta=True,
+    )
+    max_fraction_of_documents_to_embed = None
+    input_column_name: str = "video"
+    label_column_name: str = "emotion"


### PR DESCRIPTION
Mirrors RAVDESSAVClustering but with video-only inputs. 

If you add a model or a dataset, please add the corresponding checklist:

* [dataset checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_dataset/#submit-a-pull-request)
* [model checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_model/#submitting-your-model-as-a-pr)
