### PR TITLE
fix: Add SWEbenchCodeRetrieval to RTEB benchmarks

### DIFF
--- a/mteb/benchmarks/benchmarks/rteb_benchmarks.py
+++ b/mteb/benchmarks/benchmarks/rteb_benchmarks.py
@@ -31,6 +31,7 @@ RTEB_MAIN = RtebBenchmark(
             "MBPPRetrieval",
             "WikiSQLRetrieval",
             "FreshStackRetrieval",
+            "SWEbenchCodeRetrieval",
             "ChatDoctorRetrieval",
             "CUREv1",
             "MIRACLRetrievalHardNegatives",
@@ -75,6 +76,7 @@ RTEB_ENGLISH = RtebBenchmark(
                 "MBPPRetrieval",
                 "WikiSQLRetrieval",
                 "FreshStackRetrieval",
+                "SWEbenchCodeRetrieval",
                 "ChatDoctorRetrieval",
                 # Closed datasets
                 "Code1Retrieval",
@@ -210,6 +212,7 @@ RTEB_CODE = RtebBenchmark(
             "MBPPRetrieval",
             "WikiSQLRetrieval",
             "FreshStackRetrieval",
+            "SWEbenchCodeRetrieval",
             # Closed datasets
             "Code1Retrieval",
             "JapaneseCode1Retrieval",


### PR DESCRIPTION
## Summary
- Add SWEbenchCodeRetrieval task to RTEB(beta), RTEB(eng, beta), and RTEB(Code, beta) benchmark lists
- The task definition was merged in #4365, this PR adds it to the benchmark listings
- Results for 76 models have been evaluated and will be submitted to the results repo

## Context
Follow-up to #4365 as suggested by @Samoed — the task was merged without benchmark integration to allow results to be collected first.