### PR TITLE
fix: Compute missing statistics

### DIFF
--- a/mteb/descriptive_stats/AudioMultilabelClassification/AudioSet.json
+++ b/mteb/descriptive_stats/AudioMultilabelClassification/AudioSet.json
@@ -1,0 +1,3218 @@
+{
+    "test": {
+        "num_samples": 17141,
+        "samples_in_train": 9,
+        "text_statistics": null,
+        "image_statistics": null,
+        "audio_statistics": {
+            "total_duration_seconds": 169636.8799387755,
+            "min_duration_seconds": 0.7935,
+            "average_duration_seconds": 9.89655679008083,
+            "max_duration_seconds": 10.000793650793652,
+            "unique_audios": 17119,
+            "average_sampling_rate": 47664.62866810571,
+            "sampling_rates": {
+                "48000": 15667,
+                "44100": 1474
+            }
+        },
+        "video_statistics": null,
+        "label_statistics": {
+            "min_labels_per_text": 1,
+            "average_label_per_text": 2.5531765941310307,
+            "max_labels_per_text": 11,
+            "unique_labels": 527,
+            "labels": {
+                "Smash, crash": {
+                    "count": 50
+                },
+                "Sink (filling or washing)": {
+                    "count": 52
+                },
+                "Water tap, faucet": {
+                    "count": 66
+                },
+                "Speech": {
+                    "count": 4419
+                },
+                "Hands": {
+                    "count": 49
+                },
+                "Inside, small room": {
+                    "count": 479
+                },
+                "Heart murmur": {
+                    "count": 49
+                },
+                "Music": {
+                    "count": 4654
+                },
+                "Radio": {
+                    "count": 52
+                },
+                "Beep, bleep": {
+                    "count": 49
+                },
+                "Female speech, woman speaking": {
+                    "count": 59
+                },
+                "Rattle": {
+                    "count": 52
+                },
+                "Sniff": {
+                    "count": 52
+                },
+                "Engine knocking": {
+                    "count": 56
+                },
+                "Engine": {
+                    "count": 173
+                },
+                "Idling": {
+                    "count": 80
+                },
+                "Explosion": {
+                    "count": 46
+                },
+                "Sawing": {
+                    "count": 55
+                },
+                "Wood": {
+                    "count": 151
+                },
+                "Reversing beeps": {
+                    "count": 51
+                },
+                "Truck": {
+                    "count": 89
+                },
+                "Vehicle": {
+                    "count": 698
+                },
+                "Oink": {
+                    "count": 48
+                },
+                "Laughter": {
+                    "count": 96
+                },
+                "Television": {
+                    "count": 49
+                },
+                "Funny music": {
+                    "count": 45
+                },
+                "Horse": {
+                    "count": 73
+                },
+                "Neigh, whinny": {
+                    "count": 44
+                },
+                "Animal": {
+                    "count": 586
+                },
+                "Finger snapping": {
+                    "count": 47
+                },
+                "Bathtub (filling or washing)": {
+                    "count": 42
+                },
+                "Domestic animals, pets": {
+                    "count": 295
+                },
+                "Fill (with liquid)": {
+                    "count": 53
+                },
+                "Pump (liquid)": {
+                    "count": 53
+                },
+                "Water": {
+                    "count": 239
+                },
+                "Gush": {
+                    "count": 50
+                },
+                "Bird": {
+                    "count": 187
+                },
+                "White noise": {
+                    "count": 54
+                },
+                "Outside, urban or manmade": {
+                    "count": 177
+                },
+                "Firecracker": {
+                    "count": 42
+                },
+                "Crackle": {
+                    "count": 50
+                },
+                "Maraca": {
+                    "count": 48
+                },
+                "Sanding": {
+                    "count": 55
+                },
+                "Rub": {
+                    "count": 127
+                },
+                "Plop": {
+                    "count": 45
+                },
+                "Filing (rasp)": {
+                    "count": 56
+                },
+                "Electric piano": {
+                    "count": 55
+                },
+                "Harpsichord": {
+                    "count": 56
+                },
+                "Keyboard (musical)": {
+                    "count": 134
+                },
+                "Chopping (food)": {
+                    "count": 47
+                },
+                "Babbling": {
+                    "count": 50
+                },
+                "Splinter": {
+                    "count": 54
+                },
+                "Bird flight, flapping wings": {
+                    "count": 46
+                },
+                "Boat, Water vehicle": {
+                    "count": 223
+                },
+                "Ship": {
+                    "count": 56
+                },
+                "Sailboat, sailing ship": {
+                    "count": 57
+                },
+                "Scissors": {
+                    "count": 52
+                },
+                "Chink, clink": {
+                    "count": 48
+                },
+                "Angry music": {
+                    "count": 53
+                },
+                "Smoke detector, smoke alarm": {
+                    "count": 48
+                },
+                "Chant": {
+                    "count": 48
+                },
+                "Ambulance (siren)": {
+                    "count": 54
+                },
+                "Emergency vehicle": {
+                    "count": 121
+                },
+                "Siren": {
+                    "count": 181
+                },
+                "Hammer": {
+                    "count": 58
+                },
+                "Tools": {
+                    "count": 93
+                },
+                "Hair dryer": {
+                    "count": 50
+                },
+                "Piano": {
+                    "count": 83
+                },
+                "Clip-clop": {
+                    "count": 55
+                },
+                "Subway, metro, underground": {
+                    "count": 58
+                },
+                "Railroad car, train wagon": {
+                    "count": 155
+                },
+                "Train horn": {
+                    "count": 54
+                },
+                "Rail transport": {
+                    "count": 161
+                },
+                "Train": {
+                    "count": 160
+                },
+                "Drum": {
+                    "count": 171
+                },
+                "Drum kit": {
+                    "count": 73
+                },
+                "Drum roll": {
+                    "count": 56
+                },
+                "Rimshot": {
+                    "count": 69
+                },
+                "Snare drum": {
+                    "count": 72
+                },
+                "Bass drum": {
+                    "count": 81
+                },
+                "Percussion": {
+                    "count": 215
+                },
+                "Didgeridoo": {
+                    "count": 54
+                },
+                "Foghorn": {
+                    "count": 54
+                },
+                "Run": {
+                    "count": 50
+                },
+                "Breaking": {
+                    "count": 47
+                },
+                "Rodents, rats, mice": {
+                    "count": 51
+                },
+                "Hiccup": {
+                    "count": 53
+                },
+                "Inside, large room or hall": {
+                    "count": 133
+                },
+                "Tap": {
+                    "count": 55
+                },
+                "Howl": {
+                    "count": 51
+                },
+                "Yip": {
+                    "count": 54
+                },
+                "Dog": {
+                    "count": 193
+                },
+                "Whimper (dog)": {
+                    "count": 48
+                },
+                "Squish": {
+                    "count": 53
+                },
+                "Electric toothbrush": {
+                    "count": 49
+                },
+                "A capella": {
+                    "count": 54
+                },
+                "Wail, moan": {
+                    "count": 41
+                },
+                "Typewriter": {
+                    "count": 53
+                },
+                "Swing music": {
+                    "count": 50
+                },
+                "Soul music": {
+                    "count": 56
+                },
+                "Cat": {
+                    "count": 96
+                },
+                "Meow": {
+                    "count": 56
+                },
+                "Snicker": {
+                    "count": 54
+                },
+                "Rain": {
+                    "count": 86
+                },
+                "Rustle": {
+                    "count": 51
+                },
+                "Raindrop": {
+                    "count": 54
+                },
+                "Typing": {
+                    "count": 52
+                },
+                "Power windows, electric windows": {
+                    "count": 54
+                },
+                "Car": {
+                    "count": 250
+                },
+                "Purr": {
+                    "count": 56
+                },
+                "Boom": {
+                    "count": 53
+                },
+                "Scratching (performance technique)": {
+                    "count": 56
+                },
+                "Scratch": {
+                    "count": 53
+                },
+                "Drum machine": {
+                    "count": 60
+                },
+                "Harmonica": {
+                    "count": 50
+                },
+                "Wind instrument, woodwind instrument": {
+                    "count": 224
+                },
+                "Brass instrument": {
+                    "count": 179
+                },
+                "French horn": {
+                    "count": 51
+                },
+                "Jingle, tinkle": {
+                    "count": 48
+                },
+                "Patter": {
+                    "count": 56
+                },
+                "Lawn mower": {
+                    "count": 56
+                },
+                "Aircraft engine": {
+                    "count": 51
+                },
+                "Fixed-wing aircraft, airplane": {
+                    "count": 59
+                },
+                "Aircraft": {
+                    "count": 99
+                },
+                "Toilet flush": {
+                    "count": 46
+                },
+                "Cough": {
+                    "count": 42
+                },
+                "Breathing": {
+                    "count": 49
+                },
+                "Child singing": {
+                    "count": 50
+                },
+                "Whale vocalization": {
+                    "count": 48
+                },
+                "Insect": {
+                    "count": 141
+                },
+                "Mosquito": {
+                    "count": 47
+                },
+                "Fly, housefly": {
+                    "count": 94
+                },
+                "Clarinet": {
+                    "count": 55
+                },
+                "Civil defense siren": {
+                    "count": 52
+                },
+                "Telephone dialing, DTMF": {
+                    "count": 47
+                },
+                "Buzzer": {
+                    "count": 55
+                },
+                "Fire alarm": {
+                    "count": 50
+                },
+                "Fart": {
+                    "count": 48
+                },
+                "Sizzle": {
+                    "count": 64
+                },
+                "Stir": {
+                    "count": 57
+                },
+                "Frying (food)": {
+                    "count": 58
+                },
+                "Keys jangling": {
+                    "count": 52
+                },
+                "Choir": {
+                    "count": 84
+                },
+                "Male singing": {
+                    "count": 55
+                },
+                "Electronic tuner": {
+                    "count": 53
+                },
+                "Snoring": {
+                    "count": 51
+                },
+                "Rowboat, canoe, kayak": {
+                    "count": 58
+                },
+                "Crowd": {
+                    "count": 126
+                },
+                "Battle cry": {
+                    "count": 54
+                },
+                "Electric guitar": {
+                    "count": 115
+                },
+                "Guitar": {
+                    "count": 274
+                },
+                "Musical instrument": {
+                    "count": 369
+                },
+                "Bang": {
+                    "count": 51
+                },
+                "Plucked string instrument": {
+                    "count": 232
+                },
+                "Folk music": {
+                    "count": 47
+                },
+                "Middle Eastern music": {
+                    "count": 43
+                },
+                "Lullaby": {
+                    "count": 50
+                },
+                "Motorboat, speedboat": {
+                    "count": 56
+                },
+                "Ocean": {
+                    "count": 59
+                },
+                "Jazz": {
+                    "count": 53
+                },
+                "Hubbub, speech noise, speech babble": {
+                    "count": 50
+                },
+                "Hip hop music": {
+                    "count": 51
+                },
+                "Sliding door": {
+                    "count": 54
+                },
+                "Fowl": {
+                    "count": 179
+                },
+                "Cluck": {
+                    "count": 42
+                },
+                "Chicken, rooster": {
+                    "count": 62
+                },
+                "Toot": {
+                    "count": 53
+                },
+                "Traffic noise, roadway noise": {
+                    "count": 61
+                },
+                "Scary music": {
+                    "count": 48
+                },
+                "Wind chime": {
+                    "count": 47
+                },
+                "Chime": {
+                    "count": 49
+                },
+                "Techno": {
+                    "count": 78
+                },
+                "Zing": {
+                    "count": 43
+                },
+                "Saxophone": {
+                    "count": 53
+                },
+                "Throat clearing": {
+                    "count": 50
+                },
+                "Cymbal": {
+                    "count": 60
+                },
+                "Hi-hat": {
+                    "count": 53
+                },
+                "Burst, pop": {
+                    "count": 52
+                },
+                "Dubstep": {
+                    "count": 83
+                },
+                "Hoot": {
+                    "count": 53
+                },
+                "Owl": {
+                    "count": 54
+                },
+                "Sound effect": {
+                    "count": 40
+                },
+                "Mouse": {
+                    "count": 51
+                },
+                "Slap, smack": {
+                    "count": 50
+                },
+                "Sidetone": {
+                    "count": 53
+                },
+                "Child speech, kid speaking": {
+                    "count": 159
+                },
+                "Singing": {
+                    "count": 292
+                },
+                "Rock music": {
+                    "count": 81
+                },
+                "Shout": {
+                    "count": 52
+                },
+                "Rock and roll": {
+                    "count": 75
+                },
+                "Clickety-clack": {
+                    "count": 57
+                },
+                "Mains hum": {
+                    "count": 56
+                },
+                "Hum": {
+                    "count": 71
+                },
+                "Air brake": {
+                    "count": 56
+                },
+                "Rapping": {
+                    "count": 55
+                },
+                "Theremin": {
+                    "count": 51
+                },
+                "Squeak": {
+                    "count": 51
+                },
+                "Medium engine (mid frequency)": {
+                    "count": 53
+                },
+                "Engine starting": {
+                    "count": 56
+                },
+                "Sonar": {
+                    "count": 48
+                },
+                "Eruption": {
+                    "count": 52
+                },
+                "Goat": {
+                    "count": 48
+                },
+                "Music for children": {
+                    "count": 50
+                },
+                "Stomach rumble": {
+                    "count": 41
+                },
+                "Gunshot, gunfire": {
+                    "count": 138
+                },
+                "Cap gun": {
+                    "count": 45
+                },
+                "Canidae, dogs, wolves": {
+                    "count": 52
+                },
+                "Bark": {
+                    "count": 51
+                },
+                "Growling": {
+                    "count": 56
+                },
+                "Field recording": {
+                    "count": 55
+                },
+                "Cattle, bovinae": {
+                    "count": 53
+                },
+                "Moo": {
+                    "count": 51
+                },
+                "Livestock, farm animals, working animals": {
+                    "count": 99
+                },
+                "Camera": {
+                    "count": 51
+                },
+                "Organ": {
+                    "count": 115
+                },
+                "Hammond organ": {
+                    "count": 57
+                },
+                "Pour": {
+                    "count": 49
+                },
+                "Trickle, dribble": {
+                    "count": 50
+                },
+                "Machine gun": {
+                    "count": 49
+                },
+                "Tubular bells": {
+                    "count": 53
+                },
+                "Tick": {
+                    "count": 55
+                },
+                "Boing": {
+                    "count": 40
+                },
+                "Creak": {
+                    "count": 50
+                },
+                "Flute": {
+                    "count": 46
+                },
+                "Acoustic guitar": {
+                    "count": 84
+                },
+                "Steel guitar, slide guitar": {
+                    "count": 56
+                },
+                "Strum": {
+                    "count": 56
+                },
+                "Motor vehicle (road)": {
+                    "count": 77
+                },
+                "Accelerating, revving, vroom": {
+                    "count": 131
+                },
+                "Trombone": {
+                    "count": 53
+                },
+                "Ratchet, pawl": {
+                    "count": 48
+                },
+                "Pulleys": {
+                    "count": 51
+                },
+                "Mechanisms": {
+                    "count": 91
+                },
+                "Cutlery, silverware": {
+                    "count": 51
+                },
+                "Dishes, pots, and pans": {
+                    "count": 51
+                },
+                "Thunk": {
+                    "count": 47
+                },
+                "Video game music": {
+                    "count": 47
+                },
+                "Background music": {
+                    "count": 54
+                },
+                "Soundtrack music": {
+                    "count": 48
+                },
+                "Whistle": {
+                    "count": 49
+                },
+                "Train whistle": {
+                    "count": 56
+                },
+                "Steam whistle": {
+                    "count": 66
+                },
+                "Steam": {
+                    "count": 55
+                },
+                "Hiss": {
+                    "count": 78
+                },
+                "Whimper": {
+                    "count": 45
+                },
+                "Silence": {
+                    "count": 47
+                },
+                "Clapping": {
+                    "count": 52
+                },
+                "Mechanical fan": {
+                    "count": 55
+                },
+                "Jet engine": {
+                    "count": 58
+                },
+                "Harmonic": {
+                    "count": 50
+                },
+                "Throbbing": {
+                    "count": 52
+                },
+                "Blender": {
+                    "count": 51
+                },
+                "Train wheels squealing": {
+                    "count": 56
+                },
+                "Blues": {
+                    "count": 55
+                },
+                "Alarm": {
+                    "count": 53
+                },
+                "Wind": {
+                    "count": 170
+                },
+                "Wind noise (microphone)": {
+                    "count": 139
+                },
+                "Bee, wasp, etc.": {
+                    "count": 50
+                },
+                "Bird vocalization, bird call, bird song": {
+                    "count": 151
+                },
+                "Chirp, tweet": {
+                    "count": 62
+                },
+                "Conversation": {
+                    "count": 50
+                },
+                "Male speech, man speaking": {
+                    "count": 58
+                },
+                "Chuckle, chortle": {
+                    "count": 54
+                },
+                "Crushing": {
+                    "count": 54
+                },
+                "Drill": {
+                    "count": 55
+                },
+                "Power tool": {
+                    "count": 72
+                },
+                "Whip": {
+                    "count": 50
+                },
+                "Echo": {
+                    "count": 53
+                },
+                "Effects unit": {
+                    "count": 102
+                },
+                "Distortion": {
+                    "count": 107
+                },
+                "Scrape": {
+                    "count": 47
+                },
+                "Chainsaw": {
+                    "count": 52
+                },
+                "Environmental noise": {
+                    "count": 48
+                },
+                "String section": {
+                    "count": 54
+                },
+                "Reverberation": {
+                    "count": 55
+                },
+                "Microwave oven": {
+                    "count": 52
+                },
+                "Ding": {
+                    "count": 54
+                },
+                "Clang": {
+                    "count": 50
+                },
+                "Knock": {
+                    "count": 45
+                },
+                "Humming": {
+                    "count": 42
+                },
+                "Rustling leaves": {
+                    "count": 54
+                },
+                "Air conditioning": {
+                    "count": 55
+                },
+                "Applause": {
+                    "count": 51
+                },
+                "Static": {
+                    "count": 50
+                },
+                "Tender music": {
+                    "count": 55
+                },
+                "Waterfall": {
+                    "count": 53
+                },
+                "Zither": {
+                    "count": 49
+                },
+                "Pizzicato": {
+                    "count": 115
+                },
+                "Funk": {
+                    "count": 49
+                },
+                "Bow-wow": {
+                    "count": 62
+                },
+                "Motorcycle": {
+                    "count": 50
+                },
+                "Biting": {
+                    "count": 54
+                },
+                "Tuning fork": {
+                    "count": 53
+                },
+                "Sad music": {
+                    "count": 47
+                },
+                "Church bell": {
+                    "count": 54
+                },
+                "Afrobeat": {
+                    "count": 51
+                },
+                "Fusillade": {
+                    "count": 44
+                },
+                "Whack, thwack": {
+                    "count": 46
+                },
+                "Sigh": {
+                    "count": 46
+                },
+                "New-age music": {
+                    "count": 52
+                },
+                "Cheering": {
+                    "count": 52
+                },
+                "Children shouting": {
+                    "count": 53
+                },
+                "Gasp": {
+                    "count": 47
+                },
+                "Toothbrush": {
+                    "count": 50
+                },
+                "Pig": {
+                    "count": 45
+                },
+                "Snort": {
+                    "count": 50
+                },
+                "Shuffle": {
+                    "count": 56
+                },
+                "Harp": {
+                    "count": 50
+                },
+                "Belly laugh": {
+                    "count": 52
+                },
+                "Disco": {
+                    "count": 51
+                },
+                "Gears": {
+                    "count": 47
+                },
+                "Heavy engine (low frequency)": {
+                    "count": 56
+                },
+                "Heart sounds, heartbeat": {
+                    "count": 57
+                },
+                "Music of Africa": {
+                    "count": 63
+                },
+                "Reggae": {
+                    "count": 45
+                },
+                "Exciting music": {
+                    "count": 47
+                },
+                "Rattle (instrument)": {
+                    "count": 49
+                },
+                "Grunt": {
+                    "count": 43
+                },
+                "Outside, rural or natural": {
+                    "count": 157
+                },
+                "Pant": {
+                    "count": 47
+                },
+                "Drawer open or close": {
+                    "count": 54
+                },
+                "Door": {
+                    "count": 57
+                },
+                "Jingle (music)": {
+                    "count": 50
+                },
+                "Salsa music": {
+                    "count": 53
+                },
+                "Rhythm and blues": {
+                    "count": 52
+                },
+                "Sheep": {
+                    "count": 52
+                },
+                "Bleat": {
+                    "count": 49
+                },
+                "Busy signal": {
+                    "count": 46
+                },
+                "Cash register": {
+                    "count": 53
+                },
+                "Arrow": {
+                    "count": 55
+                },
+                "Ska": {
+                    "count": 54
+                },
+                "Music of Latin America": {
+                    "count": 49
+                },
+                "Bicycle": {
+                    "count": 56
+                },
+                "Bicycle bell": {
+                    "count": 50
+                },
+                "Cowbell": {
+                    "count": 57
+                },
+                "Zipper (clothing)": {
+                    "count": 52
+                },
+                "Waves, surf": {
+                    "count": 54
+                },
+                "Ding-dong": {
+                    "count": 42
+                },
+                "Gargling": {
+                    "count": 41
+                },
+                "House music": {
+                    "count": 50
+                },
+                "Electronic dance music": {
+                    "count": 72
+                },
+                "Dance music": {
+                    "count": 71
+                },
+                "Electronica": {
+                    "count": 70
+                },
+                "Punk rock": {
+                    "count": 58
+                },
+                "Psychedelic rock": {
+                    "count": 51
+                },
+                "Vibraphone": {
+                    "count": 54
+                },
+                "Thunderstorm": {
+                    "count": 53
+                },
+                "Thunder": {
+                    "count": 52
+                },
+                "Rain on surface": {
+                    "count": 52
+                },
+                "Theme music": {
+                    "count": 53
+                },
+                "Timpani": {
+                    "count": 51
+                },
+                "Bellow": {
+                    "count": 52
+                },
+                "Crowing, cock-a-doodle-doo": {
+                    "count": 45
+                },
+                "Screaming": {
+                    "count": 38
+                },
+                "Children playing": {
+                    "count": 48
+                },
+                "Fireworks": {
+                    "count": 48
+                },
+                "Doorbell": {
+                    "count": 49
+                },
+                "Dental drill, dentist's drill": {
+                    "count": 52
+                },
+                "Drip": {
+                    "count": 52
+                },
+                "Croak": {
+                    "count": 49
+                },
+                "Frog": {
+                    "count": 50
+                },
+                "Cello": {
+                    "count": 59
+                },
+                "Double bass": {
+                    "count": 52
+                },
+                "Violin, fiddle": {
+                    "count": 53
+                },
+                "Bowed string instrument": {
+                    "count": 101
+                },
+                "Heavy metal": {
+                    "count": 60
+                },
+                "Progressive rock": {
+                    "count": 64
+                },
+                "Grunge": {
+                    "count": 51
+                },
+                "Basketball bounce": {
+                    "count": 52
+                },
+                "Bouncing": {
+                    "count": 52
+                },
+                "Printer": {
+                    "count": 50
+                },
+                "Slam": {
+                    "count": 51
+                },
+                "Orchestra": {
+                    "count": 53
+                },
+                "Trumpet": {
+                    "count": 50
+                },
+                "Classical music": {
+                    "count": 51
+                },
+                "Slosh": {
+                    "count": 48
+                },
+                "Giggle": {
+                    "count": 54
+                },
+                "Narration, monologue": {
+                    "count": 55
+                },
+                "Fire": {
+                    "count": 54
+                },
+                "Baby laughter": {
+                    "count": 56
+                },
+                "Yell": {
+                    "count": 45
+                },
+                "Glass": {
+                    "count": 54
+                },
+                "Jingle bell": {
+                    "count": 50
+                },
+                "Burping, eructation": {
+                    "count": 48
+                },
+                "Yodeling": {
+                    "count": 53
+                },
+                "Ice cream truck, ice cream van": {
+                    "count": 52
+                },
+                "Caterwaul": {
+                    "count": 56
+                },
+                "Vocal music": {
+                    "count": 66
+                },
+                "Traditional music": {
+                    "count": 54
+                },
+                "Liquid": {
+                    "count": 53
+                },
+                "Turkey": {
+                    "count": 56
+                },
+                "Gobble": {
+                    "count": 56
+                },
+                "Bus": {
+                    "count": 54
+                },
+                "Gurgling": {
+                    "count": 52
+                },
+                "Wood block": {
+                    "count": 52
+                },
+                "Clicking": {
+                    "count": 48
+                },
+                "Rumble": {
+                    "count": 50
+                },
+                "Synthesizer": {
+                    "count": 49
+                },
+                "Whoosh, swoosh, swish": {
+                    "count": 51
+                },
+                "Sewing machine": {
+                    "count": 56
+                },
+                "Sitar": {
+                    "count": 49
+                },
+                "Crying, sobbing": {
+                    "count": 40
+                },
+                "Skidding": {
+                    "count": 49
+                },
+                "Tire squeal": {
+                    "count": 50
+                },
+                "Race car, auto racing": {
+                    "count": 64
+                },
+                "Whistling": {
+                    "count": 46
+                },
+                "Squeal": {
+                    "count": 51
+                },
+                "Whispering": {
+                    "count": 51
+                },
+                "Skateboard": {
+                    "count": 55
+                },
+                "Electric shaver, electric razor": {
+                    "count": 49
+                },
+                "Pink noise": {
+                    "count": 50
+                },
+                "Splash, splatter": {
+                    "count": 42
+                },
+                "Fire engine, fire truck (siren)": {
+                    "count": 51
+                },
+                "Single-lens reflex camera": {
+                    "count": 51
+                },
+                "Coo": {
+                    "count": 50
+                },
+                "Pigeon, dove": {
+                    "count": 50
+                },
+                "Ping": {
+                    "count": 51
+                },
+                "Roll": {
+                    "count": 50
+                },
+                "Stream": {
+                    "count": 52
+                },
+                "Drum and bass": {
+                    "count": 66
+                },
+                "Trance music": {
+                    "count": 52
+                },
+                "Buzz": {
+                    "count": 52
+                },
+                "Independent music": {
+                    "count": 56
+                },
+                "Tambourine": {
+                    "count": 54
+                },
+                "Walk, footsteps": {
+                    "count": 49
+                },
+                "Car alarm": {
+                    "count": 50
+                },
+                "Flamenco": {
+                    "count": 54
+                },
+                "Crow": {
+                    "count": 59
+                },
+                "Caw": {
+                    "count": 57
+                },
+                "Ambient music": {
+                    "count": 49
+                },
+                "Police car (siren)": {
+                    "count": 52
+                },
+                "Song": {
+                    "count": 135
+                },
+                "Chatter": {
+                    "count": 46
+                },
+                "Bass guitar": {
+                    "count": 52
+                },
+                "Tapping (guitar technique)": {
+                    "count": 54
+                },
+                "Whoop": {
+                    "count": 54
+                },
+                "Chorus effect": {
+                    "count": 52
+                },
+                "Bagpipes": {
+                    "count": 58
+                },
+                "Pulse": {
+                    "count": 48
+                },
+                "Beatboxing": {
+                    "count": 46
+                },
+                "Honk": {
+                    "count": 53
+                },
+                "Goose": {
+                    "count": 61
+                },
+                "Electronic organ": {
+                    "count": 59
+                },
+                "Artillery fire": {
+                    "count": 48
+                },
+                "Snake": {
+                    "count": 37
+                },
+                "Mantra": {
+                    "count": 54
+                },
+                "Clock": {
+                    "count": 54
+                },
+                "Coin (dropping)": {
+                    "count": 55
+                },
+                "Vibration": {
+                    "count": 56
+                },
+                "Ukulele": {
+                    "count": 53
+                },
+                "Marimba, xylophone": {
+                    "count": 57
+                },
+                "Glockenspiel": {
+                    "count": 48
+                },
+                "Mallet percussion": {
+                    "count": 46
+                },
+                "Quack": {
+                    "count": 55
+                },
+                "Noise": {
+                    "count": 56
+                },
+                "Air horn, truck horn": {
+                    "count": 51
+                },
+                "Bell": {
+                    "count": 52
+                },
+                "Computer keyboard": {
+                    "count": 51
+                },
+                "Writing": {
+                    "count": 51
+                },
+                "Shuffling cards": {
+                    "count": 57
+                },
+                "Cacophony": {
+                    "count": 53
+                },
+                "Wild animals": {
+                    "count": 42
+                },
+                "Roar": {
+                    "count": 50
+                },
+                "Roaring cats (lions, tigers)": {
+                    "count": 44
+                },
+                "Accordion": {
+                    "count": 55
+                },
+                "Change ringing (campanology)": {
+                    "count": 58
+                },
+                "Baby cry, infant cry": {
+                    "count": 36
+                },
+                "Wheeze": {
+                    "count": 51
+                },
+                "Ringtone": {
+                    "count": 46
+                },
+                "Sneeze": {
+                    "count": 37
+                },
+                "Squawk": {
+                    "count": 50
+                },
+                "Telephone": {
+                    "count": 45
+                },
+                "Christmas music": {
+                    "count": 44
+                },
+                "Chirp tone": {
+                    "count": 52
+                },
+                "Propeller, airscrew": {
+                    "count": 55
+                },
+                "Steelpan": {
+                    "count": 53
+                },
+                "Country": {
+                    "count": 56
+                },
+                "Bluegrass": {
+                    "count": 60
+                },
+                "Happy music": {
+                    "count": 53
+                },
+                "Tick-tock": {
+                    "count": 56
+                },
+                "Whir": {
+                    "count": 54
+                },
+                "Vehicle horn, car horn, honking": {
+                    "count": 54
+                },
+                "Thump, thud": {
+                    "count": 46
+                },
+                "Pop music": {
+                    "count": 70
+                },
+                "Inside, public space": {
+                    "count": 45
+                },
+                "Spray": {
+                    "count": 54
+                },
+                "Chewing, mastication": {
+                    "count": 42
+                },
+                "Cricket": {
+                    "count": 55
+                },
+                "Telephone bell ringing": {
+                    "count": 47
+                },
+                "Female singing": {
+                    "count": 47
+                },
+                "Crack": {
+                    "count": 46
+                },
+                "Singing bowl": {
+                    "count": 51
+                },
+                "Boiling": {
+                    "count": 55
+                },
+                "Tabla": {
+                    "count": 54
+                },
+                "Carnatic music": {
+                    "count": 56
+                },
+                "Music of Bollywood": {
+                    "count": 36
+                },
+                "Jackhammer": {
+                    "count": 55
+                },
+                "Gospel music": {
+                    "count": 46
+                },
+                "Opera": {
+                    "count": 54
+                },
+                "Music of Asia": {
+                    "count": 50
+                },
+                "Groan": {
+                    "count": 43
+                },
+                "Sampler": {
+                    "count": 54
+                },
+                "Shatter": {
+                    "count": 47
+                },
+                "Banjo": {
+                    "count": 57
+                },
+                "Cupboard open or close": {
+                    "count": 48
+                },
+                "Sine wave": {
+                    "count": 53
+                },
+                "Electronic music": {
+                    "count": 52
+                },
+                "Mandolin": {
+                    "count": 55
+                },
+                "Duck": {
+                    "count": 50
+                },
+                "Gong": {
+                    "count": 51
+                },
+                "Dial tone": {
+                    "count": 50
+                },
+                "Vacuum cleaner": {
+                    "count": 47
+                },
+                "Alarm clock": {
+                    "count": 54
+                },
+                "Crunch": {
+                    "count": 46
+                },
+                "Light engine (high frequency)": {
+                    "count": 53
+                },
+                "Wedding music": {
+                    "count": 53
+                },
+                "Speech synthesizer": {
+                    "count": 54
+                },
+                "Synthetic singing": {
+                    "count": 45
+                },
+                "Helicopter": {
+                    "count": 52
+                },
+                "Flap": {
+                    "count": 51
+                },
+                "Christian music": {
+                    "count": 36
+                },
+                "Car passing by": {
+                    "count": 53
+                },
+                "Chop": {
+                    "count": 49
+                },
+                "Tearing": {
+                    "count": 49
+                },
+                "Crumpling, crinkling": {
+                    "count": 51
+                },
+                "Clatter": {
+                    "count": 58
+                },
+                "Shofar": {
+                    "count": 52
+                }
+            }
+        }
+    },
+    "train": {
+        "num_samples": 18683,
+        "samples_in_train": null,
+        "text_statistics": null,
+        "image_statistics": null,
+        "audio_statistics": {
+            "total_duration_seconds": 185066.06181292518,
+            "min_duration_seconds": 0.5135,
+            "average_duration_seconds": 9.905585923723448,
+            "max_duration_seconds": 10.000793650793652,
+            "unique_audios": 18670,
+            "average_sampling_rate": 47626.971043194346,
+            "sampling_rates": {
+                "48000": 16896,
+                "44100": 1787
+            }
+        },
+        "video_statistics": null,
+        "label_statistics": {
+            "min_labels_per_text": 1,
+            "average_label_per_text": 2.4003104426483968,
+            "max_labels_per_text": 12,
+            "unique_labels": 527,
+            "labels": {
+                "Speech": {
+                    "count": 4752
+                },
+                "Gush": {
+                    "count": 53
+                },
+                "Goat": {
+                    "count": 51
+                },
+                "Music": {
+                    "count": 5179
+                },
+                "Smoke detector, smoke alarm": {
+                    "count": 54
+                },
+                "Gunshot, gunfire": {
+                    "count": 152
+                },
+                "Cap gun": {
+                    "count": 54
+                },
+                "Ping": {
+                    "count": 51
+                },
+                "Singing": {
+                    "count": 444
+                },
+                "Bang": {
+                    "count": 49
+                },
+                "Sink (filling or washing)": {
+                    "count": 50
+                },
+                "Water tap, faucet": {
+                    "count": 67
+                },
+                "Water": {
+                    "count": 218
+                },
+                "Blues": {
+                    "count": 51
+                },
+                "Country": {
+                    "count": 53
+                },
+                "Guitar": {
+                    "count": 325
+                },
+                "Acoustic guitar": {
+                    "count": 57
+                },
+                "Musical instrument": {
+                    "count": 497
+                },
+                "Strum": {
+                    "count": 55
+                },
+                "Plucked string instrument": {
+                    "count": 279
+                },
+                "Bluegrass": {
+                    "count": 57
+                },
+                "Traditional music": {
+                    "count": 48
+                },
+                "Knock": {
+                    "count": 52
+                },
+                "Inside, small room": {
+                    "count": 634
+                },
+                "Train whistle": {
+                    "count": 52
+                },
+                "Rattle": {
+                    "count": 57
+                },
+                "Engine": {
+                    "count": 174
+                },
+                "Idling": {
+                    "count": 58
+                },
+                "Medium engine (mid frequency)": {
+                    "count": 58
+                },
+                "Squeak": {
+                    "count": 49
+                },
+                "Walk, footsteps": {
+                    "count": 54
+                },
+                "Liquid": {
+                    "count": 48
+                },
+                "Boiling": {
+                    "count": 53
+                },
+                "Vehicle": {
+                    "count": 773
+                },
+                "Air brake": {
+                    "count": 56
+                },
+                "Radio": {
+                    "count": 54
+                },
+                "Organ": {
+                    "count": 104
+                },
+                "Electronic organ": {
+                    "count": 54
+                },
+                "Boat, Water vehicle": {
+                    "count": 221
+                },
+                "Ship": {
+                    "count": 53
+                },
+                "Ska": {
+                    "count": 53
+                },
+                "Clarinet": {
+                    "count": 52
+                },
+                "Horse": {
+                    "count": 64
+                },
+                "Neigh, whinny": {
+                    "count": 47
+                },
+                "Animal": {
+                    "count": 637
+                },
+                "Tender music": {
+                    "count": 48
+                },
+                "Splinter": {
+                    "count": 54
+                },
+                "Wood": {
+                    "count": 148
+                },
+                "Carnatic music": {
+                    "count": 52
+                },
+                "Ambulance (siren)": {
+                    "count": 62
+                },
+                "Car alarm": {
+                    "count": 57
+                },
+                "Emergency vehicle": {
+                    "count": 123
+                },
+                "Siren": {
+                    "count": 172
+                },
+                "Female speech, woman speaking": {
+                    "count": 51
+                },
+                "Run": {
+                    "count": 47
+                },
+                "Timpani": {
+                    "count": 51
+                },
+                "Buzzer": {
+                    "count": 49
+                },
+                "Crackle": {
+                    "count": 54
+                },
+                "Flap": {
+                    "count": 54
+                },
+                "Clatter": {
+                    "count": 53
+                },
+                "Folk music": {
+                    "count": 49
+                },
+                "Reversing beeps": {
+                    "count": 51
+                },
+                "Truck": {
+                    "count": 67
+                },
+                "Tabla": {
+                    "count": 49
+                },
+                "Drum": {
+                    "count": 166
+                },
+                "Percussion": {
+                    "count": 233
+                },
+                "Bass guitar": {
+                    "count": 54
+                },
+                "Roaring cats (lions, tigers)": {
+                    "count": 43
+                },
+                "Camera": {
+                    "count": 49
+                },
+                "Yodeling": {
+                    "count": 55
+                },
+                "Middle Eastern music": {
+                    "count": 45
+                },
+                "Soundtrack music": {
+                    "count": 41
+                },
+                "Sliding door": {
+                    "count": 56
+                },
+                "Exciting music": {
+                    "count": 50
+                },
+                "Chopping (food)": {
+                    "count": 53
+                },
+                "Cat": {
+                    "count": 104
+                },
+                "Domestic animals, pets": {
+                    "count": 368
+                },
+                "Meow": {
+                    "count": 47
+                },
+                "Mandolin": {
+                    "count": 58
+                },
+                "Engine starting": {
+                    "count": 54
+                },
+                "Heart murmur": {
+                    "count": 44
+                },
+                "Engine knocking": {
+                    "count": 56
+                },
+                "Lawn mower": {
+                    "count": 57
+                },
+                "Whale vocalization": {
+                    "count": 50
+                },
+                "Gong": {
+                    "count": 52
+                },
+                "Theme music": {
+                    "count": 48
+                },
+                "Drawer open or close": {
+                    "count": 58
+                },
+                "Electric toothbrush": {
+                    "count": 56
+                },
+                "Chink, clink": {
+                    "count": 54
+                },
+                "Pump (liquid)": {
+                    "count": 57
+                },
+                "Techno": {
+                    "count": 48
+                },
+                "Ukulele": {
+                    "count": 56
+                },
+                "Inside, large room or hall": {
+                    "count": 142
+                },
+                "Motorboat, speedboat": {
+                    "count": 57
+                },
+                "Wind": {
+                    "count": 153
+                },
+                "Wind noise (microphone)": {
+                    "count": 131
+                },
+                "Zipper (clothing)": {
+                    "count": 52
+                },
+                "Humming": {
+                    "count": 48
+                },
+                "Dental drill, dentist's drill": {
+                    "count": 55
+                },
+                "Helicopter": {
+                    "count": 52
+                },
+                "Television": {
+                    "count": 40
+                },
+                "Doorbell": {
+                    "count": 43
+                },
+                "Pink noise": {
+                    "count": 44
+                },
+                "Snoring": {
+                    "count": 54
+                },
+                "Car passing by": {
+                    "count": 55
+                },
+                "Sheep": {
+                    "count": 49
+                },
+                "Bleat": {
+                    "count": 48
+                },
+                "Computer keyboard": {
+                    "count": 51
+                },
+                "Jingle, tinkle": {
+                    "count": 44
+                },
+                "Shuffle": {
+                    "count": 52
+                },
+                "Caterwaul": {
+                    "count": 52
+                },
+                "Cutlery, silverware": {
+                    "count": 53
+                },
+                "Dishes, pots, and pans": {
+                    "count": 52
+                },
+                "Cymbal": {
+                    "count": 58
+                },
+                "Drum kit": {
+                    "count": 87
+                },
+                "Hi-hat": {
+                    "count": 55
+                },
+                "Rimshot": {
+                    "count": 80
+                },
+                "Bass drum": {
+                    "count": 80
+                },
+                "Finger snapping": {
+                    "count": 45
+                },
+                "Filing (rasp)": {
+                    "count": 52
+                },
+                "Rub": {
+                    "count": 130
+                },
+                "Female singing": {
+                    "count": 52
+                },
+                "Oink": {
+                    "count": 45
+                },
+                "Belly laugh": {
+                    "count": 43
+                },
+                "Steelpan": {
+                    "count": 54
+                },
+                "Opera": {
+                    "count": 53
+                },
+                "Creak": {
+                    "count": 53
+                },
+                "Bagpipes": {
+                    "count": 55
+                },
+                "Wind instrument, woodwind instrument": {
+                    "count": 229
+                },
+                "Scratching (performance technique)": {
+                    "count": 50
+                },
+                "Drum and bass": {
+                    "count": 51
+                },
+                "Scratch": {
+                    "count": 49
+                },
+                "Choir": {
+                    "count": 54
+                },
+                "Male singing": {
+                    "count": 53
+                },
+                "Applause": {
+                    "count": 50
+                },
+                "Male speech, man speaking": {
+                    "count": 49
+                },
+                "Yell": {
+                    "count": 54
+                },
+                "Bicycle bell": {
+                    "count": 45
+                },
+                "Synthetic singing": {
+                    "count": 52
+                },
+                "Fart": {
+                    "count": 48
+                },
+                "Video game music": {
+                    "count": 40
+                },
+                "Outside, rural or natural": {
+                    "count": 212
+                },
+                "Squish": {
+                    "count": 50
+                },
+                "White noise": {
+                    "count": 53
+                },
+                "Drum roll": {
+                    "count": 61
+                },
+                "Snare drum": {
+                    "count": 86
+                },
+                "Church bell": {
+                    "count": 58
+                },
+                "Bell": {
+                    "count": 52
+                },
+                "Scary music": {
+                    "count": 50
+                },
+                "Coin (dropping)": {
+                    "count": 46
+                },
+                "Whimper (dog)": {
+                    "count": 50
+                },
+                "Bee, wasp, etc.": {
+                    "count": 52
+                },
+                "Insect": {
+                    "count": 144
+                },
+                "Fly, housefly": {
+                    "count": 96
+                },
+                "Fusillade": {
+                    "count": 56
+                },
+                "Motorcycle": {
+                    "count": 57
+                },
+                "Mains hum": {
+                    "count": 62
+                },
+                "Hum": {
+                    "count": 95
+                },
+                "Mouse": {
+                    "count": 50
+                },
+                "Tap": {
+                    "count": 46
+                },
+                "Music of Bollywood": {
+                    "count": 43
+                },
+                "Thump, thud": {
+                    "count": 54
+                },
+                "Electronica": {
+                    "count": 49
+                },
+                "Background music": {
+                    "count": 52
+                },
+                "Hammer": {
+                    "count": 52
+                },
+                "Rain": {
+                    "count": 96
+                },
+                "Raindrop": {
+                    "count": 55
+                },
+                "Thunderstorm": {
+                    "count": 53
+                },
+                "Thunder": {
+                    "count": 57
+                },
+                "Rain on surface": {
+                    "count": 49
+                },
+                "Singing bowl": {
+                    "count": 52
+                },
+                "Chainsaw": {
+                    "count": 57
+                },
+                "Power tool": {
+                    "count": 69
+                },
+                "Mantra": {
+                    "count": 52
+                },
+                "Crowd": {
+                    "count": 123
+                },
+                "Battle cry": {
+                    "count": 49
+                },
+                "Motor vehicle (road)": {
+                    "count": 54
+                },
+                "Noise": {
+                    "count": 51
+                },
+                "Car": {
+                    "count": 265
+                },
+                "Toothbrush": {
+                    "count": 46
+                },
+                "Drip": {
+                    "count": 48
+                },
+                "Clicking": {
+                    "count": 55
+                },
+                "Steam whistle": {
+                    "count": 65
+                },
+                "Thunk": {
+                    "count": 53
+                },
+                "Mechanical fan": {
+                    "count": 54
+                },
+                "Slosh": {
+                    "count": 46
+                },
+                "Outside, urban or manmade": {
+                    "count": 217
+                },
+                "Grunt": {
+                    "count": 43
+                },
+                "Sad music": {
+                    "count": 44
+                },
+                "Echo": {
+                    "count": 51
+                },
+                "Keys jangling": {
+                    "count": 54
+                },
+                "Scrape": {
+                    "count": 56
+                },
+                "Funny music": {
+                    "count": 42
+                },
+                "Scissors": {
+                    "count": 49
+                },
+                "Croak": {
+                    "count": 51
+                },
+                "Frog": {
+                    "count": 52
+                },
+                "Beatboxing": {
+                    "count": 51
+                },
+                "Vocal music": {
+                    "count": 50
+                },
+                "Trickle, dribble": {
+                    "count": 48
+                },
+                "Growling": {
+                    "count": 51
+                },
+                "Whack, thwack": {
+                    "count": 52
+                },
+                "Christmas music": {
+                    "count": 53
+                },
+                "Dance music": {
+                    "count": 45
+                },
+                "Toilet flush": {
+                    "count": 38
+                },
+                "Chop": {
+                    "count": 54
+                },
+                "Zing": {
+                    "count": 47
+                },
+                "Screaming": {
+                    "count": 45
+                },
+                "Cupboard open or close": {
+                    "count": 53
+                },
+                "Dog": {
+                    "count": 252
+                },
+                "Boing": {
+                    "count": 36
+                },
+                "Rumble": {
+                    "count": 50
+                },
+                "Cowbell": {
+                    "count": 53
+                },
+                "Single-lens reflex camera": {
+                    "count": 46
+                },
+                "Child speech, kid speaking": {
+                    "count": 111
+                },
+                "Children playing": {
+                    "count": 51
+                },
+                "Chewing, mastication": {
+                    "count": 46
+                },
+                "Crack": {
+                    "count": 52
+                },
+                "Reverberation": {
+                    "count": 59
+                },
+                "Bird flight, flapping wings": {
+                    "count": 44
+                },
+                "Biting": {
+                    "count": 42
+                },
+                "Crunch": {
+                    "count": 46
+                },
+                "Bow-wow": {
+                    "count": 55
+                },
+                "Funk": {
+                    "count": 48
+                },
+                "Gurgling": {
+                    "count": 50
+                },
+                "Inside, public space": {
+                    "count": 48
+                },
+                "Drill": {
+                    "count": 57
+                },
+                "Tools": {
+                    "count": 92
+                },
+                "Rapping": {
+                    "count": 47
+                },
+                "Bouncing": {
+                    "count": 53
+                },
+                "Bathtub (filling or washing)": {
+                    "count": 32
+                },
+                "Fill (with liquid)": {
+                    "count": 50
+                },
+                "Sewing machine": {
+                    "count": 59
+                },
+                "Zither": {
+                    "count": 52
+                },
+                "Pizzicato": {
+                    "count": 115
+                },
+                "Keyboard (musical)": {
+                    "count": 130
+                },
+                "Piano": {
+                    "count": 78
+                },
+                "Harmonic": {
+                    "count": 56
+                },
+                "Ding": {
+                    "count": 47
+                },
+                "Music of Africa": {
+                    "count": 44
+                },
+                "Burping, eructation": {
+                    "count": 49
+                },
+                "Baby cry, infant cry": {
+                    "count": 45
+                },
+                "Pant": {
+                    "count": 47
+                },
+                "Splash, splatter": {
+                    "count": 47
+                },
+                "Waterfall": {
+                    "count": 53
+                },
+                "Hair dryer": {
+                    "count": 44
+                },
+                "Pour": {
+                    "count": 54
+                },
+                "Tick-tock": {
+                    "count": 58
+                },
+                "Sizzle": {
+                    "count": 55
+                },
+                "Hands": {
+                    "count": 53
+                },
+                "Rock music": {
+                    "count": 64
+                },
+                "Shout": {
+                    "count": 49
+                },
+                "Rock and roll": {
+                    "count": 53
+                },
+                "Independent music": {
+                    "count": 50
+                },
+                "Gasp": {
+                    "count": 48
+                },
+                "Electronic music": {
+                    "count": 95
+                },
+                "House music": {
+                    "count": 47
+                },
+                "Pulse": {
+                    "count": 52
+                },
+                "Music of Asia": {
+                    "count": 44
+                },
+                "Arrow": {
+                    "count": 52
+                },
+                "Crow": {
+                    "count": 57
+                },
+                "Caw": {
+                    "count": 55
+                },
+                "Tambourine": {
+                    "count": 51
+                },
+                "Maraca": {
+                    "count": 52
+                },
+                "Baby laughter": {
+                    "count": 47
+                },
+                "Psychedelic rock": {
+                    "count": 52
+                },
+                "Railroad car, train wagon": {
+                    "count": 165
+                },
+                "Train horn": {
+                    "count": 56
+                },
+                "Rail transport": {
+                    "count": 171
+                },
+                "Train": {
+                    "count": 169
+                },
+                "Brass instrument": {
+                    "count": 200
+                },
+                "Orchestra": {
+                    "count": 53
+                },
+                "Classical music": {
+                    "count": 54
+                },
+                "Trance music": {
+                    "count": 53
+                },
+                "Cacophony": {
+                    "count": 51
+                },
+                "Propeller, airscrew": {
+                    "count": 54
+                },
+                "Jet engine": {
+                    "count": 58
+                },
+                "Clock": {
+                    "count": 48
+                },
+                "Electric guitar": {
+                    "count": 60
+                },
+                "Electronic tuner": {
+                    "count": 58
+                },
+                "Accordion": {
+                    "count": 54
+                },
+                "Tearing": {
+                    "count": 51
+                },
+                "Electronic dance music": {
+                    "count": 54
+                },
+                "Wail, moan": {
+                    "count": 40
+                },
+                "Machine gun": {
+                    "count": 47
+                },
+                "Sound effect": {
+                    "count": 42
+                },
+                "Patter": {
+                    "count": 54
+                },
+                "Air conditioning": {
+                    "count": 54
+                },
+                "Whip": {
+                    "count": 58
+                },
+                "Wind chime": {
+                    "count": 48
+                },
+                "Chime": {
+                    "count": 54
+                },
+                "String section": {
+                    "count": 55
+                },
+                "Fire alarm": {
+                    "count": 55
+                },
+                "Bicycle": {
+                    "count": 51
+                },
+                "Laughter": {
+                    "count": 83
+                },
+                "Giggle": {
+                    "count": 46
+                },
+                "Vibration": {
+                    "count": 58
+                },
+                "Aircraft": {
+                    "count": 103
+                },
+                "Sneeze": {
+                    "count": 39
+                },
+                "Police car (siren)": {
+                    "count": 53
+                },
+                "Telephone bell ringing": {
+                    "count": 46
+                },
+                "A capella": {
+                    "count": 53
+                },
+                "Theremin": {
+                    "count": 53
+                },
+                "Stir": {
+                    "count": 54
+                },
+                "Frying (food)": {
+                    "count": 54
+                },
+                "Fireworks": {
+                    "count": 50
+                },
+                "Sampler": {
+                    "count": 55
+                },
+                "Blender": {
+                    "count": 49
+                },
+                "Vibraphone": {
+                    "count": 52
+                },
+                "Breaking": {
+                    "count": 51
+                },
+                "Spray": {
+                    "count": 47
+                },
+                "Rustling leaves": {
+                    "count": 53
+                },
+                "Foghorn": {
+                    "count": 52
+                },
+                "Grunge": {
+                    "count": 51
+                },
+                "Afrobeat": {
+                    "count": 47
+                },
+                "Marimba, xylophone": {
+                    "count": 68
+                },
+                "Glockenspiel": {
+                    "count": 54
+                },
+                "Mallet percussion": {
+                    "count": 52
+                },
+                "Whispering": {
+                    "count": 46
+                },
+                "Harmonica": {
+                    "count": 56
+                },
+                "Canidae, dogs, wolves": {
+                    "count": 54
+                },
+                "Angry music": {
+                    "count": 53
+                },
+                "Environmental noise": {
+                    "count": 56
+                },
+                "Skidding": {
+                    "count": 55
+                },
+                "Tire squeal": {
+                    "count": 57
+                },
+                "Firecracker": {
+                    "count": 41
+                },
+                "Snake": {
+                    "count": 42
+                },
+                "Hiss": {
+                    "count": 78
+                },
+                "Rustle": {
+                    "count": 51
+                },
+                "Ratchet, pawl": {
+                    "count": 55
+                },
+                "Pulleys": {
+                    "count": 53
+                },
+                "Mechanisms": {
+                    "count": 106
+                },
+                "Narration, monologue": {
+                    "count": 50
+                },
+                "Whistle": {
+                    "count": 49
+                },
+                "Shofar": {
+                    "count": 52
+                },
+                "Hammond organ": {
+                    "count": 60
+                },
+                "Electric shaver, electric razor": {
+                    "count": 53
+                },
+                "Ocean": {
+                    "count": 64
+                },
+                "Typewriter": {
+                    "count": 52
+                },
+                "Saxophone": {
+                    "count": 53
+                },
+                "Howl": {
+                    "count": 56
+                },
+                "Sonar": {
+                    "count": 51
+                },
+                "Babbling": {
+                    "count": 48
+                },
+                "Chatter": {
+                    "count": 47
+                },
+                "Heavy metal": {
+                    "count": 49
+                },
+                "Printer": {
+                    "count": 53
+                },
+                "Telephone dialing, DTMF": {
+                    "count": 44
+                },
+                "Race car, auto racing": {
+                    "count": 52
+                },
+                "Flute": {
+                    "count": 50
+                },
+                "Eruption": {
+                    "count": 52
+                },
+                "Tubular bells": {
+                    "count": 54
+                },
+                "Clang": {
+                    "count": 44
+                },
+                "Dial tone": {
+                    "count": 49
+                },
+                "Hip hop music": {
+                    "count": 48
+                },
+                "Chorus effect": {
+                    "count": 54
+                },
+                "Alarm clock": {
+                    "count": 50
+                },
+                "Accelerating, revving, vroom": {
+                    "count": 54
+                },
+                "Heavy engine (low frequency)": {
+                    "count": 54
+                },
+                "Trumpet": {
+                    "count": 53
+                },
+                "Wood block": {
+                    "count": 52
+                },
+                "Sailboat, sailing ship": {
+                    "count": 57
+                },
+                "Ice cream truck, ice cream van": {
+                    "count": 50
+                },
+                "Disco": {
+                    "count": 47
+                },
+                "Sine wave": {
+                    "count": 55
+                },
+                "Chirp tone": {
+                    "count": 54
+                },
+                "Jazz": {
+                    "count": 50
+                },
+                "Pop music": {
+                    "count": 49
+                },
+                "Ringtone": {
+                    "count": 51
+                },
+                "Beep, bleep": {
+                    "count": 50
+                },
+                "Sanding": {
+                    "count": 54
+                },
+                "Artillery fire": {
+                    "count": 53
+                },
+                "Harp": {
+                    "count": 56
+                },
+                "Violin, fiddle": {
+                    "count": 58
+                },
+                "Bowed string instrument": {
+                    "count": 105
+                },
+                "Power windows, electric windows": {
+                    "count": 52
+                },
+                "Chuckle, chortle": {
+                    "count": 47
+                },
+                "Glass": {
+                    "count": 57
+                },
+                "Lullaby": {
+                    "count": 51
+                },
+                "Child singing": {
+                    "count": 49
+                },
+                "Clip-clop": {
+                    "count": 50
+                },
+                "Subway, metro, underground": {
+                    "count": 57
+                },
+                "Pig": {
+                    "count": 45
+                },
+                "Hubbub, speech noise, speech babble": {
+                    "count": 50
+                },
+                "Rowboat, canoe, kayak": {
+                    "count": 53
+                },
+                "Livestock, farm animals, working animals": {
+                    "count": 107
+                },
+                "Light engine (high frequency)": {
+                    "count": 56
+                },
+                "Cheering": {
+                    "count": 55
+                },
+                "Children shouting": {
+                    "count": 48
+                },
+                "Throat clearing": {
+                    "count": 41
+                },
+                "Crumpling, crinkling": {
+                    "count": 51
+                },
+                "Stomach rumble": {
+                    "count": 43
+                },
+                "Tuning fork": {
+                    "count": 52
+                },
+                "French horn": {
+                    "count": 59
+                },
+                "Chant": {
+                    "count": 46
+                },
+                "Flamenco": {
+                    "count": 50
+                },
+                "Cough": {
+                    "count": 44
+                },
+                "Trombone": {
+                    "count": 56
+                },
+                "Mosquito": {
+                    "count": 47
+                },
+                "Ding-dong": {
+                    "count": 50
+                },
+                "Gospel music": {
+                    "count": 50
+                },
+                "Crushing": {
+                    "count": 50
+                },
+                "Field recording": {
+                    "count": 57
+                },
+                "Roll": {
+                    "count": 55
+                },
+                "Bird": {
+                    "count": 154
+                },
+                "Bird vocalization, bird call, bird song": {
+                    "count": 111
+                },
+                "Chirp, tweet": {
+                    "count": 53
+                },
+                "Cricket": {
+                    "count": 56
+                },
+                "Plop": {
+                    "count": 52
+                },
+                "Purr": {
+                    "count": 53
+                },
+                "Slam": {
+                    "count": 44
+                },
+                "Song": {
+                    "count": 66
+                },
+                "Fire": {
+                    "count": 58
+                },
+                "Bellow": {
+                    "count": 49
+                },
+                "Groan": {
+                    "count": 47
+                },
+                "Rattle (instrument)": {
+                    "count": 47
+                },
+                "Sniff": {
+                    "count": 53
+                },
+                "Toot": {
+                    "count": 53
+                },
+                "Drum machine": {
+                    "count": 52
+                },
+                "Stream": {
+                    "count": 58
+                },
+                "Buzz": {
+                    "count": 42
+                },
+                "Wild animals": {
+                    "count": 45
+                },
+                "Roar": {
+                    "count": 42
+                },
+                "Didgeridoo": {
+                    "count": 55
+                },
+                "Rhythm and blues": {
+                    "count": 47
+                },
+                "Whir": {
+                    "count": 53
+                },
+                "Static": {
+                    "count": 57
+                },
+                "Harpsichord": {
+                    "count": 55
+                },
+                "Hiccup": {
+                    "count": 48
+                },
+                "Train wheels squealing": {
+                    "count": 59
+                },
+                "Snicker": {
+                    "count": 45
+                },
+                "Typing": {
+                    "count": 60
+                },
+                "Jingle (music)": {
+                    "count": 40
+                },
+                "Music for children": {
+                    "count": 45
+                },
+                "Fowl": {
+                    "count": 160
+                },
+                "Crowing, cock-a-doodle-doo": {
+                    "count": 33
+                },
+                "Cluck": {
+                    "count": 37
+                },
+                "Chicken, rooster": {
+                    "count": 51
+                },
+                "Music of Latin America": {
+                    "count": 51
+                },
+                "Whoosh, swoosh, swish": {
+                    "count": 54
+                },
+                "Steam": {
+                    "count": 58
+                },
+                "Hoot": {
+                    "count": 57
+                },
+                "Owl": {
+                    "count": 57
+                },
+                "Wedding music": {
+                    "count": 53
+                },
+                "Shuffling cards": {
+                    "count": 44
+                },
+                "Whimper": {
+                    "count": 41
+                },
+                "Vacuum cleaner": {
+                    "count": 50
+                },
+                "Civil defense siren": {
+                    "count": 45
+                },
+                "Busy signal": {
+                    "count": 49
+                },
+                "Speech synthesizer": {
+                    "count": 48
+                },
+                "Gargling": {
+                    "count": 42
+                },
+                "Clapping": {
+                    "count": 49
+                },
+                "Sitar": {
+                    "count": 44
+                },
+                "Coo": {
+                    "count": 55
+                },
+                "Pigeon, dove": {
+                    "count": 54
+                },
+                "Heart sounds, heartbeat": {
+                    "count": 57
+                },
+                "Throbbing": {
+                    "count": 52
+                },
+                "Quack": {
+                    "count": 59
+                },
+                "Duck": {
+                    "count": 53
+                },
+                "Bark": {
+                    "count": 52
+                },
+                "Boom": {
+                    "count": 51
+                },
+                "Jingle bell": {
+                    "count": 52
+                },
+                "Synthesizer": {
+                    "count": 56
+                },
+                "Cattle, bovinae": {
+                    "count": 52
+                },
+                "Moo": {
+                    "count": 50
+                },
+                "Traffic noise, roadway noise": {
+                    "count": 54
+                },
+                "Rodents, rats, mice": {
+                    "count": 55
+                },
+                "Ambient music": {
+                    "count": 50
+                },
+                "Effects unit": {
+                    "count": 100
+                },
+                "New-age music": {
+                    "count": 50
+                },
+                "Explosion": {
+                    "count": 55
+                },
+                "Burst, pop": {
+                    "count": 49
+                },
+                "Tick": {
+                    "count": 56
+                },
+                "Squawk": {
+                    "count": 49
+                },
+                "Telephone": {
+                    "count": 49
+                },
+                "Bus": {
+                    "count": 50
+                },
+                "Cello": {
+                    "count": 63
+                },
+                "Double bass": {
+                    "count": 57
+                },
+                "Air horn, truck horn": {
+                    "count": 54
+                },
+                "Clickety-clack": {
+                    "count": 68
+                },
+                "Sawing": {
+                    "count": 57
+                },
+                "Writing": {
+                    "count": 52
+                },
+                "Steel guitar, slide guitar": {
+                    "count": 50
+                },
+                "Fixed-wing aircraft, airplane": {
+                    "count": 54
+                },
+                "Wheeze": {
+                    "count": 41
+                },
+                "Change ringing (campanology)": {
+                    "count": 55
+                },
+                "Whistling": {
+                    "count": 51
+                },
+                "Christian music": {
+                    "count": 58
+                },
+                "Punk rock": {
+                    "count": 54
+                },
+                "Door": {
+                    "count": 55
+                },
+                "Smash, crash": {
+                    "count": 52
+                },
+                "Microwave oven": {
+                    "count": 49
+                },
+                "Aircraft engine": {
+                    "count": 55
+                },
+                "Salsa music": {
+                    "count": 49
+                },
+                "Progressive rock": {
+                    "count": 50
+                },
+                "Basketball bounce": {
+                    "count": 52
+                },
+                "Waves, surf": {
+                    "count": 60
+                },
+                "Tapping (guitar technique)": {
+                    "count": 56
+                },
+                "Sigh": {
+                    "count": 48
+                },
+                "Yip": {
+                    "count": 52
+                },
+                "Slap, smack": {
+                    "count": 39
+                },
+                "Sidetone": {
+                    "count": 50
+                },
+                "Jackhammer": {
+                    "count": 56
+                },
+                "Skateboard": {
+                    "count": 51
+                },
+                "Squeal": {
+                    "count": 46
+                },
+                "Snort": {
+                    "count": 49
+                },
+                "Swing music": {
+                    "count": 49
+                },
+                "Honk": {
+                    "count": 52
+                },
+                "Goose": {
+                    "count": 63
+                },
+                "Turkey": {
+                    "count": 58
+                },
+                "Gobble": {
+                    "count": 57
+                },
+                "Reggae": {
+                    "count": 49
+                },
+                "Gears": {
+                    "count": 53
+                },
+                "Distortion": {
+                    "count": 54
+                },
+                "Soul music": {
+                    "count": 49
+                },
+                "Alarm": {
+                    "count": 52
+                },
+                "Crying, sobbing": {
+                    "count": 42
+                },
+                "Electric piano": {
+                    "count": 56
+                },
+                "Banjo": {
+                    "count": 54
+                },
+                "Conversation": {
+                    "count": 42
+                },
+                "Cash register": {
+                    "count": 49
+                },
+                "Breathing": {
+                    "count": 47
+                },
+                "Happy music": {
+                    "count": 51
+                },
+                "Whoop": {
+                    "count": 51
+                },
+                "Silence": {
+                    "count": 53
+                },
+                "Shatter": {
+                    "count": 48
+                },
+                "Fire engine, fire truck (siren)": {
+                    "count": 50
+                },
+                "Vehicle horn, car horn, honking": {
+                    "count": 51
+                },
+                "Dubstep": {
+                    "count": 49
+                }
+            }
+        }
+    }
+}

--- a/mteb/descriptive_stats/AudioMultilabelClassification/BirdSet.json
+++ b/mteb/descriptive_stats/AudioMultilabelClassification/BirdSet.json
@@ -1,0 +1,174 @@
+{
+    "test_5s": {
+        "num_samples": 2050,
+        "samples_in_train": 0,
+        "text_statistics": null,
+        "image_statistics": null,
+        "audio_statistics": {
+            "total_duration_seconds": 10247.0026875,
+            "min_duration_seconds": 2.0026875,
+            "average_duration_seconds": 4.998537896341464,
+            "max_duration_seconds": 5.0,
+            "unique_audios": 2050,
+            "average_sampling_rate": 32000.0,
+            "sampling_rates": {
+                "32000": 2050
+            }
+        },
+        "video_statistics": null,
+        "label_statistics": {
+            "min_labels_per_text": 1,
+            "average_label_per_text": 1.1624390243902438,
+            "max_labels_per_text": 3,
+            "unique_labels": 19,
+            "labels": {
+                "Gray-crowned Rosy-Finch": {
+                    "count": 256
+                },
+                "White-crowned Sparrow": {
+                    "count": 1019
+                },
+                "American Pipit": {
+                    "count": 412
+                },
+                "Spotted Sandpiper": {
+                    "count": 8
+                },
+                "Rock Wren": {
+                    "count": 280
+                },
+                "Dark-eyed Junco": {
+                    "count": 67
+                },
+                "Clark's Nutcracker": {
+                    "count": 122
+                },
+                "Mountain Bluebird": {
+                    "count": 10
+                },
+                "Fox Sparrow": {
+                    "count": 11
+                },
+                "Mallard": {
+                    "count": 1
+                },
+                "Hermit Thrush": {
+                    "count": 101
+                },
+                "American Robin": {
+                    "count": 48
+                },
+                "Yellow-rumped Warbler": {
+                    "count": 7
+                },
+                "Cassin's Finch": {
+                    "count": 6
+                },
+                "Dusky Flycatcher": {
+                    "count": 2
+                },
+                "Mountain Chickadee": {
+                    "count": 24
+                },
+                "Orange-crowned Warbler": {
+                    "count": 3
+                },
+                "Warbling Vireo": {
+                    "count": 3
+                },
+                "Northern Flicker": {
+                    "count": 3
+                }
+            }
+        }
+    },
+    "train": {
+        "num_samples": 5460,
+        "samples_in_train": null,
+        "text_statistics": null,
+        "image_statistics": null,
+        "audio_statistics": {
+            "total_duration_seconds": 318765.00225,
+            "min_duration_seconds": 0.184,
+            "average_duration_seconds": 58.381868543956045,
+            "max_duration_seconds": 1190.092,
+            "unique_audios": 5449,
+            "average_sampling_rate": 32000.0,
+            "sampling_rates": {
+                "32000": 5460
+            }
+        },
+        "video_statistics": null,
+        "label_statistics": {
+            "min_labels_per_text": 1,
+            "average_label_per_text": 1.0,
+            "max_labels_per_text": 1,
+            "unique_labels": 21,
+            "labels": {
+                "Mallard": {
+                    "count": 891
+                },
+                "Spotted Sandpiper": {
+                    "count": 132
+                },
+                "Northern Flicker": {
+                    "count": 316
+                },
+                "Dusky Flycatcher": {
+                    "count": 143
+                },
+                "Warbling Vireo": {
+                    "count": 499
+                },
+                "Clark's Nutcracker": {
+                    "count": 94
+                },
+                "Brewer's Blackbird": {
+                    "count": 74
+                },
+                "Orange-crowned Warbler": {
+                    "count": 266
+                },
+                "Yellow Warbler": {
+                    "count": 167
+                },
+                "Yellow-rumped Warbler": {
+                    "count": 223
+                },
+                "Hermit Thrush": {
+                    "count": 353
+                },
+                "Mountain Chickadee": {
+                    "count": 193
+                },
+                "American Robin": {
+                    "count": 604
+                },
+                "American Pipit": {
+                    "count": 154
+                },
+                "Gray-crowned Rosy-Finch": {
+                    "count": 17
+                },
+                "Cassin's Finch": {
+                    "count": 142
+                },
+                "Rock Wren": {
+                    "count": 116
+                },
+                "Mountain Bluebird": {
+                    "count": 34
+                },
+                "Fox Sparrow": {
+                    "count": 189
+                },
+                "Dark-eyed Junco": {
+                    "count": 478
+                },
+                "White-crowned Sparrow": {
+                    "count": 375
+                }
+            }
+        }
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/FleursA2TRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/FleursA2TRetrieval.json
@@ -1,0 +1,3712 @@
+{
+    "test": {
+        "num_samples": 155618,
+        "number_of_characters": 10233378,
+        "documents_text_statistics": {
+            "total_text_length": 10233378,
+            "min_text_length": 17,
+            "average_text_length": 131.51920728964515,
+            "max_text_length": 458,
+            "unique_texts": 33017
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": null,
+        "queries_audio_statistics": {
+            "total_duration_seconds": 1018095.652125,
+            "min_duration_seconds": 0.84,
+            "average_duration_seconds": 13.08454872990271,
+            "max_duration_seconds": 159.48,
+            "unique_audios": 77809,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 77809
+            }
+        },
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 33018,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 33018
+        },
+        "top_ranked_statistics": null,
+        "hf_subset_descriptive_stats": {
+            "af_za": {
+                "num_samples": 528,
+                "number_of_characters": 34125,
+                "documents_text_statistics": {
+                    "total_text_length": 34125,
+                    "min_text_length": 44,
+                    "average_text_length": 129.26136363636363,
+                    "max_text_length": 313,
+                    "unique_texts": 233
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 3237.2511250000002,
+                    "min_duration_seconds": 3.058375,
+                    "average_duration_seconds": 12.262314867424243,
+                    "max_duration_seconds": 29.82,
+                    "unique_audios": 264,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 264
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 233,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 233
+                },
+                "top_ranked_statistics": null
+            },
+            "am_et": {
+                "num_samples": 1032,
+                "number_of_characters": 41719,
+                "documents_text_statistics": {
+                    "total_text_length": 41719,
+                    "min_text_length": 31,
+                    "average_text_length": 80.85077519379846,
+                    "max_text_length": 213,
+                    "unique_texts": 296
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 5805.72,
+                    "min_duration_seconds": 4.98,
+                    "average_duration_seconds": 11.25139534883721,
+                    "max_duration_seconds": 28.92,
+                    "unique_audios": 516,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 516
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 296,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 296
+                },
+                "top_ranked_statistics": null
+            },
+            "ar_eg": {
+                "num_samples": 854,
+                "number_of_characters": 46436,
+                "documents_text_statistics": {
+                    "total_text_length": 46436,
+                    "min_text_length": 35,
+                    "average_text_length": 108.74941451990632,
+                    "max_text_length": 252,
+                    "unique_texts": 283
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 4683.1,
+                    "min_duration_seconds": 4.02,
+                    "average_duration_seconds": 10.96744730679157,
+                    "max_duration_seconds": 25.74,
+                    "unique_audios": 427,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 427
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 283,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 283
+                },
+                "top_ranked_statistics": null
+            },
+            "as_in": {
+                "num_samples": 1968,
+                "number_of_characters": 123064,
+                "documents_text_statistics": {
+                    "total_text_length": 123064,
+                    "min_text_length": 41,
+                    "average_text_length": 125.0650406504065,
+                    "max_text_length": 330,
+                    "unique_texts": 349
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 12491.76,
+                    "min_duration_seconds": 3.72,
+                    "average_duration_seconds": 12.694878048780488,
+                    "max_duration_seconds": 33.96,
+                    "unique_audios": 984,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 984
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "ast_es": {
+                "num_samples": 1892,
+                "number_of_characters": 125288,
+                "documents_text_statistics": {
+                    "total_text_length": 125288,
+                    "min_text_length": 51,
+                    "average_text_length": 132.43974630021143,
+                    "max_text_length": 382,
+                    "unique_texts": 349
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 8771.34,
+                    "min_duration_seconds": 3.24,
+                    "average_duration_seconds": 9.272029598308668,
+                    "max_duration_seconds": 26.88,
+                    "unique_audios": 946,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 946
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "az_az": {
+                "num_samples": 1846,
+                "number_of_characters": 129273,
+                "documents_text_statistics": {
+                    "total_text_length": 129273,
+                    "min_text_length": 46,
+                    "average_text_length": 140.05742145178766,
+                    "max_text_length": 377,
+                    "unique_texts": 343
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 11655.06,
+                    "min_duration_seconds": 3.66,
+                    "average_duration_seconds": 12.627367280606716,
+                    "max_duration_seconds": 31.86,
+                    "unique_audios": 923,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 923
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 343,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 343
+                },
+                "top_ranked_statistics": null
+            },
+            "be_by": {
+                "num_samples": 1934,
+                "number_of_characters": 140044,
+                "documents_text_statistics": {
+                    "total_text_length": 140044,
+                    "min_text_length": 48,
+                    "average_text_length": 144.82316442605998,
+                    "max_text_length": 389,
+                    "unique_texts": 349
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 14517.36,
+                    "min_duration_seconds": 4.68,
+                    "average_duration_seconds": 15.012781799379525,
+                    "max_duration_seconds": 51.36,
+                    "unique_audios": 967,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 967
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "bn_in": {
+                "num_samples": 1840,
+                "number_of_characters": 115513,
+                "documents_text_statistics": {
+                    "total_text_length": 115513,
+                    "min_text_length": 40,
+                    "average_text_length": 125.55760869565218,
+                    "max_text_length": 330,
+                    "unique_texts": 349
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 12360.18,
+                    "min_duration_seconds": 4.26,
+                    "average_duration_seconds": 13.434978260869565,
+                    "max_duration_seconds": 34.56,
+                    "unique_audios": 920,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 920
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "bs_ba": {
+                "num_samples": 1850,
+                "number_of_characters": 119391,
+                "documents_text_statistics": {
+                    "total_text_length": 119391,
+                    "min_text_length": 42,
+                    "average_text_length": 129.07135135135135,
+                    "max_text_length": 373,
+                    "unique_texts": 349
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 11389.38,
+                    "min_duration_seconds": 5.46,
+                    "average_duration_seconds": 12.312843243243242,
+                    "max_duration_seconds": 37.62,
+                    "unique_audios": 925,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 925
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "ca_es": {
+                "num_samples": 1880,
+                "number_of_characters": 134037,
+                "documents_text_statistics": {
+                    "total_text_length": 134037,
+                    "min_text_length": 43,
+                    "average_text_length": 142.59255319148937,
+                    "max_text_length": 378,
+                    "unique_texts": 350
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 11287.64,
+                    "min_duration_seconds": 4.26,
+                    "average_duration_seconds": 12.008127659574468,
+                    "max_duration_seconds": 33.02,
+                    "unique_audios": 940,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 940
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 350,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 350
+                },
+                "top_ranked_statistics": null
+            },
+            "ceb_ph": {
+                "num_samples": 1082,
+                "number_of_characters": 79958,
+                "documents_text_statistics": {
+                    "total_text_length": 79958,
+                    "min_text_length": 58,
+                    "average_text_length": 147.79667282809612,
+                    "max_text_length": 388,
+                    "unique_texts": 301
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 7976.4,
+                    "min_duration_seconds": 4.68,
+                    "average_duration_seconds": 14.743807763401108,
+                    "max_duration_seconds": 48.72,
+                    "unique_audios": 541,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 541
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 301,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 301
+                },
+                "top_ranked_statistics": null
+            },
+            "cmn_hans_cn": {
+                "num_samples": 1890,
+                "number_of_characters": 67643,
+                "documents_text_statistics": {
+                    "total_text_length": 67643,
+                    "min_text_length": 17,
+                    "average_text_length": 71.57989417989418,
+                    "max_text_length": 180,
+                    "unique_texts": 349
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 11065.18,
+                    "min_duration_seconds": 4.02,
+                    "average_duration_seconds": 11.709185185185186,
+                    "max_duration_seconds": 31.12,
+                    "unique_audios": 945,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 945
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "yue_hant_hk": {
+                "num_samples": 1638,
+                "number_of_characters": 56811,
+                "documents_text_statistics": {
+                    "total_text_length": 56811,
+                    "min_text_length": 21,
+                    "average_text_length": 69.36630036630036,
+                    "max_text_length": 180,
+                    "unique_texts": 339
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 9539.34,
+                    "min_duration_seconds": 3.96,
+                    "average_duration_seconds": 11.647545787545788,
+                    "max_duration_seconds": 28.5,
+                    "unique_audios": 819,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 819
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 339,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 339
+                },
+                "top_ranked_statistics": null
+            },
+            "cs_cz": {
+                "num_samples": 1446,
+                "number_of_characters": 88246,
+                "documents_text_statistics": {
+                    "total_text_length": 88246,
+                    "min_text_length": 40,
+                    "average_text_length": 122.05532503457815,
+                    "max_text_length": 355,
+                    "unique_texts": 338
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 8819.82,
+                    "min_duration_seconds": 3.36,
+                    "average_duration_seconds": 12.198921161825727,
+                    "max_duration_seconds": 31.62,
+                    "unique_audios": 723,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 723
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 338,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 338
+                },
+                "top_ranked_statistics": null
+            },
+            "cy_gb": {
+                "num_samples": 2042,
+                "number_of_characters": 140536,
+                "documents_text_statistics": {
+                    "total_text_length": 140536,
+                    "min_text_length": 48,
+                    "average_text_length": 137.6454456415279,
+                    "max_text_length": 354,
+                    "unique_texts": 350
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 15421.5,
+                    "min_duration_seconds": 1.5,
+                    "average_duration_seconds": 15.104309500489716,
+                    "max_duration_seconds": 49.44,
+                    "unique_audios": 1021,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 1021
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 350,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 350
+                },
+                "top_ranked_statistics": null
+            },
+            "da_dk": {
+                "num_samples": 1860,
+                "number_of_characters": 122362,
+                "documents_text_statistics": {
+                    "total_text_length": 122362,
+                    "min_text_length": 31,
+                    "average_text_length": 131.57204301075268,
+                    "max_text_length": 365,
+                    "unique_texts": 350
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 10579.14,
+                    "min_duration_seconds": 3.84,
+                    "average_duration_seconds": 11.375419354838709,
+                    "max_duration_seconds": 31.44,
+                    "unique_audios": 930,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 930
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 350,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 350
+                },
+                "top_ranked_statistics": null
+            },
+            "de_de": {
+                "num_samples": 1724,
+                "number_of_characters": 127944,
+                "documents_text_statistics": {
+                    "total_text_length": 127944,
+                    "min_text_length": 45,
+                    "average_text_length": 148.42691415313226,
+                    "max_text_length": 404,
+                    "unique_texts": 347
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 11349.3,
+                    "min_duration_seconds": 3.6,
+                    "average_duration_seconds": 13.166241299303943,
+                    "max_duration_seconds": 47.94,
+                    "unique_audios": 862,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 862
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 347,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 347
+                },
+                "top_ranked_statistics": null
+            },
+            "el_gr": {
+                "num_samples": 1300,
+                "number_of_characters": 97630,
+                "documents_text_statistics": {
+                    "total_text_length": 97630,
+                    "min_text_length": 46,
+                    "average_text_length": 150.2,
+                    "max_text_length": 458,
+                    "unique_texts": 333
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 6861.96,
+                    "min_duration_seconds": 4.2,
+                    "average_duration_seconds": 10.556861538461538,
+                    "max_duration_seconds": 32.4,
+                    "unique_audios": 650,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 650
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 333,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 333
+                },
+                "top_ranked_statistics": null
+            },
+            "en_us": {
+                "num_samples": 1294,
+                "number_of_characters": 83956,
+                "documents_text_statistics": {
+                    "total_text_length": 83956,
+                    "min_text_length": 42,
+                    "average_text_length": 129.76197836166924,
+                    "max_text_length": 362,
+                    "unique_texts": 350
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 6387.9,
+                    "min_duration_seconds": 3.6,
+                    "average_duration_seconds": 9.873106646058732,
+                    "max_duration_seconds": 29.3,
+                    "unique_audios": 647,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 647
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 350,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 350
+                },
+                "top_ranked_statistics": null
+            },
+            "es_419": {
+                "num_samples": 1816,
+                "number_of_characters": 136891,
+                "documents_text_statistics": {
+                    "total_text_length": 136891,
+                    "min_text_length": 54,
+                    "average_text_length": 150.76101321585904,
+                    "max_text_length": 391,
+                    "unique_texts": 348
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 11126.1,
+                    "min_duration_seconds": 4.92,
+                    "average_duration_seconds": 12.2534140969163,
+                    "max_duration_seconds": 30.3,
+                    "unique_audios": 908,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 908
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 348,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 348
+                },
+                "top_ranked_statistics": null
+            },
+            "et_ee": {
+                "num_samples": 1786,
+                "number_of_characters": 110895,
+                "documents_text_statistics": {
+                    "total_text_length": 110895,
+                    "min_text_length": 44,
+                    "average_text_length": 124.1825307950728,
+                    "max_text_length": 347,
+                    "unique_texts": 345
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 10825.44,
+                    "min_duration_seconds": 5.04,
+                    "average_duration_seconds": 12.122553191489363,
+                    "max_duration_seconds": 31.08,
+                    "unique_audios": 893,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 893
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 345,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 345
+                },
+                "top_ranked_statistics": null
+            },
+            "fa_ir": {
+                "num_samples": 1742,
+                "number_of_characters": 102847,
+                "documents_text_statistics": {
+                    "total_text_length": 102847,
+                    "min_text_length": 41,
+                    "average_text_length": 118.07921928817451,
+                    "max_text_length": 317,
+                    "unique_texts": 324
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 13321.86,
+                    "min_duration_seconds": 5.34,
+                    "average_duration_seconds": 15.294902411021814,
+                    "max_duration_seconds": 39.24,
+                    "unique_audios": 871,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 871
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 324,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 324
+                },
+                "top_ranked_statistics": null
+            },
+            "ff_sn": {
+                "num_samples": 1320,
+                "number_of_characters": 81543,
+                "documents_text_statistics": {
+                    "total_text_length": 81543,
+                    "min_text_length": 42,
+                    "average_text_length": 123.55,
+                    "max_text_length": 303,
+                    "unique_texts": 330
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 9457.26,
+                    "min_duration_seconds": 4.92,
+                    "average_duration_seconds": 14.32918181818182,
+                    "max_duration_seconds": 38.1,
+                    "unique_audios": 660,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 660
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 330,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 330
+                },
+                "top_ranked_statistics": null
+            },
+            "fi_fi": {
+                "num_samples": 1836,
+                "number_of_characters": 124453,
+                "documents_text_statistics": {
+                    "total_text_length": 124453,
+                    "min_text_length": 48,
+                    "average_text_length": 135.56971677559912,
+                    "max_text_length": 369,
+                    "unique_texts": 348
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 11894.401,
+                    "min_duration_seconds": 4.26,
+                    "average_duration_seconds": 12.956863834422657,
+                    "max_duration_seconds": 33.72,
+                    "unique_audios": 918,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 918
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 348,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 348
+                },
+                "top_ranked_statistics": null
+            },
+            "fil_ph": {
+                "num_samples": 1928,
+                "number_of_characters": 157346,
+                "documents_text_statistics": {
+                    "total_text_length": 157346,
+                    "min_text_length": 56,
+                    "average_text_length": 163.2219917012448,
+                    "max_text_length": 429,
+                    "unique_texts": 349
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 17243.1,
+                    "min_duration_seconds": 5.04,
+                    "average_duration_seconds": 17.887033195020745,
+                    "max_duration_seconds": 58.2,
+                    "unique_audios": 964,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 964
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "fr_fr": {
+                "num_samples": 1352,
+                "number_of_characters": 103340,
+                "documents_text_statistics": {
+                    "total_text_length": 103340,
+                    "min_text_length": 54,
+                    "average_text_length": 152.8698224852071,
+                    "max_text_length": 409,
+                    "unique_texts": 332
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 7024.08,
+                    "min_duration_seconds": 3.54,
+                    "average_duration_seconds": 10.390650887573964,
+                    "max_duration_seconds": 33.54,
+                    "unique_audios": 676,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 676
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 332,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 332
+                },
+                "top_ranked_statistics": null
+            },
+            "ga_ie": {
+                "num_samples": 1684,
+                "number_of_characters": 122032,
+                "documents_text_statistics": {
+                    "total_text_length": 122032,
+                    "min_text_length": 49,
+                    "average_text_length": 144.9311163895487,
+                    "max_text_length": 375,
+                    "unique_texts": 343
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 12462.12,
+                    "min_duration_seconds": 5.34,
+                    "average_duration_seconds": 14.800617577197151,
+                    "max_duration_seconds": 39.72,
+                    "unique_audios": 842,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 842
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 343,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 343
+                },
+                "top_ranked_statistics": null
+            },
+            "gl_es": {
+                "num_samples": 1854,
+                "number_of_characters": 133737,
+                "documents_text_statistics": {
+                    "total_text_length": 133737,
+                    "min_text_length": 51,
+                    "average_text_length": 144.26860841423948,
+                    "max_text_length": 363,
+                    "unique_texts": 347
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 9375.78,
+                    "min_duration_seconds": 3.12,
+                    "average_duration_seconds": 10.11411003236246,
+                    "max_duration_seconds": 26.76,
+                    "unique_audios": 927,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 927
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 347,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 347
+                },
+                "top_ranked_statistics": null
+            },
+            "gu_in": {
+                "num_samples": 2000,
+                "number_of_characters": 123109,
+                "documents_text_statistics": {
+                    "total_text_length": 123109,
+                    "min_text_length": 45,
+                    "average_text_length": 123.109,
+                    "max_text_length": 347,
+                    "unique_texts": 349
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 10493.58,
+                    "min_duration_seconds": 3.24,
+                    "average_duration_seconds": 10.49358,
+                    "max_duration_seconds": 26.52,
+                    "unique_audios": 1000,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 1000
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "ha_ng": {
+                "num_samples": 1242,
+                "number_of_characters": 86290,
+                "documents_text_statistics": {
+                    "total_text_length": 86290,
+                    "min_text_length": 45,
+                    "average_text_length": 138.95330112721416,
+                    "max_text_length": 369,
+                    "unique_texts": 331
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 12023.94,
+                    "min_duration_seconds": 6.12,
+                    "average_duration_seconds": 19.362222222222222,
+                    "max_duration_seconds": 78.9,
+                    "unique_audios": 621,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 621
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 331,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 331
+                },
+                "top_ranked_statistics": null
+            },
+            "he_il": {
+                "num_samples": 1584,
+                "number_of_characters": 77398,
+                "documents_text_statistics": {
+                    "total_text_length": 77398,
+                    "min_text_length": 33,
+                    "average_text_length": 97.72474747474747,
+                    "max_text_length": 276,
+                    "unique_texts": 347
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 7382.52,
+                    "min_duration_seconds": 0.84,
+                    "average_duration_seconds": 9.321363636363637,
+                    "max_duration_seconds": 29.88,
+                    "unique_audios": 792,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 792
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 347,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 347
+                },
+                "top_ranked_statistics": null
+            },
+            "hi_in": {
+                "num_samples": 836,
+                "number_of_characters": 51459,
+                "documents_text_statistics": {
+                    "total_text_length": 51459,
+                    "min_text_length": 42,
+                    "average_text_length": 123.10765550239235,
+                    "max_text_length": 377,
+                    "unique_texts": 265
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 4832.22,
+                    "min_duration_seconds": 3.84,
+                    "average_duration_seconds": 11.560334928229665,
+                    "max_duration_seconds": 31.44,
+                    "unique_audios": 418,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 418
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 265,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 265
+                },
+                "top_ranked_statistics": null
+            },
+            "hr_hr": {
+                "num_samples": 1828,
+                "number_of_characters": 113568,
+                "documents_text_statistics": {
+                    "total_text_length": 113568,
+                    "min_text_length": 42,
+                    "average_text_length": 124.25382932166302,
+                    "max_text_length": 344,
+                    "unique_texts": 349
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 9237.48,
+                    "min_duration_seconds": 3.6,
+                    "average_duration_seconds": 10.106652078774617,
+                    "max_duration_seconds": 28.02,
+                    "unique_audios": 914,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 914
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "hu_hu": {
+                "num_samples": 1810,
+                "number_of_characters": 120376,
+                "documents_text_statistics": {
+                    "total_text_length": 120376,
+                    "min_text_length": 46,
+                    "average_text_length": 133.0121546961326,
+                    "max_text_length": 386,
+                    "unique_texts": 348
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 11050.86,
+                    "min_duration_seconds": 5.28,
+                    "average_duration_seconds": 12.21089502762431,
+                    "max_duration_seconds": 36.06,
+                    "unique_audios": 905,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 905
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 348,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 348
+                },
+                "top_ranked_statistics": null
+            },
+            "hy_am": {
+                "num_samples": 1864,
+                "number_of_characters": 132109,
+                "documents_text_statistics": {
+                    "total_text_length": 132109,
+                    "min_text_length": 46,
+                    "average_text_length": 141.7478540772532,
+                    "max_text_length": 379,
+                    "unique_texts": 350
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 10823.28,
+                    "min_duration_seconds": 4.62,
+                    "average_duration_seconds": 11.612961373390558,
+                    "max_duration_seconds": 32.76,
+                    "unique_audios": 932,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 932
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 350,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 350
+                },
+                "top_ranked_statistics": null
+            },
+            "id_id": {
+                "num_samples": 1374,
+                "number_of_characters": 93895,
+                "documents_text_statistics": {
+                    "total_text_length": 93895,
+                    "min_text_length": 42,
+                    "average_text_length": 136.67394468704512,
+                    "max_text_length": 347,
+                    "unique_texts": 328
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 8515.44,
+                    "min_duration_seconds": 4.44,
+                    "average_duration_seconds": 12.395109170305677,
+                    "max_duration_seconds": 41.28,
+                    "unique_audios": 687,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 687
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 328,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 328
+                },
+                "top_ranked_statistics": null
+            },
+            "ig_ng": {
+                "num_samples": 1938,
+                "number_of_characters": 128712,
+                "documents_text_statistics": {
+                    "total_text_length": 128712,
+                    "min_text_length": 47,
+                    "average_text_length": 132.8297213622291,
+                    "max_text_length": 387,
+                    "unique_texts": 350
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 17321.58,
+                    "min_duration_seconds": 5.28,
+                    "average_duration_seconds": 17.87572755417957,
+                    "max_duration_seconds": 64.2,
+                    "unique_audios": 969,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 969
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 350,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 350
+                },
+                "top_ranked_statistics": null
+            },
+            "is_is": {
+                "num_samples": 92,
+                "number_of_characters": 6484,
+                "documents_text_statistics": {
+                    "total_text_length": 6484,
+                    "min_text_length": 85,
+                    "average_text_length": 140.95652173913044,
+                    "max_text_length": 293,
+                    "unique_texts": 45
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 644.88,
+                    "min_duration_seconds": 8.52,
+                    "average_duration_seconds": 14.019130434782609,
+                    "max_duration_seconds": 27.6,
+                    "unique_audios": 46,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 46
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 45,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 45
+                },
+                "top_ranked_statistics": null
+            },
+            "it_it": {
+                "num_samples": 1730,
+                "number_of_characters": 128808,
+                "documents_text_statistics": {
+                    "total_text_length": 128808,
+                    "min_text_length": 59,
+                    "average_text_length": 148.91098265895954,
+                    "max_text_length": 451,
+                    "unique_texts": 346
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 12676.26,
+                    "min_duration_seconds": 5.28,
+                    "average_duration_seconds": 14.65463583815029,
+                    "max_duration_seconds": 52.92,
+                    "unique_audios": 865,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 865
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 346,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 346
+                },
+                "top_ranked_statistics": null
+            },
+            "ja_jp": {
+                "num_samples": 1300,
+                "number_of_characters": 34099,
+                "documents_text_statistics": {
+                    "total_text_length": 34099,
+                    "min_text_length": 20,
+                    "average_text_length": 52.46,
+                    "max_text_length": 134,
+                    "unique_texts": 321
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 8511.12,
+                    "min_duration_seconds": 6.36,
+                    "average_duration_seconds": 13.09403076923077,
+                    "max_duration_seconds": 28.2,
+                    "unique_audios": 650,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 650
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 321,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 321
+                },
+                "top_ranked_statistics": null
+            },
+            "jv_id": {
+                "num_samples": 1456,
+                "number_of_characters": 96141,
+                "documents_text_statistics": {
+                    "total_text_length": 96141,
+                    "min_text_length": 49,
+                    "average_text_length": 132.0618131868132,
+                    "max_text_length": 352,
+                    "unique_texts": 336
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 10125.66,
+                    "min_duration_seconds": 4.68,
+                    "average_duration_seconds": 13.908873626373627,
+                    "max_duration_seconds": 41.88,
+                    "unique_audios": 728,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 728
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 336,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 336
+                },
+                "top_ranked_statistics": null
+            },
+            "ka_ge": {
+                "num_samples": 1958,
+                "number_of_characters": 137318,
+                "documents_text_statistics": {
+                    "total_text_length": 137318,
+                    "min_text_length": 43,
+                    "average_text_length": 140.2635342185904,
+                    "max_text_length": 364,
+                    "unique_texts": 350
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 11053.5,
+                    "min_duration_seconds": 3.6,
+                    "average_duration_seconds": 11.290602655771195,
+                    "max_duration_seconds": 33.24,
+                    "unique_audios": 979,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 979
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 350,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 350
+                },
+                "top_ranked_statistics": null
+            },
+            "kam_ke": {
+                "num_samples": 1654,
+                "number_of_characters": 104844,
+                "documents_text_statistics": {
+                    "total_text_length": 104844,
+                    "min_text_length": 38,
+                    "average_text_length": 126.77629987908101,
+                    "max_text_length": 392,
+                    "unique_texts": 346
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 13428.12,
+                    "min_duration_seconds": 5.52,
+                    "average_duration_seconds": 16.23714631197098,
+                    "max_duration_seconds": 45.48,
+                    "unique_audios": 827,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 827
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 346,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 346
+                },
+                "top_ranked_statistics": null
+            },
+            "kea_cv": {
+                "num_samples": 1728,
+                "number_of_characters": 107865,
+                "documents_text_statistics": {
+                    "total_text_length": 107865,
+                    "min_text_length": 41,
+                    "average_text_length": 124.84375,
+                    "max_text_length": 323,
+                    "unique_texts": 344
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 11760.72,
+                    "min_duration_seconds": 4.92,
+                    "average_duration_seconds": 13.611944444444443,
+                    "max_duration_seconds": 34.26,
+                    "unique_audios": 864,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 864
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 344,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 344
+                },
+                "top_ranked_statistics": null
+            },
+            "kk_kz": {
+                "num_samples": 1712,
+                "number_of_characters": 113186,
+                "documents_text_statistics": {
+                    "total_text_length": 113186,
+                    "min_text_length": 42,
+                    "average_text_length": 132.22663551401868,
+                    "max_text_length": 383,
+                    "unique_texts": 349
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 13804.26,
+                    "min_duration_seconds": 5.82,
+                    "average_duration_seconds": 16.126471962616822,
+                    "max_duration_seconds": 43.32,
+                    "unique_audios": 856,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 856
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "km_kh": {
+                "num_samples": 1542,
+                "number_of_characters": 106195,
+                "documents_text_statistics": {
+                    "total_text_length": 106195,
+                    "min_text_length": 50,
+                    "average_text_length": 137.7367055771725,
+                    "max_text_length": 309,
+                    "unique_texts": 335
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 11343.54,
+                    "min_duration_seconds": 4.68,
+                    "average_duration_seconds": 14.712762645914397,
+                    "max_duration_seconds": 33.96,
+                    "unique_audios": 771,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 771
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 335,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 335
+                },
+                "top_ranked_statistics": null
+            },
+            "kn_in": {
+                "num_samples": 1676,
+                "number_of_characters": 111241,
+                "documents_text_statistics": {
+                    "total_text_length": 111241,
+                    "min_text_length": 46,
+                    "average_text_length": 132.74582338902147,
+                    "max_text_length": 385,
+                    "unique_texts": 344
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 11438.04,
+                    "min_duration_seconds": 0.84,
+                    "average_duration_seconds": 13.649212410501194,
+                    "max_duration_seconds": 39.6,
+                    "unique_audios": 838,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 838
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 344,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 344
+                },
+                "top_ranked_statistics": null
+            },
+            "ko_kr": {
+                "num_samples": 764,
+                "number_of_characters": 23085,
+                "documents_text_statistics": {
+                    "total_text_length": 23085,
+                    "min_text_length": 23,
+                    "average_text_length": 60.431937172774866,
+                    "max_text_length": 171,
+                    "unique_texts": 270
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 4804.92,
+                    "min_duration_seconds": 4.2,
+                    "average_duration_seconds": 12.578324607329844,
+                    "max_duration_seconds": 25.8,
+                    "unique_audios": 382,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 382
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 270,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 270
+                },
+                "top_ranked_statistics": null
+            },
+            "ckb_iq": {
+                "num_samples": 1844,
+                "number_of_characters": 113572,
+                "documents_text_statistics": {
+                    "total_text_length": 113572,
+                    "min_text_length": 42,
+                    "average_text_length": 123.18004338394793,
+                    "max_text_length": 352,
+                    "unique_texts": 348
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 10777.86,
+                    "min_duration_seconds": 4.68,
+                    "average_duration_seconds": 11.689652928416487,
+                    "max_duration_seconds": 37.32,
+                    "unique_audios": 922,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 922
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 348,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 348
+                },
+                "top_ranked_statistics": null
+            },
+            "ky_kg": {
+                "num_samples": 1954,
+                "number_of_characters": 129475,
+                "documents_text_statistics": {
+                    "total_text_length": 129475,
+                    "min_text_length": 34,
+                    "average_text_length": 132.52302968270214,
+                    "max_text_length": 393,
+                    "unique_texts": 350
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 11686.5,
+                    "min_duration_seconds": 3.42,
+                    "average_duration_seconds": 11.961617195496418,
+                    "max_duration_seconds": 36.6,
+                    "unique_audios": 977,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 977
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 350,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 350
+                },
+                "top_ranked_statistics": null
+            },
+            "lb_lu": {
+                "num_samples": 1868,
+                "number_of_characters": 133806,
+                "documents_text_statistics": {
+                    "total_text_length": 133806,
+                    "min_text_length": 55,
+                    "average_text_length": 143.26124197002142,
+                    "max_text_length": 408,
+                    "unique_texts": 349
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 9833.52,
+                    "min_duration_seconds": 3.66,
+                    "average_duration_seconds": 10.528394004282656,
+                    "max_duration_seconds": 35.1,
+                    "unique_audios": 934,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 934
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "lg_ug": {
+                "num_samples": 1446,
+                "number_of_characters": 94913,
+                "documents_text_statistics": {
+                    "total_text_length": 94913,
+                    "min_text_length": 37,
+                    "average_text_length": 131.27662517289073,
+                    "max_text_length": 388,
+                    "unique_texts": 339
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 12249.66,
+                    "min_duration_seconds": 6.24,
+                    "average_duration_seconds": 16.942821576763485,
+                    "max_duration_seconds": 46.14,
+                    "unique_audios": 723,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 723
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 339,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 339
+                },
+                "top_ranked_statistics": null
+            },
+            "ln_cd": {
+                "num_samples": 956,
+                "number_of_characters": 60700,
+                "documents_text_statistics": {
+                    "total_text_length": 60700,
+                    "min_text_length": 34,
+                    "average_text_length": 126.98744769874477,
+                    "max_text_length": 374,
+                    "unique_texts": 284
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 9302.22,
+                    "min_duration_seconds": 5.58,
+                    "average_duration_seconds": 19.46071129707113,
+                    "max_duration_seconds": 56.76,
+                    "unique_audios": 478,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 478
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 285,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 285
+                },
+                "top_ranked_statistics": null
+            },
+            "lo_la": {
+                "num_samples": 810,
+                "number_of_characters": 50115,
+                "documents_text_statistics": {
+                    "total_text_length": 50115,
+                    "min_text_length": 42,
+                    "average_text_length": 123.74074074074075,
+                    "max_text_length": 317,
+                    "unique_texts": 261
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 5062.92,
+                    "min_duration_seconds": 3.54,
+                    "average_duration_seconds": 12.501037037037037,
+                    "max_duration_seconds": 159.48,
+                    "unique_audios": 405,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 405
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 261,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 261
+                },
+                "top_ranked_statistics": null
+            },
+            "lt_lt": {
+                "num_samples": 1972,
+                "number_of_characters": 125364,
+                "documents_text_statistics": {
+                    "total_text_length": 125364,
+                    "min_text_length": 39,
+                    "average_text_length": 127.14401622718053,
+                    "max_text_length": 348,
+                    "unique_texts": 349
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 10686.54,
+                    "min_duration_seconds": 2.7,
+                    "average_duration_seconds": 10.838275862068967,
+                    "max_duration_seconds": 39.36,
+                    "unique_audios": 986,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 986
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "luo_ke": {
+                "num_samples": 512,
+                "number_of_characters": 33287,
+                "documents_text_statistics": {
+                    "total_text_length": 33287,
+                    "min_text_length": 50,
+                    "average_text_length": 130.02734375,
+                    "max_text_length": 365,
+                    "unique_texts": 194
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 3507.6,
+                    "min_duration_seconds": 5.22,
+                    "average_duration_seconds": 13.7015625,
+                    "max_duration_seconds": 35.4,
+                    "unique_audios": 256,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 256
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 194,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 194
+                },
+                "top_ranked_statistics": null
+            },
+            "lv_lv": {
+                "num_samples": 1702,
+                "number_of_characters": 107767,
+                "documents_text_statistics": {
+                    "total_text_length": 107767,
+                    "min_text_length": 51,
+                    "average_text_length": 126.63572267920094,
+                    "max_text_length": 355,
+                    "unique_texts": 346
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 10218.6,
+                    "min_duration_seconds": 5.22,
+                    "average_duration_seconds": 12.007755581668626,
+                    "max_duration_seconds": 32.04,
+                    "unique_audios": 851,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 851
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 346,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 346
+                },
+                "top_ranked_statistics": null
+            },
+            "mi_nz": {
+                "num_samples": 2016,
+                "number_of_characters": 144687,
+                "documents_text_statistics": {
+                    "total_text_length": 144687,
+                    "min_text_length": 47,
+                    "average_text_length": 143.53869047619048,
+                    "max_text_length": 385,
+                    "unique_texts": 349
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 21036.3,
+                    "min_duration_seconds": 6.6,
+                    "average_duration_seconds": 20.86934523809524,
+                    "max_duration_seconds": 60.06,
+                    "unique_audios": 1008,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 1008
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "mk_mk": {
+                "num_samples": 1946,
+                "number_of_characters": 131754,
+                "documents_text_statistics": {
+                    "total_text_length": 131754,
+                    "min_text_length": 41,
+                    "average_text_length": 135.41007194244605,
+                    "max_text_length": 360,
+                    "unique_texts": 348
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 11532.6,
+                    "min_duration_seconds": 4.32,
+                    "average_duration_seconds": 11.85262076053443,
+                    "max_duration_seconds": 32.28,
+                    "unique_audios": 973,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 973
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 348,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 348
+                },
+                "top_ranked_statistics": null
+            },
+            "ml_in": {
+                "num_samples": 1916,
+                "number_of_characters": 139560,
+                "documents_text_statistics": {
+                    "total_text_length": 139560,
+                    "min_text_length": 49,
+                    "average_text_length": 145.678496868476,
+                    "max_text_length": 366,
+                    "unique_texts": 344
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 14072.46,
+                    "min_duration_seconds": 4.5,
+                    "average_duration_seconds": 14.689415448851774,
+                    "max_duration_seconds": 48.0,
+                    "unique_audios": 958,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 958
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 344,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 344
+                },
+                "top_ranked_statistics": null
+            },
+            "mn_mn": {
+                "num_samples": 1898,
+                "number_of_characters": 126468,
+                "documents_text_statistics": {
+                    "total_text_length": 126468,
+                    "min_text_length": 52,
+                    "average_text_length": 133.2644889357218,
+                    "max_text_length": 352,
+                    "unique_texts": 350
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 10266.9,
+                    "min_duration_seconds": 4.68,
+                    "average_duration_seconds": 10.818651211801896,
+                    "max_duration_seconds": 27.48,
+                    "unique_audios": 949,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 949
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 350,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 350
+                },
+                "top_ranked_statistics": null
+            },
+            "mr_in": {
+                "num_samples": 2030,
+                "number_of_characters": 133014,
+                "documents_text_statistics": {
+                    "total_text_length": 133014,
+                    "min_text_length": 50,
+                    "average_text_length": 131.04827586206898,
+                    "max_text_length": 351,
+                    "unique_texts": 349
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 13883.28,
+                    "min_duration_seconds": 4.68,
+                    "average_duration_seconds": 13.678108374384237,
+                    "max_duration_seconds": 41.64,
+                    "unique_audios": 1015,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 1015
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "ms_my": {
+                "num_samples": 1498,
+                "number_of_characters": 102949,
+                "documents_text_statistics": {
+                    "total_text_length": 102949,
+                    "min_text_length": 53,
+                    "average_text_length": 137.44859813084113,
+                    "max_text_length": 356,
+                    "unique_texts": 337
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 8150.4,
+                    "min_duration_seconds": 4.68,
+                    "average_duration_seconds": 10.881708945260346,
+                    "max_duration_seconds": 27.54,
+                    "unique_audios": 749,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 749
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 337,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 337
+                },
+                "top_ranked_statistics": null
+            },
+            "mt_mt": {
+                "num_samples": 1852,
+                "number_of_characters": 131626,
+                "documents_text_statistics": {
+                    "total_text_length": 131626,
+                    "min_text_length": 40,
+                    "average_text_length": 142.14470842332614,
+                    "max_text_length": 394,
+                    "unique_texts": 348
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 12770.58,
+                    "min_duration_seconds": 6.06,
+                    "average_duration_seconds": 13.791123110151188,
+                    "max_duration_seconds": 39.96,
+                    "unique_audios": 926,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 926
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 348,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 348
+                },
+                "top_ranked_statistics": null
+            },
+            "my_mm": {
+                "num_samples": 1760,
+                "number_of_characters": 138514,
+                "documents_text_statistics": {
+                    "total_text_length": 138514,
+                    "min_text_length": 53,
+                    "average_text_length": 157.40227272727273,
+                    "max_text_length": 425,
+                    "unique_texts": 346
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 13731.72,
+                    "min_duration_seconds": 4.2,
+                    "average_duration_seconds": 15.604227272727272,
+                    "max_duration_seconds": 39.12,
+                    "unique_audios": 880,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 880
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 346,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 346
+                },
+                "top_ranked_statistics": null
+            },
+            "nb_no": {
+                "num_samples": 714,
+                "number_of_characters": 45435,
+                "documents_text_statistics": {
+                    "total_text_length": 45435,
+                    "min_text_length": 42,
+                    "average_text_length": 127.26890756302521,
+                    "max_text_length": 348,
+                    "unique_texts": 247
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 4488.96,
+                    "min_duration_seconds": 4.14,
+                    "average_duration_seconds": 12.574117647058824,
+                    "max_duration_seconds": 28.08,
+                    "unique_audios": 357,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 357
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 247,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 247
+                },
+                "top_ranked_statistics": null
+            },
+            "ne_np": {
+                "num_samples": 1452,
+                "number_of_characters": 88344,
+                "documents_text_statistics": {
+                    "total_text_length": 88344,
+                    "min_text_length": 42,
+                    "average_text_length": 121.68595041322314,
+                    "max_text_length": 358,
+                    "unique_texts": 343
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 8224.14,
+                    "min_duration_seconds": 3.24,
+                    "average_duration_seconds": 11.32801652892562,
+                    "max_duration_seconds": 37.32,
+                    "unique_audios": 726,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 726
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 343,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 343
+                },
+                "top_ranked_statistics": null
+            },
+            "nl_nl": {
+                "num_samples": 728,
+                "number_of_characters": 52469,
+                "documents_text_statistics": {
+                    "total_text_length": 52469,
+                    "min_text_length": 43,
+                    "average_text_length": 144.1456043956044,
+                    "max_text_length": 379,
+                    "unique_texts": 251
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 3487.38,
+                    "min_duration_seconds": 3.6,
+                    "average_duration_seconds": 9.580714285714286,
+                    "max_duration_seconds": 23.7,
+                    "unique_audios": 364,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 364
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 251,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 251
+                },
+                "top_ranked_statistics": null
+            },
+            "nso_za": {
+                "num_samples": 1580,
+                "number_of_characters": 118202,
+                "documents_text_statistics": {
+                    "total_text_length": 118202,
+                    "min_text_length": 45,
+                    "average_text_length": 149.62278481012657,
+                    "max_text_length": 417,
+                    "unique_texts": 341
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 15128.16,
+                    "min_duration_seconds": 6.54,
+                    "average_duration_seconds": 19.149569620253164,
+                    "max_duration_seconds": 61.44,
+                    "unique_audios": 790,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 790
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 341,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 341
+                },
+                "top_ranked_statistics": null
+            },
+            "ny_mw": {
+                "num_samples": 1522,
+                "number_of_characters": 105413,
+                "documents_text_statistics": {
+                    "total_text_length": 105413,
+                    "min_text_length": 53,
+                    "average_text_length": 138.51905387647832,
+                    "max_text_length": 417,
+                    "unique_texts": 334
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 12660.3,
+                    "min_duration_seconds": 4.2,
+                    "average_duration_seconds": 16.63639947437582,
+                    "max_duration_seconds": 45.36,
+                    "unique_audios": 761,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 761
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 334,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 334
+                },
+                "top_ranked_statistics": null
+            },
+            "oc_fr": {
+                "num_samples": 1996,
+                "number_of_characters": 149382,
+                "documents_text_statistics": {
+                    "total_text_length": 149382,
+                    "min_text_length": 48,
+                    "average_text_length": 149.6813627254509,
+                    "max_text_length": 402,
+                    "unique_texts": 350
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 16231.26,
+                    "min_duration_seconds": 5.28,
+                    "average_duration_seconds": 16.2637875751503,
+                    "max_duration_seconds": 44.34,
+                    "unique_audios": 998,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 998
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 350,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 350
+                },
+                "top_ranked_statistics": null
+            },
+            "om_et": {
+                "num_samples": 82,
+                "number_of_characters": 4663,
+                "documents_text_statistics": {
+                    "total_text_length": 4663,
+                    "min_text_length": 54,
+                    "average_text_length": 113.73170731707317,
+                    "max_text_length": 228,
+                    "unique_texts": 36
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 467.94,
+                    "min_duration_seconds": 4.26,
+                    "average_duration_seconds": 11.413170731707318,
+                    "max_duration_seconds": 25.86,
+                    "unique_audios": 41,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 41
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 36,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 36
+                },
+                "top_ranked_statistics": null
+            },
+            "or_in": {
+                "num_samples": 1766,
+                "number_of_characters": 118557,
+                "documents_text_statistics": {
+                    "total_text_length": 118557,
+                    "min_text_length": 50,
+                    "average_text_length": 134.2661381653454,
+                    "max_text_length": 349,
+                    "unique_texts": 334
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 10674.64,
+                    "min_duration_seconds": 4.38,
+                    "average_duration_seconds": 12.089060022650056,
+                    "max_duration_seconds": 36.78,
+                    "unique_audios": 883,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 883
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 334,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 334
+                },
+                "top_ranked_statistics": null
+            },
+            "pa_in": {
+                "num_samples": 1148,
+                "number_of_characters": 71487,
+                "documents_text_statistics": {
+                    "total_text_length": 71487,
+                    "min_text_length": 41,
+                    "average_text_length": 124.5418118466899,
+                    "max_text_length": 268,
+                    "unique_texts": 279
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 6611.52,
+                    "min_duration_seconds": 3.96,
+                    "average_duration_seconds": 11.518327526132405,
+                    "max_duration_seconds": 28.08,
+                    "unique_audios": 574,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 574
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 279,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 279
+                },
+                "top_ranked_statistics": null
+            },
+            "pl_pl": {
+                "num_samples": 1516,
+                "number_of_characters": 99994,
+                "documents_text_statistics": {
+                    "total_text_length": 99994,
+                    "min_text_length": 34,
+                    "average_text_length": 131.91820580474933,
+                    "max_text_length": 313,
+                    "unique_texts": 330
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 7382.46,
+                    "min_duration_seconds": 3.0,
+                    "average_duration_seconds": 9.739393139841688,
+                    "max_duration_seconds": 24.48,
+                    "unique_audios": 758,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 758
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 330,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 330
+                },
+                "top_ranked_statistics": null
+            },
+            "ps_af": {
+                "num_samples": 1024,
+                "number_of_characters": 59989,
+                "documents_text_statistics": {
+                    "total_text_length": 59989,
+                    "min_text_length": 34,
+                    "average_text_length": 117.166015625,
+                    "max_text_length": 307,
+                    "unique_texts": 287
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 6349.68,
+                    "min_duration_seconds": 3.84,
+                    "average_duration_seconds": 12.40171875,
+                    "max_duration_seconds": 32.4,
+                    "unique_audios": 512,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 512
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 287,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 287
+                },
+                "top_ranked_statistics": null
+            },
+            "pt_br": {
+                "num_samples": 1838,
+                "number_of_characters": 126866,
+                "documents_text_statistics": {
+                    "total_text_length": 126866,
+                    "min_text_length": 49,
+                    "average_text_length": 138.04787812840044,
+                    "max_text_length": 381,
+                    "unique_texts": 349
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 11660.1,
+                    "min_duration_seconds": 4.44,
+                    "average_duration_seconds": 12.687812840043525,
+                    "max_duration_seconds": 37.14,
+                    "unique_audios": 919,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 919
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "ro_ro": {
+                "num_samples": 1766,
+                "number_of_characters": 126169,
+                "documents_text_statistics": {
+                    "total_text_length": 126169,
+                    "min_text_length": 47,
+                    "average_text_length": 142.8867497168743,
+                    "max_text_length": 390,
+                    "unique_texts": 348
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 9099.36,
+                    "min_duration_seconds": 3.72,
+                    "average_duration_seconds": 10.305050962627407,
+                    "max_duration_seconds": 30.54,
+                    "unique_audios": 883,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 883
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 348,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 348
+                },
+                "top_ranked_statistics": null
+            },
+            "ru_ru": {
+                "num_samples": 1550,
+                "number_of_characters": 106030,
+                "documents_text_statistics": {
+                    "total_text_length": 106030,
+                    "min_text_length": 36,
+                    "average_text_length": 136.81290322580645,
+                    "max_text_length": 343,
+                    "unique_texts": 344
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 8993.82,
+                    "min_duration_seconds": 4.5,
+                    "average_duration_seconds": 11.604929032258065,
+                    "max_duration_seconds": 33.84,
+                    "unique_audios": 775,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 775
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 344,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 344
+                },
+                "top_ranked_statistics": null
+            },
+            "bg_bg": {
+                "num_samples": 1316,
+                "number_of_characters": 88215,
+                "documents_text_statistics": {
+                    "total_text_length": 88215,
+                    "min_text_length": 43,
+                    "average_text_length": 134.06534954407294,
+                    "max_text_length": 360,
+                    "unique_texts": 344
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 6686.88,
+                    "min_duration_seconds": 3.66,
+                    "average_duration_seconds": 10.16243161094225,
+                    "max_duration_seconds": 30.18,
+                    "unique_audios": 658,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 658
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 344,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 344
+                },
+                "top_ranked_statistics": null
+            },
+            "sd_in": {
+                "num_samples": 1960,
+                "number_of_characters": 114294,
+                "documents_text_statistics": {
+                    "total_text_length": 114294,
+                    "min_text_length": 40,
+                    "average_text_length": 116.62653061224489,
+                    "max_text_length": 301,
+                    "unique_texts": 350
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 11851.98,
+                    "min_duration_seconds": 4.14,
+                    "average_duration_seconds": 12.093857142857143,
+                    "max_duration_seconds": 33.96,
+                    "unique_audios": 980,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 980
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 350,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 350
+                },
+                "top_ranked_statistics": null
+            },
+            "sk_sk": {
+                "num_samples": 1584,
+                "number_of_characters": 99597,
+                "documents_text_statistics": {
+                    "total_text_length": 99597,
+                    "min_text_length": 39,
+                    "average_text_length": 125.75378787878788,
+                    "max_text_length": 336,
+                    "unique_texts": 339
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 9408.72,
+                    "min_duration_seconds": 4.26,
+                    "average_duration_seconds": 11.879696969696969,
+                    "max_duration_seconds": 30.3,
+                    "unique_audios": 792,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 792
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 339,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 339
+                },
+                "top_ranked_statistics": null
+            },
+            "sl_si": {
+                "num_samples": 1668,
+                "number_of_characters": 103768,
+                "documents_text_statistics": {
+                    "total_text_length": 103768,
+                    "min_text_length": 42,
+                    "average_text_length": 124.4220623501199,
+                    "max_text_length": 356,
+                    "unique_texts": 347
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 8173.14,
+                    "min_duration_seconds": 3.24,
+                    "average_duration_seconds": 9.799928057553958,
+                    "max_duration_seconds": 28.2,
+                    "unique_audios": 834,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 834
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 347,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 347
+                },
+                "top_ranked_statistics": null
+            },
+            "sn_zw": {
+                "num_samples": 1850,
+                "number_of_characters": 132498,
+                "documents_text_statistics": {
+                    "total_text_length": 132498,
+                    "min_text_length": 43,
+                    "average_text_length": 143.2410810810811,
+                    "max_text_length": 393,
+                    "unique_texts": 348
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 13745.4,
+                    "min_duration_seconds": 4.62,
+                    "average_duration_seconds": 14.859891891891891,
+                    "max_duration_seconds": 33.48,
+                    "unique_audios": 925,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 925
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 348,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 348
+                },
+                "top_ranked_statistics": null
+            },
+            "so_so": {
+                "num_samples": 2038,
+                "number_of_characters": 152321,
+                "documents_text_statistics": {
+                    "total_text_length": 152321,
+                    "min_text_length": 50,
+                    "average_text_length": 149.48086359175662,
+                    "max_text_length": 409,
+                    "unique_texts": 350
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 14095.92,
+                    "min_duration_seconds": 4.38,
+                    "average_duration_seconds": 13.833091265947006,
+                    "max_duration_seconds": 79.5,
+                    "unique_audios": 1019,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 1019
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 350,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 350
+                },
+                "top_ranked_statistics": null
+            },
+            "sr_rs": {
+                "num_samples": 1400,
+                "number_of_characters": 85691,
+                "documents_text_statistics": {
+                    "total_text_length": 85691,
+                    "min_text_length": 40,
+                    "average_text_length": 122.41571428571429,
+                    "max_text_length": 348,
+                    "unique_texts": 327
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 7649.48,
+                    "min_duration_seconds": 5.1,
+                    "average_duration_seconds": 10.92782857142857,
+                    "max_duration_seconds": 29.1,
+                    "unique_audios": 700,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 700
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 327,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 327
+                },
+                "top_ranked_statistics": null
+            },
+            "sv_se": {
+                "num_samples": 1518,
+                "number_of_characters": 97177,
+                "documents_text_statistics": {
+                    "total_text_length": 97177,
+                    "min_text_length": 34,
+                    "average_text_length": 128.03293807641634,
+                    "max_text_length": 377,
+                    "unique_texts": 341
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 8399.16,
+                    "min_duration_seconds": 4.02,
+                    "average_duration_seconds": 11.066086956521739,
+                    "max_duration_seconds": 31.38,
+                    "unique_audios": 759,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 759
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 341,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 341
+                },
+                "top_ranked_statistics": null
+            },
+            "sw_ke": {
+                "num_samples": 974,
+                "number_of_characters": 63117,
+                "documents_text_statistics": {
+                    "total_text_length": 63117,
+                    "min_text_length": 40,
+                    "average_text_length": 129.60369609856264,
+                    "max_text_length": 305,
+                    "unique_texts": 312
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 6939.42,
+                    "min_duration_seconds": 4.56,
+                    "average_duration_seconds": 14.249322381930185,
+                    "max_duration_seconds": 29.16,
+                    "unique_audios": 487,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 487
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 312,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 312
+                },
+                "top_ranked_statistics": null
+            },
+            "ta_in": {
+                "num_samples": 1182,
+                "number_of_characters": 87861,
+                "documents_text_statistics": {
+                    "total_text_length": 87861,
+                    "min_text_length": 52,
+                    "average_text_length": 148.66497461928935,
+                    "max_text_length": 398,
+                    "unique_texts": 336
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 7672.32,
+                    "min_duration_seconds": 3.48,
+                    "average_duration_seconds": 12.981928934010151,
+                    "max_duration_seconds": 60.0,
+                    "unique_audios": 591,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 591
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 336,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 336
+                },
+                "top_ranked_statistics": null
+            },
+            "te_in": {
+                "num_samples": 944,
+                "number_of_characters": 59494,
+                "documents_text_statistics": {
+                    "total_text_length": 59494,
+                    "min_text_length": 45,
+                    "average_text_length": 126.04661016949153,
+                    "max_text_length": 351,
+                    "unique_texts": 302
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 5216.16,
+                    "min_duration_seconds": 4.2,
+                    "average_duration_seconds": 11.051186440677967,
+                    "max_duration_seconds": 30.48,
+                    "unique_audios": 472,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 472
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 302,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 302
+                },
+                "top_ranked_statistics": null
+            },
+            "tg_tj": {
+                "num_samples": 1200,
+                "number_of_characters": 83409,
+                "documents_text_statistics": {
+                    "total_text_length": 83409,
+                    "min_text_length": 52,
+                    "average_text_length": 139.015,
+                    "max_text_length": 340,
+                    "unique_texts": 319
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 8720.94,
+                    "min_duration_seconds": 5.22,
+                    "average_duration_seconds": 14.5349,
+                    "max_duration_seconds": 45.84,
+                    "unique_audios": 600,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 600
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 319,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 319
+                },
+                "top_ranked_statistics": null
+            },
+            "th_th": {
+                "num_samples": 2042,
+                "number_of_characters": 127146,
+                "documents_text_statistics": {
+                    "total_text_length": 127146,
+                    "min_text_length": 47,
+                    "average_text_length": 124.53085210577865,
+                    "max_text_length": 333,
+                    "unique_texts": 349
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 12318.48,
+                    "min_duration_seconds": 3.06,
+                    "average_duration_seconds": 12.06511263467189,
+                    "max_duration_seconds": 46.56,
+                    "unique_audios": 1021,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 1021
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "tr_tr": {
+                "num_samples": 1486,
+                "number_of_characters": 96540,
+                "documents_text_statistics": {
+                    "total_text_length": 96540,
+                    "min_text_length": 43,
+                    "average_text_length": 129.93270524899057,
+                    "max_text_length": 384,
+                    "unique_texts": 329
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 9380.22,
+                    "min_duration_seconds": 3.84,
+                    "average_duration_seconds": 12.62479138627187,
+                    "max_duration_seconds": 36.84,
+                    "unique_audios": 743,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 743
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 329,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 329
+                },
+                "top_ranked_statistics": null
+            },
+            "uk_ua": {
+                "num_samples": 1500,
+                "number_of_characters": 96245,
+                "documents_text_statistics": {
+                    "total_text_length": 96245,
+                    "min_text_length": 36,
+                    "average_text_length": 128.32666666666665,
+                    "max_text_length": 328,
+                    "unique_texts": 329
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 8145.12,
+                    "min_duration_seconds": 4.26,
+                    "average_duration_seconds": 10.86016,
+                    "max_duration_seconds": 28.92,
+                    "unique_audios": 750,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 750
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 329,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 329
+                },
+                "top_ranked_statistics": null
+            },
+            "umb_ao": {
+                "num_samples": 758,
+                "number_of_characters": 47323,
+                "documents_text_statistics": {
+                    "total_text_length": 47323,
+                    "min_text_length": 44,
+                    "average_text_length": 124.86279683377309,
+                    "max_text_length": 407,
+                    "unique_texts": 258
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 9883.98,
+                    "min_duration_seconds": 7.92,
+                    "average_duration_seconds": 26.079102902374668,
+                    "max_duration_seconds": 104.94,
+                    "unique_audios": 379,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 379
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 258,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 258
+                },
+                "top_ranked_statistics": null
+            },
+            "ur_pk": {
+                "num_samples": 598,
+                "number_of_characters": 38790,
+                "documents_text_statistics": {
+                    "total_text_length": 38790,
+                    "min_text_length": 38,
+                    "average_text_length": 129.73244147157192,
+                    "max_text_length": 337,
+                    "unique_texts": 230
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 2931.9,
+                    "min_duration_seconds": 3.72,
+                    "average_duration_seconds": 9.805685618729097,
+                    "max_duration_seconds": 25.8,
+                    "unique_audios": 299,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 299
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 230,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 230
+                },
+                "top_ranked_statistics": null
+            },
+            "uz_uz": {
+                "num_samples": 1724,
+                "number_of_characters": 124183,
+                "documents_text_statistics": {
+                    "total_text_length": 124183,
+                    "min_text_length": 50,
+                    "average_text_length": 144.06380510440835,
+                    "max_text_length": 379,
+                    "unique_texts": 345
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 10214.88,
+                    "min_duration_seconds": 4.02,
+                    "average_duration_seconds": 11.850208816705335,
+                    "max_duration_seconds": 35.94,
+                    "unique_audios": 862,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 862
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 345,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 345
+                },
+                "top_ranked_statistics": null
+            },
+            "vi_vn": {
+                "num_samples": 1714,
+                "number_of_characters": 114861,
+                "documents_text_statistics": {
+                    "total_text_length": 114861,
+                    "min_text_length": 48,
+                    "average_text_length": 134.02683780630105,
+                    "max_text_length": 329,
+                    "unique_texts": 347
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 10813.68,
+                    "min_duration_seconds": 4.98,
+                    "average_duration_seconds": 12.61806301050175,
+                    "max_duration_seconds": 38.1,
+                    "unique_audios": 857,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 857
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 347,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 347
+                },
+                "top_ranked_statistics": null
+            },
+            "wo_sn": {
+                "num_samples": 742,
+                "number_of_characters": 44403,
+                "documents_text_statistics": {
+                    "total_text_length": 44403,
+                    "min_text_length": 38,
+                    "average_text_length": 119.68463611859838,
+                    "max_text_length": 323,
+                    "unique_texts": 239
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 6290.34,
+                    "min_duration_seconds": 5.28,
+                    "average_duration_seconds": 16.955094339622644,
+                    "max_duration_seconds": 60.24,
+                    "unique_audios": 371,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 371
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 239,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 239
+                },
+                "top_ranked_statistics": null
+            },
+            "xh_za": {
+                "num_samples": 2082,
+                "number_of_characters": 141588,
+                "documents_text_statistics": {
+                    "total_text_length": 141588,
+                    "min_text_length": 43,
+                    "average_text_length": 136.01152737752162,
+                    "max_text_length": 389,
+                    "unique_texts": 350
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 13616.64,
+                    "min_duration_seconds": 3.48,
+                    "average_duration_seconds": 13.080345821325649,
+                    "max_duration_seconds": 36.96,
+                    "unique_audios": 1041,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 1041
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 350,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 350
+                },
+                "top_ranked_statistics": null
+            },
+            "yo_ng": {
+                "num_samples": 1662,
+                "number_of_characters": 98126,
+                "documents_text_statistics": {
+                    "total_text_length": 98126,
+                    "min_text_length": 37,
+                    "average_text_length": 118.08182912154031,
+                    "max_text_length": 332,
+                    "unique_texts": 340
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 13559.16,
+                    "min_duration_seconds": 5.52,
+                    "average_duration_seconds": 16.31667870036101,
+                    "max_duration_seconds": 51.84,
+                    "unique_audios": 831,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 831
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 340,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 340
+                },
+                "top_ranked_statistics": null
+            },
+            "zu_za": {
+                "num_samples": 1708,
+                "number_of_characters": 122918,
+                "documents_text_statistics": {
+                    "total_text_length": 122918,
+                    "min_text_length": 52,
+                    "average_text_length": 143.9320843091335,
+                    "max_text_length": 419,
+                    "unique_texts": 346
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 13950.96,
+                    "min_duration_seconds": 6.18,
+                    "average_duration_seconds": 16.336018735362998,
+                    "max_duration_seconds": 46.74,
+                    "unique_audios": 854,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 854
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 346,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 346
+                },
+                "top_ranked_statistics": null
+            }
+        }
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/FleursT2ARetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/FleursT2ARetrieval.json
@@ -1,0 +1,3712 @@
+{
+    "test": {
+        "num_samples": 155618,
+        "number_of_characters": 10233642,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": {
+            "total_duration_seconds": 1018095.652125,
+            "min_duration_seconds": 0.84,
+            "average_duration_seconds": 13.08454872990271,
+            "max_duration_seconds": 159.48,
+            "unique_audios": 77809,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 77809
+            }
+        },
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 10233642,
+            "min_text_length": 17,
+            "average_text_length": 131.52260021334294,
+            "max_text_length": 458,
+            "unique_texts": 33017
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 33018,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 33018
+        },
+        "top_ranked_statistics": null,
+        "hf_subset_descriptive_stats": {
+            "af_za": {
+                "num_samples": 528,
+                "number_of_characters": 34125,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 3237.2511250000002,
+                    "min_duration_seconds": 3.058375,
+                    "average_duration_seconds": 12.262314867424243,
+                    "max_duration_seconds": 29.82,
+                    "unique_audios": 264,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 264
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 34125,
+                    "min_text_length": 44,
+                    "average_text_length": 129.26136363636363,
+                    "max_text_length": 313,
+                    "unique_texts": 233
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 233,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 233
+                },
+                "top_ranked_statistics": null
+            },
+            "am_et": {
+                "num_samples": 1032,
+                "number_of_characters": 41720,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 5805.72,
+                    "min_duration_seconds": 4.98,
+                    "average_duration_seconds": 11.25139534883721,
+                    "max_duration_seconds": 28.92,
+                    "unique_audios": 516,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 516
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 41720,
+                    "min_text_length": 31,
+                    "average_text_length": 80.85271317829458,
+                    "max_text_length": 213,
+                    "unique_texts": 296
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 296,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 296
+                },
+                "top_ranked_statistics": null
+            },
+            "ar_eg": {
+                "num_samples": 854,
+                "number_of_characters": 46439,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 4683.1,
+                    "min_duration_seconds": 4.02,
+                    "average_duration_seconds": 10.96744730679157,
+                    "max_duration_seconds": 25.74,
+                    "unique_audios": 427,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 427
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 46439,
+                    "min_text_length": 35,
+                    "average_text_length": 108.75644028103045,
+                    "max_text_length": 252,
+                    "unique_texts": 283
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 283,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 283
+                },
+                "top_ranked_statistics": null
+            },
+            "as_in": {
+                "num_samples": 1968,
+                "number_of_characters": 123067,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 12491.76,
+                    "min_duration_seconds": 3.72,
+                    "average_duration_seconds": 12.694878048780488,
+                    "max_duration_seconds": 33.96,
+                    "unique_audios": 984,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 984
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 123067,
+                    "min_text_length": 41,
+                    "average_text_length": 125.0680894308943,
+                    "max_text_length": 330,
+                    "unique_texts": 349
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "ast_es": {
+                "num_samples": 1892,
+                "number_of_characters": 125296,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 8771.34,
+                    "min_duration_seconds": 3.24,
+                    "average_duration_seconds": 9.272029598308668,
+                    "max_duration_seconds": 26.88,
+                    "unique_audios": 946,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 946
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 125296,
+                    "min_text_length": 51,
+                    "average_text_length": 132.44820295983087,
+                    "max_text_length": 382,
+                    "unique_texts": 349
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "az_az": {
+                "num_samples": 1846,
+                "number_of_characters": 129273,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 11655.06,
+                    "min_duration_seconds": 3.66,
+                    "average_duration_seconds": 12.627367280606716,
+                    "max_duration_seconds": 31.86,
+                    "unique_audios": 923,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 923
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 129273,
+                    "min_text_length": 46,
+                    "average_text_length": 140.05742145178766,
+                    "max_text_length": 377,
+                    "unique_texts": 343
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 343,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 343
+                },
+                "top_ranked_statistics": null
+            },
+            "be_by": {
+                "num_samples": 1934,
+                "number_of_characters": 140047,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 14517.36,
+                    "min_duration_seconds": 4.68,
+                    "average_duration_seconds": 15.012781799379525,
+                    "max_duration_seconds": 51.36,
+                    "unique_audios": 967,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 967
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 140047,
+                    "min_text_length": 48,
+                    "average_text_length": 144.82626680455016,
+                    "max_text_length": 389,
+                    "unique_texts": 349
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "bn_in": {
+                "num_samples": 1840,
+                "number_of_characters": 115525,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 12360.18,
+                    "min_duration_seconds": 4.26,
+                    "average_duration_seconds": 13.434978260869565,
+                    "max_duration_seconds": 34.56,
+                    "unique_audios": 920,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 920
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 115525,
+                    "min_text_length": 40,
+                    "average_text_length": 125.57065217391305,
+                    "max_text_length": 330,
+                    "unique_texts": 349
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "bs_ba": {
+                "num_samples": 1850,
+                "number_of_characters": 119394,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 11389.38,
+                    "min_duration_seconds": 5.46,
+                    "average_duration_seconds": 12.312843243243242,
+                    "max_duration_seconds": 37.62,
+                    "unique_audios": 925,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 925
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 119394,
+                    "min_text_length": 42,
+                    "average_text_length": 129.0745945945946,
+                    "max_text_length": 373,
+                    "unique_texts": 349
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "ca_es": {
+                "num_samples": 1880,
+                "number_of_characters": 134037,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 11287.64,
+                    "min_duration_seconds": 4.26,
+                    "average_duration_seconds": 12.008127659574468,
+                    "max_duration_seconds": 33.02,
+                    "unique_audios": 940,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 940
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 134037,
+                    "min_text_length": 43,
+                    "average_text_length": 142.59255319148937,
+                    "max_text_length": 378,
+                    "unique_texts": 350
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 350,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 350
+                },
+                "top_ranked_statistics": null
+            },
+            "ceb_ph": {
+                "num_samples": 1082,
+                "number_of_characters": 79958,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 7976.4,
+                    "min_duration_seconds": 4.68,
+                    "average_duration_seconds": 14.743807763401108,
+                    "max_duration_seconds": 48.72,
+                    "unique_audios": 541,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 541
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 79958,
+                    "min_text_length": 58,
+                    "average_text_length": 147.79667282809612,
+                    "max_text_length": 388,
+                    "unique_texts": 301
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 301,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 301
+                },
+                "top_ranked_statistics": null
+            },
+            "cmn_hans_cn": {
+                "num_samples": 1890,
+                "number_of_characters": 67646,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 11065.18,
+                    "min_duration_seconds": 4.02,
+                    "average_duration_seconds": 11.709185185185186,
+                    "max_duration_seconds": 31.12,
+                    "unique_audios": 945,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 945
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 67646,
+                    "min_text_length": 17,
+                    "average_text_length": 71.58306878306878,
+                    "max_text_length": 180,
+                    "unique_texts": 349
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "yue_hant_hk": {
+                "num_samples": 1638,
+                "number_of_characters": 56811,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 9539.34,
+                    "min_duration_seconds": 3.96,
+                    "average_duration_seconds": 11.647545787545788,
+                    "max_duration_seconds": 28.5,
+                    "unique_audios": 819,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 819
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 56811,
+                    "min_text_length": 21,
+                    "average_text_length": 69.36630036630036,
+                    "max_text_length": 180,
+                    "unique_texts": 339
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 339,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 339
+                },
+                "top_ranked_statistics": null
+            },
+            "cs_cz": {
+                "num_samples": 1446,
+                "number_of_characters": 88246,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 8819.82,
+                    "min_duration_seconds": 3.36,
+                    "average_duration_seconds": 12.198921161825727,
+                    "max_duration_seconds": 31.62,
+                    "unique_audios": 723,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 723
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 88246,
+                    "min_text_length": 40,
+                    "average_text_length": 122.05532503457815,
+                    "max_text_length": 355,
+                    "unique_texts": 338
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 338,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 338
+                },
+                "top_ranked_statistics": null
+            },
+            "cy_gb": {
+                "num_samples": 2042,
+                "number_of_characters": 140536,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 15421.5,
+                    "min_duration_seconds": 1.5,
+                    "average_duration_seconds": 15.104309500489716,
+                    "max_duration_seconds": 49.44,
+                    "unique_audios": 1021,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 1021
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 140536,
+                    "min_text_length": 48,
+                    "average_text_length": 137.6454456415279,
+                    "max_text_length": 354,
+                    "unique_texts": 350
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 350,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 350
+                },
+                "top_ranked_statistics": null
+            },
+            "da_dk": {
+                "num_samples": 1860,
+                "number_of_characters": 122365,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 10579.14,
+                    "min_duration_seconds": 3.84,
+                    "average_duration_seconds": 11.375419354838709,
+                    "max_duration_seconds": 31.44,
+                    "unique_audios": 930,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 930
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 122365,
+                    "min_text_length": 31,
+                    "average_text_length": 131.5752688172043,
+                    "max_text_length": 365,
+                    "unique_texts": 350
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 350,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 350
+                },
+                "top_ranked_statistics": null
+            },
+            "de_de": {
+                "num_samples": 1724,
+                "number_of_characters": 127945,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 11349.3,
+                    "min_duration_seconds": 3.6,
+                    "average_duration_seconds": 13.166241299303943,
+                    "max_duration_seconds": 47.94,
+                    "unique_audios": 862,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 862
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 127945,
+                    "min_text_length": 45,
+                    "average_text_length": 148.42807424593968,
+                    "max_text_length": 404,
+                    "unique_texts": 347
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 347,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 347
+                },
+                "top_ranked_statistics": null
+            },
+            "el_gr": {
+                "num_samples": 1300,
+                "number_of_characters": 97630,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 6861.96,
+                    "min_duration_seconds": 4.2,
+                    "average_duration_seconds": 10.556861538461538,
+                    "max_duration_seconds": 32.4,
+                    "unique_audios": 650,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 650
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 97630,
+                    "min_text_length": 46,
+                    "average_text_length": 150.2,
+                    "max_text_length": 458,
+                    "unique_texts": 333
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 333,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 333
+                },
+                "top_ranked_statistics": null
+            },
+            "en_us": {
+                "num_samples": 1294,
+                "number_of_characters": 83956,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 6387.9,
+                    "min_duration_seconds": 3.6,
+                    "average_duration_seconds": 9.873106646058732,
+                    "max_duration_seconds": 29.3,
+                    "unique_audios": 647,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 647
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 83956,
+                    "min_text_length": 42,
+                    "average_text_length": 129.76197836166924,
+                    "max_text_length": 362,
+                    "unique_texts": 350
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 350,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 350
+                },
+                "top_ranked_statistics": null
+            },
+            "es_419": {
+                "num_samples": 1816,
+                "number_of_characters": 136891,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 11126.1,
+                    "min_duration_seconds": 4.92,
+                    "average_duration_seconds": 12.2534140969163,
+                    "max_duration_seconds": 30.3,
+                    "unique_audios": 908,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 908
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 136891,
+                    "min_text_length": 54,
+                    "average_text_length": 150.76101321585904,
+                    "max_text_length": 391,
+                    "unique_texts": 348
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 348,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 348
+                },
+                "top_ranked_statistics": null
+            },
+            "et_ee": {
+                "num_samples": 1786,
+                "number_of_characters": 110895,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 10825.44,
+                    "min_duration_seconds": 5.04,
+                    "average_duration_seconds": 12.122553191489363,
+                    "max_duration_seconds": 31.08,
+                    "unique_audios": 893,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 893
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 110895,
+                    "min_text_length": 44,
+                    "average_text_length": 124.1825307950728,
+                    "max_text_length": 347,
+                    "unique_texts": 345
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 345,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 345
+                },
+                "top_ranked_statistics": null
+            },
+            "fa_ir": {
+                "num_samples": 1742,
+                "number_of_characters": 102847,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 13321.86,
+                    "min_duration_seconds": 5.34,
+                    "average_duration_seconds": 15.294902411021814,
+                    "max_duration_seconds": 39.24,
+                    "unique_audios": 871,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 871
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 102847,
+                    "min_text_length": 41,
+                    "average_text_length": 118.07921928817451,
+                    "max_text_length": 317,
+                    "unique_texts": 324
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 324,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 324
+                },
+                "top_ranked_statistics": null
+            },
+            "ff_sn": {
+                "num_samples": 1320,
+                "number_of_characters": 81556,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 9457.26,
+                    "min_duration_seconds": 4.92,
+                    "average_duration_seconds": 14.32918181818182,
+                    "max_duration_seconds": 38.1,
+                    "unique_audios": 660,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 660
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 81556,
+                    "min_text_length": 42,
+                    "average_text_length": 123.56969696969696,
+                    "max_text_length": 303,
+                    "unique_texts": 330
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 330,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 330
+                },
+                "top_ranked_statistics": null
+            },
+            "fi_fi": {
+                "num_samples": 1836,
+                "number_of_characters": 124453,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 11894.401,
+                    "min_duration_seconds": 4.26,
+                    "average_duration_seconds": 12.956863834422657,
+                    "max_duration_seconds": 33.72,
+                    "unique_audios": 918,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 918
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 124453,
+                    "min_text_length": 48,
+                    "average_text_length": 135.56971677559912,
+                    "max_text_length": 369,
+                    "unique_texts": 348
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 348,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 348
+                },
+                "top_ranked_statistics": null
+            },
+            "fil_ph": {
+                "num_samples": 1928,
+                "number_of_characters": 157346,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 17243.1,
+                    "min_duration_seconds": 5.04,
+                    "average_duration_seconds": 17.887033195020745,
+                    "max_duration_seconds": 58.2,
+                    "unique_audios": 964,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 964
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 157346,
+                    "min_text_length": 56,
+                    "average_text_length": 163.2219917012448,
+                    "max_text_length": 429,
+                    "unique_texts": 349
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "fr_fr": {
+                "num_samples": 1352,
+                "number_of_characters": 103342,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 7024.08,
+                    "min_duration_seconds": 3.54,
+                    "average_duration_seconds": 10.390650887573964,
+                    "max_duration_seconds": 33.54,
+                    "unique_audios": 676,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 676
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 103342,
+                    "min_text_length": 54,
+                    "average_text_length": 152.87278106508876,
+                    "max_text_length": 409,
+                    "unique_texts": 332
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 332,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 332
+                },
+                "top_ranked_statistics": null
+            },
+            "ga_ie": {
+                "num_samples": 1684,
+                "number_of_characters": 122032,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 12462.12,
+                    "min_duration_seconds": 5.34,
+                    "average_duration_seconds": 14.800617577197151,
+                    "max_duration_seconds": 39.72,
+                    "unique_audios": 842,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 842
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 122032,
+                    "min_text_length": 49,
+                    "average_text_length": 144.9311163895487,
+                    "max_text_length": 375,
+                    "unique_texts": 343
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 343,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 343
+                },
+                "top_ranked_statistics": null
+            },
+            "gl_es": {
+                "num_samples": 1854,
+                "number_of_characters": 133737,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 9375.78,
+                    "min_duration_seconds": 3.12,
+                    "average_duration_seconds": 10.11411003236246,
+                    "max_duration_seconds": 26.76,
+                    "unique_audios": 927,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 927
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 133737,
+                    "min_text_length": 51,
+                    "average_text_length": 144.26860841423948,
+                    "max_text_length": 363,
+                    "unique_texts": 347
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 347,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 347
+                },
+                "top_ranked_statistics": null
+            },
+            "gu_in": {
+                "num_samples": 2000,
+                "number_of_characters": 123126,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 10493.58,
+                    "min_duration_seconds": 3.24,
+                    "average_duration_seconds": 10.49358,
+                    "max_duration_seconds": 26.52,
+                    "unique_audios": 1000,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 1000
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 123126,
+                    "min_text_length": 45,
+                    "average_text_length": 123.126,
+                    "max_text_length": 347,
+                    "unique_texts": 349
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "ha_ng": {
+                "num_samples": 1242,
+                "number_of_characters": 86292,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 12023.94,
+                    "min_duration_seconds": 6.12,
+                    "average_duration_seconds": 19.362222222222222,
+                    "max_duration_seconds": 78.9,
+                    "unique_audios": 621,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 621
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 86292,
+                    "min_text_length": 45,
+                    "average_text_length": 138.95652173913044,
+                    "max_text_length": 369,
+                    "unique_texts": 331
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 331,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 331
+                },
+                "top_ranked_statistics": null
+            },
+            "he_il": {
+                "num_samples": 1584,
+                "number_of_characters": 77398,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 7382.52,
+                    "min_duration_seconds": 0.84,
+                    "average_duration_seconds": 9.321363636363637,
+                    "max_duration_seconds": 29.88,
+                    "unique_audios": 792,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 792
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 77398,
+                    "min_text_length": 33,
+                    "average_text_length": 97.72474747474747,
+                    "max_text_length": 276,
+                    "unique_texts": 347
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 347,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 347
+                },
+                "top_ranked_statistics": null
+            },
+            "hi_in": {
+                "num_samples": 836,
+                "number_of_characters": 51459,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 4832.22,
+                    "min_duration_seconds": 3.84,
+                    "average_duration_seconds": 11.560334928229665,
+                    "max_duration_seconds": 31.44,
+                    "unique_audios": 418,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 418
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 51459,
+                    "min_text_length": 42,
+                    "average_text_length": 123.10765550239235,
+                    "max_text_length": 377,
+                    "unique_texts": 265
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 265,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 265
+                },
+                "top_ranked_statistics": null
+            },
+            "hr_hr": {
+                "num_samples": 1828,
+                "number_of_characters": 113595,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 9237.48,
+                    "min_duration_seconds": 3.6,
+                    "average_duration_seconds": 10.106652078774617,
+                    "max_duration_seconds": 28.02,
+                    "unique_audios": 914,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 914
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 113595,
+                    "min_text_length": 42,
+                    "average_text_length": 124.28336980306345,
+                    "max_text_length": 344,
+                    "unique_texts": 349
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "hu_hu": {
+                "num_samples": 1810,
+                "number_of_characters": 120383,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 11050.86,
+                    "min_duration_seconds": 5.28,
+                    "average_duration_seconds": 12.21089502762431,
+                    "max_duration_seconds": 36.06,
+                    "unique_audios": 905,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 905
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 120383,
+                    "min_text_length": 46,
+                    "average_text_length": 133.01988950276242,
+                    "max_text_length": 386,
+                    "unique_texts": 348
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 348,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 348
+                },
+                "top_ranked_statistics": null
+            },
+            "hy_am": {
+                "num_samples": 1864,
+                "number_of_characters": 132109,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 10823.28,
+                    "min_duration_seconds": 4.62,
+                    "average_duration_seconds": 11.612961373390558,
+                    "max_duration_seconds": 32.76,
+                    "unique_audios": 932,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 932
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 132109,
+                    "min_text_length": 46,
+                    "average_text_length": 141.7478540772532,
+                    "max_text_length": 379,
+                    "unique_texts": 350
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 350,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 350
+                },
+                "top_ranked_statistics": null
+            },
+            "id_id": {
+                "num_samples": 1374,
+                "number_of_characters": 93904,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 8515.44,
+                    "min_duration_seconds": 4.44,
+                    "average_duration_seconds": 12.395109170305677,
+                    "max_duration_seconds": 41.28,
+                    "unique_audios": 687,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 687
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 93904,
+                    "min_text_length": 42,
+                    "average_text_length": 136.68704512372634,
+                    "max_text_length": 347,
+                    "unique_texts": 328
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 328,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 328
+                },
+                "top_ranked_statistics": null
+            },
+            "ig_ng": {
+                "num_samples": 1938,
+                "number_of_characters": 128712,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 17321.58,
+                    "min_duration_seconds": 5.28,
+                    "average_duration_seconds": 17.87572755417957,
+                    "max_duration_seconds": 64.2,
+                    "unique_audios": 969,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 969
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 128712,
+                    "min_text_length": 47,
+                    "average_text_length": 132.8297213622291,
+                    "max_text_length": 387,
+                    "unique_texts": 350
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 350,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 350
+                },
+                "top_ranked_statistics": null
+            },
+            "is_is": {
+                "num_samples": 92,
+                "number_of_characters": 6484,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 644.88,
+                    "min_duration_seconds": 8.52,
+                    "average_duration_seconds": 14.019130434782609,
+                    "max_duration_seconds": 27.6,
+                    "unique_audios": 46,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 46
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 6484,
+                    "min_text_length": 85,
+                    "average_text_length": 140.95652173913044,
+                    "max_text_length": 293,
+                    "unique_texts": 45
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 45,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 45
+                },
+                "top_ranked_statistics": null
+            },
+            "it_it": {
+                "num_samples": 1730,
+                "number_of_characters": 128808,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 12676.26,
+                    "min_duration_seconds": 5.28,
+                    "average_duration_seconds": 14.65463583815029,
+                    "max_duration_seconds": 52.92,
+                    "unique_audios": 865,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 865
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 128808,
+                    "min_text_length": 59,
+                    "average_text_length": 148.91098265895954,
+                    "max_text_length": 451,
+                    "unique_texts": 346
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 346,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 346
+                },
+                "top_ranked_statistics": null
+            },
+            "ja_jp": {
+                "num_samples": 1300,
+                "number_of_characters": 34100,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 8511.12,
+                    "min_duration_seconds": 6.36,
+                    "average_duration_seconds": 13.09403076923077,
+                    "max_duration_seconds": 28.2,
+                    "unique_audios": 650,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 650
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 34100,
+                    "min_text_length": 20,
+                    "average_text_length": 52.46153846153846,
+                    "max_text_length": 134,
+                    "unique_texts": 321
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 321,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 321
+                },
+                "top_ranked_statistics": null
+            },
+            "jv_id": {
+                "num_samples": 1456,
+                "number_of_characters": 96141,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 10125.66,
+                    "min_duration_seconds": 4.68,
+                    "average_duration_seconds": 13.908873626373627,
+                    "max_duration_seconds": 41.88,
+                    "unique_audios": 728,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 728
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 96141,
+                    "min_text_length": 49,
+                    "average_text_length": 132.0618131868132,
+                    "max_text_length": 352,
+                    "unique_texts": 336
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 336,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 336
+                },
+                "top_ranked_statistics": null
+            },
+            "ka_ge": {
+                "num_samples": 1958,
+                "number_of_characters": 137318,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 11053.5,
+                    "min_duration_seconds": 3.6,
+                    "average_duration_seconds": 11.290602655771195,
+                    "max_duration_seconds": 33.24,
+                    "unique_audios": 979,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 979
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 137318,
+                    "min_text_length": 43,
+                    "average_text_length": 140.2635342185904,
+                    "max_text_length": 364,
+                    "unique_texts": 350
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 350,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 350
+                },
+                "top_ranked_statistics": null
+            },
+            "kam_ke": {
+                "num_samples": 1654,
+                "number_of_characters": 104846,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 13428.12,
+                    "min_duration_seconds": 5.52,
+                    "average_duration_seconds": 16.23714631197098,
+                    "max_duration_seconds": 45.48,
+                    "unique_audios": 827,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 827
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 104846,
+                    "min_text_length": 38,
+                    "average_text_length": 126.77871825876663,
+                    "max_text_length": 392,
+                    "unique_texts": 346
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 346,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 346
+                },
+                "top_ranked_statistics": null
+            },
+            "kea_cv": {
+                "num_samples": 1728,
+                "number_of_characters": 107868,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 11760.72,
+                    "min_duration_seconds": 4.92,
+                    "average_duration_seconds": 13.611944444444443,
+                    "max_duration_seconds": 34.26,
+                    "unique_audios": 864,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 864
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 107868,
+                    "min_text_length": 41,
+                    "average_text_length": 124.84722222222223,
+                    "max_text_length": 323,
+                    "unique_texts": 344
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 344,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 344
+                },
+                "top_ranked_statistics": null
+            },
+            "kk_kz": {
+                "num_samples": 1712,
+                "number_of_characters": 113186,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 13804.26,
+                    "min_duration_seconds": 5.82,
+                    "average_duration_seconds": 16.126471962616822,
+                    "max_duration_seconds": 43.32,
+                    "unique_audios": 856,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 856
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 113186,
+                    "min_text_length": 42,
+                    "average_text_length": 132.22663551401868,
+                    "max_text_length": 383,
+                    "unique_texts": 349
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "km_kh": {
+                "num_samples": 1542,
+                "number_of_characters": 106195,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 11343.54,
+                    "min_duration_seconds": 4.68,
+                    "average_duration_seconds": 14.712762645914397,
+                    "max_duration_seconds": 33.96,
+                    "unique_audios": 771,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 771
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 106195,
+                    "min_text_length": 50,
+                    "average_text_length": 137.7367055771725,
+                    "max_text_length": 309,
+                    "unique_texts": 335
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 335,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 335
+                },
+                "top_ranked_statistics": null
+            },
+            "kn_in": {
+                "num_samples": 1676,
+                "number_of_characters": 111246,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 11438.04,
+                    "min_duration_seconds": 0.84,
+                    "average_duration_seconds": 13.649212410501194,
+                    "max_duration_seconds": 39.6,
+                    "unique_audios": 838,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 838
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 111246,
+                    "min_text_length": 46,
+                    "average_text_length": 132.75178997613367,
+                    "max_text_length": 385,
+                    "unique_texts": 344
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 344,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 344
+                },
+                "top_ranked_statistics": null
+            },
+            "ko_kr": {
+                "num_samples": 764,
+                "number_of_characters": 23091,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 4804.92,
+                    "min_duration_seconds": 4.2,
+                    "average_duration_seconds": 12.578324607329844,
+                    "max_duration_seconds": 25.8,
+                    "unique_audios": 382,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 382
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 23091,
+                    "min_text_length": 23,
+                    "average_text_length": 60.44764397905759,
+                    "max_text_length": 171,
+                    "unique_texts": 270
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 270,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 270
+                },
+                "top_ranked_statistics": null
+            },
+            "ckb_iq": {
+                "num_samples": 1844,
+                "number_of_characters": 113572,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 10777.86,
+                    "min_duration_seconds": 4.68,
+                    "average_duration_seconds": 11.689652928416487,
+                    "max_duration_seconds": 37.32,
+                    "unique_audios": 922,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 922
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 113572,
+                    "min_text_length": 42,
+                    "average_text_length": 123.18004338394793,
+                    "max_text_length": 352,
+                    "unique_texts": 348
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 348,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 348
+                },
+                "top_ranked_statistics": null
+            },
+            "ky_kg": {
+                "num_samples": 1954,
+                "number_of_characters": 129475,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 11686.5,
+                    "min_duration_seconds": 3.42,
+                    "average_duration_seconds": 11.961617195496418,
+                    "max_duration_seconds": 36.6,
+                    "unique_audios": 977,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 977
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 129475,
+                    "min_text_length": 34,
+                    "average_text_length": 132.52302968270214,
+                    "max_text_length": 393,
+                    "unique_texts": 350
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 350,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 350
+                },
+                "top_ranked_statistics": null
+            },
+            "lb_lu": {
+                "num_samples": 1868,
+                "number_of_characters": 133809,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 9833.52,
+                    "min_duration_seconds": 3.66,
+                    "average_duration_seconds": 10.528394004282656,
+                    "max_duration_seconds": 35.1,
+                    "unique_audios": 934,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 934
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 133809,
+                    "min_text_length": 55,
+                    "average_text_length": 143.2644539614561,
+                    "max_text_length": 408,
+                    "unique_texts": 349
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "lg_ug": {
+                "num_samples": 1446,
+                "number_of_characters": 94927,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 12249.66,
+                    "min_duration_seconds": 6.24,
+                    "average_duration_seconds": 16.942821576763485,
+                    "max_duration_seconds": 46.14,
+                    "unique_audios": 723,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 723
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 94927,
+                    "min_text_length": 37,
+                    "average_text_length": 131.2959889349931,
+                    "max_text_length": 388,
+                    "unique_texts": 339
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 339,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 339
+                },
+                "top_ranked_statistics": null
+            },
+            "ln_cd": {
+                "num_samples": 956,
+                "number_of_characters": 60700,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 9302.22,
+                    "min_duration_seconds": 5.58,
+                    "average_duration_seconds": 19.46071129707113,
+                    "max_duration_seconds": 56.76,
+                    "unique_audios": 478,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 478
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 60700,
+                    "min_text_length": 34,
+                    "average_text_length": 126.98744769874477,
+                    "max_text_length": 374,
+                    "unique_texts": 284
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 285,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 285
+                },
+                "top_ranked_statistics": null
+            },
+            "lo_la": {
+                "num_samples": 810,
+                "number_of_characters": 50116,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 5062.92,
+                    "min_duration_seconds": 3.54,
+                    "average_duration_seconds": 12.501037037037037,
+                    "max_duration_seconds": 159.48,
+                    "unique_audios": 405,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 405
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 50116,
+                    "min_text_length": 42,
+                    "average_text_length": 123.7432098765432,
+                    "max_text_length": 317,
+                    "unique_texts": 261
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 261,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 261
+                },
+                "top_ranked_statistics": null
+            },
+            "lt_lt": {
+                "num_samples": 1972,
+                "number_of_characters": 125364,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 10686.54,
+                    "min_duration_seconds": 2.7,
+                    "average_duration_seconds": 10.838275862068967,
+                    "max_duration_seconds": 39.36,
+                    "unique_audios": 986,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 986
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 125364,
+                    "min_text_length": 39,
+                    "average_text_length": 127.14401622718053,
+                    "max_text_length": 348,
+                    "unique_texts": 349
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "luo_ke": {
+                "num_samples": 512,
+                "number_of_characters": 33290,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 3507.6,
+                    "min_duration_seconds": 5.22,
+                    "average_duration_seconds": 13.7015625,
+                    "max_duration_seconds": 35.4,
+                    "unique_audios": 256,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 256
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 33290,
+                    "min_text_length": 50,
+                    "average_text_length": 130.0390625,
+                    "max_text_length": 365,
+                    "unique_texts": 194
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 194,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 194
+                },
+                "top_ranked_statistics": null
+            },
+            "lv_lv": {
+                "num_samples": 1702,
+                "number_of_characters": 107767,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 10218.6,
+                    "min_duration_seconds": 5.22,
+                    "average_duration_seconds": 12.007755581668626,
+                    "max_duration_seconds": 32.04,
+                    "unique_audios": 851,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 851
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 107767,
+                    "min_text_length": 51,
+                    "average_text_length": 126.63572267920094,
+                    "max_text_length": 355,
+                    "unique_texts": 346
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 346,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 346
+                },
+                "top_ranked_statistics": null
+            },
+            "mi_nz": {
+                "num_samples": 2016,
+                "number_of_characters": 144687,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 21036.3,
+                    "min_duration_seconds": 6.6,
+                    "average_duration_seconds": 20.86934523809524,
+                    "max_duration_seconds": 60.06,
+                    "unique_audios": 1008,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 1008
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 144687,
+                    "min_text_length": 47,
+                    "average_text_length": 143.53869047619048,
+                    "max_text_length": 385,
+                    "unique_texts": 349
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "mk_mk": {
+                "num_samples": 1946,
+                "number_of_characters": 131754,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 11532.6,
+                    "min_duration_seconds": 4.32,
+                    "average_duration_seconds": 11.85262076053443,
+                    "max_duration_seconds": 32.28,
+                    "unique_audios": 973,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 973
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 131754,
+                    "min_text_length": 41,
+                    "average_text_length": 135.41007194244605,
+                    "max_text_length": 360,
+                    "unique_texts": 348
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 348,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 348
+                },
+                "top_ranked_statistics": null
+            },
+            "ml_in": {
+                "num_samples": 1916,
+                "number_of_characters": 139566,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 14072.46,
+                    "min_duration_seconds": 4.5,
+                    "average_duration_seconds": 14.689415448851774,
+                    "max_duration_seconds": 48.0,
+                    "unique_audios": 958,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 958
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 139566,
+                    "min_text_length": 49,
+                    "average_text_length": 145.68475991649268,
+                    "max_text_length": 366,
+                    "unique_texts": 344
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 344,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 344
+                },
+                "top_ranked_statistics": null
+            },
+            "mn_mn": {
+                "num_samples": 1898,
+                "number_of_characters": 126471,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 10266.9,
+                    "min_duration_seconds": 4.68,
+                    "average_duration_seconds": 10.818651211801896,
+                    "max_duration_seconds": 27.48,
+                    "unique_audios": 949,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 949
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 126471,
+                    "min_text_length": 52,
+                    "average_text_length": 133.26765015806112,
+                    "max_text_length": 352,
+                    "unique_texts": 350
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 350,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 350
+                },
+                "top_ranked_statistics": null
+            },
+            "mr_in": {
+                "num_samples": 2030,
+                "number_of_characters": 133030,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 13883.28,
+                    "min_duration_seconds": 4.68,
+                    "average_duration_seconds": 13.678108374384237,
+                    "max_duration_seconds": 41.64,
+                    "unique_audios": 1015,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 1015
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 133030,
+                    "min_text_length": 50,
+                    "average_text_length": 131.064039408867,
+                    "max_text_length": 351,
+                    "unique_texts": 349
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "ms_my": {
+                "num_samples": 1498,
+                "number_of_characters": 102950,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 8150.4,
+                    "min_duration_seconds": 4.68,
+                    "average_duration_seconds": 10.881708945260346,
+                    "max_duration_seconds": 27.54,
+                    "unique_audios": 749,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 749
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 102950,
+                    "min_text_length": 53,
+                    "average_text_length": 137.44993324432576,
+                    "max_text_length": 356,
+                    "unique_texts": 337
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 337,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 337
+                },
+                "top_ranked_statistics": null
+            },
+            "mt_mt": {
+                "num_samples": 1852,
+                "number_of_characters": 131626,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 12770.58,
+                    "min_duration_seconds": 6.06,
+                    "average_duration_seconds": 13.791123110151188,
+                    "max_duration_seconds": 39.96,
+                    "unique_audios": 926,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 926
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 131626,
+                    "min_text_length": 40,
+                    "average_text_length": 142.14470842332614,
+                    "max_text_length": 394,
+                    "unique_texts": 348
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 348,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 348
+                },
+                "top_ranked_statistics": null
+            },
+            "my_mm": {
+                "num_samples": 1760,
+                "number_of_characters": 138514,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 13731.72,
+                    "min_duration_seconds": 4.2,
+                    "average_duration_seconds": 15.604227272727272,
+                    "max_duration_seconds": 39.12,
+                    "unique_audios": 880,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 880
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 138514,
+                    "min_text_length": 53,
+                    "average_text_length": 157.40227272727273,
+                    "max_text_length": 425,
+                    "unique_texts": 346
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 346,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 346
+                },
+                "top_ranked_statistics": null
+            },
+            "nb_no": {
+                "num_samples": 714,
+                "number_of_characters": 45435,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 4488.96,
+                    "min_duration_seconds": 4.14,
+                    "average_duration_seconds": 12.574117647058824,
+                    "max_duration_seconds": 28.08,
+                    "unique_audios": 357,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 357
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 45435,
+                    "min_text_length": 42,
+                    "average_text_length": 127.26890756302521,
+                    "max_text_length": 348,
+                    "unique_texts": 247
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 247,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 247
+                },
+                "top_ranked_statistics": null
+            },
+            "ne_np": {
+                "num_samples": 1452,
+                "number_of_characters": 88348,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 8224.14,
+                    "min_duration_seconds": 3.24,
+                    "average_duration_seconds": 11.32801652892562,
+                    "max_duration_seconds": 37.32,
+                    "unique_audios": 726,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 726
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 88348,
+                    "min_text_length": 42,
+                    "average_text_length": 121.69146005509641,
+                    "max_text_length": 358,
+                    "unique_texts": 343
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 343,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 343
+                },
+                "top_ranked_statistics": null
+            },
+            "nl_nl": {
+                "num_samples": 728,
+                "number_of_characters": 52469,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 3487.38,
+                    "min_duration_seconds": 3.6,
+                    "average_duration_seconds": 9.580714285714286,
+                    "max_duration_seconds": 23.7,
+                    "unique_audios": 364,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 364
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 52469,
+                    "min_text_length": 43,
+                    "average_text_length": 144.1456043956044,
+                    "max_text_length": 379,
+                    "unique_texts": 251
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 251,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 251
+                },
+                "top_ranked_statistics": null
+            },
+            "nso_za": {
+                "num_samples": 1580,
+                "number_of_characters": 118202,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 15128.16,
+                    "min_duration_seconds": 6.54,
+                    "average_duration_seconds": 19.149569620253164,
+                    "max_duration_seconds": 61.44,
+                    "unique_audios": 790,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 790
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 118202,
+                    "min_text_length": 45,
+                    "average_text_length": 149.62278481012657,
+                    "max_text_length": 417,
+                    "unique_texts": 341
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 341,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 341
+                },
+                "top_ranked_statistics": null
+            },
+            "ny_mw": {
+                "num_samples": 1522,
+                "number_of_characters": 105415,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 12660.3,
+                    "min_duration_seconds": 4.2,
+                    "average_duration_seconds": 16.63639947437582,
+                    "max_duration_seconds": 45.36,
+                    "unique_audios": 761,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 761
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 105415,
+                    "min_text_length": 53,
+                    "average_text_length": 138.52168199737187,
+                    "max_text_length": 417,
+                    "unique_texts": 334
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 334,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 334
+                },
+                "top_ranked_statistics": null
+            },
+            "oc_fr": {
+                "num_samples": 1996,
+                "number_of_characters": 149382,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 16231.26,
+                    "min_duration_seconds": 5.28,
+                    "average_duration_seconds": 16.2637875751503,
+                    "max_duration_seconds": 44.34,
+                    "unique_audios": 998,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 998
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 149382,
+                    "min_text_length": 48,
+                    "average_text_length": 149.6813627254509,
+                    "max_text_length": 402,
+                    "unique_texts": 350
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 350,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 350
+                },
+                "top_ranked_statistics": null
+            },
+            "om_et": {
+                "num_samples": 82,
+                "number_of_characters": 4663,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 467.94,
+                    "min_duration_seconds": 4.26,
+                    "average_duration_seconds": 11.413170731707318,
+                    "max_duration_seconds": 25.86,
+                    "unique_audios": 41,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 41
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 4663,
+                    "min_text_length": 54,
+                    "average_text_length": 113.73170731707317,
+                    "max_text_length": 228,
+                    "unique_texts": 36
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 36,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 36
+                },
+                "top_ranked_statistics": null
+            },
+            "or_in": {
+                "num_samples": 1766,
+                "number_of_characters": 118557,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 10674.64,
+                    "min_duration_seconds": 4.38,
+                    "average_duration_seconds": 12.089060022650056,
+                    "max_duration_seconds": 36.78,
+                    "unique_audios": 883,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 883
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 118557,
+                    "min_text_length": 50,
+                    "average_text_length": 134.2661381653454,
+                    "max_text_length": 349,
+                    "unique_texts": 334
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 334,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 334
+                },
+                "top_ranked_statistics": null
+            },
+            "pa_in": {
+                "num_samples": 1148,
+                "number_of_characters": 71487,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 6611.52,
+                    "min_duration_seconds": 3.96,
+                    "average_duration_seconds": 11.518327526132405,
+                    "max_duration_seconds": 28.08,
+                    "unique_audios": 574,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 574
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 71487,
+                    "min_text_length": 41,
+                    "average_text_length": 124.5418118466899,
+                    "max_text_length": 268,
+                    "unique_texts": 279
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 279,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 279
+                },
+                "top_ranked_statistics": null
+            },
+            "pl_pl": {
+                "num_samples": 1516,
+                "number_of_characters": 99994,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 7382.46,
+                    "min_duration_seconds": 3.0,
+                    "average_duration_seconds": 9.739393139841688,
+                    "max_duration_seconds": 24.48,
+                    "unique_audios": 758,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 758
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 99994,
+                    "min_text_length": 34,
+                    "average_text_length": 131.91820580474933,
+                    "max_text_length": 313,
+                    "unique_texts": 330
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 330,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 330
+                },
+                "top_ranked_statistics": null
+            },
+            "ps_af": {
+                "num_samples": 1024,
+                "number_of_characters": 59992,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 6349.68,
+                    "min_duration_seconds": 3.84,
+                    "average_duration_seconds": 12.40171875,
+                    "max_duration_seconds": 32.4,
+                    "unique_audios": 512,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 512
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 59992,
+                    "min_text_length": 34,
+                    "average_text_length": 117.171875,
+                    "max_text_length": 307,
+                    "unique_texts": 287
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 287,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 287
+                },
+                "top_ranked_statistics": null
+            },
+            "pt_br": {
+                "num_samples": 1838,
+                "number_of_characters": 126866,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 11660.1,
+                    "min_duration_seconds": 4.44,
+                    "average_duration_seconds": 12.687812840043525,
+                    "max_duration_seconds": 37.14,
+                    "unique_audios": 919,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 919
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 126866,
+                    "min_text_length": 49,
+                    "average_text_length": 138.04787812840044,
+                    "max_text_length": 381,
+                    "unique_texts": 349
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "ro_ro": {
+                "num_samples": 1766,
+                "number_of_characters": 126169,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 9099.36,
+                    "min_duration_seconds": 3.72,
+                    "average_duration_seconds": 10.305050962627407,
+                    "max_duration_seconds": 30.54,
+                    "unique_audios": 883,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 883
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 126169,
+                    "min_text_length": 47,
+                    "average_text_length": 142.8867497168743,
+                    "max_text_length": 390,
+                    "unique_texts": 348
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 348,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 348
+                },
+                "top_ranked_statistics": null
+            },
+            "ru_ru": {
+                "num_samples": 1550,
+                "number_of_characters": 106030,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 8993.82,
+                    "min_duration_seconds": 4.5,
+                    "average_duration_seconds": 11.604929032258065,
+                    "max_duration_seconds": 33.84,
+                    "unique_audios": 775,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 775
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 106030,
+                    "min_text_length": 36,
+                    "average_text_length": 136.81290322580645,
+                    "max_text_length": 343,
+                    "unique_texts": 344
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 344,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 344
+                },
+                "top_ranked_statistics": null
+            },
+            "bg_bg": {
+                "num_samples": 1316,
+                "number_of_characters": 88215,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 6686.88,
+                    "min_duration_seconds": 3.66,
+                    "average_duration_seconds": 10.16243161094225,
+                    "max_duration_seconds": 30.18,
+                    "unique_audios": 658,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 658
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 88215,
+                    "min_text_length": 43,
+                    "average_text_length": 134.06534954407294,
+                    "max_text_length": 360,
+                    "unique_texts": 344
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 344,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 344
+                },
+                "top_ranked_statistics": null
+            },
+            "sd_in": {
+                "num_samples": 1960,
+                "number_of_characters": 114294,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 11851.98,
+                    "min_duration_seconds": 4.14,
+                    "average_duration_seconds": 12.093857142857143,
+                    "max_duration_seconds": 33.96,
+                    "unique_audios": 980,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 980
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 114294,
+                    "min_text_length": 40,
+                    "average_text_length": 116.62653061224489,
+                    "max_text_length": 301,
+                    "unique_texts": 350
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 350,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 350
+                },
+                "top_ranked_statistics": null
+            },
+            "sk_sk": {
+                "num_samples": 1584,
+                "number_of_characters": 99597,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 9408.72,
+                    "min_duration_seconds": 4.26,
+                    "average_duration_seconds": 11.879696969696969,
+                    "max_duration_seconds": 30.3,
+                    "unique_audios": 792,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 792
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 99597,
+                    "min_text_length": 39,
+                    "average_text_length": 125.75378787878788,
+                    "max_text_length": 336,
+                    "unique_texts": 339
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 339,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 339
+                },
+                "top_ranked_statistics": null
+            },
+            "sl_si": {
+                "num_samples": 1668,
+                "number_of_characters": 103768,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 8173.14,
+                    "min_duration_seconds": 3.24,
+                    "average_duration_seconds": 9.799928057553958,
+                    "max_duration_seconds": 28.2,
+                    "unique_audios": 834,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 834
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 103768,
+                    "min_text_length": 42,
+                    "average_text_length": 124.4220623501199,
+                    "max_text_length": 356,
+                    "unique_texts": 347
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 347,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 347
+                },
+                "top_ranked_statistics": null
+            },
+            "sn_zw": {
+                "num_samples": 1850,
+                "number_of_characters": 132498,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 13745.4,
+                    "min_duration_seconds": 4.62,
+                    "average_duration_seconds": 14.859891891891891,
+                    "max_duration_seconds": 33.48,
+                    "unique_audios": 925,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 925
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 132498,
+                    "min_text_length": 43,
+                    "average_text_length": 143.2410810810811,
+                    "max_text_length": 393,
+                    "unique_texts": 348
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 348,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 348
+                },
+                "top_ranked_statistics": null
+            },
+            "so_so": {
+                "num_samples": 2038,
+                "number_of_characters": 152321,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 14095.92,
+                    "min_duration_seconds": 4.38,
+                    "average_duration_seconds": 13.833091265947006,
+                    "max_duration_seconds": 79.5,
+                    "unique_audios": 1019,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 1019
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 152321,
+                    "min_text_length": 50,
+                    "average_text_length": 149.48086359175662,
+                    "max_text_length": 409,
+                    "unique_texts": 350
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 350,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 350
+                },
+                "top_ranked_statistics": null
+            },
+            "sr_rs": {
+                "num_samples": 1400,
+                "number_of_characters": 85691,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 7649.48,
+                    "min_duration_seconds": 5.1,
+                    "average_duration_seconds": 10.92782857142857,
+                    "max_duration_seconds": 29.1,
+                    "unique_audios": 700,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 700
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 85691,
+                    "min_text_length": 40,
+                    "average_text_length": 122.41571428571429,
+                    "max_text_length": 348,
+                    "unique_texts": 327
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 327,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 327
+                },
+                "top_ranked_statistics": null
+            },
+            "sv_se": {
+                "num_samples": 1518,
+                "number_of_characters": 97195,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 8399.16,
+                    "min_duration_seconds": 4.02,
+                    "average_duration_seconds": 11.066086956521739,
+                    "max_duration_seconds": 31.38,
+                    "unique_audios": 759,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 759
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 97195,
+                    "min_text_length": 34,
+                    "average_text_length": 128.0566534914361,
+                    "max_text_length": 377,
+                    "unique_texts": 341
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 341,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 341
+                },
+                "top_ranked_statistics": null
+            },
+            "sw_ke": {
+                "num_samples": 974,
+                "number_of_characters": 63120,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 6939.42,
+                    "min_duration_seconds": 4.56,
+                    "average_duration_seconds": 14.249322381930185,
+                    "max_duration_seconds": 29.16,
+                    "unique_audios": 487,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 487
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 63120,
+                    "min_text_length": 40,
+                    "average_text_length": 129.6098562628337,
+                    "max_text_length": 305,
+                    "unique_texts": 312
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 312,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 312
+                },
+                "top_ranked_statistics": null
+            },
+            "ta_in": {
+                "num_samples": 1182,
+                "number_of_characters": 87879,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 7672.32,
+                    "min_duration_seconds": 3.48,
+                    "average_duration_seconds": 12.981928934010151,
+                    "max_duration_seconds": 60.0,
+                    "unique_audios": 591,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 591
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 87879,
+                    "min_text_length": 52,
+                    "average_text_length": 148.69543147208122,
+                    "max_text_length": 398,
+                    "unique_texts": 336
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 336,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 336
+                },
+                "top_ranked_statistics": null
+            },
+            "te_in": {
+                "num_samples": 944,
+                "number_of_characters": 59496,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 5216.16,
+                    "min_duration_seconds": 4.2,
+                    "average_duration_seconds": 11.051186440677967,
+                    "max_duration_seconds": 30.48,
+                    "unique_audios": 472,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 472
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 59496,
+                    "min_text_length": 45,
+                    "average_text_length": 126.05084745762711,
+                    "max_text_length": 353,
+                    "unique_texts": 302
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 302,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 302
+                },
+                "top_ranked_statistics": null
+            },
+            "tg_tj": {
+                "num_samples": 1200,
+                "number_of_characters": 83409,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 8720.94,
+                    "min_duration_seconds": 5.22,
+                    "average_duration_seconds": 14.5349,
+                    "max_duration_seconds": 45.84,
+                    "unique_audios": 600,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 600
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 83409,
+                    "min_text_length": 52,
+                    "average_text_length": 139.015,
+                    "max_text_length": 340,
+                    "unique_texts": 319
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 319,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 319
+                },
+                "top_ranked_statistics": null
+            },
+            "th_th": {
+                "num_samples": 2042,
+                "number_of_characters": 127146,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 12318.48,
+                    "min_duration_seconds": 3.06,
+                    "average_duration_seconds": 12.06511263467189,
+                    "max_duration_seconds": 46.56,
+                    "unique_audios": 1021,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 1021
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 127146,
+                    "min_text_length": 47,
+                    "average_text_length": 124.53085210577865,
+                    "max_text_length": 333,
+                    "unique_texts": 349
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 349,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 349
+                },
+                "top_ranked_statistics": null
+            },
+            "tr_tr": {
+                "num_samples": 1486,
+                "number_of_characters": 96540,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 9380.22,
+                    "min_duration_seconds": 3.84,
+                    "average_duration_seconds": 12.62479138627187,
+                    "max_duration_seconds": 36.84,
+                    "unique_audios": 743,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 743
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 96540,
+                    "min_text_length": 43,
+                    "average_text_length": 129.93270524899057,
+                    "max_text_length": 384,
+                    "unique_texts": 329
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 329,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 329
+                },
+                "top_ranked_statistics": null
+            },
+            "uk_ua": {
+                "num_samples": 1500,
+                "number_of_characters": 96247,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 8145.12,
+                    "min_duration_seconds": 4.26,
+                    "average_duration_seconds": 10.86016,
+                    "max_duration_seconds": 28.92,
+                    "unique_audios": 750,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 750
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 96247,
+                    "min_text_length": 36,
+                    "average_text_length": 128.32933333333332,
+                    "max_text_length": 328,
+                    "unique_texts": 329
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 329,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 329
+                },
+                "top_ranked_statistics": null
+            },
+            "umb_ao": {
+                "num_samples": 758,
+                "number_of_characters": 47333,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 9883.98,
+                    "min_duration_seconds": 7.92,
+                    "average_duration_seconds": 26.079102902374668,
+                    "max_duration_seconds": 104.94,
+                    "unique_audios": 379,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 379
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 47333,
+                    "min_text_length": 44,
+                    "average_text_length": 124.8891820580475,
+                    "max_text_length": 407,
+                    "unique_texts": 258
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 258,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 258
+                },
+                "top_ranked_statistics": null
+            },
+            "ur_pk": {
+                "num_samples": 598,
+                "number_of_characters": 38790,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 2931.9,
+                    "min_duration_seconds": 3.72,
+                    "average_duration_seconds": 9.805685618729097,
+                    "max_duration_seconds": 25.8,
+                    "unique_audios": 299,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 299
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 38790,
+                    "min_text_length": 38,
+                    "average_text_length": 129.73244147157192,
+                    "max_text_length": 337,
+                    "unique_texts": 230
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 230,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 230
+                },
+                "top_ranked_statistics": null
+            },
+            "uz_uz": {
+                "num_samples": 1724,
+                "number_of_characters": 124183,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 10214.88,
+                    "min_duration_seconds": 4.02,
+                    "average_duration_seconds": 11.850208816705335,
+                    "max_duration_seconds": 35.94,
+                    "unique_audios": 862,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 862
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 124183,
+                    "min_text_length": 50,
+                    "average_text_length": 144.06380510440835,
+                    "max_text_length": 379,
+                    "unique_texts": 345
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 345,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 345
+                },
+                "top_ranked_statistics": null
+            },
+            "vi_vn": {
+                "num_samples": 1714,
+                "number_of_characters": 114861,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 10813.68,
+                    "min_duration_seconds": 4.98,
+                    "average_duration_seconds": 12.61806301050175,
+                    "max_duration_seconds": 38.1,
+                    "unique_audios": 857,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 857
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 114861,
+                    "min_text_length": 48,
+                    "average_text_length": 134.02683780630105,
+                    "max_text_length": 329,
+                    "unique_texts": 347
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 347,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 347
+                },
+                "top_ranked_statistics": null
+            },
+            "wo_sn": {
+                "num_samples": 742,
+                "number_of_characters": 44405,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 6290.34,
+                    "min_duration_seconds": 5.28,
+                    "average_duration_seconds": 16.955094339622644,
+                    "max_duration_seconds": 60.24,
+                    "unique_audios": 371,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 371
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 44405,
+                    "min_text_length": 38,
+                    "average_text_length": 119.6900269541779,
+                    "max_text_length": 323,
+                    "unique_texts": 239
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 239,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 239
+                },
+                "top_ranked_statistics": null
+            },
+            "xh_za": {
+                "num_samples": 2082,
+                "number_of_characters": 141594,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 13616.64,
+                    "min_duration_seconds": 3.48,
+                    "average_duration_seconds": 13.080345821325649,
+                    "max_duration_seconds": 36.96,
+                    "unique_audios": 1041,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 1041
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 141594,
+                    "min_text_length": 43,
+                    "average_text_length": 136.0172910662824,
+                    "max_text_length": 389,
+                    "unique_texts": 350
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 350,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 350
+                },
+                "top_ranked_statistics": null
+            },
+            "yo_ng": {
+                "num_samples": 1662,
+                "number_of_characters": 98136,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 13559.16,
+                    "min_duration_seconds": 5.52,
+                    "average_duration_seconds": 16.31667870036101,
+                    "max_duration_seconds": 51.84,
+                    "unique_audios": 831,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 831
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 98136,
+                    "min_text_length": 37,
+                    "average_text_length": 118.09386281588448,
+                    "max_text_length": 332,
+                    "unique_texts": 340
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 340,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 340
+                },
+                "top_ranked_statistics": null
+            },
+            "zu_za": {
+                "num_samples": 1708,
+                "number_of_characters": 122921,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 13950.96,
+                    "min_duration_seconds": 6.18,
+                    "average_duration_seconds": 16.336018735362998,
+                    "max_duration_seconds": 46.74,
+                    "unique_audios": 854,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 854
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 122921,
+                    "min_text_length": 52,
+                    "average_text_length": 143.93559718969556,
+                    "max_text_length": 419,
+                    "unique_texts": 346
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 346,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 346
+                },
+                "top_ranked_statistics": null
+            }
+        }
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/SoundDescsA2TRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/SoundDescsA2TRetrieval.json
@@ -1,0 +1,39 @@
+{
+    "test": {
+        "num_samples": 9893,
+        "number_of_characters": 509915,
+        "documents_text_statistics": {
+            "total_text_length": 509915,
+            "min_text_length": 10,
+            "average_text_length": 103.07560137457045,
+            "max_text_length": 324,
+            "unique_texts": 4837
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": null,
+        "queries_audio_statistics": {
+            "total_duration_seconds": 552523.898638322,
+            "min_duration_seconds": 2.6466666666666665,
+            "average_duration_seconds": 111.71126135024707,
+            "max_duration_seconds": 1841.5106575963719,
+            "unique_audios": 4946,
+            "average_sampling_rate": 44124.443995147594,
+            "sampling_rates": {
+                "44100": 4915,
+                "48000": 31
+            }
+        },
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 4947,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 4947
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/SoundDescsT2ARetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/SoundDescsT2ARetrieval.json
@@ -1,0 +1,39 @@
+{
+    "test": {
+        "num_samples": 9893,
+        "number_of_characters": 509933,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": {
+            "total_duration_seconds": 552523.898638322,
+            "min_duration_seconds": 2.6466666666666665,
+            "average_duration_seconds": 111.71126135024707,
+            "max_duration_seconds": 1841.5106575963719,
+            "unique_audios": 4946,
+            "average_sampling_rate": 44124.443995147594,
+            "sampling_rates": {
+                "44100": 4915,
+                "48000": 31
+            }
+        },
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 509933,
+            "min_text_length": 10,
+            "average_text_length": 103.07923994340004,
+            "max_text_length": 324,
+            "unique_texts": 4837
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 4947,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 4947
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/tasks/classification/multilingual/vox_populi_language_id.py
+++ b/mteb/tasks/classification/multilingual/vox_populi_language_id.py
@@ -65,11 +65,8 @@ Dupoux, Emmanuel},
         test_ds = self.dataset["train"]
 
         def is_valid_audio(example):
-            try:
-                audio = example["audio"]
-                audio_arr = audio["array"]
-            except (KeyError, TypeError):
-                return False
+            audio = example["audio"]
+            audio_arr = audio["array"]
             # require at least 500 samples (so that Kaldi fbank(window_size=400) won't fail)
             if (audio_arr is None) or (len(audio_arr) < 500):
                 return False

--- a/mteb/tasks/multilabel_classification/zxx/bird_set.py
+++ b/mteb/tasks/multilabel_classification/zxx/bird_set.py
@@ -1,4 +1,4 @@
-from datasets import Sequence, Value
+from datasets import Audio, DatasetDict
 from sklearn.linear_model import LogisticRegression
 from sklearn.multioutput import MultiOutputClassifier
 
@@ -48,11 +48,10 @@ class BirdSetMultilabelClassification(AbsTaskMultilabelClassification):
     samples_per_label: int = 21
 
     def dataset_transform(self, **kwargs):
-        """Rename ebird_code_multilabel → labels and turn IDs → bird names."""
         if "ebird_code_multilabel" in self.dataset.column_names[self.eval_splits[0]]:
             self.dataset = self.dataset.rename_column(
                 original_column_name="ebird_code_multilabel",
-                new_column_name=self.label_column_name,  # "labels"
+                new_column_name=self.label_column_name,
             )
 
         id2name = {
@@ -79,35 +78,26 @@ class BirdSetMultilabelClassification(AbsTaskMultilabelClassification):
             20: "Northern Flicker",
         }
 
-        def ids_to_names(example):
-            """Convert a list of ints to a list of bird-name strings."""
-            labels = example[self.label_column_name]
-            if labels is None:
-                return {self.label_column_name: []}
-            return {self.label_column_name: [id2name[i] for i in labels]}
+        new_dataset = {}
+        for split, ds in self.dataset.items():
+            converted = [
+                [id2name[int(i)] for i in example[self.label_column_name]]
+                if example[self.label_column_name]
+                else []
+                for example in ds
+            ]
+            new_dataset[split] = (
+                ds.remove_columns(self.label_column_name)
+                .add_column(self.label_column_name, converted)
+                .filter(lambda x: bool(x[self.label_column_name]))
+            )
 
-        # Cast to int64 to remove ClassLabel schema before mapping to strings
-        self.dataset = self.dataset.cast_column(
-            self.label_column_name, Sequence(Value("int64"))
-        )
+        self.dataset = DatasetDict(new_dataset)
 
-        self.dataset = self.dataset.map(
-            ids_to_names,
-            num_proc=4,
-        )
-
-        # Filter out empty labels
-        self.dataset = self.dataset.filter(
-            lambda x: x[self.label_column_name] is not None
-            and len(x[self.label_column_name]) > 0
-        )
-
-        # Only subsample splits that are larger than n_samples to avoid division by zero
         n_samples = 2048
         splits_to_subsample = [
             split for split in self.eval_splits if len(self.dataset[split]) > n_samples
         ]
-
         if splits_to_subsample:
             self.dataset = self.stratified_subsampling(
                 self.dataset,
@@ -116,3 +106,6 @@ class BirdSetMultilabelClassification(AbsTaskMultilabelClassification):
                 label=self.label_column_name,
                 n_samples=n_samples,
             )
+
+        for split, ds in self.dataset.items():
+            self.dataset[split] = ds.cast_column("audio", Audio(sampling_rate=32000))

--- a/mteb/tasks/retrieval/multilingual/fleurs.py
+++ b/mteb/tasks/retrieval/multilingual/fleurs.py
@@ -121,7 +121,7 @@ class FleursA2TRetrieval(AbsTaskRetrieval):
         reference="https://github.com/google-research-datasets/fleurs",
         dataset={
             "path": "mteb/fleurs",
-            "revision": "720cfffb024c8a4691f26a2b79d471b1f99a49a0",
+            "revision": "cadac46d4cd7d721f5cf8844a5b9f0f20e6fcde8",
         },
         type="Any2AnyRetrieval",
         category="a2t",
@@ -168,35 +168,15 @@ class FleursA2TRetrieval(AbsTaskRetrieval):
 
             for split in self.metadata.eval_splits:
                 split_dataset = lang_dataset[split]
-
-                selected_queries = split_dataset.select_columns(["id", "audio"])
-                queries_ds = selected_queries.cast(
-                    datasets.Features(
-                        {
-                            "id": datasets.Value("string"),
-                            "audio": selected_queries.features["audio"],
-                        }
-                    )
-                ).map(
-                    lambda x: {"id": str(x["id"]), "audio": x["audio"]},
-                    desc="Converting query IDs to strings",
+                split_dataset = split_dataset.cast_column(
+                    "id", datasets.Value("string")
                 )
-                selected_corpus = split_dataset.select_columns(
+
+                queries_ds = split_dataset.select_columns(["id", "audio"])
+                corpus_ds = split_dataset.select_columns(
                     ["id", "transcription"]
                 ).rename_column("transcription", "text")
-                corpus_ds = selected_corpus.cast(
-                    datasets.Features(
-                        {
-                            "id": datasets.Value("string"),
-                            "text": selected_corpus.features["text"],
-                        }
-                    )
-                ).map(
-                    lambda x: {"id": str(x["id"]), "text": x["text"]},
-                    desc="Converting corpus IDs to strings",
-                )
 
-                # Keep IDs as strings for pytrec_eval compatibility
                 relevant_docs_ = {
                     str(row["id"]): {str(row["id"]): 1} for row in split_dataset
                 }
@@ -213,7 +193,7 @@ class FleursT2ARetrieval(AbsTaskRetrieval):
         reference="https://github.com/google-research-datasets/fleurs",
         dataset={
             "path": "mteb/fleurs",
-            "revision": "720cfffb024c8a4691f26a2b79d471b1f99a49a0",
+            "revision": "cadac46d4cd7d721f5cf8844a5b9f0f20e6fcde8",
         },
         type="Any2AnyRetrieval",
         category="t2a",
@@ -260,38 +240,18 @@ class FleursT2ARetrieval(AbsTaskRetrieval):
 
             for split in self.metadata.eval_splits:
                 split_dataset = lang_dataset[split]
+                split_dataset = split_dataset.cast_column(
+                    "id", datasets.Value("string")
+                )
 
                 # Create datasets directly without intermediate lists
-                selected_queries = split_dataset.select_columns(
+                queries_ds = split_dataset.select_columns(
                     ["id", "transcription"]
                 ).rename_column("transcription", "text")
-                queries_ds = selected_queries.cast(
-                    datasets.Features(
-                        {
-                            "id": datasets.Value("string"),
-                            "text": selected_queries.features["text"],
-                        }
-                    )
-                ).map(
-                    lambda x: {"id": str(x["id"]), "text": x["text"]},
-                    desc="Converting query IDs to strings",
-                )
 
-                selected_corpus = split_dataset.select_columns(["id", "audio"])
-                corpus_ds = selected_corpus.cast(
-                    datasets.Features(
-                        {
-                            "id": datasets.Value("string"),
-                            "audio": selected_corpus.features["audio"],
-                        }
-                    )
-                ).map(
-                    lambda x: {"id": str(x["id"]), "audio": x["audio"]},
-                    desc="Converting corpus IDs to strings",
-                )
+                corpus_ds = split_dataset.select_columns(["id", "audio"])
 
                 # Create relevant_docs mapping
-                # Keep IDs as strings for pytrec_eval compatibility
                 relevant_docs_ = {
                     str(row["id"]): {str(row["id"]): 1} for row in split_dataset
                 }

--- a/mteb/tasks/retrieval/zxx/sound_descs.py
+++ b/mteb/tasks/retrieval/zxx/sound_descs.py
@@ -8,8 +8,8 @@ class SoundDescsA2TRetrieval(AbsTaskRetrieval):
         description="Natural language description for different audio sources from the BBC Sound Effects webpage.",
         reference="https://github.com/akoepke/audio-retrieval-benchmark",
         dataset={
-            "path": "mteb/sounddescs_a2t",
-            "revision": "581617dc897ac566c8b9eaba96762102bbc0d663",
+            "path": "mteb/SoundDescsA2TRetrieval",
+            "revision": "27f6d092e00721205296ebbb44f28ff2498d6b7e",
         },
         type="Any2AnyRetrieval",
         category="a2t",
@@ -41,8 +41,8 @@ class SoundDescsT2ARetrieval(AbsTaskRetrieval):
         description="Natural language description for different audio sources from the BBC Sound Effects webpage.",
         reference="https://github.com/akoepke/audio-retrieval-benchmark",
         dataset={
-            "path": "mteb/sounddescs_t2a",
-            "revision": "5804523a933cf8dff1e737052467d106e718e202",
+            "path": "mteb/SoundDescsT2ARetrieval",
+            "revision": "cfb2f05e4b75512e650468b1bf4d15891eec5be7",
         },
         type="Any2AnyRetrieval",
         category="t2a",

--- a/mteb/tasks/retrieval/zxx/sound_descs.py
+++ b/mteb/tasks/retrieval/zxx/sound_descs.py
@@ -9,7 +9,7 @@ class SoundDescsA2TRetrieval(AbsTaskRetrieval):
         reference="https://github.com/akoepke/audio-retrieval-benchmark",
         dataset={
             "path": "mteb/sounddescs_a2t",
-            "revision": "dbdd4928c401ff122c5b0d6c66accee653b3355c",
+            "revision": "581617dc897ac566c8b9eaba96762102bbc0d663",
         },
         type="Any2AnyRetrieval",
         category="a2t",
@@ -42,7 +42,7 @@ class SoundDescsT2ARetrieval(AbsTaskRetrieval):
         reference="https://github.com/akoepke/audio-retrieval-benchmark",
         dataset={
             "path": "mteb/sounddescs_t2a",
-            "revision": "140da665f966e3871682813cf3d3030eb87d68bb",
+            "revision": "5804523a933cf8dff1e737052467d106e718e202",
         },
         type="Any2AnyRetrieval",
         category="t2a",

--- a/tests/test_tasks/test_metadata.py
+++ b/tests/test_tasks/test_metadata.py
@@ -43,18 +43,6 @@ def test_all_metadata_is_filled_and_valid(task: AbsTask):
         )
         return
 
-    # TODO https://github.com/embeddings-benchmark/mteb/issues/3498
-    if task.metadata.name in (  # noqa: PLR6201
-        "FleursA2TRetrieval",
-        "FleursT2ARetrieval",
-        "SoundDescsA2TRetrieval",
-        "SoundDescsT2ARetrieval",
-        "BirdSet",
-        "AudioSet",
-    ):
-        assert task.metadata.descriptive_stats is None
-        pytest.skip("Skipping audio tasks for now, see issue #3498")
-
     assert task.metadata.descriptive_stats is not None, (
         f"Dataset {task.metadata.name} should have descriptive stats. You can add metadata to your task by running `YourTask().calculate_descriptive_statistics()`"
     )


### PR DESCRIPTION
1. Reuploaded `fleurs` `ar_eg`, which contained 1 undecodable audio
2. Reuploaded `SoundDescs` `A2T`/`T2A` with 1 undecodable audio
3. Fixed `offset overflow while concatenating arrays` for BirdSet
4. Computed missing statistics

Close https://github.com/embeddings-benchmark/mteb/issues/3498
