### PR TITLE
fix: restrict FSD2019Kaggle eval to curated subset only

### DIFF
--- a/mteb/tasks/multilabel_classification/eng/fsd2019_kaggle.py
+++ b/mteb/tasks/multilabel_classification/eng/fsd2019_kaggle.py
@@ -18,7 +18,7 @@ class FSD2019KaggleMultilingualClassification(AbsTaskMultilabelClassification):
         type="AudioMultilabelClassification",
         category="a2t",
         eval_splits=["test"],
-        eval_langs={"curated": ["eng-Latn"], "noisy": ["eng-Latn"]},
+        eval_langs={"curated": ["eng-Latn"]},
         main_score="lrap",
         date=(
             "2020-01-01",


### PR DESCRIPTION
The noisy subset has automatically-extracted labels with known label noise, it was intended as additional training data in the original FSDKaggle2019 Kaggle competition, not as a test set. Evaluating on noisy bounds lrap by the label-noise floor regardless of model quality, which confounds comparison across models.

If you add a model or a dataset, please add the corresponding checklist:

* [dataset checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_dataset/#submit-a-pull-request)
* [model checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_model/#submitting-your-model-as-a-pr)
