### PR TITLE
Move directory creation to write-time call.

### DIFF
--- a/mteb/abstasks/abstask.py
+++ b/mteb/abstasks/abstask.py
@@ -444,7 +444,10 @@ class AbsTask(ABC):  # noqa: PLR0904
                 )
                 descriptive_stats[split] = split_details  # type: ignore[assignment]
 
-        with self.metadata.descriptive_stat_path.open("w") as f:
+        stat_path = self.metadata.descriptive_stat_path
+        if not stat_path.parent.exists():
+            stat_path.parent.mkdir(parents=True, exist_ok=True)
+        with stat_path.open("w") as f:
             json.dump(descriptive_stats, f, indent=4)
 
         return descriptive_stats

--- a/mteb/abstasks/task_metadata.py
+++ b/mteb/abstasks/task_metadata.py
@@ -615,10 +615,6 @@ class TaskMetadata(BaseModel):
         if self.type in MIEB_TASK_TYPE:
             descriptive_stat_base_dir = descriptive_stat_base_dir / "Image"  # noqa: PLR6104
         task_type_dir = descriptive_stat_base_dir / self.type
-        if not descriptive_stat_base_dir.exists():
-            descriptive_stat_base_dir.mkdir()
-        if not task_type_dir.exists():
-            task_type_dir.mkdir()
         return task_type_dir / f"{self.name}.json"
 
     @property


### PR DESCRIPTION
Accessing `TaskMetadata.descriptive_stat_path` currently triggers `.mkdir()` calls as a side effect, which causes pure read operations (such as checking `.exists()`) to crash with `PermissionError` in read-only or sandboxed execution environments. This change moves directory creation from the property getter into `calculate_descriptive_statistics()` where the write to this directory actually happens.
  