### PR TITLE
Append MVEB sampling notes to video / AV task descriptions

### DIFF
--- a/mteb/tasks/classification/eng/ave_dataset_classification.py
+++ b/mteb/tasks/classification/eng/ave_dataset_classification.py
@@ -7,7 +7,7 @@ from mteb.abstasks.task_metadata import TaskMetadata
 class AVEDatasetClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="AVEDatasetClassification",
-        description="Audio-Visual Event (AVE) classification dataset containing 28 event categories such as church bell, truck, dog barking, and other everyday sounds sourced from YouTube videos. The goal is to predict the sound event category from synchronized video and audio.",
+        description="Audio-Visual Event (AVE) classification dataset containing 28 event categories such as church bell, truck, dog barking, and other everyday sounds sourced from YouTube videos. The goal is to predict the sound event category from synchronized video and audio. Used the official train and test splits across 28 audio-visual event classes (~3,312 train / ~402 test).",
         reference="https://openaccess.thecvf.com/content_ECCV_2018/papers/Yapeng_Tian_Audio-Visual_Event_Localization_ECCV_2018_paper.pdf",
         dataset={
             "path": "mteb/AVE-Dataset",
@@ -48,7 +48,7 @@ class AVEDatasetClassification(AbsTaskClassification):
 class AVEDatasetVideoClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="AVEDatasetVideoClassification",
-        description="Audio-Visual Event (AVE) classification dataset containing 28 event categories such as church bell, truck, dog barking, and other everyday sounds sourced from YouTube videos. The goal is to predict the sound event category from video only.",
+        description="Audio-Visual Event (AVE) classification dataset containing 28 event categories such as church bell, truck, dog barking, and other everyday sounds sourced from YouTube videos. The goal is to predict the sound event category from video only. Used the official train and test splits across 28 audio-visual event classes (~3,312 train / ~402 test).",
         reference="https://openaccess.thecvf.com/content_ECCV_2018/papers/Yapeng_Tian_Audio-Visual_Event_Localization_ECCV_2018_paper.pdf",
         dataset={
             "path": "mteb/AVE-Dataset",

--- a/mteb/tasks/classification/eng/breakfast_classification.py
+++ b/mteb/tasks/classification/eng/breakfast_classification.py
@@ -7,7 +7,7 @@ from mteb.abstasks.task_metadata import TaskMetadata
 class BreakfastClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="BreakfastClassification",
-        description="The Breakfast Actions dataset contains 433 videos of 10 breakfast-related activities (e.g. making coffee, preparing cereal, frying eggs) recorded in 18 different kitchens. The task is to classify each video into the correct activity.",
+        description="The Breakfast Actions dataset contains 433 videos of 10 breakfast-related activities (e.g. making coffee, preparing cereal, frying eggs) recorded in 18 different kitchens. The task is to classify each video into the correct activity. Used only camera-01 clips, capped at 50 per class across 10 meal classes (~433 test).",
         reference="https://ieeexplore.ieee.org/document/6909500",
         dataset={
             "path": "mteb/Breakfast",

--- a/mteb/tasks/classification/eng/hmdb51_classification.py
+++ b/mteb/tasks/classification/eng/hmdb51_classification.py
@@ -7,7 +7,7 @@ from mteb.abstasks.task_metadata import TaskMetadata
 class HMDB51Classification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="HMDB51Classification",
-        description="HMDB51 is a large video database for human motion recognition with 51 action categories from digitized movies and online sources.",
+        description="HMDB51 is a large video database for human motion recognition with 51 action categories from digitized movies and online sources. Used official split 1 across 51 action classes (~3,570 train / ~1,530 test).",
         reference="https://serre-lab.clps.brown.edu/resource/hmdb-a-large-human-motion-database/",
         dataset={
             "path": "mteb/HMDB51",

--- a/mteb/tasks/classification/eng/human_animal_cartoon.py
+++ b/mteb/tasks/classification/eng/human_animal_cartoon.py
@@ -20,7 +20,8 @@ class HumanAnimalCartoonVAClassification(AbsTaskClassification):
             "Human-Animal-Cartoon (HAC) is a multi-domain action recognition "
             "dataset containing clips of humans, animals, and cartoon figures. "
             "This MTEB subset uses video and audio clips labelled with one of "
-            "seven actions. This variant uses both video and audio modalities."
+            "seven actions. This variant uses both video and audio modalities. "
+            "Concatenated the three HAC test-only domain CSVs, capped at 32 per class across 7 action classes (~644 examples)."
         ),
         reference="https://arxiv.org/abs/2310.19795",
         dataset={
@@ -57,7 +58,8 @@ class HumanAnimalCartoonVClassification(AbsTaskClassification):
             "Human-Animal-Cartoon (HAC) is a multi-domain action recognition "
             "dataset containing clips of humans, animals, and cartoon figures. "
             "This MTEB subset uses video and audio clips labelled with one of "
-            "seven actions. This variant uses only the video modality."
+            "seven actions. This variant uses only the video modality. "
+            "Concatenated the three HAC test-only domain CSVs, capped at 32 per class across 7 action classes (~644 examples)."
         ),
         reference="https://arxiv.org/abs/2310.19795",
         dataset={

--- a/mteb/tasks/classification/eng/kinetics400.py
+++ b/mteb/tasks/classification/eng/kinetics400.py
@@ -19,7 +19,7 @@ CITATION = r"""
 class Kinetics400VAClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="Kinetics400VA",
-        description="Kinetics-400 is a large-scale action recognition dataset containing 400 human action classes from YouTube videos. Each clip is approximately 10 seconds long.",
+        description="Kinetics-400 is a large-scale action recognition dataset containing 400 human action classes from YouTube videos. Each clip is approximately 10 seconds long. Sampled 25 random shard files from each official path list, capped at 10 per class across 400 classes (~3,970 train / ~4,000 test).",
         reference="https://arxiv.org/abs/1705.06950",
         dataset={
             "path": "mteb/kinetics-400",
@@ -54,7 +54,7 @@ class Kinetics400VAClassification(AbsTaskClassification):
 class Kinetics400VClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="Kinetics400V",
-        description="Kinetics-400 is a large-scale action recognition dataset containing 400 human action classes from YouTube videos. Each clip is approximately 10 seconds long.",
+        description="Kinetics-400 is a large-scale action recognition dataset containing 400 human action classes from YouTube videos. Each clip is approximately 10 seconds long. Sampled 25 random shard files from each official path list, capped at 10 per class across 400 classes (~3,970 train / ~4,000 test).",
         reference="https://arxiv.org/abs/1705.06950",
         dataset={
             "path": "mteb/kinetics-400",

--- a/mteb/tasks/classification/eng/kinetics600.py
+++ b/mteb/tasks/classification/eng/kinetics600.py
@@ -16,7 +16,7 @@ CITATION = r"""
 class Kinetics600VAClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="Kinetics600VA",
-        description="Kinetics-600 is a large-scale action recognition dataset containing 600 human action classes from YouTube videos. Each clip is approximately 10 seconds long. This variant uses both video and audio modalities.",
+        description="Kinetics-600 is a large-scale action recognition dataset containing 600 human action classes from YouTube videos. Each clip is approximately 10 seconds long. This variant uses both video and audio modalities. Sampled the official test split, capped at ~16 per class across 600 classes (~9,576 examples).",
         reference="https://arxiv.org/abs/1808.01340",
         dataset={
             "path": "mteb/kinetics-600",
@@ -52,7 +52,7 @@ class Kinetics600VAClassification(AbsTaskClassification):
 class Kinetics600VClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="Kinetics600V",
-        description="Kinetics-600 is a large-scale action recognition dataset containing 600 human action classes from YouTube videos. Each clip is approximately 10 seconds long. This variant uses video only.",
+        description="Kinetics-600 is a large-scale action recognition dataset containing 600 human action classes from YouTube videos. Each clip is approximately 10 seconds long. This variant uses video only. Sampled the official test split, capped at ~16 per class across 600 classes (~9,576 examples).",
         reference="https://arxiv.org/abs/1808.01340",
         dataset={
             "path": "mteb/kinetics-600",

--- a/mteb/tasks/classification/eng/kinetics700.py
+++ b/mteb/tasks/classification/eng/kinetics700.py
@@ -16,7 +16,7 @@ CITATION = r"""
 class Kinetics700VAClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="Kinetics700VA",
-        description="Kinetics-700-2020 is a large-scale action recognition dataset containing 700 human action classes from YouTube videos. Each clip is approximately 10 seconds long. This variant uses both video and audio modalities.",
+        description="Kinetics-700-2020 is a large-scale action recognition dataset containing 700 human action classes from YouTube videos. Each clip is approximately 10 seconds long. This variant uses both video and audio modalities. Sampled the official test split, capped at ~16 per class across 700 classes (~11,190 examples).",
         reference="https://arxiv.org/abs/2010.10864",
         dataset={
             "path": "mteb/kinetics-700-2020",
@@ -52,7 +52,7 @@ class Kinetics700VAClassification(AbsTaskClassification):
 class Kinetics700VClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="Kinetics700V",
-        description="Kinetics-700-2020 is a large-scale action recognition dataset containing 700 human action classes from YouTube videos. Each clip is approximately 10 seconds long. This variant uses video only.",
+        description="Kinetics-700-2020 is a large-scale action recognition dataset containing 700 human action classes from YouTube videos. Each clip is approximately 10 seconds long. This variant uses video only. Sampled the official test split, capped at ~16 per class across 700 classes (~11,190 examples).",
         reference="https://arxiv.org/abs/2010.10864",
         dataset={
             "path": "mteb/kinetics-700-2020",

--- a/mteb/tasks/classification/eng/meld_classification.py
+++ b/mteb/tasks/classification/eng/meld_classification.py
@@ -7,7 +7,7 @@ from mteb.abstasks.task_metadata import TaskMetadata
 class MELDAudioVideoClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="MELDAudioVideoClassification",
-        description="MELD (Multimodal EmotionLines Dataset) is a multimodal emotion recognition dataset containing over 13,000 utterances from the Friends TV series, labeled with 7 emotion categories: Anger, Disgust, Sadness, Joy, Neutral, Surprise, and Fear",
+        description="MELD (Multimodal EmotionLines Dataset) is a multimodal emotion recognition dataset containing over 13,000 utterances from the Friends TV series, labeled with 7 emotion categories: Anger, Disgust, Sadness, Joy, Neutral, Surprise, and Fear Sampled the test split (~2,610 examples).",
         reference="https://aclanthology.org/P19-1050.pdf",
         dataset={
             "path": "mteb/MELD",
@@ -55,7 +55,7 @@ class MELDAudioVideoClassification(AbsTaskClassification):
 class MELDVideoClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="MELDVideoClassification",
-        description="MELD (Multimodal EmotionLines Dataset) is a multimodal emotion recognition dataset containing over 13,000 utterances from the Friends TV series, labeled with 7 emotion categories: Anger, Disgust, Sadness, Joy, Neutral, Surprise, and Fear",
+        description="MELD (Multimodal EmotionLines Dataset) is a multimodal emotion recognition dataset containing over 13,000 utterances from the Friends TV series, labeled with 7 emotion categories: Anger, Disgust, Sadness, Joy, Neutral, Surprise, and Fear Sampled the test split (~2,610 examples).",
         reference="https://aclanthology.org/P19-1050.pdf",
         dataset={
             "path": "mteb/MELD",

--- a/mteb/tasks/classification/eng/music_avqa_classification.py
+++ b/mteb/tasks/classification/eng/music_avqa_classification.py
@@ -7,7 +7,7 @@ from mteb.abstasks.task_metadata import TaskMetadata
 class MusicAVQACLSAudioVideoClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="MusicAVQACLSAudioVideoClassification",
-        description="MUSIC-AVQA classification dataset containing 22 instrument categories. Given a video and audio of someone playing an instrument, the goal is to predict the instrument type.",
+        description="MUSIC-AVQA classification dataset containing 22 instrument categories. Given a video and audio of someone playing an instrument, the goal is to predict the instrument type. Filtered the test split to rows with a 22-class instrument answer (~1,706 examples).",
         reference="https://arxiv.org/abs/2203.14072",
         dataset={
             "path": "mteb/MUSIC-AVQA_cls-preprocessed",
@@ -46,7 +46,7 @@ class MusicAVQACLSAudioVideoClassification(AbsTaskClassification):
 class MusicAVQACLSVideoClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="MusicAVQACLSVideoClassification",
-        description="MUSIC-AVQA classification dataset containing 22 instrument categories. Given a video and audio of someone playing an instrument, the goal is to predict the instrument type.",
+        description="MUSIC-AVQA classification dataset containing 22 instrument categories. Given a video and audio of someone playing an instrument, the goal is to predict the instrument type. Filtered the test split to rows with a 22-class instrument answer (~1,706 examples).",
         reference="https://arxiv.org/abs/2203.14072",
         dataset={
             "path": "mteb/MUSIC-AVQA_cls-preprocessed",

--- a/mteb/tasks/classification/eng/ravdess_av_classification.py
+++ b/mteb/tasks/classification/eng/ravdess_av_classification.py
@@ -7,7 +7,7 @@ from mteb.abstasks.task_metadata import TaskMetadata
 class RAVDESSAVClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="RAVDESSAVClassification",
-        description="Emotion classification task with video and audio data for 8 emotions: neutral, calm, happy, sad, angry, fearful, surprise, and disgust expressions.",
+        description="Emotion classification task with video and audio data for 8 emotions: neutral, calm, happy, sad, angry, fearful, surprise, and disgust expressions. Used the metadata train split remapped to audio-visual filenames (~1,440 examples).",
         reference="https://doi.org/10.1371/journal.pone.0196391",
         dataset={
             "path": "mteb/RAVDESS_AV",
@@ -52,7 +52,7 @@ class RAVDESSAVClassification(AbsTaskClassification):
 class RAVDESSVClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="RAVDESSVClassification",
-        description="Emotion classification task with video data only for 8 emotions: neutral, calm, happy, sad, angry, fearful, surprise, and disgust expressions.",
+        description="Emotion classification task with video data only for 8 emotions: neutral, calm, happy, sad, angry, fearful, surprise, and disgust expressions. Used the metadata train split remapped to audio-visual filenames (~1,440 examples).",
         reference="https://doi.org/10.1371/journal.pone.0196391",
         dataset={
             "path": "mteb/RAVDESS_AV",

--- a/mteb/tasks/classification/eng/something_something_v2_classification.py
+++ b/mteb/tasks/classification/eng/something_something_v2_classification.py
@@ -7,7 +7,7 @@ from mteb.abstasks.task_metadata import TaskMetadata
 class SomethingSomethingV2Classification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="SomethingSomethingV2Classification",
-        description="Something-Something V2 contains 220,847 short video clips of humans performing pre-defined basic actions with everyday objects. This subset of 5,444 clips is used for action classification into 174 fine-grained categories.",
+        description="Something-Something V2 contains 220,847 short video clips of humans performing pre-defined basic actions with everyday objects. This subset of 5,444 clips is used for action classification into 174 fine-grained categories. Used the official validation as test, capped at 32 per class across 174 classes (~5,444 examples).",
         reference="https://developer.qualcomm.com/software/ai-datasets/something-something",
         dataset={
             "path": "mteb/SomethingSomethingV2",

--- a/mteb/tasks/classification/eng/ucf101_classification.py
+++ b/mteb/tasks/classification/eng/ucf101_classification.py
@@ -50,7 +50,8 @@ class UCF101VideoAudioClassification(AbsTaskClassification):
         name="UCF101VideoAudioClassification",
         description=(
             "Classifying video clips with audio into 51 human "
-            "action categories from the UCF101 dataset."
+            "action categories from the UCF101 dataset. "
+            "Used official split 1 restricted to a 51-class audio-bearing subset (~4,890 train / ~1,944 test)."
         ),
         reference="https://arxiv.org/abs/1212.0402",
         dataset={
@@ -99,7 +100,8 @@ class UCF101VideoClassification(AbsTaskClassification):
         name="UCF101VideoClassification",
         description=(
             "Classifying video clips without audio into 51 human "
-            "action categories from the UCF101 dataset."
+            "action categories from the UCF101 dataset. "
+            "Used official split 1 restricted to a 51-class audio-bearing subset (~4,890 train / ~1,944 test)."
         ),
         reference="https://arxiv.org/abs/1212.0402",
         dataset={

--- a/mteb/tasks/classification/eng/vggsound.py
+++ b/mteb/tasks/classification/eng/vggsound.py
@@ -19,7 +19,7 @@ CITATION = r"""
 class VGGSoundVAClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="VGGSoundVA",
-        description="VGGSound is a large-scale audio-visual dataset of short YouTube clips spanning 308 sound classes (e.g. 'playing piano', 'dog barking'). Audio is the primary signal. This variant uses both video and audio modalities.",
+        description="VGGSound is a large-scale audio-visual dataset of short YouTube clips spanning 308 sound classes (e.g. 'playing piano', 'dog barking'). Audio is the primary signal. This variant uses both video and audio modalities. Filtered the test split, capped at 32 per class across 309 classes (~9,888 examples).",
         reference="https://arxiv.org/abs/2004.14368",
         dataset={
             "path": "mteb/VGGSound",
@@ -55,7 +55,7 @@ class VGGSoundVAClassification(AbsTaskClassification):
 class VGGSoundVClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="VGGSoundV",
-        description="VGGSound is a large-scale audio-visual dataset of short YouTube clips spanning 308 sound classes (e.g. 'playing piano', 'dog barking'). This variant uses video only as a baseline; audio is the primary signal in the original task.",
+        description="VGGSound is a large-scale audio-visual dataset of short YouTube clips spanning 308 sound classes (e.g. 'playing piano', 'dog barking'). This variant uses video only as a baseline; audio is the primary signal in the original task. Filtered the test split, capped at 32 per class across 309 classes (~9,888 examples).",
         reference="https://arxiv.org/abs/2004.14368",
         dataset={
             "path": "mteb/VGGSound",

--- a/mteb/tasks/classification/eng/worldsense_classification.py
+++ b/mteb/tasks/classification/eng/worldsense_classification.py
@@ -7,7 +7,7 @@ from mteb.abstasks.task_metadata import TaskMetadata
 class WorldSenseAudioVideoClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="WorldSenseAudioVideoClassification",
-        description="WorldSense is a multimodal video understanding benchmark encompassing visual, audio, and text inputs. Videos are categorized into 8 primary domains across 67 fine-grained subcategories. This classification task predicts the domain category of a video clip",
+        description="WorldSense is a multimodal video understanding benchmark encompassing visual, audio, and text inputs. Videos are categorized into 8 primary domains across 67 fine-grained subcategories. This classification task predicts the domain category of a video clip Filtered the test split to short (<1min) clips (~1,047 examples).",
         reference="https://arxiv.org/abs/2502.04326",
         dataset={
             "path": "mteb/WorldSense_1min",
@@ -45,7 +45,7 @@ class WorldSenseAudioVideoClassification(AbsTaskClassification):
 class WorldSenseVideoClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="WorldSenseVideoClassification",
-        description="WorldSense is a multimodal video understanding benchmark encompassing visual, audio, and text inputs. Videos are categorized into 8 primary domains across 67 fine-grained subcategories. This classification task predicts the domain category of a video clip",
+        description="WorldSense is a multimodal video understanding benchmark encompassing visual, audio, and text inputs. Videos are categorized into 8 primary domains across 67 fine-grained subcategories. This classification task predicts the domain category of a video clip Filtered the test split to short (<1min) clips (~1,047 examples).",
         reference="https://arxiv.org/abs/2502.04326",
         dataset={
             "path": "mteb/WorldSense_1min",

--- a/mteb/tasks/clustering/eng/ave_dataset_clustering.py
+++ b/mteb/tasks/clustering/eng/ave_dataset_clustering.py
@@ -28,7 +28,7 @@ DESCRIPTION_BASE = (
 class AVEDatasetAudioVideoClustering(AbsTaskClustering):
     metadata = TaskMetadata(
         name="AVEDatasetAudioVideoClustering",
-        description=DESCRIPTION_BASE + " Uses synchronized video and audio.",
+        description=DESCRIPTION_BASE + " Uses synchronized video and audio. Used the official train and test splits across 28 audio-visual event classes (~3,312 train / ~402 test).",
         reference="https://openaccess.thecvf.com/content_ECCV_2018/html/Yapeng_Tian_Audio-Visual_Event_Localization_ECCV_2018_paper.html",
         dataset=DATASET,
         type="VideoClustering",
@@ -61,7 +61,7 @@ class AVEDatasetAudioVideoClustering(AbsTaskClustering):
 class AVEDatasetVideoClustering(AbsTaskClustering):
     metadata = TaskMetadata(
         name="AVEDatasetVideoClustering",
-        description=DESCRIPTION_BASE + " Uses video only.",
+        description=DESCRIPTION_BASE + " Uses video only. Used the official train and test splits across 28 audio-visual event classes (~3,312 train / ~402 test).",
         reference="https://openaccess.thecvf.com/content_ECCV_2018/html/Yapeng_Tian_Audio-Visual_Event_Localization_ECCV_2018_paper.html",
         dataset=DATASET,
         type="VideoClustering",

--- a/mteb/tasks/clustering/eng/ave_dataset_clustering.py
+++ b/mteb/tasks/clustering/eng/ave_dataset_clustering.py
@@ -28,7 +28,8 @@ DESCRIPTION_BASE = (
 class AVEDatasetAudioVideoClustering(AbsTaskClustering):
     metadata = TaskMetadata(
         name="AVEDatasetAudioVideoClustering",
-        description=DESCRIPTION_BASE + " Uses synchronized video and audio. Used the official train and test splits across 28 audio-visual event classes (~3,312 train / ~402 test).",
+        description=DESCRIPTION_BASE
+        + " Uses synchronized video and audio. Used the official train and test splits across 28 audio-visual event classes (~3,312 train / ~402 test).",
         reference="https://openaccess.thecvf.com/content_ECCV_2018/html/Yapeng_Tian_Audio-Visual_Event_Localization_ECCV_2018_paper.html",
         dataset=DATASET,
         type="VideoClustering",
@@ -61,7 +62,8 @@ class AVEDatasetAudioVideoClustering(AbsTaskClustering):
 class AVEDatasetVideoClustering(AbsTaskClustering):
     metadata = TaskMetadata(
         name="AVEDatasetVideoClustering",
-        description=DESCRIPTION_BASE + " Uses video only. Used the official train and test splits across 28 audio-visual event classes (~3,312 train / ~402 test).",
+        description=DESCRIPTION_BASE
+        + " Uses video only. Used the official train and test splits across 28 audio-visual event classes (~3,312 train / ~402 test).",
         reference="https://openaccess.thecvf.com/content_ECCV_2018/html/Yapeng_Tian_Audio-Visual_Event_Localization_ECCV_2018_paper.html",
         dataset=DATASET,
         type="VideoClustering",

--- a/mteb/tasks/clustering/eng/hmdb51_clustering.py
+++ b/mteb/tasks/clustering/eng/hmdb51_clustering.py
@@ -9,7 +9,8 @@ class HMDB51Clustering(AbsTaskClustering):
         name="HMDB51Clustering",
         description=(
             "Clustering of video clips into 51 human action categories from "
-            "HMDB51, a large video database for human motion recognition."
+            "HMDB51, a large video database for human motion recognition. "
+            "Used official split 1 across 51 action classes (~3,570 train / ~1,530 test)."
         ),
         reference="https://serre-lab.clps.brown.edu/resource/hmdb-a-large-human-motion-database/",
         dataset={

--- a/mteb/tasks/clustering/eng/meld_clustering.py
+++ b/mteb/tasks/clustering/eng/meld_clustering.py
@@ -38,7 +38,7 @@ EMOTION_DESCRIPTION_SUFFIX = (
 class MELDEmotionAudioVideoClustering(AbsTaskClustering):
     metadata = TaskMetadata(
         name="MELDEmotionAudioVideoClustering",
-        description=DESCRIPTION + EMOTION_DESCRIPTION_SUFFIX,
+        description=DESCRIPTION + EMOTION_DESCRIPTION_SUFFIX + " Sampled the test split (~2,610 examples).",
         reference=REFERENCE,
         dataset=DATASET,
         type="VideoClustering",
@@ -72,7 +72,7 @@ class MELDEmotionAudioVideoClustering(AbsTaskClustering):
 class MELDEmotionVideoClustering(AbsTaskClustering):
     metadata = TaskMetadata(
         name="MELDEmotionVideoClustering",
-        description=DESCRIPTION + EMOTION_DESCRIPTION_SUFFIX,
+        description=DESCRIPTION + EMOTION_DESCRIPTION_SUFFIX + " Sampled the test split (~2,610 examples).",
         reference=REFERENCE,
         dataset=DATASET,
         type="VideoClustering",
@@ -106,7 +106,7 @@ class MELDEmotionVideoClustering(AbsTaskClustering):
 class MELDSpeakerAudioVideoClustering(AbsTaskClustering):
     metadata = TaskMetadata(
         name="MELDSpeakerAudioVideoClustering",
-        description=DESCRIPTION + " This task clusters by speaker identity.",
+        description=DESCRIPTION + " This task clusters by speaker identity. Sampled the test split (~2,610 examples).",
         reference=REFERENCE,
         dataset=DATASET,
         type="VideoClustering",
@@ -139,7 +139,7 @@ class MELDSpeakerAudioVideoClustering(AbsTaskClustering):
 class MELDSpeakerVideoClustering(AbsTaskClustering):
     metadata = TaskMetadata(
         name="MELDSpeakerVideoClustering",
-        description=DESCRIPTION + " This task clusters by speaker identity.",
+        description=DESCRIPTION + " This task clusters by speaker identity. Sampled the test split (~2,610 examples).",
         reference=REFERENCE,
         dataset=DATASET,
         type="VideoClustering",

--- a/mteb/tasks/clustering/eng/meld_clustering.py
+++ b/mteb/tasks/clustering/eng/meld_clustering.py
@@ -38,7 +38,9 @@ EMOTION_DESCRIPTION_SUFFIX = (
 class MELDEmotionAudioVideoClustering(AbsTaskClustering):
     metadata = TaskMetadata(
         name="MELDEmotionAudioVideoClustering",
-        description=DESCRIPTION + EMOTION_DESCRIPTION_SUFFIX + " Sampled the test split (~2,610 examples).",
+        description=DESCRIPTION
+        + EMOTION_DESCRIPTION_SUFFIX
+        + " Sampled the test split (~2,610 examples).",
         reference=REFERENCE,
         dataset=DATASET,
         type="VideoClustering",
@@ -72,7 +74,9 @@ class MELDEmotionAudioVideoClustering(AbsTaskClustering):
 class MELDEmotionVideoClustering(AbsTaskClustering):
     metadata = TaskMetadata(
         name="MELDEmotionVideoClustering",
-        description=DESCRIPTION + EMOTION_DESCRIPTION_SUFFIX + " Sampled the test split (~2,610 examples).",
+        description=DESCRIPTION
+        + EMOTION_DESCRIPTION_SUFFIX
+        + " Sampled the test split (~2,610 examples).",
         reference=REFERENCE,
         dataset=DATASET,
         type="VideoClustering",
@@ -106,7 +110,8 @@ class MELDEmotionVideoClustering(AbsTaskClustering):
 class MELDSpeakerAudioVideoClustering(AbsTaskClustering):
     metadata = TaskMetadata(
         name="MELDSpeakerAudioVideoClustering",
-        description=DESCRIPTION + " This task clusters by speaker identity. Sampled the test split (~2,610 examples).",
+        description=DESCRIPTION
+        + " This task clusters by speaker identity. Sampled the test split (~2,610 examples).",
         reference=REFERENCE,
         dataset=DATASET,
         type="VideoClustering",
@@ -139,7 +144,8 @@ class MELDSpeakerAudioVideoClustering(AbsTaskClustering):
 class MELDSpeakerVideoClustering(AbsTaskClustering):
     metadata = TaskMetadata(
         name="MELDSpeakerVideoClustering",
-        description=DESCRIPTION + " This task clusters by speaker identity. Sampled the test split (~2,610 examples).",
+        description=DESCRIPTION
+        + " This task clusters by speaker identity. Sampled the test split (~2,610 examples).",
         reference=REFERENCE,
         dataset=DATASET,
         type="VideoClustering",

--- a/mteb/tasks/clustering/eng/music_avqa_clustering.py
+++ b/mteb/tasks/clustering/eng/music_avqa_clustering.py
@@ -26,7 +26,7 @@ DESCRIPTION_BASE = (
 class MusicAVQACLSAudioVideoClustering(AbsTaskClustering):
     metadata = TaskMetadata(
         name="MusicAVQACLSAudioVideoClustering",
-        description=DESCRIPTION_BASE + " Uses synchronized video and audio.",
+        description=DESCRIPTION_BASE + " Uses synchronized video and audio. Filtered the test split to rows with a 22-class instrument answer (~1,706 examples).",
         reference="https://gewu-lab.github.io/MUSIC-AVQA/",
         dataset=DATASET,
         type="VideoClustering",
@@ -59,7 +59,7 @@ class MusicAVQACLSAudioVideoClustering(AbsTaskClustering):
 class MusicAVQACLSVideoClustering(AbsTaskClustering):
     metadata = TaskMetadata(
         name="MusicAVQACLSVideoClustering",
-        description=DESCRIPTION_BASE + " Uses video only.",
+        description=DESCRIPTION_BASE + " Uses video only. Filtered the test split to rows with a 22-class instrument answer (~1,706 examples).",
         reference="https://gewu-lab.github.io/MUSIC-AVQA/",
         dataset=DATASET,
         type="VideoClustering",

--- a/mteb/tasks/clustering/eng/music_avqa_clustering.py
+++ b/mteb/tasks/clustering/eng/music_avqa_clustering.py
@@ -26,7 +26,8 @@ DESCRIPTION_BASE = (
 class MusicAVQACLSAudioVideoClustering(AbsTaskClustering):
     metadata = TaskMetadata(
         name="MusicAVQACLSAudioVideoClustering",
-        description=DESCRIPTION_BASE + " Uses synchronized video and audio. Filtered the test split to rows with a 22-class instrument answer (~1,706 examples).",
+        description=DESCRIPTION_BASE
+        + " Uses synchronized video and audio. Filtered the test split to rows with a 22-class instrument answer (~1,706 examples).",
         reference="https://gewu-lab.github.io/MUSIC-AVQA/",
         dataset=DATASET,
         type="VideoClustering",
@@ -59,7 +60,8 @@ class MusicAVQACLSAudioVideoClustering(AbsTaskClustering):
 class MusicAVQACLSVideoClustering(AbsTaskClustering):
     metadata = TaskMetadata(
         name="MusicAVQACLSVideoClustering",
-        description=DESCRIPTION_BASE + " Uses video only. Filtered the test split to rows with a 22-class instrument answer (~1,706 examples).",
+        description=DESCRIPTION_BASE
+        + " Uses video only. Filtered the test split to rows with a 22-class instrument answer (~1,706 examples).",
         reference="https://gewu-lab.github.io/MUSIC-AVQA/",
         dataset=DATASET,
         type="VideoClustering",

--- a/mteb/tasks/clustering/eng/ravdess_av_clustering.py
+++ b/mteb/tasks/clustering/eng/ravdess_av_clustering.py
@@ -7,7 +7,7 @@ from mteb.abstasks.task_metadata import TaskMetadata
 class RAVDESSAVClustering(AbsTaskClustering):
     metadata = TaskMetadata(
         name="RAVDESSAVClustering",
-        description="Emotion clustering task with video and audio data for 8 emotions: neutral, calm, happy, sad, angry, fearful, surprise, and disgust expressions.",
+        description="Emotion clustering task with video and audio data for 8 emotions: neutral, calm, happy, sad, angry, fearful, surprise, and disgust expressions. Used the metadata train split remapped to audio-visual filenames (~1,440 examples).",
         reference="https://doi.org/10.1371/journal.pone.0196391",
         dataset={
             "path": "mteb/RAVDESS_AV",
@@ -51,7 +51,7 @@ class RAVDESSAVClustering(AbsTaskClustering):
 class RAVDESSVideoClustering(AbsTaskClustering):
     metadata = TaskMetadata(
         name="RAVDESSVideoClustering",
-        description="Emotion clustering task with video data only for 8 emotions: neutral, calm, happy, sad, angry, fearful, surprise, and disgust expressions.",
+        description="Emotion clustering task with video data only for 8 emotions: neutral, calm, happy, sad, angry, fearful, surprise, and disgust expressions. Used the metadata train split remapped to audio-visual filenames (~1,440 examples).",
         reference="https://doi.org/10.1371/journal.pone.0196391",
         dataset={
             "path": "mteb/RAVDESS_AV",

--- a/mteb/tasks/clustering/eng/ucf101_clustering.py
+++ b/mteb/tasks/clustering/eng/ucf101_clustering.py
@@ -28,7 +28,7 @@ DESCRIPTION_BASE = (
 class UCF101AudioVideoClustering(AbsTaskClustering):
     metadata = TaskMetadata(
         name="UCF101AudioVideoClustering",
-        description=DESCRIPTION_BASE + " Uses synchronized video and audio.",
+        description=DESCRIPTION_BASE + " Uses synchronized video and audio. Used official split 1 restricted to a 51-class audio-bearing subset (~4,890 train / ~1,944 test).",
         reference="https://arxiv.org/abs/1212.0402",
         dataset=DATASET,
         type="VideoClustering",
@@ -61,7 +61,7 @@ class UCF101AudioVideoClustering(AbsTaskClustering):
 class UCF101VideoClustering(AbsTaskClustering):
     metadata = TaskMetadata(
         name="UCF101VideoClustering",
-        description=DESCRIPTION_BASE + " Uses video only.",
+        description=DESCRIPTION_BASE + " Uses video only. Used official split 1 restricted to a 51-class audio-bearing subset (~4,890 train / ~1,944 test).",
         reference="https://arxiv.org/abs/1212.0402",
         dataset=DATASET,
         type="VideoClustering",

--- a/mteb/tasks/clustering/eng/ucf101_clustering.py
+++ b/mteb/tasks/clustering/eng/ucf101_clustering.py
@@ -28,7 +28,8 @@ DESCRIPTION_BASE = (
 class UCF101AudioVideoClustering(AbsTaskClustering):
     metadata = TaskMetadata(
         name="UCF101AudioVideoClustering",
-        description=DESCRIPTION_BASE + " Uses synchronized video and audio. Used official split 1 restricted to a 51-class audio-bearing subset (~4,890 train / ~1,944 test).",
+        description=DESCRIPTION_BASE
+        + " Uses synchronized video and audio. Used official split 1 restricted to a 51-class audio-bearing subset (~4,890 train / ~1,944 test).",
         reference="https://arxiv.org/abs/1212.0402",
         dataset=DATASET,
         type="VideoClustering",
@@ -61,7 +62,8 @@ class UCF101AudioVideoClustering(AbsTaskClustering):
 class UCF101VideoClustering(AbsTaskClustering):
     metadata = TaskMetadata(
         name="UCF101VideoClustering",
-        description=DESCRIPTION_BASE + " Uses video only. Used official split 1 restricted to a 51-class audio-bearing subset (~4,890 train / ~1,944 test).",
+        description=DESCRIPTION_BASE
+        + " Uses video only. Used official split 1 restricted to a 51-class audio-bearing subset (~4,890 train / ~1,944 test).",
         reference="https://arxiv.org/abs/1212.0402",
         dataset=DATASET,
         type="VideoClustering",

--- a/mteb/tasks/clustering/eng/worldsense_1min_domain_clustering.py
+++ b/mteb/tasks/clustering/eng/worldsense_1min_domain_clustering.py
@@ -46,7 +46,8 @@ def _dedupe_one_per_video_id(ds: Dataset) -> Dataset:
 class WorldSense1MinDomainAudioVideoClustering(AbsTaskClustering):
     metadata = TaskMetadata(
         name="WorldSense1MinDomainAudioVideoClustering",
-        description=DESCRIPTION_BASE + " Uses synchronized video and audio. Filtered the test split to short (<1min) clips (~1,047 examples).",
+        description=DESCRIPTION_BASE
+        + " Uses synchronized video and audio. Filtered the test split to short (<1min) clips (~1,047 examples).",
         reference="https://arxiv.org/abs/2502.04326",
         dataset=DATASET,
         type="VideoClustering",
@@ -81,7 +82,8 @@ class WorldSense1MinDomainAudioVideoClustering(AbsTaskClustering):
 class WorldSense1MinDomainVideoClustering(AbsTaskClustering):
     metadata = TaskMetadata(
         name="WorldSense1MinDomainVideoClustering",
-        description=DESCRIPTION_BASE + " Uses video only. Filtered the test split to short (<1min) clips (~1,047 examples).",
+        description=DESCRIPTION_BASE
+        + " Uses video only. Filtered the test split to short (<1min) clips (~1,047 examples).",
         reference="https://arxiv.org/abs/2502.04326",
         dataset=DATASET,
         type="VideoClustering",

--- a/mteb/tasks/clustering/eng/worldsense_1min_domain_clustering.py
+++ b/mteb/tasks/clustering/eng/worldsense_1min_domain_clustering.py
@@ -46,7 +46,7 @@ def _dedupe_one_per_video_id(ds: Dataset) -> Dataset:
 class WorldSense1MinDomainAudioVideoClustering(AbsTaskClustering):
     metadata = TaskMetadata(
         name="WorldSense1MinDomainAudioVideoClustering",
-        description=DESCRIPTION_BASE + " Uses synchronized video and audio.",
+        description=DESCRIPTION_BASE + " Uses synchronized video and audio. Filtered the test split to short (<1min) clips (~1,047 examples).",
         reference="https://arxiv.org/abs/2502.04326",
         dataset=DATASET,
         type="VideoClustering",
@@ -81,7 +81,7 @@ class WorldSense1MinDomainAudioVideoClustering(AbsTaskClustering):
 class WorldSense1MinDomainVideoClustering(AbsTaskClustering):
     metadata = TaskMetadata(
         name="WorldSense1MinDomainVideoClustering",
-        description=DESCRIPTION_BASE + " Uses video only.",
+        description=DESCRIPTION_BASE + " Uses video only. Filtered the test split to short (<1min) clips (~1,047 examples).",
         reference="https://arxiv.org/abs/2502.04326",
         dataset=DATASET,
         type="VideoClustering",

--- a/mteb/tasks/multichoice/eng/avmeme_exam.py
+++ b/mteb/tasks/multichoice/eng/avmeme_exam.py
@@ -10,7 +10,7 @@ from mteb.abstasks.task_metadata import TaskMetadata
 class AVMemeExamVideoCentricQA(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="AVMemeExamVideoCentricQA",
-        description="AVMeme-Exam is an audio-visual meme understanding benchmark testing models on humor, emotion, and cultural knowledge in meme videos. Each example pairs a video with a question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate.",
+        description="AVMeme-Exam is an audio-visual meme understanding benchmark testing models on humor, emotion, and cultural knowledge in meme videos. Each example pairs a video with a question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate. Used the `full`/`test` split (~900 examples).",
         reference="https://arxiv.org/abs/2601.17645",
         dataset={
             "path": "mteb/AVMeme-Exam",
@@ -83,7 +83,7 @@ class AVMemeExamVideoCentricQA(AbsTaskRetrieval):
 class AVMemeExamVideoAudioCentricQA(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="AVMemeExamVideoAudioCentricQA",
-        description="AVMeme-Exam is an audio-visual meme understanding benchmark testing models on humor, emotion, and cultural knowledge in meme videos. Each example pairs a video with audio and a question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, audio, question) tuple, retrieve the correct candidate.",
+        description="AVMeme-Exam is an audio-visual meme understanding benchmark testing models on humor, emotion, and cultural knowledge in meme videos. Each example pairs a video with audio and a question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, audio, question) tuple, retrieve the correct candidate. Used the `full`/`test` split (~900 examples).",
         reference="https://arxiv.org/abs/2601.17645",
         dataset={
             "path": "mteb/AVMeme-Exam",

--- a/mteb/tasks/multichoice/eng/avqa.py
+++ b/mteb/tasks/multichoice/eng/avqa.py
@@ -10,7 +10,7 @@ from mteb.abstasks.task_metadata import TaskMetadata
 class AVQAVideoCentricQA(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="AVQAVideoCentricQA",
-        description="AVQA is an audio-visual question answering benchmark requiring models to understand both the audio and visual content of videos to answer questions. Each example pairs a video with a question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate.",
+        description="AVQA is an audio-visual question answering benchmark requiring models to understand both the audio and visual content of videos to answer questions. Each example pairs a video with a question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate. Used the test QA split keyed by (video, question) (~921 examples).",
         reference="https://arxiv.org/abs/2207.10489",
         dataset={
             "path": "mteb/AVQA_val",
@@ -83,7 +83,7 @@ class AVQAVideoCentricQA(AbsTaskRetrieval):
 class AVQAVideoAudioCentricQA(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="AVQAVideoAudioCentricQA",
-        description="AVQA is an audio-visual question answering benchmark requiring models to understand both the audio and visual content of videos to answer questions. Each example pairs a video with audio and a question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, audio, question) tuple, retrieve the correct candidate.",
+        description="AVQA is an audio-visual question answering benchmark requiring models to understand both the audio and visual content of videos to answer questions. Each example pairs a video with audio and a question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, audio, question) tuple, retrieve the correct candidate. Used the test QA split keyed by (video, question) (~921 examples).",
         reference="https://arxiv.org/abs/2207.10489",
         dataset={
             "path": "mteb/AVQA_val",

--- a/mteb/tasks/multichoice/eng/daily_omni.py
+++ b/mteb/tasks/multichoice/eng/daily_omni.py
@@ -10,7 +10,7 @@ from mteb.abstasks.task_metadata import TaskMetadata
 class DailyOmniVideoCentricQA(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="DailyOmniVideoCentricQA",
-        description="Daily-Omni is a video question answering benchmark covering everyday scenarios with audio-visual content. Each example pairs a video with a question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate.",
+        description="Daily-Omni is a video question answering benchmark covering everyday scenarios with audio-visual content. Each example pairs a video with a question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate. Used the upstream evaluation split keyed by (video, question) (~1,200 examples).",
         reference="https://arxiv.org/abs/2505.17862",
         dataset={
             "path": "mteb/Daily-Omni",
@@ -83,7 +83,7 @@ class DailyOmniVideoCentricQA(AbsTaskRetrieval):
 class DailyOmniVideoAudioCentricQA(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="DailyOmniVideoAudioCentricQA",
-        description="Daily-Omni is a video question answering benchmark covering everyday scenarios with audio-visual content. Each example pairs a video with audio and a question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, audio, question) tuple, retrieve the correct candidate.",
+        description="Daily-Omni is a video question answering benchmark covering everyday scenarios with audio-visual content. Each example pairs a video with audio and a question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, audio, question) tuple, retrieve the correct candidate. Used the upstream evaluation split keyed by (video, question) (~1,200 examples).",
         reference="https://arxiv.org/abs/2505.17862",
         dataset={
             "path": "mteb/Daily-Omni",

--- a/mteb/tasks/multichoice/eng/egoschema.py
+++ b/mteb/tasks/multichoice/eng/egoschema.py
@@ -10,7 +10,7 @@ from mteb.abstasks.task_metadata import TaskMetadata
 class EgoSchemaVideoCentricQA(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="EgoSchemaVideoCentricQA",
-        description="EgoSchema is a long-form video language understanding benchmark built from egocentric video. Each example pairs a ~3-minute first-person video with a question and 5 candidate answers. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate from its 5 choices.",
+        description="EgoSchema is a long-form video language understanding benchmark built from egocentric video. Each example pairs a ~3-minute first-person video with a question and 5 candidate answers. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate from its 5 choices. Used the `Subset` config test split (500 examples).",
         reference="https://arxiv.org/abs/2308.09126",
         dataset={
             "path": "mteb/EgoSchema_subset",

--- a/mteb/tasks/multichoice/eng/nextqa.py
+++ b/mteb/tasks/multichoice/eng/nextqa.py
@@ -10,7 +10,7 @@ from mteb.abstasks.task_metadata import TaskMetadata
 class NExTQAVideoCentricQA(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="NExTQAVideoCentricQA",
-        description="NExT-QA is a video question answering benchmark targeting causal and temporal reasoning over everyday videos. Each example pairs a short video with a natural language question and 5 candidate answers, of which exactly one is correct. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate from its 5 choices.",
+        description="NExT-QA is a video question answering benchmark targeting causal and temporal reasoning over everyday videos. Each example pairs a short video with a natural language question and 5 candidate answers, of which exactly one is correct. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate from its 5 choices. Sampled the test split (~993 examples).",
         reference="https://arxiv.org/abs/2105.08276",
         dataset={
             "path": "mteb/NExT-QA",

--- a/mteb/tasks/multichoice/eng/omni_video_bench.py
+++ b/mteb/tasks/multichoice/eng/omni_video_bench.py
@@ -10,7 +10,7 @@ from mteb.abstasks.task_metadata import TaskMetadata
 class OmniVideoBenchVideoCentricQA(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="OmniVideoBenchVideoCentricQA",
-        description="OmniVideoBench is a comprehensive audio-visual video question answering benchmark evaluating omni-modal understanding in multimodal LLMs. Each example pairs a video with a question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate.",
+        description="OmniVideoBench is a comprehensive audio-visual video question answering benchmark evaluating omni-modal understanding in multimodal LLMs. Each example pairs a video with a question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate. Filtered the test split to clips under 5 minutes (~509 examples).",
         reference="https://arxiv.org/abs/2510.10689",
         dataset={
             "path": "mteb/OmniVideoBench_subset",
@@ -83,7 +83,7 @@ class OmniVideoBenchVideoCentricQA(AbsTaskRetrieval):
 class OmniVideoBenchVideoAudioCentricQA(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="OmniVideoBenchVideoAudioCentricQA",
-        description="OmniVideoBench is a comprehensive audio-visual video question answering benchmark evaluating omni-modal understanding in multimodal LLMs. Each example pairs a video with audio and a question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, audio, question) tuple, retrieve the correct candidate.",
+        description="OmniVideoBench is a comprehensive audio-visual video question answering benchmark evaluating omni-modal understanding in multimodal LLMs. Each example pairs a video with audio and a question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, audio, question) tuple, retrieve the correct candidate. Filtered the test split to clips under 5 minutes (~509 examples).",
         reference="https://arxiv.org/abs/2510.10689",
         dataset={
             "path": "mteb/OmniVideoBench_subset",

--- a/mteb/tasks/multichoice/eng/perception_test.py
+++ b/mteb/tasks/multichoice/eng/perception_test.py
@@ -10,7 +10,7 @@ from mteb.abstasks.task_metadata import TaskMetadata
 class PerceptionTestVideoCentricQA(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="PerceptionTestVideoCentricQA",
-        description="Perception Test is a multimodal benchmark designed to evaluate perception and reasoning skills of video models across memory, abstraction, physics, and semantics. Each example pairs a video with a question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate.",
+        description="Perception Test is a multimodal benchmark designed to evaluate perception and reasoning skills of video models across memory, abstraction, physics, and semantics. Each example pairs a video with a question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate. Used the `mc_question_val` validation split (~938 examples).",
         reference="https://arxiv.org/abs/2305.13786",
         dataset={
             "path": "mteb/PerceptionTest_val",
@@ -83,7 +83,7 @@ class PerceptionTestVideoCentricQA(AbsTaskRetrieval):
 class PerceptionTestVideoAudioCentricQA(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="PerceptionTestVideoAudioCentricQA",
-        description="Perception Test is a multimodal benchmark designed to evaluate perception and reasoning skills of video models across memory, abstraction, physics, and semantics. Each example pairs a video with audio and a question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, audio, question) tuple, retrieve the correct candidate.",
+        description="Perception Test is a multimodal benchmark designed to evaluate perception and reasoning skills of video models across memory, abstraction, physics, and semantics. Each example pairs a video with audio and a question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, audio, question) tuple, retrieve the correct candidate. Used the `mc_question_val` validation split (~938 examples).",
         reference="https://arxiv.org/abs/2305.13786",
         dataset={
             "path": "mteb/PerceptionTest_val",

--- a/mteb/tasks/multichoice/eng/video_mme.py
+++ b/mteb/tasks/multichoice/eng/video_mme.py
@@ -10,7 +10,7 @@ from mteb.abstasks.task_metadata import TaskMetadata
 class VideoMMEShortVideoCentricQA(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="VideoMMEShortVideoCentricQA",
-        description="Video-MME is a comprehensive evaluation benchmark for multimodal LLMs in video analysis. The short-video subset contains videos under 2 minutes. Each example pairs a video with a question and 4 candidate answers. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate.",
+        description="Video-MME is a comprehensive evaluation benchmark for multimodal LLMs in video analysis. The short-video subset contains videos under 2 minutes. Each example pairs a video with a question and 4 candidate answers. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate. Filtered the test split to `duration == \"short\"` clips, shuffled (seed=42), capped at 2,000 (~900 examples).",
         reference="https://arxiv.org/abs/2405.21075",
         dataset={
             "path": "mteb/Video-MME_short",
@@ -83,7 +83,7 @@ class VideoMMEShortVideoCentricQA(AbsTaskRetrieval):
 class VideoMMEShortVideoAudioCentricQA(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="VideoMMEShortVideoAudioCentricQA",
-        description="Video-MME is a comprehensive evaluation benchmark for multimodal LLMs in video analysis. The short-video subset contains videos under 2 minutes. Each example pairs a video with audio and a question and 4 candidate answers. The task is formulated as multiple-choice retrieval: given the (video, audio, question) tuple, retrieve the correct candidate.",
+        description="Video-MME is a comprehensive evaluation benchmark for multimodal LLMs in video analysis. The short-video subset contains videos under 2 minutes. Each example pairs a video with audio and a question and 4 candidate answers. The task is formulated as multiple-choice retrieval: given the (video, audio, question) tuple, retrieve the correct candidate. Filtered the test split to `duration == \"short\"` clips, shuffled (seed=42), capped at 2,000 (~900 examples).",
         reference="https://arxiv.org/abs/2405.21075",
         dataset={
             "path": "mteb/Video-MME_short",

--- a/mteb/tasks/multichoice/eng/video_mme.py
+++ b/mteb/tasks/multichoice/eng/video_mme.py
@@ -10,7 +10,7 @@ from mteb.abstasks.task_metadata import TaskMetadata
 class VideoMMEShortVideoCentricQA(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="VideoMMEShortVideoCentricQA",
-        description="Video-MME is a comprehensive evaluation benchmark for multimodal LLMs in video analysis. The short-video subset contains videos under 2 minutes. Each example pairs a video with a question and 4 candidate answers. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate. Filtered the test split to `duration == \"short\"` clips, shuffled (seed=42), capped at 2,000 (~900 examples).",
+        description='Video-MME is a comprehensive evaluation benchmark for multimodal LLMs in video analysis. The short-video subset contains videos under 2 minutes. Each example pairs a video with a question and 4 candidate answers. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate. Filtered the test split to `duration == "short"` clips, shuffled (seed=42), capped at 2,000 (~900 examples).',
         reference="https://arxiv.org/abs/2405.21075",
         dataset={
             "path": "mteb/Video-MME_short",
@@ -83,7 +83,7 @@ class VideoMMEShortVideoCentricQA(AbsTaskRetrieval):
 class VideoMMEShortVideoAudioCentricQA(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="VideoMMEShortVideoAudioCentricQA",
-        description="Video-MME is a comprehensive evaluation benchmark for multimodal LLMs in video analysis. The short-video subset contains videos under 2 minutes. Each example pairs a video with audio and a question and 4 candidate answers. The task is formulated as multiple-choice retrieval: given the (video, audio, question) tuple, retrieve the correct candidate. Filtered the test split to `duration == \"short\"` clips, shuffled (seed=42), capped at 2,000 (~900 examples).",
+        description='Video-MME is a comprehensive evaluation benchmark for multimodal LLMs in video analysis. The short-video subset contains videos under 2 minutes. Each example pairs a video with audio and a question and 4 candidate answers. The task is formulated as multiple-choice retrieval: given the (video, audio, question) tuple, retrieve the correct candidate. Filtered the test split to `duration == "short"` clips, shuffled (seed=42), capped at 2,000 (~900 examples).',
         reference="https://arxiv.org/abs/2405.21075",
         dataset={
             "path": "mteb/Video-MME_short",

--- a/mteb/tasks/multichoice/eng/worldqa.py
+++ b/mteb/tasks/multichoice/eng/worldqa.py
@@ -10,7 +10,7 @@ from mteb.abstasks.task_metadata import TaskMetadata
 class WorldQAVideoCentricQA(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="WorldQAVideoCentricQA",
-        description="WorldQA is a multimodal long video benchmark evaluating world knowledge through long-chain reasoning. Each example pairs a video with a question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate.",
+        description="WorldQA is a multimodal long video benchmark evaluating world knowledge through long-chain reasoning. Each example pairs a video with a question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate. Used the `MC` config test split keyed by (video, question_idx) (~3,284 examples).",
         reference="https://arxiv.org/abs/2405.03272",
         dataset={
             "path": "mteb/worldqa",
@@ -83,7 +83,7 @@ class WorldQAVideoCentricQA(AbsTaskRetrieval):
 class WorldQAVideoAudioCentricQA(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="WorldQAVideoAudioCentricQA",
-        description="WorldQA is a multimodal long video benchmark evaluating world knowledge through long-chain reasoning. Each example pairs a video with audio and a question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, audio, question) tuple, retrieve the correct candidate.",
+        description="WorldQA is a multimodal long video benchmark evaluating world knowledge through long-chain reasoning. Each example pairs a video with audio and a question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, audio, question) tuple, retrieve the correct candidate. Used the `MC` config test split keyed by (video, question_idx) (~3,284 examples).",
         reference="https://arxiv.org/abs/2405.03272",
         dataset={
             "path": "mteb/worldqa",

--- a/mteb/tasks/multichoice/eng/worldsense.py
+++ b/mteb/tasks/multichoice/eng/worldsense.py
@@ -10,7 +10,7 @@ from mteb.abstasks.task_metadata import TaskMetadata
 class WorldSense1MinVideoCentricQA(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="WorldSense1MinVideoCentricQA",
-        description="WorldSense_1min is a video question answering benchmark covering diverse real-world domains including sports, culture, music, and daily life. Each example pairs a ~1-minute video with a question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate.",
+        description="WorldSense_1min is a video question answering benchmark covering diverse real-world domains including sports, culture, music, and daily life. Each example pairs a ~1-minute video with a question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate. Filtered the test split to short (<1min) clips (~1,047 examples).",
         reference="https://arxiv.org/abs/2502.04326",
         dataset={
             "path": "mteb/WorldSense_1min",
@@ -83,7 +83,7 @@ class WorldSense1MinVideoCentricQA(AbsTaskRetrieval):
 class WorldSense1MinVideoAudioCentricQA(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="WorldSense1MinVideoAudioCentricQA",
-        description="WorldSense_1min is a video question answering benchmark covering diverse real-world domains including sports, culture, music, and daily life. Each example pairs a ~1-minute video with audio and a question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, audio, question) tuple, retrieve the correct candidate.",
+        description="WorldSense_1min is a video question answering benchmark covering diverse real-world domains including sports, culture, music, and daily life. Each example pairs a ~1-minute video with audio and a question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, audio, question) tuple, retrieve the correct candidate. Filtered the test split to short (<1min) clips (~1,047 examples).",
         reference="https://arxiv.org/abs/2502.04326",
         dataset={
             "path": "mteb/WorldSense_1min",

--- a/mteb/tasks/retrieval/eng/activitynet_captions_retrieval.py
+++ b/mteb/tasks/retrieval/eng/activitynet_captions_retrieval.py
@@ -58,6 +58,7 @@ class ActivityNetCaptionsV2TRetrieval(AbsTaskRetrieval):
             "Retrieve the English caption that describes a given video clip from "
             "ActivityNet Captions. Each example pairs one video with one reference "
             "description (1:1 retrieval)."
+            " Used the upstream `val2` split as the test split (~4,884 examples)."
         ),
         reference="https://huggingface.co/datasets/mteb/ActivityNet_Captions_val2",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -90,6 +91,7 @@ class ActivityNetCaptionsT2VRetrieval(AbsTaskRetrieval):
             "Retrieve the video clip that matches a given English caption from "
             "ActivityNet Captions. Each example pairs one caption with one reference "
             "video (1:1 retrieval)."
+            " Used the upstream `val2` split as the test split (~4,884 examples)."
         ),
         reference="https://huggingface.co/datasets/mteb/ActivityNet_Captions_val2",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},

--- a/mteb/tasks/retrieval/eng/audiocaps_av_retrieval.py
+++ b/mteb/tasks/retrieval/eng/audiocaps_av_retrieval.py
@@ -59,6 +59,7 @@ class AudioCapsAVV2TRetrieval(AbsTaskRetrieval):
             "Retrieve the English caption that describes a given video clip (video "
             "only) from AudioCaps-AV, an audio-visual extension of the AudioCaps "
             "dataset sourced from YouTube."
+            " Sampled the test split (~665 examples)."
         ),
         reference="https://audiocaps.github.io/",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -91,6 +92,7 @@ class AudioCapsAVT2VRetrieval(AbsTaskRetrieval):
             "Retrieve the video clip (video only) that matches a given English "
             "caption from AudioCaps-AV, an audio-visual extension of the AudioCaps "
             "dataset sourced from YouTube."
+            " Sampled the test split (~665 examples)."
         ),
         reference="https://audiocaps.github.io/",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -123,6 +125,7 @@ class AudioCapsAVVA2TRetrieval(AbsTaskRetrieval):
             "Retrieve the English caption that describes a given video+audio clip "
             "from AudioCaps-AV, an audio-visual extension of the AudioCaps dataset "
             "sourced from YouTube."
+            " Sampled the test split (~665 examples)."
         ),
         reference="https://audiocaps.github.io/",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -157,6 +160,7 @@ class AudioCapsAVT2VARetrieval(AbsTaskRetrieval):
             "Retrieve the video+audio clip that matches a given English caption "
             "from AudioCaps-AV, an audio-visual extension of the AudioCaps dataset "
             "sourced from YouTube."
+            " Sampled the test split (~665 examples)."
         ),
         reference="https://audiocaps.github.io/",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -192,6 +196,7 @@ class AudioCapsAVV2ARetrieval(AbsTaskRetrieval):
             "AudioCaps-AV, an audio-visual extension of the AudioCaps dataset "
             "sourced from YouTube. Tests cross-modal alignment between video "
             "frames and audio."
+            " Sampled the test split (~665 examples)."
         ),
         reference="https://audiocaps.github.io/",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -225,6 +230,7 @@ class AudioCapsAVA2VRetrieval(AbsTaskRetrieval):
             "AudioCaps-AV, an audio-visual extension of the AudioCaps dataset "
             "sourced from YouTube. Tests cross-modal alignment between audio "
             "and video frames."
+            " Sampled the test split (~665 examples)."
         ),
         reference="https://audiocaps.github.io/",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -257,6 +263,7 @@ class AudioCapsAVVT2ARetrieval(AbsTaskRetrieval):
             "Retrieve the audio track that matches a given video clip and its "
             "caption from AudioCaps-AV, an audio-visual extension of the AudioCaps "
             "dataset sourced from YouTube."
+            " Sampled the test split (~665 examples)."
         ),
         reference="https://audiocaps.github.io/",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -293,6 +300,7 @@ class AudioCapsAVAT2VRetrieval(AbsTaskRetrieval):
             "Retrieve the video clip that matches a given audio track and its "
             "caption from AudioCaps-AV, an audio-visual extension of the AudioCaps "
             "dataset sourced from YouTube."
+            " Sampled the test split (~665 examples)."
         ),
         reference="https://audiocaps.github.io/",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},

--- a/mteb/tasks/retrieval/eng/avmeme_exam_retrieval.py
+++ b/mteb/tasks/retrieval/eng/avmeme_exam_retrieval.py
@@ -56,6 +56,7 @@ class AVMemeExamV2TRetrieval(AbsTaskRetrieval):
             "Retrieve the summary that describes a given meme video clip (video "
             "only) from AVMeme-Exam, a multilingual audio-visual meme understanding "
             "benchmark."
+            " Used the `full`/`test` split (~900 examples)."
         ),
         reference="https://huggingface.co/datasets/mteb/AVMeme-Exam",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -88,6 +89,7 @@ class AVMemeExamT2VRetrieval(AbsTaskRetrieval):
             "Retrieve the meme video clip (video only) that matches a given summary "
             "from AVMeme-Exam, a multilingual audio-visual meme understanding "
             "benchmark."
+            " Used the `full`/`test` split (~900 examples)."
         ),
         reference="https://huggingface.co/datasets/mteb/AVMeme-Exam",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -120,6 +122,7 @@ class AVMemeExamVA2TRetrieval(AbsTaskRetrieval):
             "Retrieve the summary that describes a given meme video+audio clip "
             "from AVMeme-Exam, a multilingual audio-visual meme understanding "
             "benchmark."
+            " Used the `full`/`test` split (~900 examples)."
         ),
         reference="https://huggingface.co/datasets/mteb/AVMeme-Exam",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -154,6 +157,7 @@ class AVMemeExamT2VARetrieval(AbsTaskRetrieval):
             "Retrieve the meme video+audio clip that matches a given summary "
             "from AVMeme-Exam, a multilingual audio-visual meme understanding "
             "benchmark."
+            " Used the `full`/`test` split (~900 examples)."
         ),
         reference="https://huggingface.co/datasets/mteb/AVMeme-Exam",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -188,6 +192,7 @@ class AVMemeExamV2ARetrieval(AbsTaskRetrieval):
             "Retrieve the audio track that matches a given meme video clip (video "
             "only) from AVMeme-Exam. Tests cross-modal alignment between meme visual "
             "content and its paired audio."
+            " Used the `full`/`test` split (~900 examples)."
         ),
         reference="https://huggingface.co/datasets/mteb/AVMeme-Exam",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -222,6 +227,7 @@ class AVMemeExamA2VRetrieval(AbsTaskRetrieval):
             "Retrieve the meme video clip that matches a given audio track from "
             "AVMeme-Exam. Tests cross-modal alignment between meme audio and its "
             "paired visual content."
+            " Used the `full`/`test` split (~900 examples)."
         ),
         reference="https://huggingface.co/datasets/mteb/AVMeme-Exam",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -256,6 +262,7 @@ class AVMemeExamVT2ARetrieval(AbsTaskRetrieval):
             "Retrieve the audio track that matches a given meme video clip and its "
             "summary from AVMeme-Exam, a multilingual audio-visual meme understanding "
             "benchmark."
+            " Used the `full`/`test` split (~900 examples)."
         ),
         reference="https://huggingface.co/datasets/mteb/AVMeme-Exam",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -292,6 +299,7 @@ class AVMemeExamAT2VRetrieval(AbsTaskRetrieval):
             "Retrieve the meme video clip that matches a given audio track and its "
             "summary from AVMeme-Exam, a multilingual audio-visual meme understanding "
             "benchmark."
+            " Used the `full`/`test` split (~900 examples)."
         ),
         reference="https://huggingface.co/datasets/mteb/AVMeme-Exam",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},

--- a/mteb/tasks/retrieval/eng/didemo_retrieval.py
+++ b/mteb/tasks/retrieval/eng/didemo_retrieval.py
@@ -58,6 +58,7 @@ class DiDeMoV2TRetrieval(AbsTaskRetrieval):
             "Retrieve the English caption that describes a given video clip (video "
             "only) from the DiDeMo dataset of Flickr videos with temporally grounded "
             "sentence descriptions."
+            " Used the test split (~999 examples)."
         ),
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
         type="Any2AnyRetrieval",
@@ -90,6 +91,7 @@ class DiDeMoT2VRetrieval(AbsTaskRetrieval):
             "Retrieve the video clip (video only) that matches a given English "
             "caption from the DiDeMo dataset of Flickr videos with temporally "
             "grounded sentence descriptions."
+            " Used the test split (~999 examples)."
         ),
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
         type="Any2AnyRetrieval",
@@ -122,6 +124,7 @@ class DiDeMoVA2TRetrieval(AbsTaskRetrieval):
             "Retrieve the English caption that describes a given video clip "
             "from the DiDeMo dataset of Flickr videos with temporally grounded "
             "sentence descriptions."
+            " Used the test split (~999 examples)."
         ),
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
         type="Any2AnyRetrieval",
@@ -154,6 +157,7 @@ class DiDeMoT2VARetrieval(AbsTaskRetrieval):
             "Retrieve the video clip that matches a given English caption "
             "from the DiDeMo dataset of Flickr videos with temporally grounded "
             "sentence descriptions."
+            " Used the test split (~999 examples)."
         ),
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
         type="Any2AnyRetrieval",
@@ -185,6 +189,7 @@ class DiDeMoV2ARetrieval(AbsTaskRetrieval):
         description=(
             "Retrieve the audio track that matches a given video clip from the "
             "DiDeMo dataset. Tests cross-modal alignment between video frames and audio."
+            " Used the test split (~999 examples)."
         ),
         reference="https://arxiv.org/abs/1708.01355",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -216,6 +221,7 @@ class DiDeMoA2VRetrieval(AbsTaskRetrieval):
         description=(
             "Retrieve the video clip that matches a given audio track from the "
             "DiDeMo dataset. Tests cross-modal alignment between audio and video frames."
+            " Used the test split (~999 examples)."
         ),
         reference="https://arxiv.org/abs/1708.01355",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -248,6 +254,7 @@ class DiDeMoVT2ARetrieval(AbsTaskRetrieval):
             "Retrieve the audio track that matches a given video clip and its caption "
             "from the DiDeMo dataset of Flickr videos with temporally grounded "
             "sentence descriptions."
+            " Used the test split (~999 examples)."
         ),
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
         type="Any2AnyRetrieval",
@@ -282,6 +289,7 @@ class DiDeMoAT2VRetrieval(AbsTaskRetrieval):
             "Retrieve the video clip that matches a given audio track and its caption "
             "from the DiDeMo dataset of Flickr videos with temporally grounded "
             "sentence descriptions."
+            " Used the test split (~999 examples)."
         ),
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
         type="Any2AnyRetrieval",

--- a/mteb/tasks/retrieval/eng/msr_vtt.py
+++ b/mteb/tasks/retrieval/eng/msr_vtt.py
@@ -54,7 +54,7 @@ def _load_msr_vtt(
 class MSRVTTV2T(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="MSRVTTV2T",
-        description="A large video description dataset for bridging video and language",
+        description="A large video description dataset for bridging video and language. Used the msrvtt_ret_test1k retrieval split (879 examples).",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
         type="Any2AnyRetrieval",
         eval_langs=["eng-Latn"],
@@ -82,7 +82,7 @@ class MSRVTTV2T(AbsTaskRetrieval):
 class MSRVTTT2V(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="MSRVTTT2V",
-        description="A large video description dataset for bridging video and language",
+        description="A large video description dataset for bridging video and language. Used the msrvtt_ret_test1k retrieval split (879 examples).",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
         type="Any2AnyRetrieval",
         eval_langs=["eng-Latn"],
@@ -110,7 +110,7 @@ class MSRVTTT2V(AbsTaskRetrieval):
 class MSRVTTVA2T(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="MSRVTTVA2T",
-        description="A large video description dataset for bridging video and language",
+        description="A large video description dataset for bridging video and language. Used the msrvtt_ret_test1k retrieval split (879 examples).",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
         type="Any2AnyRetrieval",
         eval_langs=["eng-Latn"],
@@ -140,7 +140,7 @@ class MSRVTTVA2T(AbsTaskRetrieval):
 class MSRVTTT2VA(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="MSRVTTT2VA",
-        description="A large video description dataset for bridging video and language",
+        description="A large video description dataset for bridging video and language. Used the msrvtt_ret_test1k retrieval split (879 examples).",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
         type="Any2AnyRetrieval",
         eval_langs=["eng-Latn"],
@@ -173,6 +173,7 @@ class MSRVTTV2A(AbsTaskRetrieval):
         description=(
             "Retrieve the audio track that matches a given video clip from MSR-VTT. "
             "Tests cross-modal alignment between video frames and audio."
+            " Used the msrvtt_ret_test1k retrieval split (879 examples)."
         ),
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
         type="Any2AnyRetrieval",
@@ -204,6 +205,7 @@ class MSRVTTA2V(AbsTaskRetrieval):
         description=(
             "Retrieve the video clip that matches a given audio track from MSR-VTT. "
             "Tests cross-modal alignment between audio and video frames."
+            " Used the msrvtt_ret_test1k retrieval split (879 examples)."
         ),
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
         type="Any2AnyRetrieval",
@@ -232,7 +234,7 @@ class MSRVTTA2V(AbsTaskRetrieval):
 class MSRVTTVT2A(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="MSRVTTVT2A",
-        description="A large video description dataset for bridging video and language",
+        description="A large video description dataset for bridging video and language. Used the msrvtt_ret_test1k retrieval split (879 examples).",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
         type="Any2AnyRetrieval",
         eval_langs=["eng-Latn"],
@@ -264,7 +266,7 @@ class MSRVTTVT2A(AbsTaskRetrieval):
 class MSRVTTAT2V(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="MSRVTTAT2V",
-        description="A large video description dataset for bridging video and language",
+        description="A large video description dataset for bridging video and language. Used the msrvtt_ret_test1k retrieval split (879 examples).",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
         type="Any2AnyRetrieval",
         eval_langs=["eng-Latn"],

--- a/mteb/tasks/retrieval/eng/msvd_t2v_retrieval.py
+++ b/mteb/tasks/retrieval/eng/msvd_t2v_retrieval.py
@@ -13,6 +13,7 @@ class MSVDT2VRetrieval(AbsTaskRetrieval):
         description=(
             "Retrieve the short video clip that matches a given English caption. "
             "Each example pairs one caption with one video (1:1 retrieval)."
+            " Used the test split with the first caption per clip (~660 examples)."
         ),
         reference="https://huggingface.co/datasets/mteb/MSVD",
         dataset={

--- a/mteb/tasks/retrieval/eng/msvd_v2t_retrieval.py
+++ b/mteb/tasks/retrieval/eng/msvd_v2t_retrieval.py
@@ -13,6 +13,7 @@ class MSVDV2TRetrieval(AbsTaskRetrieval):
         description=(
             "Retrieve the English caption that describes a given short video clip. "
             "Each example pairs one video with one reference sentence (1:1 retrieval)."
+            " Used the test split with the first caption per clip (~660 examples)."
         ),
         reference="https://huggingface.co/datasets/mteb/MSVD",
         dataset={

--- a/mteb/tasks/retrieval/eng/panda70m_retrieval.py
+++ b/mteb/tasks/retrieval/eng/panda70m_retrieval.py
@@ -58,6 +58,7 @@ class Panda70MV2TRetrieval(AbsTaskRetrieval):
             "Retrieve the English caption that describes a given video clip (video "
             "only) from Panda-70M, a large-scale video captioning dataset sourced "
             "from YouTube."
+            " Sampled the test split (~3,395 examples)."
         ),
         reference="https://arxiv.org/abs/2402.19479",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -90,6 +91,7 @@ class Panda70MT2VRetrieval(AbsTaskRetrieval):
             "Retrieve the video clip (video only) that matches a given English "
             "caption from Panda-70M, a large-scale video captioning dataset sourced "
             "from YouTube."
+            " Sampled the test split (~3,395 examples)."
         ),
         reference="https://arxiv.org/abs/2402.19479",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -121,6 +123,7 @@ class Panda70MVA2TRetrieval(AbsTaskRetrieval):
         description=(
             "Retrieve the English caption that describes a given video clip from "
             "Panda-70M, a large-scale video captioning dataset sourced from YouTube."
+            " Sampled the test split (~3,395 examples)."
         ),
         reference="https://arxiv.org/abs/2402.19479",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -154,6 +157,7 @@ class Panda70MT2VARetrieval(AbsTaskRetrieval):
         description=(
             "Retrieve the video clip that matches a given English caption from "
             "Panda-70M, a large-scale video captioning dataset sourced from YouTube."
+            " Sampled the test split (~3,395 examples)."
         ),
         reference="https://arxiv.org/abs/2402.19479",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},

--- a/mteb/tasks/retrieval/eng/shot2story_retrieval.py
+++ b/mteb/tasks/retrieval/eng/shot2story_retrieval.py
@@ -57,6 +57,7 @@ class Shot2Story20KV2TRetrieval(AbsTaskRetrieval):
         description=(
             "Retrieve the detailed summary caption that describes a given video "
             "clip (video only) from the Shot2Story20K benchmark of multi-shot videos."
+            " Used the test split (~4,023 examples)."
         ),
         reference="https://arxiv.org/abs/2312.10300",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -88,6 +89,7 @@ class Shot2Story20KT2VRetrieval(AbsTaskRetrieval):
         description=(
             "Retrieve the video clip (video only) that matches a given detailed "
             "summary caption from the Shot2Story20K benchmark of multi-shot videos."
+            " Used the test split (~4,023 examples)."
         ),
         reference="https://arxiv.org/abs/2312.10300",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -119,6 +121,7 @@ class Shot2Story20KVA2TRetrieval(AbsTaskRetrieval):
         description=(
             "Retrieve the detailed summary caption that describes a given video "
             "clip from the Shot2Story20K benchmark of multi-shot videos."
+            " Used the test split (~4,023 examples)."
         ),
         reference="https://arxiv.org/abs/2312.10300",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -152,6 +155,7 @@ class Shot2Story20KT2VARetrieval(AbsTaskRetrieval):
         description=(
             "Retrieve the video clip that matches a given detailed summary caption "
             "from the Shot2Story20K benchmark of multi-shot videos."
+            " Used the test split (~4,023 examples)."
         ),
         reference="https://arxiv.org/abs/2312.10300",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -186,6 +190,7 @@ class Shot2Story20KV2ARetrieval(AbsTaskRetrieval):
             "Retrieve the audio track that matches a given video clip from the "
             "Shot2Story dataset. Tests cross-modal alignment between video frames "
             "and audio."
+            " Used the test split (~4,023 examples)."
         ),
         reference="https://arxiv.org/abs/2312.10300",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -218,6 +223,7 @@ class Shot2Story20KA2VRetrieval(AbsTaskRetrieval):
             "Retrieve the video clip that matches a given audio track from the "
             "Shot2Story dataset. Tests cross-modal alignment between audio and "
             "video frames."
+            " Used the test split (~4,023 examples)."
         ),
         reference="https://arxiv.org/abs/2312.10300",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -249,6 +255,7 @@ class Shot2Story20KVT2ARetrieval(AbsTaskRetrieval):
         description=(
             "Retrieve the audio track that matches a given video clip and its summary "
             "caption from the Shot2Story20K benchmark of multi-shot videos."
+            " Used the test split (~4,023 examples)."
         ),
         reference="https://arxiv.org/abs/2312.10300",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -284,6 +291,7 @@ class Shot2Story20KAT2VRetrieval(AbsTaskRetrieval):
         description=(
             "Retrieve the video clip that matches a given audio track and its summary "
             "caption from the Shot2Story20K benchmark of multi-shot videos."
+            " Used the test split (~4,023 examples)."
         ),
         reference="https://arxiv.org/abs/2312.10300",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},

--- a/mteb/tasks/retrieval/eng/tuna_bench_t2v_retrieval.py
+++ b/mteb/tasks/retrieval/eng/tuna_bench_t2v_retrieval.py
@@ -14,6 +14,7 @@ class TUNABenchT2VRetrieval(AbsTaskRetrieval):
             "Retrieve the video clip that matches a given fine-grained English caption "
             "from the TUNA-Bench dataset of dense dynamic videos with detailed "
             "temporal descriptions."
+            " Used the `TUNA-1K` config test split (~1,000 examples)."
         ),
         reference="https://arxiv.org/abs/2505.20124",
         dataset={

--- a/mteb/tasks/retrieval/eng/tuna_bench_v2t_retrieval.py
+++ b/mteb/tasks/retrieval/eng/tuna_bench_v2t_retrieval.py
@@ -14,6 +14,7 @@ class TUNABenchV2TRetrieval(AbsTaskRetrieval):
             "Retrieve the fine-grained English caption that describes a given video "
             "from the TUNA-Bench dataset of dense dynamic videos with detailed "
             "temporal descriptions."
+            " Used the `TUNA-1K` config test split (~1,000 examples)."
         ),
         reference="https://arxiv.org/abs/2505.20124",
         dataset={

--- a/mteb/tasks/retrieval/eng/valor_32k_retrieval.py
+++ b/mteb/tasks/retrieval/eng/valor_32k_retrieval.py
@@ -57,6 +57,7 @@ class VALOR32KV2TRetrieval(AbsTaskRetrieval):
         description=(
             "Retrieve the description that matches a given video clip (video only) "
             "from the VALOR-32K benchmark of vision-audio-language understanding."
+            " Used the official `desc_test.json` test split (~3,491 examples)."
         ),
         reference="https://arxiv.org/abs/2304.08345",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -88,6 +89,7 @@ class VALOR32KT2VRetrieval(AbsTaskRetrieval):
         description=(
             "Retrieve the video clip (video only) that matches a given description "
             "from the VALOR-32K benchmark of vision-audio-language understanding."
+            " Used the official `desc_test.json` test split (~3,491 examples)."
         ),
         reference="https://arxiv.org/abs/2304.08345",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -119,6 +121,7 @@ class VALOR32KVA2TRetrieval(AbsTaskRetrieval):
         description=(
             "Retrieve the description that matches a given video+audio clip "
             "from the VALOR-32K benchmark of vision-audio-language understanding."
+            " Used the official `desc_test.json` test split (~3,491 examples)."
         ),
         reference="https://arxiv.org/abs/2304.08345",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -152,6 +155,7 @@ class VALOR32KT2VARetrieval(AbsTaskRetrieval):
         description=(
             "Retrieve the video+audio clip that matches a given description "
             "from the VALOR-32K benchmark of vision-audio-language understanding."
+            " Used the official `desc_test.json` test split (~3,491 examples)."
         ),
         reference="https://arxiv.org/abs/2304.08345",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -186,6 +190,7 @@ class VALOR32KV2ARetrieval(AbsTaskRetrieval):
             "Retrieve the audio track that matches a given video clip from the "
             "VALOR-32K benchmark of vision-audio-language understanding. Tests "
             "cross-modal alignment between video frames and audio."
+            " Used the official `desc_test.json` test split (~3,491 examples)."
         ),
         reference="https://arxiv.org/abs/2304.08345",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -218,6 +223,7 @@ class VALOR32KA2VRetrieval(AbsTaskRetrieval):
             "Retrieve the video clip that matches a given audio track from the "
             "VALOR-32K benchmark of vision-audio-language understanding. Tests "
             "cross-modal alignment between audio and video frames."
+            " Used the official `desc_test.json` test split (~3,491 examples)."
         ),
         reference="https://arxiv.org/abs/2304.08345",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -250,6 +256,7 @@ class VALOR32KVT2ARetrieval(AbsTaskRetrieval):
             "Retrieve the audio track that matches a given video clip and its "
             "description from the VALOR-32K benchmark of vision-audio-language "
             "understanding."
+            " Used the official `desc_test.json` test split (~3,491 examples)."
         ),
         reference="https://arxiv.org/abs/2304.08345",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -286,6 +293,7 @@ class VALOR32KAT2VRetrieval(AbsTaskRetrieval):
             "Retrieve the video clip that matches a given audio track and its "
             "description from the VALOR-32K benchmark of vision-audio-language "
             "understanding."
+            " Used the official `desc_test.json` test split (~3,491 examples)."
         ),
         reference="https://arxiv.org/abs/2304.08345",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},

--- a/mteb/tasks/retrieval/eng/vatex_retrieval.py
+++ b/mteb/tasks/retrieval/eng/vatex_retrieval.py
@@ -57,6 +57,7 @@ class VATEXV2TRetrieval(AbsTaskRetrieval):
         description=(
             "Retrieve the English caption that describes a given video clip (video "
             "only) from VATEX, a large-scale multilingual video description dataset."
+            " Used the `vatex_test` config with the first English caption, capped at 1,000 (~1,000 examples)."
         ),
         reference="https://arxiv.org/abs/1904.03493",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -88,6 +89,7 @@ class VATEXT2VRetrieval(AbsTaskRetrieval):
         description=(
             "Retrieve the video clip (video only) that matches a given English "
             "caption from VATEX, a large-scale multilingual video description dataset."
+            " Used the `vatex_test` config with the first English caption, capped at 1,000 (~1,000 examples)."
         ),
         reference="https://arxiv.org/abs/1904.03493",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -119,6 +121,7 @@ class VATEXVA2TRetrieval(AbsTaskRetrieval):
         description=(
             "Retrieve the English caption that describes a given video clip from "
             "VATEX, a large-scale multilingual video description dataset."
+            " Used the `vatex_test` config with the first English caption, capped at 1,000 (~1,000 examples)."
         ),
         reference="https://arxiv.org/abs/1904.03493",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -150,6 +153,7 @@ class VATEXT2VARetrieval(AbsTaskRetrieval):
         description=(
             "Retrieve the video clip that matches a given English caption from "
             "VATEX, a large-scale multilingual video description dataset."
+            " Used the `vatex_test` config with the first English caption, capped at 1,000 (~1,000 examples)."
         ),
         reference="https://arxiv.org/abs/1904.03493",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -181,6 +185,7 @@ class VATEXV2ARetrieval(AbsTaskRetrieval):
         description=(
             "Retrieve the audio track that matches a given video clip from the "
             "VATEX dataset. Tests cross-modal alignment between video frames and audio."
+            " Used the `vatex_test` config with the first English caption, capped at 1,000 (~1,000 examples)."
         ),
         reference="https://arxiv.org/abs/1904.03493",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -212,6 +217,7 @@ class VATEXA2VRetrieval(AbsTaskRetrieval):
         description=(
             "Retrieve the video clip that matches a given audio track from the "
             "VATEX dataset. Tests cross-modal alignment between audio and video frames."
+            " Used the `vatex_test` config with the first English caption, capped at 1,000 (~1,000 examples)."
         ),
         reference="https://arxiv.org/abs/1904.03493",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -243,6 +249,7 @@ class VATEXVT2ARetrieval(AbsTaskRetrieval):
         description=(
             "Retrieve the audio track that matches a given video clip and its English "
             "caption from VATEX, a large-scale multilingual video description dataset."
+            " Used the `vatex_test` config with the first English caption, capped at 1,000 (~1,000 examples)."
         ),
         reference="https://arxiv.org/abs/1904.03493",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -276,6 +283,7 @@ class VATEXAT2VRetrieval(AbsTaskRetrieval):
         description=(
             "Retrieve the video clip that matches a given audio track and its English "
             "caption from VATEX, a large-scale multilingual video description dataset."
+            " Used the `vatex_test` config with the first English caption, capped at 1,000 (~1,000 examples)."
         ),
         reference="https://arxiv.org/abs/1904.03493",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},

--- a/mteb/tasks/retrieval/eng/vggsound_av_retrieval.py
+++ b/mteb/tasks/retrieval/eng/vggsound_av_retrieval.py
@@ -71,6 +71,7 @@ class VGGSoundAVV2TRetrieval(AbsTaskRetrieval):
             "Retrieve the caption that describes the visual content of a given video "
             "clip from the VGGSound-AV dataset, a large-scale audio-visual dataset "
             "sourced from YouTube."
+            " Used the VGGSound-T2AV test split (~696 examples)."
         ),
         reference="https://www.robots.ox.ac.uk/~vgg/data/vggsound/",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -105,6 +106,7 @@ class VGGSoundAVT2VRetrieval(AbsTaskRetrieval):
             "Retrieve the video clip that matches a given caption describing its "
             "visual content, from the VGGSound-AV dataset, a large-scale "
             "audio-visual dataset sourced from YouTube."
+            " Used the VGGSound-T2AV test split (~696 examples)."
         ),
         reference="https://www.robots.ox.ac.uk/~vgg/data/vggsound/",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -139,6 +141,7 @@ class VGGSoundAVVA2TRetrieval(AbsTaskRetrieval):
             "Retrieve the caption covering both what is seen and what is heard in a "
             "given video+audio clip from the VGGSound-AV dataset, a large-scale "
             "audio-visual dataset sourced from YouTube."
+            " Used the VGGSound-T2AV test split (~696 examples)."
         ),
         reference="https://www.robots.ox.ac.uk/~vgg/data/vggsound/",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -175,6 +178,7 @@ class VGGSoundAVT2VARetrieval(AbsTaskRetrieval):
             "Retrieve the video+audio clip that matches a given caption covering "
             "both what is seen and what is heard, from the VGGSound-AV dataset, a "
             "large-scale audio-visual dataset sourced from YouTube."
+            " Used the VGGSound-T2AV test split (~696 examples)."
         ),
         reference="https://www.robots.ox.ac.uk/~vgg/data/vggsound/",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -211,6 +215,7 @@ class VGGSoundAVV2ARetrieval(AbsTaskRetrieval):
             "Retrieve the audio track that matches a given video clip from the "
             "VGGSound-AV dataset, a large-scale audio-visual dataset sourced from "
             "YouTube. Tests cross-modal alignment between video frames and audio."
+            " Used the VGGSound-T2AV test split (~696 examples)."
         ),
         reference="https://www.robots.ox.ac.uk/~vgg/data/vggsound/",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -243,6 +248,7 @@ class VGGSoundAVA2VRetrieval(AbsTaskRetrieval):
             "Retrieve the video clip that matches a given audio track from the "
             "VGGSound-AV dataset, a large-scale audio-visual dataset sourced from "
             "YouTube. Tests cross-modal alignment between audio and video frames."
+            " Used the VGGSound-T2AV test split (~696 examples)."
         ),
         reference="https://www.robots.ox.ac.uk/~vgg/data/vggsound/",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -275,6 +281,7 @@ class VGGSoundAVVT2ARetrieval(AbsTaskRetrieval):
             "Retrieve the audio track that matches a given video clip and its "
             "caption from the VGGSound-AV dataset, a large-scale audio-visual "
             "dataset sourced from YouTube."
+            " Used the VGGSound-T2AV test split (~696 examples)."
         ),
         reference="https://www.robots.ox.ac.uk/~vgg/data/vggsound/",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -311,6 +318,7 @@ class VGGSoundAVAT2VRetrieval(AbsTaskRetrieval):
             "Retrieve the video clip that matches a given audio track and its "
             "caption from the VGGSound-AV dataset, a large-scale audio-visual "
             "dataset sourced from YouTube."
+            " Used the VGGSound-T2AV test split (~696 examples)."
         ),
         reference="https://www.robots.ox.ac.uk/~vgg/data/vggsound/",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},

--- a/mteb/tasks/retrieval/eng/youcook2_retrieval.py
+++ b/mteb/tasks/retrieval/eng/youcook2_retrieval.py
@@ -58,6 +58,7 @@ class YouCook2V2TRetrieval(AbsTaskRetrieval):
             "Retrieve the English sentence that describes a given cooking video "
             "clip (video only) from the YouCook2 dataset of instructional cooking "
             "videos."
+            " Used the official validation annotations cut into ~3 per-step segments per video (3,104 examples)."
         ),
         reference="https://arxiv.org/abs/1703.09788",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -90,6 +91,7 @@ class YouCook2T2VRetrieval(AbsTaskRetrieval):
             "Retrieve the cooking video clip (video only) that matches a given "
             "English sentence from the YouCook2 dataset of instructional cooking "
             "videos."
+            " Used the official validation annotations cut into ~3 per-step segments per video (3,104 examples)."
         ),
         reference="https://arxiv.org/abs/1703.09788",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -121,6 +123,7 @@ class YouCook2VA2TRetrieval(AbsTaskRetrieval):
         description=(
             "Retrieve the English sentence that describes a given cooking video "
             "clip from the YouCook2 dataset of instructional cooking videos."
+            " Used the official validation annotations cut into ~3 per-step segments per video (3,104 examples)."
         ),
         reference="https://arxiv.org/abs/1703.09788",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -154,6 +157,7 @@ class YouCook2T2VARetrieval(AbsTaskRetrieval):
         description=(
             "Retrieve the cooking video clip that matches a given English sentence "
             "from the YouCook2 dataset of instructional cooking videos."
+            " Used the official validation annotations cut into ~3 per-step segments per video (3,104 examples)."
         ),
         reference="https://arxiv.org/abs/1703.09788",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -188,6 +192,7 @@ class YouCook2V2ARetrieval(AbsTaskRetrieval):
             "Retrieve the audio track that matches a given video clip from the "
             "YouCook2 dataset of instructional cooking videos. Tests cross-modal "
             "alignment between video frames and audio narration."
+            " Used the official validation annotations cut into ~3 per-step segments per video (3,104 examples)."
         ),
         reference="https://arxiv.org/abs/1703.09788",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -220,6 +225,7 @@ class YouCook2A2VRetrieval(AbsTaskRetrieval):
             "Retrieve the video clip that matches a given audio track from the "
             "YouCook2 dataset of instructional cooking videos. Tests cross-modal "
             "alignment between audio narration and video frames."
+            " Used the official validation annotations cut into ~3 per-step segments per video (3,104 examples)."
         ),
         reference="https://arxiv.org/abs/1703.09788",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -252,6 +258,7 @@ class YouCook2VT2ARetrieval(AbsTaskRetrieval):
             "Retrieve the audio track that matches a given cooking video clip and "
             "its sentence description from the YouCook2 dataset of instructional "
             "cooking videos."
+            " Used the official validation annotations cut into ~3 per-step segments per video (3,104 examples)."
         ),
         reference="https://arxiv.org/abs/1703.09788",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
@@ -288,6 +295,7 @@ class YouCook2AT2VRetrieval(AbsTaskRetrieval):
             "Retrieve the cooking video clip that matches a given audio track and "
             "its sentence description from the YouCook2 dataset of instructional "
             "cooking videos."
+            " Used the official validation annotations cut into ~3 per-step segments per video (3,104 examples)."
         ),
         reference="https://arxiv.org/abs/1703.09788",
         dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},

--- a/mteb/tasks/zeroshot_classification/eng/ave_dataset.py
+++ b/mteb/tasks/zeroshot_classification/eng/ave_dataset.py
@@ -19,7 +19,7 @@ CITATION = r"""
 class AVEDatasetZeroShotClassification(AbsTaskZeroShotClassification):
     metadata = TaskMetadata(
         name="AVEDatasetZeroShot",
-        description="Audio-Visual Event (AVE) classification dataset containing 28 event categories such as church bell, truck, dog barking, and other everyday sounds sourced from YouTube videos. The goal is to predict the sound event category from synchronized video and audio. This variant uses both video and audio modalities.",
+        description="Audio-Visual Event (AVE) classification dataset containing 28 event categories such as church bell, truck, dog barking, and other everyday sounds sourced from YouTube videos. The goal is to predict the sound event category from synchronized video and audio. This variant uses both video and audio modalities. Used the official train and test splits across 28 audio-visual event classes (~3,312 train / ~402 test).",
         reference="https://openaccess.thecvf.com/content_ECCV_2018/papers/Yapeng_Tian_Audio-Visual_Event_Localization_ECCV_2018_paper.pdf",
         dataset={
             "path": "mteb/AVE-Dataset",
@@ -55,7 +55,7 @@ class AVEDatasetZeroShotClassification(AbsTaskZeroShotClassification):
 class AVEDatasetVideoZeroShotClassification(AbsTaskZeroShotClassification):
     metadata = TaskMetadata(
         name="AVEDatasetVideoZeroShot",
-        description="Audio-Visual Event (AVE) classification dataset containing 28 event categories such as church bell, truck, dog barking, and other everyday sounds sourced from YouTube videos. The goal is to predict the sound event category from video only.",
+        description="Audio-Visual Event (AVE) classification dataset containing 28 event categories such as church bell, truck, dog barking, and other everyday sounds sourced from YouTube videos. The goal is to predict the sound event category from video only. Used the official train and test splits across 28 audio-visual event classes (~3,312 train / ~402 test).",
         reference="https://openaccess.thecvf.com/content_ECCV_2018/papers/Yapeng_Tian_Audio-Visual_Event_Localization_ECCV_2018_paper.pdf",
         dataset={
             "path": "mteb/AVE-Dataset",

--- a/mteb/tasks/zeroshot_classification/eng/breakfast_classification.py
+++ b/mteb/tasks/zeroshot_classification/eng/breakfast_classification.py
@@ -7,7 +7,7 @@ from mteb.abstasks.zeroshot_classification import (
 class BreakfastZeroShotClassification(AbsTaskZeroShotClassification):
     metadata = TaskMetadata(
         name="BreakfastZeroShot",
-        description="The Breakfast Actions dataset contains 433 videos of 10 breakfast-related activities (e.g. making coffee, preparing cereal, frying eggs) recorded in 18 different kitchens. The task is to classify each video into the correct activity.",
+        description="The Breakfast Actions dataset contains 433 videos of 10 breakfast-related activities (e.g. making coffee, preparing cereal, frying eggs) recorded in 18 different kitchens. The task is to classify each video into the correct activity. Used only camera-01 clips, capped at 50 per class across 10 meal classes (~433 test).",
         reference="https://ieeexplore.ieee.org/document/6909500",
         dataset={
             "path": "mteb/Breakfast",

--- a/mteb/tasks/zeroshot_classification/eng/hmdb51.py
+++ b/mteb/tasks/zeroshot_classification/eng/hmdb51.py
@@ -7,7 +7,7 @@ from mteb.abstasks.zeroshot_classification import (
 class HMDB51ZeroShotClassification(AbsTaskZeroShotClassification):
     metadata = TaskMetadata(
         name="HMDB51ZeroShot",
-        description="HMDB51 is a large video database for human motion recognition with 51 action categories from digitized movies and online sources.",
+        description="HMDB51 is a large video database for human motion recognition with 51 action categories from digitized movies and online sources. Used official split 1 across 51 action classes (~3,570 train / ~1,530 test).",
         reference="https://serre-lab.clps.brown.edu/resource/hmdb-a-large-human-motion-database/",
         dataset={
             "path": "mteb/HMDB51",

--- a/mteb/tasks/zeroshot_classification/eng/human_animal_cartoon.py
+++ b/mteb/tasks/zeroshot_classification/eng/human_animal_cartoon.py
@@ -30,7 +30,8 @@ class HumanAnimalCartoonZeroShotClassification(AbsTaskZeroShotClassification):
             "Human-Animal-Cartoon (HAC) is a multi-domain action recognition "
             "dataset containing clips of humans, animals, and cartoon figures. "
             "The zero-shot task matches each video clip to a text prompt for "
-            "one of seven action labels."
+            "one of seven action labels. "
+            "Concatenated the three HAC test-only domain CSVs, capped at 32 per class across 7 action classes (~644 examples)."
         ),
         reference="https://arxiv.org/abs/2310.19795",
         dataset={
@@ -71,7 +72,8 @@ class HumanAnimalCartoonVAZeroShotClassification(AbsTaskZeroShotClassification):
             "Human-Animal-Cartoon (HAC) is a multi-domain action recognition "
             "dataset containing clips of humans, animals, and cartoon figures. "
             "The zero-shot task matches each (video, audio) pair to a text "
-            "prompt for one of seven action labels."
+            "prompt for one of seven action labels. "
+            "Concatenated the three HAC test-only domain CSVs, capped at 32 per class across 7 action classes (~644 examples)."
         ),
         reference="https://arxiv.org/abs/2310.19795",
         dataset={

--- a/mteb/tasks/zeroshot_classification/eng/kinetics400.py
+++ b/mteb/tasks/zeroshot_classification/eng/kinetics400.py
@@ -7,7 +7,7 @@ from mteb.abstasks.zeroshot_classification import (
 class Kinetics400ZeroShotClassification(AbsTaskZeroShotClassification):
     metadata = TaskMetadata(
         name="Kinetics400ZeroShot",
-        description="Kinetics-400 is a large-scale action recognition dataset containing 400 human action classes from YouTube videos. Each clip is approximately 10 seconds long.",
+        description="Kinetics-400 is a large-scale action recognition dataset containing 400 human action classes from YouTube videos. Each clip is approximately 10 seconds long. Sampled 25 random shard files from each official path list, capped at 10 per class across 400 classes (~3,970 train / ~4,000 test).",
         reference="https://arxiv.org/abs/1705.06950",
         dataset={
             "path": "mteb/kinetics-400",
@@ -55,7 +55,7 @@ class Kinetics400ZeroShotClassification(AbsTaskZeroShotClassification):
 class Kinetics400VAZeroShotClassification(AbsTaskZeroShotClassification):
     metadata = TaskMetadata(
         name="Kinetics400VAZeroShot",
-        description="Kinetics-400 is a large-scale action recognition dataset containing 400 human action classes from YouTube videos. Each clip is approximately 10 seconds long. This variant uses both video and audio modalities.",
+        description="Kinetics-400 is a large-scale action recognition dataset containing 400 human action classes from YouTube videos. Each clip is approximately 10 seconds long. This variant uses both video and audio modalities. Sampled 25 random shard files from each official path list, capped at 10 per class across 400 classes (~3,970 train / ~4,000 test).",
         reference="https://arxiv.org/abs/1705.06950",
         dataset={
             "path": "mteb/kinetics-400",

--- a/mteb/tasks/zeroshot_classification/eng/kinetics600.py
+++ b/mteb/tasks/zeroshot_classification/eng/kinetics600.py
@@ -16,7 +16,7 @@ CITATION = r"""
 class Kinetics600VAZeroShotClassification(AbsTaskZeroShotClassification):
     metadata = TaskMetadata(
         name="Kinetics600VAZeroShot",
-        description="Kinetics-600 is a large-scale action recognition dataset containing 600 human action classes from YouTube videos. Each clip is approximately 10 seconds long. This variant uses both video and audio modalities.",
+        description="Kinetics-600 is a large-scale action recognition dataset containing 600 human action classes from YouTube videos. Each clip is approximately 10 seconds long. This variant uses both video and audio modalities. Sampled the official test split, capped at ~16 per class across 600 classes (~9,576 examples).",
         reference="https://arxiv.org/abs/1808.01340",
         dataset={
             "path": "mteb/kinetics-600",
@@ -55,7 +55,7 @@ class Kinetics600VAZeroShotClassification(AbsTaskZeroShotClassification):
 class Kinetics600VZeroShotClassification(AbsTaskZeroShotClassification):
     metadata = TaskMetadata(
         name="Kinetics600VZeroShot",
-        description="Kinetics-600 is a large-scale action recognition dataset containing 600 human action classes from YouTube videos. Each clip is approximately 10 seconds long. This variant uses video only.",
+        description="Kinetics-600 is a large-scale action recognition dataset containing 600 human action classes from YouTube videos. Each clip is approximately 10 seconds long. This variant uses video only. Sampled the official test split, capped at ~16 per class across 600 classes (~9,576 examples).",
         reference="https://arxiv.org/abs/1808.01340",
         dataset={
             "path": "mteb/kinetics-600",

--- a/mteb/tasks/zeroshot_classification/eng/kinetics700.py
+++ b/mteb/tasks/zeroshot_classification/eng/kinetics700.py
@@ -16,7 +16,7 @@ CITATION = r"""
 class Kinetics700VAZeroShotClassification(AbsTaskZeroShotClassification):
     metadata = TaskMetadata(
         name="Kinetics700VAZeroShot",
-        description="Kinetics-700-2020 is a large-scale action recognition dataset containing 700 human action classes from YouTube videos. Each clip is approximately 10 seconds long. This variant uses both video and audio modalities.",
+        description="Kinetics-700-2020 is a large-scale action recognition dataset containing 700 human action classes from YouTube videos. Each clip is approximately 10 seconds long. This variant uses both video and audio modalities. Sampled the official test split, capped at ~16 per class across 700 classes (~11,190 examples).",
         reference="https://arxiv.org/abs/2010.10864",
         dataset={
             "path": "mteb/kinetics-700-2020",
@@ -55,7 +55,7 @@ class Kinetics700VAZeroShotClassification(AbsTaskZeroShotClassification):
 class Kinetics700VZeroShotClassification(AbsTaskZeroShotClassification):
     metadata = TaskMetadata(
         name="Kinetics700VZeroShot",
-        description="Kinetics-700-2020 is a large-scale action recognition dataset containing 700 human action classes from YouTube videos. Each clip is approximately 10 seconds long. This variant uses video only.",
+        description="Kinetics-700-2020 is a large-scale action recognition dataset containing 700 human action classes from YouTube videos. Each clip is approximately 10 seconds long. This variant uses video only. Sampled the official test split, capped at ~16 per class across 700 classes (~11,190 examples).",
         reference="https://arxiv.org/abs/2010.10864",
         dataset={
             "path": "mteb/kinetics-700-2020",

--- a/mteb/tasks/zeroshot_classification/eng/meld_classification.py
+++ b/mteb/tasks/zeroshot_classification/eng/meld_classification.py
@@ -17,7 +17,7 @@ CITATION = r"""
 class MELDAudioVideoZeroShotClassification(AbsTaskZeroShotClassification):
     metadata = TaskMetadata(
         name="MELDAudioVideoZeroShot",
-        description="MELD (Multimodal EmotionLines Dataset) is a multimodal emotion recognition dataset containing over 13,000 utterances from the Friends TV series, labeled with 7 emotion categories: Anger, Disgust, Sadness, Joy, Neutral, Surprise, and Fear",
+        description="MELD (Multimodal EmotionLines Dataset) is a multimodal emotion recognition dataset containing over 13,000 utterances from the Friends TV series, labeled with 7 emotion categories: Anger, Disgust, Sadness, Joy, Neutral, Surprise, and Fear Sampled the test split (~2,610 examples).",
         reference="https://aclanthology.org/P19-1050.pdf",
         dataset={
             "path": "mteb/MELD",
@@ -58,7 +58,7 @@ class MELDAudioVideoZeroShotClassification(AbsTaskZeroShotClassification):
 class MELDVideoZeroShotClassification(AbsTaskZeroShotClassification):
     metadata = TaskMetadata(
         name="MELDVideoZeroShot",
-        description="MELD (Multimodal EmotionLines Dataset) is a multimodal emotion recognition dataset containing over 13,000 utterances from the Friends TV series, labeled with 7 emotion categories: Anger, Disgust, Sadness, Joy, Neutral, Surprise, and Fear",
+        description="MELD (Multimodal EmotionLines Dataset) is a multimodal emotion recognition dataset containing over 13,000 utterances from the Friends TV series, labeled with 7 emotion categories: Anger, Disgust, Sadness, Joy, Neutral, Surprise, and Fear Sampled the test split (~2,610 examples).",
         reference="https://aclanthology.org/P19-1050.pdf",
         dataset={
             "path": "mteb/MELD",

--- a/mteb/tasks/zeroshot_classification/eng/music_avqa.py
+++ b/mteb/tasks/zeroshot_classification/eng/music_avqa.py
@@ -19,7 +19,7 @@ CITATION = r"""
 class MusicAVQACLSAudioVideoZeroShotClassification(AbsTaskZeroShotClassification):
     metadata = TaskMetadata(
         name="MusicAVQACLSAudioVideoZeroShot",
-        description="MUSIC-AVQA classification dataset containing 22 instrument categories. Given a video and audio of someone playing an instrument, the goal is to predict the instrument type. This zero-shot variant uses both video and audio modalities.",
+        description="MUSIC-AVQA classification dataset containing 22 instrument categories. Given a video and audio of someone playing an instrument, the goal is to predict the instrument type. This zero-shot variant uses both video and audio modalities. Filtered the test split to rows with a 22-class instrument answer (~1,706 examples).",
         reference="https://arxiv.org/abs/2203.14072",
         dataset={
             "path": "mteb/MUSIC-AVQA_cls-preprocessed",
@@ -55,7 +55,7 @@ class MusicAVQACLSAudioVideoZeroShotClassification(AbsTaskZeroShotClassification
 class MusicAVQACLSVideoZeroShotClassification(AbsTaskZeroShotClassification):
     metadata = TaskMetadata(
         name="MusicAVQACLSVideoZeroShot",
-        description="MUSIC-AVQA classification dataset containing 22 instrument categories. Given a video and audio of someone playing an instrument, the goal is to predict the instrument type. This zero-shot variant uses video only.",
+        description="MUSIC-AVQA classification dataset containing 22 instrument categories. Given a video and audio of someone playing an instrument, the goal is to predict the instrument type. This zero-shot variant uses video only. Filtered the test split to rows with a 22-class instrument answer (~1,706 examples).",
         reference="https://arxiv.org/abs/2203.14072",
         dataset={
             "path": "mteb/MUSIC-AVQA_cls-preprocessed",

--- a/mteb/tasks/zeroshot_classification/eng/ravdess_av.py
+++ b/mteb/tasks/zeroshot_classification/eng/ravdess_av.py
@@ -37,7 +37,7 @@ def _emotion_prompts(names: list[str]) -> list[str]:
 class RAVDESSAVZeroShotClassification(AbsTaskZeroShotClassification):
     metadata = TaskMetadata(
         name="RAVDESSAVZeroShot",
-        description=DESCRIPTION_BASE + " This variant uses both video and audio.",
+        description=DESCRIPTION_BASE + " This variant uses both video and audio. Used the metadata train split remapped to audio-visual filenames (~1,440 examples).",
         reference="https://doi.org/10.1371/journal.pone.0196391",
         dataset=DATASET,
         type="VideoZeroshotClassification",
@@ -69,7 +69,7 @@ class RAVDESSAVZeroShotClassification(AbsTaskZeroShotClassification):
 class RAVDESSVZeroShotClassification(AbsTaskZeroShotClassification):
     metadata = TaskMetadata(
         name="RAVDESSVZeroShot",
-        description=DESCRIPTION_BASE + " This variant uses video only.",
+        description=DESCRIPTION_BASE + " This variant uses video only. Used the metadata train split remapped to audio-visual filenames (~1,440 examples).",
         reference="https://doi.org/10.1371/journal.pone.0196391",
         dataset=DATASET,
         type="VideoZeroshotClassification",

--- a/mteb/tasks/zeroshot_classification/eng/ravdess_av.py
+++ b/mteb/tasks/zeroshot_classification/eng/ravdess_av.py
@@ -37,7 +37,8 @@ def _emotion_prompts(names: list[str]) -> list[str]:
 class RAVDESSAVZeroShotClassification(AbsTaskZeroShotClassification):
     metadata = TaskMetadata(
         name="RAVDESSAVZeroShot",
-        description=DESCRIPTION_BASE + " This variant uses both video and audio. Used the metadata train split remapped to audio-visual filenames (~1,440 examples).",
+        description=DESCRIPTION_BASE
+        + " This variant uses both video and audio. Used the metadata train split remapped to audio-visual filenames (~1,440 examples).",
         reference="https://doi.org/10.1371/journal.pone.0196391",
         dataset=DATASET,
         type="VideoZeroshotClassification",
@@ -69,7 +70,8 @@ class RAVDESSAVZeroShotClassification(AbsTaskZeroShotClassification):
 class RAVDESSVZeroShotClassification(AbsTaskZeroShotClassification):
     metadata = TaskMetadata(
         name="RAVDESSVZeroShot",
-        description=DESCRIPTION_BASE + " This variant uses video only. Used the metadata train split remapped to audio-visual filenames (~1,440 examples).",
+        description=DESCRIPTION_BASE
+        + " This variant uses video only. Used the metadata train split remapped to audio-visual filenames (~1,440 examples).",
         reference="https://doi.org/10.1371/journal.pone.0196391",
         dataset=DATASET,
         type="VideoZeroshotClassification",

--- a/mteb/tasks/zeroshot_classification/eng/ucf101.py
+++ b/mteb/tasks/zeroshot_classification/eng/ucf101.py
@@ -52,7 +52,8 @@ class UCF101VideoAudioZeroShotClassification(AbsTaskZeroShotClassification):
         name="UCF101VideoAudioZeroShotClassification",
         description=(
             "Classifying video clips with audio into 51 human "
-            "action categories from the UCF101 dataset."
+            "action categories from the UCF101 dataset. "
+            "Used official split 1 restricted to a 51-class audio-bearing subset (~4,890 train / ~1,944 test)."
         ),
         reference="https://arxiv.org/abs/1212.0402",
         dataset={
@@ -107,7 +108,8 @@ class UCF101VideoZeroShotClassification(AbsTaskZeroShotClassification):
         name="UCF101VideoZeroShotClassification",
         description=(
             "Classifying video clips with audio into 51 human "
-            "action categories from the UCF101 dataset."
+            "action categories from the UCF101 dataset. "
+            "Used official split 1 restricted to a 51-class audio-bearing subset (~4,890 train / ~1,944 test)."
         ),
         reference="https://arxiv.org/abs/1212.0402",
         dataset={

--- a/mteb/tasks/zeroshot_classification/eng/vggsound_zeroshot.py
+++ b/mteb/tasks/zeroshot_classification/eng/vggsound_zeroshot.py
@@ -19,7 +19,7 @@ CITATION = r"""
 class VGGSoundVideoZeroshotClassification(AbsTaskZeroShotClassification):
     metadata = TaskMetadata(
         name="VGGSoundVideoZeroshot",
-        description="VGGSound is a large-scale audio-visual dataset of short YouTube clips spanning 308 sound classes (e.g. 'playing piano', 'dog barking'). Audio is the primary signal. This variant uses both video and audio modalities. This zero-shot classification task predicts the sound class of each video",
+        description="VGGSound is a large-scale audio-visual dataset of short YouTube clips spanning 308 sound classes (e.g. 'playing piano', 'dog barking'). Audio is the primary signal. This variant uses both video and audio modalities. This zero-shot classification task predicts the sound class of each video Filtered the test split, capped at 32 per class across 309 classes (~9,888 examples).",
         reference="https://arxiv.org/abs/2004.14368",
         dataset={
             "path": "mteb/VGGSound",
@@ -55,7 +55,7 @@ class VGGSoundVideoZeroshotClassification(AbsTaskZeroShotClassification):
 class VGGSoundVideoAudioZeroshotClassification(AbsTaskZeroShotClassification):
     metadata = TaskMetadata(
         name="VGGSoundVideoAudioZeroshot",
-        description="VGGSound is a large-scale audio-visual dataset of short YouTube clips spanning 308 sound classes (e.g. 'playing piano', 'dog barking'). Audio is the primary signal. This variant uses both video and audio modalities. This zero-shot classification task predicts the sound class of each video + audio",
+        description="VGGSound is a large-scale audio-visual dataset of short YouTube clips spanning 308 sound classes (e.g. 'playing piano', 'dog barking'). Audio is the primary signal. This variant uses both video and audio modalities. This zero-shot classification task predicts the sound class of each video + audio Filtered the test split, capped at 32 per class across 309 classes (~9,888 examples).",
         reference="https://arxiv.org/abs/2004.14368",
         dataset={
             "path": "mteb/VGGSound",

--- a/mteb/tasks/zeroshot_classification/eng/worldsense_classification.py
+++ b/mteb/tasks/zeroshot_classification/eng/worldsense_classification.py
@@ -16,7 +16,7 @@ CITATION = r"""
 class WorldSenseAudioVideoZeroShotClassification(AbsTaskZeroShotClassification):
     metadata = TaskMetadata(
         name="WorldSenseAudioVideoZeroShot",
-        description="WorldSense is a multimodal video understanding benchmark encompassing visual, audio, and text inputs. Videos are categorized into 8 primary domains across 67 fine-grained subcategories. This zero-shot classification task predicts the domain category of a video clip",
+        description="WorldSense is a multimodal video understanding benchmark encompassing visual, audio, and text inputs. Videos are categorized into 8 primary domains across 67 fine-grained subcategories. This zero-shot classification task predicts the domain category of a video clip Filtered the test split to short (<1min) clips (~1,047 examples).",
         reference="https://arxiv.org/abs/2502.04326",
         dataset={
             "path": "mteb/WorldSense_1min",
@@ -49,7 +49,7 @@ class WorldSenseAudioVideoZeroShotClassification(AbsTaskZeroShotClassification):
 class WorldSenseVideoZeroShotClassification(AbsTaskZeroShotClassification):
     metadata = TaskMetadata(
         name="WorldSenseVideoZeroShot",
-        description="WorldSense is a multimodal video understanding benchmark encompassing visual, audio, and text inputs. Videos are categorized into 8 primary domains across 67 fine-grained subcategories. This zero-shot classification task predicts the domain category of a video clip",
+        description="WorldSense is a multimodal video understanding benchmark encompassing visual, audio, and text inputs. Videos are categorized into 8 primary domains across 67 fine-grained subcategories. This zero-shot classification task predicts the domain category of a video clip Filtered the test split to short (<1min) clips (~1,047 examples).",
         reference="https://arxiv.org/abs/2502.04326",
         dataset={
             "path": "mteb/WorldSense_1min",


### PR DESCRIPTION
For each video / audio-visual task contributed by MVEB, append a short sentence to the description= field stating the split used, any sampling/filtering cap, and the final row count, so users can see at a glance what was processed without reading the data-prep script.

If you add a model or a dataset, please add the corresponding checklist:

* [dataset checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_dataset/#submit-a-pull-request)
* [model checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_model/#submitting-your-model-as-a-pr)
