### PR TITLE
fix: OgmaWrapper inherit from AbsEncoder

### DIFF
--- a/mteb/models/model_implementations/axiotic_models.py
+++ b/mteb/models/model_implementations/axiotic_models.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 import torch
 
+from mteb.models.abs_encoder import AbsEncoder
 from mteb.models.model_meta import ModelMeta, ScoringFunction
 
 if TYPE_CHECKING:
@@ -23,7 +24,7 @@ _QRY_TASK_TYPES = frozenset(
 )
 
 
-class OgmaWrapper:
+class OgmaWrapper(AbsEncoder):
     """MTEB wrapper for Axiotic Ogma embedding models."""
 
     def __init__(


### PR DESCRIPTION
**Issue**:
OgmaWrapper was declared as a bare class, so isinstance(model, EncoderProtocol) returns False and RetrievalEvaluator rejects it with TypeError. 

**Fix**:
Inheriting from AbsEncoder picks up the default similarity / similarity_pairwise implementations driven by ModelMeta.similarity_fn_name (already set to COSINE for all Ogma models). No change to encoding behaviour.

**Reported by**:
@Samoed on embeddings-benchmark/results#525.

