### PR TITLE
fix: tolerate off-by-one frame metadata in resample_video

### DIFF
--- a/mteb/models/modality_collators.py
+++ b/mteb/models/modality_collators.py
@@ -202,7 +202,9 @@ class FramesCollator:
             num_frames: If set, select exactly this many frames uniformly
                 (fixed-sample mode).
         """
-        num_source_frames = video.metadata.num_frames
+        # Guard against torchcodec.num_frames over-counting by 1.
+        meta_num_frames = video.metadata.num_frames
+        num_source_frames = meta_num_frames - 1 if meta_num_frames else meta_num_frames
 
         if num_frames is None and fps is None:
             # No resampling: return all frames

--- a/mteb/models/modality_collators.py
+++ b/mteb/models/modality_collators.py
@@ -203,8 +203,7 @@ class FramesCollator:
                 (fixed-sample mode).
         """
         # Guard against torchcodec.num_frames over-counting by 1.
-        meta_num_frames = video.metadata.num_frames
-        num_source_frames = meta_num_frames - 1 if meta_num_frames else meta_num_frames
+        num_source_frames = video.metadata.num_frames - 1
 
         if num_frames is None and fps is None:
             # No resampling: return all frames


### PR DESCRIPTION
Mirror PR #4625 in the inference path: drop the trailing source-frame index so get_frames_at does not request a frame that fails to decode.

If you add a model or a dataset, please add the corresponding checklist:

* [dataset checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_dataset/#submit-a-pull-request)
* [model checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_model/#submitting-your-model-as-a-pr)
