### PR TITLE
fix: Save results for every `hf_subset` instead of task

### DIFF
--- a/mteb/abstasks/abstask.py
+++ b/mteb/abstasks/abstask.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 import json
 import logging
 import tempfile
@@ -26,6 +27,7 @@ from mteb.models import (
     EncoderProtocol,
     SearchProtocol,
 )
+from mteb.results import TaskResult
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -33,9 +35,11 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from mteb.abstasks.task_metadata import TaskMetadata
+    from mteb.cache import ResultCache
     from mteb.models import (
         MTEBModels,
     )
+    from mteb.models.model_meta import ModelMeta
     from mteb.types import EncodeKwargs, HFSubset, Modalities, ScoresDict
     from mteb.types.statistics import DescriptiveStatistics, SplitDescriptiveStatistics
 
@@ -147,6 +151,8 @@ class AbsTask(ABC):  # noqa: PLR0904
         encode_kwargs: EncodeKwargs,
         prediction_folder: Path | None = None,
         num_proc: int | None = None,
+        cache: ResultCache | None = None,
+        model_meta: ModelMeta | None = None,
         **kwargs: Any,
     ) -> Mapping[HFSubset, ScoresDict]:
         """Evaluates an MTEB compatible model on the task.
@@ -158,6 +164,8 @@ class AbsTask(ABC):  # noqa: PLR0904
             encode_kwargs: Additional keyword arguments that are passed to the model's `encode` method.
             prediction_folder: Folder to save model predictions
             num_proc: Number of processes to use for loading the dataset or processing.
+            cache: Cache to save results to after evaluating each subset.
+            model_meta: Model meta required to save subset results in the cache.
             kwargs: Additional keyword arguments that are passed to the _evaluate_subset method.
 
         Returns:
@@ -217,6 +225,37 @@ class AbsTask(ABC):  # noqa: PLR0904
                 **kwargs,
             )
             self._add_main_score(scores[hf_subset])
+
+            if cache is not None and model_meta is not None:
+                try:
+                    # Create a TaskResult with ONLY the subset that was just evaluated
+                    only_current_subset = {hf_subset: scores[hf_subset]}
+                    partial_task_results = {split: only_current_subset}
+                    new_result = TaskResult.from_task_results(
+                        self,
+                        partial_task_results,
+                        evaluation_time=0.0,
+                        kg_co2_emissions=None,
+                        date=datetime.datetime.now(tz=datetime.timezone.utc),
+                    )
+
+                    existing_cached = cache.load_task_result(
+                        self.metadata.name, model_meta
+                    )
+
+                    # Merge: existing subsets + new subset
+                    if existing_cached is not None:
+                        final_result = new_result.merge(existing_cached)
+                    else:
+                        final_result = new_result
+
+                    cache.save_to_cache(final_result, model_meta)
+                    logger.debug(
+                        f"Saved intermediate results after evaluating {self.metadata.name} on {split} subset {hf_subset}"
+                    )
+                except Exception as e:
+                    logger.warning(f"Failed to save intermediate results: {e}")
+
         return scores
 
     @abstractmethod

--- a/mteb/abstasks/abstask.py
+++ b/mteb/abstasks/abstask.py
@@ -33,11 +33,9 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from mteb.abstasks.task_metadata import TaskMetadata
-    from mteb.cache import ResultCache
     from mteb.models import (
         MTEBModels,
     )
-    from mteb.models.model_meta import ModelMeta
     from mteb.types import EncodeKwargs, HFSubset, Modalities, ScoresDict
     from mteb.types.statistics import DescriptiveStatistics, SplitDescriptiveStatistics
 
@@ -149,8 +147,6 @@ class AbsTask(ABC):  # noqa: PLR0904
         encode_kwargs: EncodeKwargs,
         prediction_folder: Path | None = None,
         num_proc: int | None = None,
-        cache: ResultCache | None = None,
-        model_meta: ModelMeta | None = None,
         **kwargs: Any,
     ) -> Mapping[HFSubset, ScoresDict]:
         """Evaluates an MTEB compatible model on the task.
@@ -162,8 +158,6 @@ class AbsTask(ABC):  # noqa: PLR0904
             encode_kwargs: Additional keyword arguments that are passed to the model's `encode` method.
             prediction_folder: Folder to save model predictions
             num_proc: Number of processes to use for loading the dataset or processing.
-            cache: Cache to save results to after evaluating each subset.
-            model_meta: Model meta required to save subset results in the cache.
             kwargs: Additional keyword arguments that are passed to the _evaluate_subset method.
 
         Returns:
@@ -223,7 +217,6 @@ class AbsTask(ABC):  # noqa: PLR0904
                 **kwargs,
             )
             self._add_main_score(scores[hf_subset])
-
         return scores
 
     @abstractmethod

--- a/mteb/abstasks/abstask.py
+++ b/mteb/abstasks/abstask.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import datetime
 import json
 import logging
 import tempfile
@@ -27,7 +26,6 @@ from mteb.models import (
     EncoderProtocol,
     SearchProtocol,
 )
-from mteb.results import TaskResult
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -225,36 +223,6 @@ class AbsTask(ABC):  # noqa: PLR0904
                 **kwargs,
             )
             self._add_main_score(scores[hf_subset])
-
-            if cache is not None and model_meta is not None:
-                try:
-                    # Create a TaskResult with ONLY the subset that was just evaluated
-                    current_subset = {hf_subset: scores[hf_subset]}
-                    partial_task_results = {split: current_subset}
-                    new_result = TaskResult.from_task_results(
-                        self,
-                        partial_task_results,
-                        evaluation_time=0.0,
-                        kg_co2_emissions=None,
-                        date=datetime.datetime.now(tz=datetime.timezone.utc),
-                    )
-
-                    existing_cached = cache.load_task_result(
-                        self.metadata.name, model_meta
-                    )
-
-                    # Merge: existing subsets + new subset
-                    if existing_cached is not None:
-                        final_result = new_result.merge(existing_cached)
-                    else:
-                        final_result = new_result
-
-                    cache.save_to_cache(final_result, model_meta)
-                    logger.debug(
-                        f"Saved intermediate results after evaluating {self.metadata.name} on {split} subset {hf_subset}"
-                    )
-                except Exception as e:
-                    logger.warning(f"Failed to save intermediate results: {e}")
 
         return scores
 

--- a/mteb/abstasks/abstask.py
+++ b/mteb/abstasks/abstask.py
@@ -229,8 +229,8 @@ class AbsTask(ABC):  # noqa: PLR0904
             if cache is not None and model_meta is not None:
                 try:
                     # Create a TaskResult with ONLY the subset that was just evaluated
-                    only_current_subset = {hf_subset: scores[hf_subset]}
-                    partial_task_results = {split: only_current_subset}
+                    current_subset = {hf_subset: scores[hf_subset]}
+                    partial_task_results = {split: current_subset}
                     new_result = TaskResult.from_task_results(
                         self,
                         partial_task_results,

--- a/mteb/deprecated_evaluator.py
+++ b/mteb/deprecated_evaluator.py
@@ -530,7 +530,7 @@ class MTEB:
                 # Create new TaskResult
                 new_results = TaskResult.from_task_results(
                     task,
-                    task_results,  # type: ignore[arg-type]
+                    task_results,
                     evaluation_time=evaluation_time,
                     kg_co2_emissions=kg_co2_emissions,
                 )

--- a/mteb/evaluate.py
+++ b/mteb/evaluate.py
@@ -11,7 +11,7 @@ from datasets.exceptions import DatasetNotFoundError
 from tqdm.auto import tqdm
 
 from mteb._helpful_enum import HelpfulStrEnum
-from mteb.abstasks import AbsTaskRetrieval
+from mteb.abstasks import AbsTaskBitextMining, AbsTaskRetrieval
 from mteb.abstasks.abstask import AbsTask
 from mteb.abstasks.aggregated_task import AbsTaskAggregate
 from mteb.benchmarks.benchmark import Benchmark
@@ -26,14 +26,14 @@ from mteb.results.task_result import TaskError
 from mteb.types import PromptType
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Mapping
 
     from sentence_transformers import CrossEncoder, SentenceTransformer
 
     from mteb.models.models_protocols import (
         MTEBModels,
     )
-    from mteb.types import EncodeKwargs, HFSubset, SplitName
+    from mteb.types import EncodeKwargs, HFSubset, ScoresDict, SplitName
     from mteb.types._metadata import ModelName, Revision
 
 logger = logging.getLogger(__name__)
@@ -83,7 +83,47 @@ def _sanitize_model(
     return wrapped_model, meta, model_name, model_revision
 
 
-def _evaluate_task(
+def _save_intermediate_cache(
+    task: AbsTask,
+    split: str,
+    ss: HFSubset,
+    res: Mapping[HFSubset, ScoresDict],
+    cache: ResultCache | None,
+    model_meta: ModelMeta | None,
+) -> None:
+    if cache is None or model_meta is None:
+        return
+    try:
+        # Create a TaskResult with ONLY the subset that was just evaluated
+        current_subset = {ss: res[ss]}
+        partial_task_results: dict[SplitName, Mapping[HFSubset, ScoresDict]] = {
+            split: current_subset
+        }
+        new_result = TaskResult.from_task_results(
+            task,
+            partial_task_results,
+            evaluation_time=0.0,
+            kg_co2_emissions=None,
+            date=datetime.datetime.now(tz=datetime.timezone.utc),
+        )
+
+        existing_cached = cache.load_task_result(task.metadata.name, model_meta)
+
+        # Merge: existing subsets + new subset
+        if existing_cached is not None:
+            final_result = new_result.merge(existing_cached)
+        else:
+            final_result = new_result
+
+        cache.save_to_cache(final_result, model_meta)
+        logger.debug(
+            f"Saved intermediate results after evaluating {task.metadata.name} on {split} subset {ss}"
+        )
+    except Exception as e:
+        logger.warning(f"Failed to save intermediate results: {e}")
+
+
+def _evaluate_task(  # noqa: PLR0913
     model: MTEBModels,
     task: AbsTask,
     *,
@@ -136,7 +176,7 @@ def _evaluate_task(
             result.kg_co2_emissions = tracker.final_emissions
         return result
 
-    task_results = {}
+    task_results: dict[SplitName, dict[HFSubset, ScoresDict]] = {}
 
     task.check_if_dataset_is_superseded()
 
@@ -163,16 +203,35 @@ def _evaluate_task(
 
     for split, hf_subsets in splits.items():
         tick = time()
-        task_results[split] = task.evaluate(
-            model,
-            split,
-            subsets_to_run=hf_subsets,
-            encode_kwargs=encode_kwargs,
-            prediction_folder=prediction_folder,
-            num_proc=num_proc,
-            cache=cache,
-            model_meta=model_meta,
-        )
+        if isinstance(task, AbsTaskBitextMining):
+            task_results[split] = dict(
+                task.evaluate(
+                    model,
+                    split,
+                    subsets_to_run=hf_subsets,
+                    encode_kwargs=encode_kwargs,
+                    prediction_folder=prediction_folder,
+                    num_proc=num_proc,
+                    cache=cache,
+                    model_meta=model_meta,
+                )
+            )
+        else:
+            task_results[split] = {}
+            for ss in hf_subsets:
+                res = task.evaluate(
+                    model,
+                    split,
+                    subsets_to_run=[ss],
+                    encode_kwargs=encode_kwargs,
+                    prediction_folder=prediction_folder,
+                    num_proc=num_proc,
+                    cache=cache,
+                    model_meta=model_meta,
+                )
+                if res and ss in res:
+                    task_results[split].update(res)
+                    _save_intermediate_cache(task, split, ss, res, cache, model_meta)
         tock = time()
 
         logger.debug(

--- a/mteb/evaluate.py
+++ b/mteb/evaluate.py
@@ -133,16 +133,18 @@ def _evaluate_task(  # noqa: PLR0913
                 existing_results=existing_results,
             )
         if isinstance(result, TaskResult):
-            existing_co2 = (
+            existing_co2_val = (
                 existing_results.kg_co2_emissions
                 if (existing_results and existing_results.kg_co2_emissions is not None)
                 else 0.0
             )
-            result.kg_co2_emissions = existing_co2 + (tracker.final_emissions or 0.0)
+            result.kg_co2_emissions = existing_co2_val + (
+                tracker.final_emissions or 0.0
+            )
         return result
 
     task_results: dict[SplitName, dict[HFSubset, ScoresDict]] = {}
-    evaluation_time = 0.0
+    evaluation_time: float = 0.0
 
     model_meta = model.mteb_model_meta
 
@@ -150,7 +152,7 @@ def _evaluate_task(  # noqa: PLR0913
     if existing_results is not None:
         for split, scores_list in existing_results.scores.items():
             task_results[split] = {score["hf_subset"]: score for score in scores_list}
-        if existing_results.evaluation_time:
+        if existing_results.evaluation_time is not None:
             evaluation_time = existing_results.evaluation_time
 
     task.check_if_dataset_is_superseded()

--- a/mteb/evaluate.py
+++ b/mteb/evaluate.py
@@ -535,7 +535,7 @@ def evaluate(  # noqa: PLR0913, PLR0914
             model=model,
             splits=missing_eval,
             task=task,
-            co2_tracker=False,
+            co2_tracker=co2_tracker,
             encode_kwargs=encode_kwargs,
             prediction_folder=prediction_folder,
             public_only=public_only,

--- a/mteb/evaluate.py
+++ b/mteb/evaluate.py
@@ -133,7 +133,12 @@ def _evaluate_task(  # noqa: PLR0913
                 existing_results=existing_results,
             )
         if isinstance(result, TaskResult):
-            result.kg_co2_emissions = tracker.final_emissions
+            existing_co2 = (
+                existing_results.kg_co2_emissions
+                if (existing_results and existing_results.kg_co2_emissions is not None)
+                else 0.0
+            )
+            result.kg_co2_emissions = existing_co2 + (tracker.final_emissions or 0.0)
         return result
 
     task_results: dict[SplitName, dict[HFSubset, ScoresDict]] = {}
@@ -141,6 +146,7 @@ def _evaluate_task(  # noqa: PLR0913
 
     model_meta = model.mteb_model_meta
 
+    existing_co2 = existing_results.kg_co2_emissions if existing_results else None
     if existing_results is not None:
         for split, scores_list in existing_results.scores.items():
             task_results[split] = {score["hf_subset"]: score for score in scores_list}
@@ -191,21 +197,15 @@ def _evaluate_task(  # noqa: PLR0913
             tock_ss = time()
             task_results[split].update(res)
             # Save intermediate cache
-            if cache and model_meta:
-                try:
-                    new_result = TaskResult.from_task_results(
-                        task,
-                        task_results,
-                        evaluation_time=evaluation_time + (tock_ss - tick),
-                        kg_co2_emissions=None,
-                        date=datetime.datetime.now(tz=datetime.timezone.utc),
-                    )
-                    cache.save_to_cache(new_result, model_meta)
-                except (OSError, TypeError, ValueError) as e:
-                    logger.error(
-                        f"Failed to save intermediate results: {e}",
-                        exc_info=True,
-                    )
+            if cache:
+                new_result = TaskResult.from_task_results(
+                    task,
+                    task_results,
+                    evaluation_time=evaluation_time + (tock_ss - tick),
+                    kg_co2_emissions=existing_co2,
+                    date=datetime.datetime.now(tz=datetime.timezone.utc),
+                )
+                cache.save_to_cache(new_result, model_meta)
         tock = time()
 
         logger.debug(
@@ -217,7 +217,7 @@ def _evaluate_task(  # noqa: PLR0913
         task,
         task_results,
         evaluation_time=evaluation_time,
-        kg_co2_emissions=None,
+        kg_co2_emissions=existing_co2,
         date=datetime.datetime.now(tz=datetime.timezone.utc),
     )
 

--- a/mteb/evaluate.py
+++ b/mteb/evaluate.py
@@ -90,6 +90,7 @@ def _save_intermediate_cache(
     res: Mapping[HFSubset, ScoresDict],
     cache: ResultCache | None,
     model_meta: ModelMeta | None,
+    evaluation_time: float,
 ) -> None:
     if cache is None or model_meta is None:
         return
@@ -102,7 +103,7 @@ def _save_intermediate_cache(
         new_result = TaskResult.from_task_results(
             task,
             partial_task_results,
-            evaluation_time=0.0,
+            evaluation_time=evaluation_time,
             kg_co2_emissions=None,
             date=datetime.datetime.now(tz=datetime.timezone.utc),
         )
@@ -119,8 +120,11 @@ def _save_intermediate_cache(
         logger.debug(
             f"Saved intermediate results after evaluating {task.metadata.name} on {split} subset {ss}"
         )
-    except Exception as e:
-        logger.warning(f"Failed to save intermediate results: {e}")
+    except (OSError, TypeError, ValueError) as e:
+        logger.error(
+            f"Failed to save intermediate results: {e}",
+            exc_info=True,
+        )
 
 
 def _evaluate_task(  # noqa: PLR0913
@@ -203,6 +207,8 @@ def _evaluate_task(  # noqa: PLR0913
 
     for split, hf_subsets in splits.items():
         tick = time()
+        # BitextMining tasks evaluate all subsets together (e.g. for parallel subsets), so they
+        # are not run subset-by-subset or incrementally cached here. Their final results are cached at the end of evaluate.
         if isinstance(task, AbsTaskBitextMining):
             task_results[split] = dict(
                 task.evaluate(
@@ -219,6 +225,7 @@ def _evaluate_task(  # noqa: PLR0913
         else:
             task_results[split] = {}
             for ss in hf_subsets:
+                tick_ss = time()
                 res = task.evaluate(
                     model,
                     split,
@@ -229,9 +236,27 @@ def _evaluate_task(  # noqa: PLR0913
                     cache=cache,
                     model_meta=model_meta,
                 )
+                tock_ss = time()
                 if res and ss in res:
                     task_results[split].update(res)
-                    _save_intermediate_cache(task, split, ss, res, cache, model_meta)
+                    _save_intermediate_cache(
+                        task,
+                        split,
+                        ss,
+                        res,
+                        cache,
+                        model_meta,
+                        evaluation_time=tock_ss - tick_ss,
+                    )
+                else:
+                    logger.warning(
+                        "Requested subset %r for task %s on split %s produced no result; "
+                        "evaluation returned %s",
+                        ss,
+                        task.metadata.name,
+                        split,
+                        "no data" if not res else f"keys {list(res.keys())!r}",
+                    )
         tock = time()
 
         logger.debug(

--- a/mteb/evaluate.py
+++ b/mteb/evaluate.py
@@ -92,6 +92,8 @@ def _evaluate_task(
     encode_kwargs: EncodeKwargs,
     prediction_folder: Path | None,
     public_only: bool | None,
+    cache: ResultCache | None = None,
+    model_meta: ModelMeta | None = None,
     num_proc: int | None = None,
 ) -> TaskResult | TaskError:
     """The core logic to run a model on a given task. See `evaluate` for more details.
@@ -126,6 +128,8 @@ def _evaluate_task(
                 co2_tracker=False,
                 prediction_folder=prediction_folder,
                 public_only=public_only,
+                cache=cache,
+                model_meta=model_meta,
                 num_proc=num_proc,
             )
         if isinstance(result, TaskResult):
@@ -166,6 +170,8 @@ def _evaluate_task(
             encode_kwargs=encode_kwargs,
             prediction_folder=prediction_folder,
             num_proc=num_proc,
+            cache=cache,
+            model_meta=model_meta,
         )
         tock = time()
 
@@ -482,6 +488,8 @@ def evaluate(  # noqa: PLR0913, PLR0914
                 encode_kwargs=encode_kwargs,
                 prediction_folder=prediction_folder,
                 public_only=public_only,
+                cache=cache,
+                model_meta=meta,
                 num_proc=num_proc,
             )
         except Exception as e:
@@ -498,6 +506,8 @@ def evaluate(  # noqa: PLR0913, PLR0914
             encode_kwargs=encode_kwargs,
             prediction_folder=prediction_folder,
             public_only=public_only,
+            cache=cache,
+            model_meta=meta,
             num_proc=num_proc,
         )
     logger.info(f"✓ Finished evaluation for {task.metadata.name}")

--- a/mteb/evaluate.py
+++ b/mteb/evaluate.py
@@ -93,7 +93,6 @@ def _evaluate_task(  # noqa: PLR0913
     prediction_folder: Path | None,
     public_only: bool | None,
     cache: ResultCache | None = None,
-    model_meta: ModelMeta | None = None,
     num_proc: int | None = None,
     existing_results: TaskResult | None = None,
 ) -> TaskResult | TaskError:
@@ -130,7 +129,6 @@ def _evaluate_task(  # noqa: PLR0913
                 prediction_folder=prediction_folder,
                 public_only=public_only,
                 cache=cache,
-                model_meta=model_meta,
                 num_proc=num_proc,
                 existing_results=existing_results,
             )
@@ -140,6 +138,8 @@ def _evaluate_task(  # noqa: PLR0913
 
     task_results: dict[SplitName, dict[HFSubset, ScoresDict]] = {}
     evaluation_time = 0.0
+
+    model_meta = model.mteb_model_meta
 
     if existing_results is not None:
         for split, scores_list in existing_results.scores.items():
@@ -168,8 +168,6 @@ def _evaluate_task(  # noqa: PLR0913
             if public_only is False:
                 raise e
 
-    evaluation_time = 0.0
-
     for split, hf_subsets in splits.items():
         tick = time()
         # BitextMining tasks evaluate all subsets together (e.g. for parallel subsets), so they
@@ -189,37 +187,24 @@ def _evaluate_task(  # noqa: PLR0913
                 encode_kwargs=encode_kwargs,
                 prediction_folder=prediction_folder,
                 num_proc=num_proc,
-                cache=cache,
-                model_meta=model_meta,
             )
-            tock = time()
-
-            if res:
-                task_results[split].update(res)
-                # Save intermediate cache
-                if cache and model_meta:
-                    try:
-                        new_result = TaskResult.from_task_results(
-                            task,
-                            task_results,
-                            evaluation_time=evaluation_time + (tock - tick),
-                            kg_co2_emissions=None,
-                            date=datetime.datetime.now(tz=datetime.timezone.utc),
-                        )
-                        cache.save_to_cache(new_result, model_meta)
-                    except (OSError, TypeError, ValueError) as e:
-                        logger.error(
-                            f"Failed to save intermediate results: {e}",
-                            exc_info=True,
-                        )
-            else:
-                for ss in batch:
-                    logger.warning(
-                        "Requested subset %r for task %s on split %s produced no result; "
-                        "evaluation returned no data",
-                        ss,
-                        task.metadata.name,
-                        split,
+            tock_ss = time()
+            task_results[split].update(res)
+            # Save intermediate cache
+            if cache and model_meta:
+                try:
+                    new_result = TaskResult.from_task_results(
+                        task,
+                        task_results,
+                        evaluation_time=evaluation_time + (tock_ss - tick),
+                        kg_co2_emissions=None,
+                        date=datetime.datetime.now(tz=datetime.timezone.utc),
+                    )
+                    cache.save_to_cache(new_result, model_meta)
+                except (OSError, TypeError, ValueError) as e:
+                    logger.error(
+                        f"Failed to save intermediate results: {e}",
+                        exc_info=True,
                     )
         tock = time()
 
@@ -537,7 +522,6 @@ def evaluate(  # noqa: PLR0913, PLR0914
                 prediction_folder=prediction_folder,
                 public_only=public_only,
                 cache=cache,
-                model_meta=meta,
                 num_proc=num_proc,
                 existing_results=existing_results,
             )
@@ -556,7 +540,6 @@ def evaluate(  # noqa: PLR0913, PLR0914
             prediction_folder=prediction_folder,
             public_only=public_only,
             cache=cache,
-            model_meta=meta,
             num_proc=num_proc,
             existing_results=existing_results,
         )

--- a/mteb/evaluate.py
+++ b/mteb/evaluate.py
@@ -26,7 +26,7 @@ from mteb.results.task_result import TaskError
 from mteb.types import PromptType
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping
+    from collections.abc import Iterable
 
     from sentence_transformers import CrossEncoder, SentenceTransformer
 
@@ -83,50 +83,6 @@ def _sanitize_model(
     return wrapped_model, meta, model_name, model_revision
 
 
-def _save_intermediate_cache(
-    task: AbsTask,
-    split: str,
-    ss: HFSubset,
-    res: Mapping[HFSubset, ScoresDict],
-    cache: ResultCache | None,
-    model_meta: ModelMeta | None,
-    evaluation_time: float,
-) -> None:
-    if cache is None or model_meta is None:
-        return
-    try:
-        # Create a TaskResult with ONLY the subset that was just evaluated
-        current_subset = {ss: res[ss]}
-        partial_task_results: dict[SplitName, Mapping[HFSubset, ScoresDict]] = {
-            split: current_subset
-        }
-        new_result = TaskResult.from_task_results(
-            task,
-            partial_task_results,
-            evaluation_time=evaluation_time,
-            kg_co2_emissions=None,
-            date=datetime.datetime.now(tz=datetime.timezone.utc),
-        )
-
-        existing_cached = cache.load_task_result(task.metadata.name, model_meta)
-
-        # Merge: existing subsets + new subset
-        if existing_cached is not None:
-            final_result = new_result.merge(existing_cached)
-        else:
-            final_result = new_result
-
-        cache.save_to_cache(final_result, model_meta)
-        logger.debug(
-            f"Saved intermediate results after evaluating {task.metadata.name} on {split} subset {ss}"
-        )
-    except (OSError, TypeError, ValueError) as e:
-        logger.error(
-            f"Failed to save intermediate results: {e}",
-            exc_info=True,
-        )
-
-
 def _evaluate_task(  # noqa: PLR0913
     model: MTEBModels,
     task: AbsTask,
@@ -139,6 +95,7 @@ def _evaluate_task(  # noqa: PLR0913
     cache: ResultCache | None = None,
     model_meta: ModelMeta | None = None,
     num_proc: int | None = None,
+    existing_results: TaskResult | None = None,
 ) -> TaskResult | TaskError:
     """The core logic to run a model on a given task. See `evaluate` for more details.
 
@@ -175,12 +132,20 @@ def _evaluate_task(  # noqa: PLR0913
                 cache=cache,
                 model_meta=model_meta,
                 num_proc=num_proc,
+                existing_results=existing_results,
             )
         if isinstance(result, TaskResult):
             result.kg_co2_emissions = tracker.final_emissions
         return result
 
     task_results: dict[SplitName, dict[HFSubset, ScoresDict]] = {}
+    evaluation_time = 0.0
+
+    if existing_results is not None:
+        for split, scores_list in existing_results.scores.items():
+            task_results[split] = {score["hf_subset"]: score for score in scores_list}
+        if existing_results.evaluation_time:
+            evaluation_time = existing_results.evaluation_time
 
     task.check_if_dataset_is_superseded()
 
@@ -208,54 +173,53 @@ def _evaluate_task(  # noqa: PLR0913
     for split, hf_subsets in splits.items():
         tick = time()
         # BitextMining tasks evaluate all subsets together (e.g. for parallel subsets), so they
-        # are not run subset-by-subset or incrementally cached here. Their final results are cached at the end of evaluate.
+        # are not run subset-by-subset. Other tasks are run subset-by-subset for intermediate caching.
         if isinstance(task, AbsTaskBitextMining):
-            task_results[split] = dict(
-                task.evaluate(
-                    model,
-                    split,
-                    subsets_to_run=hf_subsets,
-                    encode_kwargs=encode_kwargs,
-                    prediction_folder=prediction_folder,
-                    num_proc=num_proc,
-                    cache=cache,
-                    model_meta=model_meta,
-                )
-            )
+            subsets_batches = [hf_subsets]
         else:
+            subsets_batches = [[ss] for ss in hf_subsets]
+
+        if split not in task_results:
             task_results[split] = {}
-            for ss in hf_subsets:
-                tick_ss = time()
-                res = task.evaluate(
-                    model,
-                    split,
-                    subsets_to_run=[ss],
-                    encode_kwargs=encode_kwargs,
-                    prediction_folder=prediction_folder,
-                    num_proc=num_proc,
-                    cache=cache,
-                    model_meta=model_meta,
-                )
-                tock_ss = time()
-                if res and ss in res:
-                    task_results[split].update(res)
-                    _save_intermediate_cache(
-                        task,
-                        split,
-                        ss,
-                        res,
-                        cache,
-                        model_meta,
-                        evaluation_time=tock_ss - tick_ss,
-                    )
-                else:
+        for batch in subsets_batches:
+            res = task.evaluate(
+                model,
+                split,
+                subsets_to_run=batch,
+                encode_kwargs=encode_kwargs,
+                prediction_folder=prediction_folder,
+                num_proc=num_proc,
+                cache=cache,
+                model_meta=model_meta,
+            )
+            tock = time()
+
+            if res:
+                task_results[split].update(res)
+                # Save intermediate cache
+                if cache and model_meta:
+                    try:
+                        new_result = TaskResult.from_task_results(
+                            task,
+                            task_results,
+                            evaluation_time=evaluation_time + (tock - tick),
+                            kg_co2_emissions=None,
+                            date=datetime.datetime.now(tz=datetime.timezone.utc),
+                        )
+                        cache.save_to_cache(new_result, model_meta)
+                    except (OSError, TypeError, ValueError) as e:
+                        logger.error(
+                            f"Failed to save intermediate results: {e}",
+                            exc_info=True,
+                        )
+            else:
+                for ss in batch:
                     logger.warning(
                         "Requested subset %r for task %s on split %s produced no result; "
-                        "evaluation returned %s",
+                        "evaluation returned no data",
                         ss,
                         task.metadata.name,
                         split,
-                        "no data" if not res else f"keys {list(res.keys())!r}",
                     )
         tock = time()
 
@@ -575,6 +539,7 @@ def evaluate(  # noqa: PLR0913, PLR0914
                 cache=cache,
                 model_meta=meta,
                 num_proc=num_proc,
+                existing_results=existing_results,
             )
         except Exception as e:
             logger.error(
@@ -593,6 +558,7 @@ def evaluate(  # noqa: PLR0913, PLR0914
             cache=cache,
             model_meta=meta,
             num_proc=num_proc,
+            existing_results=existing_results,
         )
     logger.info(f"✓ Finished evaluation for {task.metadata.name}")
 
@@ -603,9 +569,6 @@ def evaluate(  # noqa: PLR0913, PLR0914
             task_results=[],
             exceptions=[result],
         )
-
-    if existing_results:
-        result = result.merge(existing_results)
 
     if cache:
         cache.save_to_cache(result, meta)

--- a/mteb/results/task_result.py
+++ b/mteb/results/task_result.py
@@ -837,10 +837,10 @@ class TaskResult(BaseModel):  # noqa: PLR0904
                 merged_scores[split] = scores
 
         existing_kg_co2_emissions = (
-            self.kg_co2_emissions if self.kg_co2_emissions else 0.0
+            self.kg_co2_emissions if self.kg_co2_emissions else 0
         )
         new_kg_co2_emissions = (
-            new_results.kg_co2_emissions if new_results.kg_co2_emissions else 0.0
+            new_results.kg_co2_emissions if new_results.kg_co2_emissions else 0
         )
         merged_kg_co2_emissions = None
         if (

--- a/mteb/results/task_result.py
+++ b/mteb/results/task_result.py
@@ -215,14 +215,14 @@ class TaskResult(BaseModel):  # noqa: PLR0904
                     **hf_scores,
                     "hf_subset": hf_subset,
                     "languages": eval_langs,
-                    "mteb_version": mteb_ver,
+                    "mteb_version": hf_scores.get("mteb_version", mteb_ver),
                 }
                 flat_scores[split].append(_scores)
 
         return TaskResult(
             dataset_revision=task.metadata.revision,
             task_name=task.metadata.name,
-            mteb_version=mteb_ver,
+            mteb_version=cls._compute_top_level_mteb_version(flat_scores) or mteb_ver,
             scores=flat_scores,
             evaluation_time=evaluation_time,
             kg_co2_emissions=kg_co2_emissions,

--- a/mteb/results/task_result.py
+++ b/mteb/results/task_result.py
@@ -177,7 +177,7 @@ class TaskResult(BaseModel):  # noqa: PLR0904
     def from_task_results(
         cls,
         task: AbsTask | type[AbsTask],
-        scores: dict[SplitName, Mapping[HFSubset, ScoresDict]],
+        scores: Mapping[SplitName, Mapping[HFSubset, ScoresDict]],
         evaluation_time: float,
         kg_co2_emissions: float | None = None,
         date: datetime.datetime | None = None,

--- a/mteb/results/task_result.py
+++ b/mteb/results/task_result.py
@@ -196,7 +196,7 @@ class TaskResult(BaseModel):  # noqa: PLR0904
         task_meta = task.metadata
         subset2langscripts = task_meta.hf_subsets_to_langscripts
         mteb_ver = version("mteb")
-        flat_scores = defaultdict(list)
+        flat_scores: dict[SplitName, list[ScoresDict]] = defaultdict(list)
         for split, hf_subset_scores in scores.items():
             for hf_subset, hf_scores in hf_subset_scores.items():
                 if hf_subset in subset2langscripts:

--- a/mteb/results/task_result.py
+++ b/mteb/results/task_result.py
@@ -837,18 +837,23 @@ class TaskResult(BaseModel):  # noqa: PLR0904
                 merged_scores[split] = scores
 
         existing_kg_co2_emissions = (
-            self.kg_co2_emissions if self.kg_co2_emissions else 0
+            self.kg_co2_emissions if self.kg_co2_emissions else 0.0
         )
         new_kg_co2_emissions = (
-            new_results.kg_co2_emissions if new_results.kg_co2_emissions else 0
+            new_results.kg_co2_emissions if new_results.kg_co2_emissions else 0.0
         )
         merged_kg_co2_emissions = None
-        if existing_kg_co2_emissions and new_kg_co2_emissions:
+        if (
+            self.kg_co2_emissions is not None
+            or new_results.kg_co2_emissions is not None
+        ):
             merged_kg_co2_emissions = existing_kg_co2_emissions + new_kg_co2_emissions
 
         merged_evaluation_time = None
-        if self.evaluation_time and new_results.evaluation_time:
-            merged_evaluation_time = self.evaluation_time + new_results.evaluation_time
+        if self.evaluation_time is not None or new_results.evaluation_time is not None:
+            merged_evaluation_time = (self.evaluation_time or 0.0) + (
+                new_results.evaluation_time or 0.0
+            )
         date = self.date
         if new_results.date is not None and (date is None or new_results.date > date):
             date = new_results.date

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -5,7 +5,6 @@ from importlib.metadata import version
 from pathlib import Path
 
 import pytest
-from datasets import Dataset, DatasetDict
 from datasets.exceptions import DatasetNotFoundError
 
 import mteb
@@ -20,6 +19,7 @@ from tests.mock_models import MockSentenceTransformer
 from tests.mock_tasks import (
     MockAggregatedTask,
     MockClassificationTask,
+    MockMultilingualClassificationTask,
     MockMultilingualRetrievalTask,
     MockRetrievalTask,
 )
@@ -410,45 +410,10 @@ def test_mock_mmeb_tasks(task: AbsTask):
     mteb.evaluate(model, task, cache=None)
 
 
-class MockCrashTask(MockClassificationTask):
-    def __init__(self):
-        super().__init__()
-        self.hf_subsets = ["subset1", "subset2"]
-
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
-        train_texts = ["This is a test sentence", "This is another train sentence"]
-        test_texts = ["This is a test sentence", "This is another test sentence"]
-        labels = [0, 1]
-
-        self.dataset = DatasetDict(
-            {
-                "subset1": DatasetDict(
-                    {
-                        "test": Dataset.from_dict(
-                            {"text": test_texts, "label": labels}
-                        ),
-                        "train": Dataset.from_dict(
-                            {"text": train_texts, "label": labels}
-                        ),
-                    }
-                ),
-                "subset2": DatasetDict(
-                    {
-                        "test": Dataset.from_dict(
-                            {"text": test_texts, "label": labels}
-                        ),
-                        "train": Dataset.from_dict(
-                            {"text": train_texts, "label": labels}
-                        ),
-                    }
-                ),
-            }
-        )
-        self.data_loaded = True
-
+class MockCrashTask(MockMultilingualClassificationTask):
     def _evaluate_subset(self, model, data_split, hf_split, hf_subset, **kwargs):  # noqa: PLR6301
-        if hf_subset == "subset2":
-            raise RuntimeError("Crash on subset2")
+        if hf_subset == "fra":
+            raise RuntimeError("Crash on fra")
         return {"accuracy": 0.8}
 
 
@@ -457,7 +422,7 @@ def test_evaluate_intermediate_cache_on_crash(tmp_path: Path):
     task = MockCrashTask()
     cache = ResultCache(tmp_path)
 
-    with pytest.raises(RuntimeError, match="Crash on subset2"):
+    with pytest.raises(RuntimeError, match="Crash on fra"):
         mteb.evaluate(model, task, cache=cache, co2_tracker=False)
 
     cached_result = cache.load_task_result(task.metadata.name, model.mteb_model_meta)
@@ -465,7 +430,7 @@ def test_evaluate_intermediate_cache_on_crash(tmp_path: Path):
     assert "test" in cached_result.scores
     scores = cached_result.scores["test"]
     assert len(scores) == 1
-    assert scores[0]["hf_subset"] == "subset1"
+    assert scores[0]["hf_subset"] == "eng"
     assert scores[0]["main_score"] == 0.8
 
 

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -17,7 +17,6 @@ from mteb.types import OutputDType
 from tests.mock_models import MockSentenceTransformer
 from tests.mock_tasks import (
     MockAggregatedTask,
-    MockBitextMiningTask,
     MockClassificationTask,
     MockMultilingualRetrievalTask,
     MockRetrievalTask,
@@ -466,18 +465,3 @@ def test_evaluate_intermediate_cache_on_crash(tmp_path: Path):
     assert len(scores) == 1
     assert scores[0]["hf_subset"] == "subset1"
     assert scores[0]["main_score"] == 0.8
-
-
-def test_evaluate_bitext_mining_caching(tmp_path: Path):
-    model = mteb.get_model("mteb/baseline-random-encoder")
-    task = MockBitextMiningTask()
-    cache = ResultCache(tmp_path)
-
-    results = mteb.evaluate(model, task, cache=cache, co2_tracker=False)
-    assert len(results.task_results) == 1
-
-    cached_result = cache.load_task_result(task.metadata.name, model.mteb_model_meta)
-    assert cached_result is not None
-    assert "test" in cached_result.scores
-    scores = cached_result.scores["test"]
-    assert len(scores) == len(task.hf_subsets)

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -405,3 +405,75 @@ def test_mock_mmeb_tasks(task: AbsTask):
     pytest.importorskip("torchcodec", reason="Audio dependencies are not installed")
     model = mteb.get_model_meta("mteb/baseline-random-encoder")
     mteb.evaluate(model, task, cache=None)
+
+
+class MockCrashTask(MockClassificationTask):
+    metadata = copy(MockClassificationTask.metadata)
+    metadata.name = "MockCrashTask"
+
+    def __init__(self):
+        super().__init__()
+        self.hf_subsets = ["subset1", "subset2"]
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        from datasets import Dataset, DatasetDict
+
+        train_texts = ["This is a test sentence", "This is another train sentence"]
+        test_texts = ["This is a test sentence", "This is another test sentence"]
+        labels = [0, 1]
+
+        self.dataset = DatasetDict(
+            {
+                "subset1": DatasetDict(
+                    {
+                        "test": Dataset.from_dict(
+                            {"text": test_texts, "label": labels}
+                        ),
+                        "train": Dataset.from_dict(
+                            {"text": train_texts, "label": labels}
+                        ),
+                    }
+                ),
+                "subset2": DatasetDict(
+                    {
+                        "test": Dataset.from_dict(
+                            {"text": test_texts, "label": labels}
+                        ),
+                        "train": Dataset.from_dict(
+                            {"text": train_texts, "label": labels}
+                        ),
+                    }
+                ),
+            }
+        )
+        self.data_loaded = True
+
+    def _evaluate_subset(self, model, data_split, hf_split, hf_subset, **kwargs):  # noqa: PLR6301
+        if hf_subset == "subset2":
+            raise RuntimeError("Crash on subset2")
+        return {"accuracy": 0.8}
+
+
+def test_evaluate_intermediate_cache_on_crash(tmp_path: Path):
+    model = mteb.get_model("mteb/baseline-random-encoder")
+    task = MockCrashTask()
+    cache = ResultCache(tmp_path)
+
+    with pytest.raises(RuntimeError, match="Crash on subset2"):
+        mteb.evaluate(model, task, cache=cache, co2_tracker=False)
+
+    path = cache.get_task_result_path(
+        task.metadata.name,
+        model.mteb_model_meta.name,
+        model.mteb_model_meta.revision,
+    )
+    assert path.exists() and path.is_file()
+
+    from mteb.results import TaskResult
+
+    cached_result = TaskResult.from_disk(path)
+    assert "test" in cached_result.scores
+    scores = cached_result.scores["test"]
+    assert len(scores) == 1
+    assert scores[0]["hf_subset"] == "subset1"
+    assert scores[0]["main_score"] == 0.8

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -477,3 +477,28 @@ def test_evaluate_intermediate_cache_on_crash(tmp_path: Path):
     assert len(scores) == 1
     assert scores[0]["hf_subset"] == "subset1"
     assert scores[0]["main_score"] == 0.8
+
+
+def test_evaluate_bitext_mining_caching(tmp_path: Path):
+    from tests.mock_tasks import MockBitextMiningTask
+
+    model = mteb.get_model("mteb/baseline-random-encoder")
+    task = MockBitextMiningTask()
+    cache = ResultCache(tmp_path)
+
+    results = mteb.evaluate(model, task, cache=cache, co2_tracker=False)
+    assert len(results.task_results) == 1
+
+    path = cache.get_task_result_path(
+        task.metadata.name,
+        model.mteb_model_meta.name,
+        model.mteb_model_meta.revision,
+    )
+    assert path.exists() and path.is_file()
+
+    from mteb.results import TaskResult
+
+    cached_result = TaskResult.from_disk(path)
+    assert "test" in cached_result.scores
+    scores = cached_result.scores["test"]
+    assert len(scores) == len(task.hf_subsets)

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -4,6 +4,7 @@ from copy import copy
 from pathlib import Path
 
 import pytest
+from datasets import Dataset, DatasetDict
 from datasets.exceptions import DatasetNotFoundError
 
 import mteb
@@ -16,6 +17,7 @@ from mteb.types import OutputDType
 from tests.mock_models import MockSentenceTransformer
 from tests.mock_tasks import (
     MockAggregatedTask,
+    MockBitextMiningTask,
     MockClassificationTask,
     MockMultilingualRetrievalTask,
     MockRetrievalTask,
@@ -408,16 +410,11 @@ def test_mock_mmeb_tasks(task: AbsTask):
 
 
 class MockCrashTask(MockClassificationTask):
-    metadata = copy(MockClassificationTask.metadata)
-    metadata.name = "MockCrashTask"
-
     def __init__(self):
         super().__init__()
         self.hf_subsets = ["subset1", "subset2"]
 
     def load_data(self, num_proc: int | None = None, **kwargs) -> None:
-        from datasets import Dataset, DatasetDict
-
         train_texts = ["This is a test sentence", "This is another train sentence"]
         test_texts = ["This is a test sentence", "This is another test sentence"]
         labels = [0, 1]
@@ -462,16 +459,8 @@ def test_evaluate_intermediate_cache_on_crash(tmp_path: Path):
     with pytest.raises(RuntimeError, match="Crash on subset2"):
         mteb.evaluate(model, task, cache=cache, co2_tracker=False)
 
-    path = cache.get_task_result_path(
-        task.metadata.name,
-        model.mteb_model_meta.name,
-        model.mteb_model_meta.revision,
-    )
-    assert path.exists() and path.is_file()
-
-    from mteb.results import TaskResult
-
-    cached_result = TaskResult.from_disk(path)
+    cached_result = cache.load_task_result(task.metadata.name, model.mteb_model_meta)
+    assert cached_result is not None
     assert "test" in cached_result.scores
     scores = cached_result.scores["test"]
     assert len(scores) == 1
@@ -480,8 +469,6 @@ def test_evaluate_intermediate_cache_on_crash(tmp_path: Path):
 
 
 def test_evaluate_bitext_mining_caching(tmp_path: Path):
-    from tests.mock_tasks import MockBitextMiningTask
-
     model = mteb.get_model("mteb/baseline-random-encoder")
     task = MockBitextMiningTask()
     cache = ResultCache(tmp_path)
@@ -489,16 +476,8 @@ def test_evaluate_bitext_mining_caching(tmp_path: Path):
     results = mteb.evaluate(model, task, cache=cache, co2_tracker=False)
     assert len(results.task_results) == 1
 
-    path = cache.get_task_result_path(
-        task.metadata.name,
-        model.mteb_model_meta.name,
-        model.mteb_model_meta.revision,
-    )
-    assert path.exists() and path.is_file()
-
-    from mteb.results import TaskResult
-
-    cached_result = TaskResult.from_disk(path)
+    cached_result = cache.load_task_result(task.metadata.name, model.mteb_model_meta)
+    assert cached_result is not None
     assert "test" in cached_result.scores
     scores = cached_result.scores["test"]
     assert len(scores) == len(task.hf_subsets)

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from copy import copy
+from importlib.metadata import version
 from pathlib import Path
 
 import pytest
@@ -13,6 +14,7 @@ from mteb.abstasks.abstask import AbsTask
 from mteb.cache import ResultCache
 from mteb.models import ModelMeta
 from mteb.models.models_protocols import EncoderProtocol
+from mteb.results.task_result import TaskResult
 from mteb.types import OutputDType
 from tests.mock_models import MockSentenceTransformer
 from tests.mock_tasks import (
@@ -465,3 +467,49 @@ def test_evaluate_intermediate_cache_on_crash(tmp_path: Path):
     assert len(scores) == 1
     assert scores[0]["hf_subset"] == "subset1"
     assert scores[0]["main_score"] == 0.8
+
+
+def test_task_result_from_task_results_merging():
+    task = MockClassificationTask()
+    scores = {
+        "test": {
+            "subset1": {
+                "main_score": 0.8,
+                "accuracy": 0.8,
+                "mteb_version": "1.0.0",
+            },
+            "subset2": {
+                "main_score": 0.9,
+                "accuracy": 0.9,
+            },
+        }
+    }
+
+    current_version = version("mteb")
+    result = TaskResult.from_task_results(
+        task=task,
+        scores=scores,
+        evaluation_time=12.5,
+        kg_co2_emissions=0.07,
+    )
+
+    assert result.kg_co2_emissions == 0.07
+    assert result.evaluation_time == 12.5
+    assert len(result.scores["test"]) == 2
+
+    subset1_score = next(
+        s for s in result.scores["test"] if s["hf_subset"] == "subset1"
+    )
+    subset2_score = next(
+        s for s in result.scores["test"] if s["hf_subset"] == "subset2"
+    )
+
+    assert subset1_score["accuracy"] == 0.8
+    assert subset2_score["accuracy"] == 0.9
+    assert subset1_score["mteb_version"] == "1.0.0"
+    assert subset2_score["mteb_version"] == current_version
+
+    if current_version == "1.0.0":
+        assert result.mteb_version == "1.0.0"
+    else:
+        assert result.mteb_version == f"1.0.0-{current_version}"

--- a/tests/test_results/test_task_results.py
+++ b/tests/test_results/test_task_results.py
@@ -186,6 +186,7 @@ def test_merge_across_mteb_versions():
             ]
         },
         evaluation_time=50,
+        kg_co2_emissions=0.05,
     )
 
     new = TaskResult(
@@ -203,6 +204,7 @@ def test_merge_across_mteb_versions():
             ]
         },
         evaluation_time=60,
+        kg_co2_emissions=0.02,
     )
 
     assert existing.is_mergeable(new)
@@ -216,6 +218,9 @@ def test_merge_across_mteb_versions():
 
     # Top-level version should be a range when subsets differ
     assert merged.mteb_version == "2.12.4-2.20.1"
+
+    # Verify that CO2 emissions are summed when both are present
+    assert merged.kg_co2_emissions == pytest.approx(0.07)
 
 
 def test_merge_without_per_subset_version():
@@ -234,6 +239,7 @@ def test_merge_without_per_subset_version():
             ]
         },
         evaluation_time=50,
+        kg_co2_emissions=0.05,
     )
 
     new = TaskResult(
@@ -251,6 +257,7 @@ def test_merge_without_per_subset_version():
             ]
         },
         evaluation_time=60,
+        kg_co2_emissions=None,
     )
 
     merged = existing.merge(new)
@@ -261,6 +268,9 @@ def test_merge_without_per_subset_version():
 
     # Top-level should be a range across all subset versions
     assert merged.mteb_version == "2.12.4-2.20.1"
+
+    # Verify that CO2 emissions are merged when one of them is present
+    assert merged.kg_co2_emissions == pytest.approx(0.05)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
closes #4612 

Previously we are saving results after each task run completes, which becomes waste if results become interrupt/crash in between. To avoid these, now we can save results for every `hf_subset` which will avoid redundant recomputations in case of crash and also save things efficiently.  Because, every time we are just saving currently computed `hf_subset` results to already computed results in cache and also after crash when it will resume then these subset will not be run again.