### PR TITLE
fix: retrieval statistics calculation

### DIFF
--- a/mteb/abstasks/_statistics_calculation.py
+++ b/mteb/abstasks/_statistics_calculation.py
@@ -399,17 +399,16 @@ def calculate_top_ranked_statistics(
 def calculate_relevant_docs_statistics(
     relevant_docs: Mapping[str, Mapping[str, int]],
 ) -> RelevantDocsStatistics:
-    qrels_lengths = [len(relevant_docs[qid]) for qid in relevant_docs]
     unique_qrels = len({doc for qid in relevant_docs for doc in relevant_docs[qid]})
     # number of qrels that are not 0
-    num_qrels_non_zero = sum(
+    qrels_lengths = [
         sum(1 for doc_id in docs if docs[doc_id] != 0)
         for docs in relevant_docs.values()
-    )
-    qrels_per_doc = num_qrels_non_zero / len(relevant_docs)
+    ]
+    qrels_per_doc = sum(qrels_lengths) / len(relevant_docs)
 
     return RelevantDocsStatistics(
-        num_relevant_docs=num_qrels_non_zero,
+        num_relevant_docs=sum(qrels_lengths),
         min_relevant_docs_per_query=min(qrels_lengths),
         average_relevant_docs_per_query=qrels_per_doc,
         max_relevant_docs_per_query=max(qrels_lengths),

--- a/tests/mock_tasks.py
+++ b/tests/mock_tasks.py
@@ -1704,9 +1704,9 @@ class MockRerankingTask(AbsTaskRetrieval):
             "queries_video_statistics": None,
             "relevant_docs_statistics": {
                 "num_relevant_docs": 2,
-                "min_relevant_docs_per_query": 2,
+                "min_relevant_docs_per_query": 1,
                 "average_relevant_docs_per_query": 1.0,
-                "max_relevant_docs_per_query": 2,
+                "max_relevant_docs_per_query": 1,
                 "unique_relevant_docs": 2,
             },
             "top_ranked_statistics": {
@@ -1759,9 +1759,9 @@ class MockMultilingualRerankingTask(AbsTaskRetrieval):
             "queries_video_statistics": None,
             "relevant_docs_statistics": {
                 "num_relevant_docs": 4,
-                "min_relevant_docs_per_query": 2,
+                "min_relevant_docs_per_query": 1,
                 "average_relevant_docs_per_query": 1.0,
-                "max_relevant_docs_per_query": 2,
+                "max_relevant_docs_per_query": 1,
                 "unique_relevant_docs": 4,
             },
             "top_ranked_statistics": {
@@ -1796,9 +1796,9 @@ class MockMultilingualRerankingTask(AbsTaskRetrieval):
                     "queries_video_statistics": None,
                     "relevant_docs_statistics": {
                         "num_relevant_docs": 2,
-                        "min_relevant_docs_per_query": 2,
+                        "min_relevant_docs_per_query": 1,
                         "average_relevant_docs_per_query": 1.0,
-                        "max_relevant_docs_per_query": 2,
+                        "max_relevant_docs_per_query": 1,
                         "unique_relevant_docs": 2,
                     },
                     "top_ranked_statistics": {
@@ -1833,9 +1833,9 @@ class MockMultilingualRerankingTask(AbsTaskRetrieval):
                     "queries_video_statistics": None,
                     "relevant_docs_statistics": {
                         "num_relevant_docs": 2,
-                        "min_relevant_docs_per_query": 2,
+                        "min_relevant_docs_per_query": 1,
                         "average_relevant_docs_per_query": 1.0,
-                        "max_relevant_docs_per_query": 2,
+                        "max_relevant_docs_per_query": 1,
                         "unique_relevant_docs": 2,
                     },
                     "top_ranked_statistics": {
@@ -1894,9 +1894,9 @@ class MockRetrievalTask(AbsTaskRetrieval):
             "queries_video_statistics": None,
             "relevant_docs_statistics": {
                 "num_relevant_docs": 2,
-                "min_relevant_docs_per_query": 2,
+                "min_relevant_docs_per_query": 1,
                 "average_relevant_docs_per_query": 1.0,
-                "max_relevant_docs_per_query": 2,
+                "max_relevant_docs_per_query": 1,
                 "unique_relevant_docs": 2,
             },
             "top_ranked_statistics": None,
@@ -1926,9 +1926,9 @@ class MockRetrievalTask(AbsTaskRetrieval):
             "queries_video_statistics": None,
             "relevant_docs_statistics": {
                 "num_relevant_docs": 2,
-                "min_relevant_docs_per_query": 2,
+                "min_relevant_docs_per_query": 1,
                 "average_relevant_docs_per_query": 1.0,
-                "max_relevant_docs_per_query": 2,
+                "max_relevant_docs_per_query": 1,
                 "unique_relevant_docs": 2,
             },
             "top_ranked_statistics": None,
@@ -1978,9 +1978,9 @@ class MockRetrievalDialogTask(AbsTaskRetrieval):
             "queries_video_statistics": None,
             "relevant_docs_statistics": {
                 "num_relevant_docs": 2,
-                "min_relevant_docs_per_query": 2,
+                "min_relevant_docs_per_query": 1,
                 "average_relevant_docs_per_query": 1.0,
-                "max_relevant_docs_per_query": 2,
+                "max_relevant_docs_per_query": 1,
                 "unique_relevant_docs": 2,
             },
             "top_ranked_statistics": None,
@@ -2010,9 +2010,9 @@ class MockRetrievalDialogTask(AbsTaskRetrieval):
             "queries_video_statistics": None,
             "relevant_docs_statistics": {
                 "num_relevant_docs": 2,
-                "min_relevant_docs_per_query": 2,
+                "min_relevant_docs_per_query": 1,
                 "average_relevant_docs_per_query": 1.0,
-                "max_relevant_docs_per_query": 2,
+                "max_relevant_docs_per_query": 1,
                 "unique_relevant_docs": 2,
             },
             "top_ranked_statistics": None,
@@ -2079,9 +2079,9 @@ class MockMultilingualRetrievalTask(AbsTaskRetrieval):
             "queries_video_statistics": None,
             "relevant_docs_statistics": {
                 "num_relevant_docs": 4,
-                "min_relevant_docs_per_query": 2,
+                "min_relevant_docs_per_query": 1,
                 "average_relevant_docs_per_query": 1.0,
-                "max_relevant_docs_per_query": 2,
+                "max_relevant_docs_per_query": 1,
                 "unique_relevant_docs": 4,
             },
             "top_ranked_statistics": None,
@@ -2111,9 +2111,9 @@ class MockMultilingualRetrievalTask(AbsTaskRetrieval):
                     "queries_video_statistics": None,
                     "relevant_docs_statistics": {
                         "num_relevant_docs": 2,
-                        "min_relevant_docs_per_query": 2,
+                        "min_relevant_docs_per_query": 1,
                         "average_relevant_docs_per_query": 1.0,
-                        "max_relevant_docs_per_query": 2,
+                        "max_relevant_docs_per_query": 1,
                         "unique_relevant_docs": 2,
                     },
                     "top_ranked_statistics": None,
@@ -2143,9 +2143,9 @@ class MockMultilingualRetrievalTask(AbsTaskRetrieval):
                     "queries_video_statistics": None,
                     "relevant_docs_statistics": {
                         "num_relevant_docs": 2,
-                        "min_relevant_docs_per_query": 2,
+                        "min_relevant_docs_per_query": 1,
                         "average_relevant_docs_per_query": 1.0,
-                        "max_relevant_docs_per_query": 2,
+                        "max_relevant_docs_per_query": 1,
                         "unique_relevant_docs": 2,
                     },
                     "top_ranked_statistics": None,
@@ -2177,9 +2177,9 @@ class MockMultilingualRetrievalTask(AbsTaskRetrieval):
             "queries_video_statistics": None,
             "relevant_docs_statistics": {
                 "num_relevant_docs": 4,
-                "min_relevant_docs_per_query": 2,
+                "min_relevant_docs_per_query": 1,
                 "average_relevant_docs_per_query": 1.0,
-                "max_relevant_docs_per_query": 2,
+                "max_relevant_docs_per_query": 1,
                 "unique_relevant_docs": 4,
             },
             "top_ranked_statistics": None,
@@ -2209,9 +2209,9 @@ class MockMultilingualRetrievalTask(AbsTaskRetrieval):
                     "queries_video_statistics": None,
                     "relevant_docs_statistics": {
                         "num_relevant_docs": 2,
-                        "min_relevant_docs_per_query": 2,
+                        "min_relevant_docs_per_query": 1,
                         "average_relevant_docs_per_query": 1.0,
-                        "max_relevant_docs_per_query": 2,
+                        "max_relevant_docs_per_query": 1,
                         "unique_relevant_docs": 2,
                     },
                     "top_ranked_statistics": None,
@@ -2241,9 +2241,9 @@ class MockMultilingualRetrievalTask(AbsTaskRetrieval):
                     "queries_video_statistics": None,
                     "relevant_docs_statistics": {
                         "num_relevant_docs": 2,
-                        "min_relevant_docs_per_query": 2,
+                        "min_relevant_docs_per_query": 1,
                         "average_relevant_docs_per_query": 1.0,
-                        "max_relevant_docs_per_query": 2,
+                        "max_relevant_docs_per_query": 1,
                         "unique_relevant_docs": 2,
                     },
                     "top_ranked_statistics": None,
@@ -2546,9 +2546,9 @@ class MockInstructionRetrieval(AbsTaskRetrieval):
             "queries_video_statistics": None,
             "relevant_docs_statistics": {
                 "num_relevant_docs": 2,
-                "min_relevant_docs_per_query": 2,
+                "min_relevant_docs_per_query": 1,
                 "average_relevant_docs_per_query": 1.0,
-                "max_relevant_docs_per_query": 2,
+                "max_relevant_docs_per_query": 1,
                 "unique_relevant_docs": 2,
             },
             "top_ranked_statistics": None,
@@ -2597,9 +2597,9 @@ class MockInstructionReranking(AbsTaskRetrieval):
             "queries_video_statistics": None,
             "relevant_docs_statistics": {
                 "num_relevant_docs": 2,
-                "min_relevant_docs_per_query": 2,
+                "min_relevant_docs_per_query": 1,
                 "average_relevant_docs_per_query": 1.0,
-                "max_relevant_docs_per_query": 2,
+                "max_relevant_docs_per_query": 1,
                 "unique_relevant_docs": 2,
             },
             "top_ranked_statistics": {
@@ -2651,9 +2651,9 @@ class MockMultilingualInstructionRetrieval(AbsTaskRetrieval):
             "queries_video_statistics": None,
             "relevant_docs_statistics": {
                 "num_relevant_docs": 4,
-                "min_relevant_docs_per_query": 2,
+                "min_relevant_docs_per_query": 1,
                 "average_relevant_docs_per_query": 1.0,
-                "max_relevant_docs_per_query": 2,
+                "max_relevant_docs_per_query": 1,
                 "unique_relevant_docs": 4,
             },
             "top_ranked_statistics": None,
@@ -2683,9 +2683,9 @@ class MockMultilingualInstructionRetrieval(AbsTaskRetrieval):
                     "queries_video_statistics": None,
                     "relevant_docs_statistics": {
                         "num_relevant_docs": 2,
-                        "min_relevant_docs_per_query": 2,
+                        "min_relevant_docs_per_query": 1,
                         "average_relevant_docs_per_query": 1.0,
-                        "max_relevant_docs_per_query": 2,
+                        "max_relevant_docs_per_query": 1,
                         "unique_relevant_docs": 2,
                     },
                     "top_ranked_statistics": None,
@@ -2715,9 +2715,9 @@ class MockMultilingualInstructionRetrieval(AbsTaskRetrieval):
                     "queries_video_statistics": None,
                     "relevant_docs_statistics": {
                         "num_relevant_docs": 2,
-                        "min_relevant_docs_per_query": 2,
+                        "min_relevant_docs_per_query": 1,
                         "average_relevant_docs_per_query": 1.0,
-                        "max_relevant_docs_per_query": 2,
+                        "max_relevant_docs_per_query": 1,
                         "unique_relevant_docs": 2,
                     },
                     "top_ranked_statistics": None,
@@ -2771,9 +2771,9 @@ class MockMultilingualInstructionReranking(AbsTaskRetrieval):
             "queries_video_statistics": None,
             "relevant_docs_statistics": {
                 "num_relevant_docs": 4,
-                "min_relevant_docs_per_query": 2,
+                "min_relevant_docs_per_query": 1,
                 "average_relevant_docs_per_query": 1.0,
-                "max_relevant_docs_per_query": 2,
+                "max_relevant_docs_per_query": 1,
                 "unique_relevant_docs": 4,
             },
             "top_ranked_statistics": {
@@ -2808,9 +2808,9 @@ class MockMultilingualInstructionReranking(AbsTaskRetrieval):
                     "queries_video_statistics": None,
                     "relevant_docs_statistics": {
                         "num_relevant_docs": 2,
-                        "min_relevant_docs_per_query": 2,
+                        "min_relevant_docs_per_query": 1,
                         "average_relevant_docs_per_query": 1.0,
-                        "max_relevant_docs_per_query": 2,
+                        "max_relevant_docs_per_query": 1,
                         "unique_relevant_docs": 2,
                     },
                     "top_ranked_statistics": {
@@ -2845,9 +2845,9 @@ class MockMultilingualInstructionReranking(AbsTaskRetrieval):
                     "queries_video_statistics": None,
                     "relevant_docs_statistics": {
                         "num_relevant_docs": 2,
-                        "min_relevant_docs_per_query": 2,
+                        "min_relevant_docs_per_query": 1,
                         "average_relevant_docs_per_query": 1.0,
-                        "max_relevant_docs_per_query": 2,
+                        "max_relevant_docs_per_query": 1,
                         "unique_relevant_docs": 2,
                     },
                     "top_ranked_statistics": {
@@ -2928,9 +2928,9 @@ class MockMultiChoiceTask(AbsTaskRetrieval):
             "queries_video_statistics": None,
             "relevant_docs_statistics": {
                 "num_relevant_docs": 2,
-                "min_relevant_docs_per_query": 2,
+                "min_relevant_docs_per_query": 1,
                 "average_relevant_docs_per_query": 1.0,
-                "max_relevant_docs_per_query": 2,
+                "max_relevant_docs_per_query": 1,
                 "unique_relevant_docs": 2,
             },
             "top_ranked_statistics": {
@@ -3020,9 +3020,9 @@ class MockMultilingualMultiChoiceTask(AbsTaskRetrieval):
             "queries_video_statistics": None,
             "relevant_docs_statistics": {
                 "num_relevant_docs": 4,
-                "min_relevant_docs_per_query": 2,
+                "min_relevant_docs_per_query": 1,
                 "average_relevant_docs_per_query": 1.0,
-                "max_relevant_docs_per_query": 2,
+                "max_relevant_docs_per_query": 1,
                 "unique_relevant_docs": 4,
             },
             "top_ranked_statistics": {
@@ -3067,9 +3067,9 @@ class MockMultilingualMultiChoiceTask(AbsTaskRetrieval):
                     "queries_video_statistics": None,
                     "relevant_docs_statistics": {
                         "num_relevant_docs": 2,
-                        "min_relevant_docs_per_query": 2,
+                        "min_relevant_docs_per_query": 1,
                         "average_relevant_docs_per_query": 1.0,
-                        "max_relevant_docs_per_query": 2,
+                        "max_relevant_docs_per_query": 1,
                         "unique_relevant_docs": 2,
                     },
                     "top_ranked_statistics": {
@@ -3114,9 +3114,9 @@ class MockMultilingualMultiChoiceTask(AbsTaskRetrieval):
                     "queries_video_statistics": None,
                     "relevant_docs_statistics": {
                         "num_relevant_docs": 2,
-                        "min_relevant_docs_per_query": 2,
+                        "min_relevant_docs_per_query": 1,
                         "average_relevant_docs_per_query": 1.0,
-                        "max_relevant_docs_per_query": 2,
+                        "max_relevant_docs_per_query": 1,
                         "unique_relevant_docs": 2,
                     },
                     "top_ranked_statistics": {
@@ -3129,7 +3129,6 @@ class MockMultilingualMultiChoiceTask(AbsTaskRetrieval):
             },
         }
     }
-
     metadata = TaskMetadata(
         type="VisionCentricQA",
         name="MockMultilingualVisionCentricQA",
@@ -3210,9 +3209,9 @@ class MockAny2AnyRetrievalI2TTask(AbsTaskRetrieval):
             "queries_video_statistics": None,
             "relevant_docs_statistics": {
                 "num_relevant_docs": 2,
-                "min_relevant_docs_per_query": 2,
+                "min_relevant_docs_per_query": 1,
                 "average_relevant_docs_per_query": 1.0,
-                "max_relevant_docs_per_query": 2,
+                "max_relevant_docs_per_query": 1,
                 "unique_relevant_docs": 2,
             },
             "top_ranked_statistics": None,
@@ -3286,15 +3285,14 @@ class MockAny2AnyRetrievalT2ITask(AbsTaskRetrieval):
             "queries_video_statistics": None,
             "relevant_docs_statistics": {
                 "num_relevant_docs": 2,
-                "min_relevant_docs_per_query": 2,
+                "min_relevant_docs_per_query": 1,
                 "average_relevant_docs_per_query": 1.0,
-                "max_relevant_docs_per_query": 2,
+                "max_relevant_docs_per_query": 1,
                 "unique_relevant_docs": 2,
             },
             "top_ranked_statistics": None,
         }
     }
-
     metadata = TaskMetadata(
         type="Any2AnyRetrieval",
         name="MockAny2AnyRetrievalT2I",
@@ -4514,9 +4512,9 @@ class MockAny2AnyRetrievalT2ATask(AbsTaskRetrieval):
             "queries_video_statistics": None,
             "relevant_docs_statistics": {
                 "num_relevant_docs": 2,
-                "min_relevant_docs_per_query": 2,
+                "min_relevant_docs_per_query": 1,
                 "average_relevant_docs_per_query": 1.0,
-                "max_relevant_docs_per_query": 2,
+                "max_relevant_docs_per_query": 1,
                 "unique_relevant_docs": 2,
             },
             "top_ranked_statistics": None,
@@ -4600,9 +4598,9 @@ class MockAny2AnyRetrievalA2TTask(AbsTaskRetrieval):
             "queries_video_statistics": None,
             "relevant_docs_statistics": {
                 "num_relevant_docs": 2,
-                "min_relevant_docs_per_query": 2,
+                "min_relevant_docs_per_query": 1,
                 "average_relevant_docs_per_query": 1.0,
-                "max_relevant_docs_per_query": 2,
+                "max_relevant_docs_per_query": 1,
                 "unique_relevant_docs": 2,
             },
             "top_ranked_statistics": None,
@@ -4687,9 +4685,9 @@ class MockAny2AnyRetrievalA2ATask(AbsTaskRetrieval):
             "queries_video_statistics": None,
             "relevant_docs_statistics": {
                 "num_relevant_docs": 2,
-                "min_relevant_docs_per_query": 2,
+                "min_relevant_docs_per_query": 1,
                 "average_relevant_docs_per_query": 1.0,
-                "max_relevant_docs_per_query": 2,
+                "max_relevant_docs_per_query": 1,
                 "unique_relevant_docs": 2,
             },
             "top_ranked_statistics": None,
@@ -4774,9 +4772,9 @@ class MockAudioReranking(AbsTaskRetrieval):
             "queries_video_statistics": None,
             "relevant_docs_statistics": {
                 "num_relevant_docs": 2,
-                "min_relevant_docs_per_query": 2,
+                "min_relevant_docs_per_query": 1,
                 "average_relevant_docs_per_query": 1.0,
-                "max_relevant_docs_per_query": 2,
+                "max_relevant_docs_per_query": 1,
                 "unique_relevant_docs": 2,
             },
             "top_ranked_statistics": {
@@ -6200,9 +6198,9 @@ class MockVideoRetrievalV2T(AbsTaskRetrieval):
             },
             "relevant_docs_statistics": {
                 "num_relevant_docs": 2,
-                "min_relevant_docs_per_query": 2,
+                "min_relevant_docs_per_query": 1,
                 "average_relevant_docs_per_query": 1.0,
-                "max_relevant_docs_per_query": 2,
+                "max_relevant_docs_per_query": 1,
                 "unique_relevant_docs": 2,
             },
             "top_ranked_statistics": None,
@@ -6299,9 +6297,9 @@ class MockVideoRetrievalT2V(AbsTaskRetrieval):
             "queries_video_statistics": None,
             "relevant_docs_statistics": {
                 "num_relevant_docs": 2,
-                "min_relevant_docs_per_query": 2,
+                "min_relevant_docs_per_query": 1,
                 "average_relevant_docs_per_query": 1.0,
-                "max_relevant_docs_per_query": 2,
+                "max_relevant_docs_per_query": 1,
                 "unique_relevant_docs": 2,
             },
             "top_ranked_statistics": None,
@@ -6406,9 +6404,9 @@ class MockVideoAudioRetrievalVA2T(AbsTaskRetrieval):
             },
             "relevant_docs_statistics": {
                 "num_relevant_docs": 2,
-                "min_relevant_docs_per_query": 2,
+                "min_relevant_docs_per_query": 1,
                 "average_relevant_docs_per_query": 1.0,
-                "max_relevant_docs_per_query": 2,
+                "max_relevant_docs_per_query": 1,
                 "unique_relevant_docs": 2,
             },
             "top_ranked_statistics": None,
@@ -6516,9 +6514,9 @@ class MockVideoAudioRetrievalT2VA(AbsTaskRetrieval):
             "queries_video_statistics": None,
             "relevant_docs_statistics": {
                 "num_relevant_docs": 2,
-                "min_relevant_docs_per_query": 2,
+                "min_relevant_docs_per_query": 1,
                 "average_relevant_docs_per_query": 1.0,
-                "max_relevant_docs_per_query": 2,
+                "max_relevant_docs_per_query": 1,
                 "unique_relevant_docs": 2,
             },
             "top_ranked_statistics": None,
@@ -6632,9 +6630,9 @@ class MockVideoAudioTextRetrievalVAT2T(AbsTaskRetrieval):
             },
             "relevant_docs_statistics": {
                 "num_relevant_docs": 2,
-                "min_relevant_docs_per_query": 2,
+                "min_relevant_docs_per_query": 1,
                 "average_relevant_docs_per_query": 1.0,
-                "max_relevant_docs_per_query": 2,
+                "max_relevant_docs_per_query": 1,
                 "unique_relevant_docs": 2,
             },
             "top_ranked_statistics": None,


### PR DESCRIPTION
Previously, average relevant docs were calculated using only relevant docs (non-zero score), while min and max used all relevant docs split (including 0). Found during reviewing https://github.com/embeddings-benchmark/mteb/pull/4665