### PR TITLE
task: add RAVDESS V classification and V/VA zero-shot variants

### DIFF
--- a/mteb/tasks/classification/eng/__init__.py
+++ b/mteb/tasks/classification/eng/__init__.py
@@ -226,7 +226,10 @@ from .poem_sentiment_classification import (
     PoemSentimentClassification,
     PoemSentimentClassificationV2,
 )
-from .ravdess_av_classification import RAVDESSAVClassification
+from .ravdess_av_classification import (
+    RAVDESSAVClassification,
+    RAVDESSVClassification,
+)
 from .resisc45_classification import RESISC45Classification
 from .sds_eye_protection_classification import (
     SDSEyeProtectionClassification,
@@ -505,6 +508,7 @@ __all__ = [
     "PoemSentimentClassification",
     "PoemSentimentClassificationV2",
     "RAVDESSAVClassification",
+    "RAVDESSVClassification",
     "RESISC45Classification",
     "SCDBPAccountabilityLegalBenchClassification",
     "SCDBPAuditsLegalBenchClassification",

--- a/mteb/tasks/classification/eng/ravdess_av_classification.py
+++ b/mteb/tasks/classification/eng/ravdess_av_classification.py
@@ -47,3 +47,48 @@ class RAVDESSAVClassification(AbsTaskClassification):
     label_column_name: str = "emotion"
     is_cross_validation = True
     train_split: str = "test"
+
+
+class RAVDESSVClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="RAVDESSVClassification",
+        description="Emotion classification task with video data only for 8 emotions: neutral, calm, happy, sad, angry, fearful, surprise, and disgust expressions.",
+        reference="https://doi.org/10.1371/journal.pone.0196391",
+        dataset={
+            "path": "mteb/RAVDESS_AV",
+            "revision": "13af08387c3ce5e86c179a3718eb158669268d65",
+        },
+        type="VideoClassification",
+        category="v2c",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2018-05-16", "2018-05-16"),
+        domains=["Spoken"],
+        task_subtypes=["Emotion classification"],
+        license="cc-by-4.0",
+        annotations_creators="human-annotated",
+        dialect=["eng-US", "eng-CA"],
+        modalities=["video"],
+        sample_creation="found",
+        bibtex_citation=r"""
+@article{10.1371/journal.pone.0196391,
+  author = {Livingstone, Steven R. AND Russo, Frank A.},
+  doi = {10.1371/journal.pone.0196391},
+  journal = {PLOS ONE},
+  month = {05},
+  number = {5},
+  pages = {1-35},
+  publisher = {Public Library of Science},
+  title = {The Ryerson Audio-Visual Database of Emotional Speech and Song (RAVDESS): A dynamic, multimodal set of facial and vocal expressions in North American English},
+  url = {https://doi.org/10.1371/journal.pone.0196391},
+  volume = {13},
+  year = {2018},
+}
+""",
+        is_beta=True,
+    )
+    input_column_name = "video"
+    label_column_name: str = "emotion"
+    is_cross_validation = True
+    train_split: str = "test"

--- a/mteb/tasks/zeroshot_classification/eng/__init__.py
+++ b/mteb/tasks/zeroshot_classification/eng/__init__.py
@@ -45,6 +45,10 @@ from .music_avqa import (
 from .oxford_pets import OxfordPetsZeroShotClassification
 from .patch_camelyon import PatchCamelyonZeroShotClassification
 from .ravdess import RavdessZeroshotClassification
+from .ravdess_av import (
+    RAVDESSAVZeroShotClassification,
+    RAVDESSVZeroShotClassification,
+)
 from .rendered_sst2 import RenderedSST2
 from .resisc45 import RESISC45ZeroShotClassification
 from .sci_mmir import SciMMIR
@@ -104,6 +108,8 @@ __all__ = [
     "MusicAVQACLSVideoZeroShotClassification",
     "OxfordPetsZeroShotClassification",
     "PatchCamelyonZeroShotClassification",
+    "RAVDESSAVZeroShotClassification",
+    "RAVDESSVZeroShotClassification",
     "RESISC45ZeroShotClassification",
     "RavdessZeroshotClassification",
     "RenderedSST2",

--- a/mteb/tasks/zeroshot_classification/eng/ravdess_av.py
+++ b/mteb/tasks/zeroshot_classification/eng/ravdess_av.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from mteb.abstasks.task_metadata import TaskMetadata
+from mteb.abstasks.zeroshot_classification import AbsTaskZeroShotClassification
+
+CITATION = r"""
+@article{10.1371/journal.pone.0196391,
+  author = {Livingstone, Steven R. AND Russo, Frank A.},
+  doi = {10.1371/journal.pone.0196391},
+  journal = {PLOS ONE},
+  month = {05},
+  number = {5},
+  pages = {1-35},
+  publisher = {Public Library of Science},
+  title = {The Ryerson Audio-Visual Database of Emotional Speech and Song (RAVDESS): A dynamic, multimodal set of facial and vocal expressions in North American English},
+  url = {https://doi.org/10.1371/journal.pone.0196391},
+  volume = {13},
+  year = {2018},
+}
+"""
+
+DATASET = {
+    "path": "mteb/RAVDESS_AV",
+    "revision": "13af08387c3ce5e86c179a3718eb158669268d65",
+}
+
+DESCRIPTION_BASE = (
+    "Emotion zero-shot classification on RAVDESS for 8 emotions: neutral, "
+    "calm, happy, sad, angry, fearful, surprise, and disgust expressions."
+)
+
+
+def _emotion_prompts(names: list[str]) -> list[str]:
+    return [f"this person is feeling {name}" for name in names]
+
+
+class RAVDESSAVZeroShotClassification(AbsTaskZeroShotClassification):
+    metadata = TaskMetadata(
+        name="RAVDESSAVZeroShot",
+        description=DESCRIPTION_BASE + " This variant uses both video and audio.",
+        reference="https://doi.org/10.1371/journal.pone.0196391",
+        dataset=DATASET,
+        type="VideoZeroshotClassification",
+        category="va2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2018-05-16", "2018-05-16"),
+        domains=["Spoken"],
+        task_subtypes=["Emotion classification"],
+        license="cc-by-4.0",
+        annotations_creators="human-annotated",
+        dialect=["eng-US", "eng-CA"],
+        modalities=["video", "audio", "text"],
+        sample_creation="found",
+        bibtex_citation=CITATION,
+        is_beta=True,
+    )
+
+    input_column_name = ("video", "audio")
+    label_column_name: str = "emotion"
+
+    def get_candidate_labels(self) -> list[str]:
+        return _emotion_prompts(
+            self.dataset["test"].features[self.label_column_name].names
+        )
+
+
+class RAVDESSVZeroShotClassification(AbsTaskZeroShotClassification):
+    metadata = TaskMetadata(
+        name="RAVDESSVZeroShot",
+        description=DESCRIPTION_BASE + " This variant uses video only.",
+        reference="https://doi.org/10.1371/journal.pone.0196391",
+        dataset=DATASET,
+        type="VideoZeroshotClassification",
+        category="v2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2018-05-16", "2018-05-16"),
+        domains=["Spoken"],
+        task_subtypes=["Emotion classification"],
+        license="cc-by-4.0",
+        annotations_creators="human-annotated",
+        dialect=["eng-US", "eng-CA"],
+        modalities=["video", "text"],
+        sample_creation="found",
+        bibtex_citation=CITATION,
+        is_beta=True,
+    )
+
+    input_column_name: str = "video"
+    label_column_name: str = "emotion"
+
+    def get_candidate_labels(self) -> list[str]:
+        return _emotion_prompts(
+            self.dataset["test"].features[self.label_column_name].names
+        )


### PR DESCRIPTION
Rounds out the RAVDESS_AV grid with the missing variants:
- RAVDESSVClassification: video-only emotion classification, mirrors RAVDESSAVClassification.
- RAVDESSAVZeroShot, RAVDESSVZeroShot: zero-shot emotion classification using "this person is feeling {emotion}" prompts derived from the ClassLabel feature on the HF dataset.


If you add a model or a dataset, please add the corresponding checklist:

* [dataset checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_dataset/#submit-a-pull-request)
* [model checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_model/#submitting-your-model-as-a-pr)
