### PR TITLE
ci: Speedup CI

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -40,7 +40,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-          version: "0.10.12"
+
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/leaderboard_build.yml
+++ b/.github/workflows/leaderboard_build.yml
@@ -37,7 +37,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-          version: "0.10.12"
+
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-          version: "0.10.12"
+
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/model_loading.yml
+++ b/.github/workflows/model_loading.yml
@@ -39,7 +39,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-          version: "0.10.12"
+
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
-          version: "0.10.12"
+
 
       # required for evaluation the audio subset
       - name: Install FFmpeg (Ubuntu)

--- a/.github/workflows/test_lowest.yml
+++ b/.github/workflows/test_lowest.yml
@@ -50,7 +50,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.10"
-          version: "0.10.12"
+
 
       - name: Install dependencies
         shell: bash

--- a/.github/workflows/typechecking.yml
+++ b/.github/workflows/typechecking.yml
@@ -36,7 +36,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-          version: "0.10.12"
+
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/update_leaderboard_models.yml
+++ b/.github/workflows/update_leaderboard_models.yml
@@ -25,7 +25,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.10"
-          version: "0.10.12"
+
 
       - name: Install mteb
         run: uv sync --frozen

--- a/.github/workflows/update_leaderboard_models.yml
+++ b/.github/workflows/update_leaderboard_models.yml
@@ -28,7 +28,7 @@ jobs:
           version: "0.10.12"
 
       - name: Install mteb
-        run: uv sync
+        run: uv sync --frozen
 
       - name: Generate model list
         run: uv run python scripts/generate_leaderboard_models.py > leaderboard_models.py

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ install:
 install-for-tests:
 	@echo "--- 🚀 Installing project dependencies for test ---"
 	@echo "This ensures that the project is not installed in editable mode"
-	uv sync --extra bm25s --extra image --extra audio --extra leaderboard --extra faiss-cpu --extra github --group dev
+	uv sync --extra bm25s --extra image --extra audio --extra leaderboard --extra faiss-cpu --extra github --group dev --frozen
 
 lint:
 	@echo "--- 🧹 Running linters ---"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -401,6 +401,7 @@ markers = [
 ]
 
 [tool.uv]
+required-version = ">=0.10.0"
 default-groups = ["test", "docs", "typing", "lint"]
 override-dependencies = [
     "salesforce-lavis", # salesforce-lavis is not valid with sentence transformers >=3.0.0


### PR DESCRIPTION
Changed to `uv sync --frozen`, because `uv lock` takes a lot of time: 30 minutes on CI and 20 minutes locally for me. Also moved pinning uv version from workflow files to pyproject