### PR TITLE
task: add HumanAnimalCartoonVAZeroShot

### DIFF
--- a/mteb/tasks/zeroshot_classification/eng/__init__.py
+++ b/mteb/tasks/zeroshot_classification/eng/__init__.py
@@ -19,7 +19,10 @@ from .fgvc_aircraft import FGVCAircraftZeroShotClassification
 from .food101 import Food101ZeroShotClassification
 from .gtsrb import GTSRBZeroShotClassification
 from .hmdb51 import HMDB51ZeroShotClassification
-from .human_animal_cartoon import HumanAnimalCartoonZeroShotClassification
+from .human_animal_cartoon import (
+    HumanAnimalCartoonVAZeroShotClassification,
+    HumanAnimalCartoonZeroShotClassification,
+)
 from .imagenet1k import Imagenet1kZeroShotClassification
 from .kinetics400 import (
     Kinetics400VAZeroShotClassification,
@@ -89,6 +92,7 @@ __all__ = [
     "Food101ZeroShotClassification",
     "GTSRBZeroShotClassification",
     "HMDB51ZeroShotClassification",
+    "HumanAnimalCartoonVAZeroShotClassification",
     "HumanAnimalCartoonZeroShotClassification",
     "Imagenet1kZeroShotClassification",
     "Kinetics400VAZeroShotClassification",

--- a/mteb/tasks/zeroshot_classification/eng/human_animal_cartoon.py
+++ b/mteb/tasks/zeroshot_classification/eng/human_animal_cartoon.py
@@ -62,3 +62,44 @@ class HumanAnimalCartoonZeroShotClassification(AbsTaskZeroShotClassification):
             LABEL_PROMPTS.get(name, f"a video of {name}")
             for name in self.dataset["test"].features[self.label_column_name].names
         ]
+
+
+class HumanAnimalCartoonVAZeroShotClassification(AbsTaskZeroShotClassification):
+    metadata = TaskMetadata(
+        name="HumanAnimalCartoonVAZeroShot",
+        description=(
+            "Human-Animal-Cartoon (HAC) is a multi-domain action recognition "
+            "dataset containing clips of humans, animals, and cartoon figures. "
+            "The zero-shot task matches each (video, audio) pair to a text "
+            "prompt for one of seven action labels."
+        ),
+        reference="https://arxiv.org/abs/2310.19795",
+        dataset={
+            "path": "mteb/Human-Animal-Cartoon",
+            "revision": "d38566c4bb055c7325314d3e46610792c2799c4b",
+        },
+        type="VideoZeroshotClassification",
+        category="va2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2023-10-30", "2023-10-30"),
+        domains=["Web", "Scene"],
+        task_subtypes=["Activity recognition"],
+        license="apache-2.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video", "audio", "text"],
+        sample_creation="found",
+        bibtex_citation=CITATION,
+        is_beta=True,
+    )
+
+    input_column_name = ("video", "audio")
+    label_column_name: str = "action"
+
+    def get_candidate_labels(self) -> list[str]:
+        return [
+            LABEL_PROMPTS.get(name, f"a video of {name}")
+            for name in self.dataset["test"].features[self.label_column_name].names
+        ]


### PR DESCRIPTION
Adds the audio+video variant of the HAC zero-shot action classification task. 
If you add a model or a dataset, please add the corresponding checklist:

* [dataset checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_dataset/#submit-a-pull-request)
* [model checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_model/#submitting-your-model-as-a-pr)
