### PR TITLE
docs: Update documentation for caching by default in `task.calculate_descriptive_statistics()`

### DIFF
--- a/docs/contributing/adding_a_dataset.md
+++ b/docs/contributing/adding_a_dataset.md
@@ -480,7 +480,7 @@ Once you have your task you can create a pull request (PR) to the main repositor
 
 Before creating a pull request, it is important to calculate some descriptive statistics about the dataset. This is to ensure that the dataset is not too small, does not contain duplicates and that the documents are not too short. This is important to ensure that the dataset is of high quality and that it can be used to evaluate models in a meaningful way.
 
-To calculate the descriptive statistics, you can run [`task.calculate_descriptive_statistics()`][mteb.AbsTask.calculate_descriptive_statistics]. 
+To calculate the descriptive statistics, you can run [`task.calculate_descriptive_statistics()`][mteb.AbsTask.calculate_descriptive_statistics].
 By default, this method caches the results and loads them from cache on subsequent calls. To recalculate the statistics (overwriting the cached results), use the `overwrite_results=True` parameter:
 
 ```python

--- a/docs/contributing/adding_a_dataset.md
+++ b/docs/contributing/adding_a_dataset.md
@@ -480,7 +480,21 @@ Once you have your task you can create a pull request (PR) to the main repositor
 
 Before creating a pull request, it is important to calculate some descriptive statistics about the dataset. This is to ensure that the dataset is not too small, does not contain duplicates and that the documents are not too short. This is important to ensure that the dataset is of high quality and that it can be used to evaluate models in a meaningful way.
 
-To calculate the descriptive statistics, you can simply run [`task.calculate_descriptive_statistics()`][mteb.AbsTask.calculate_descriptive_statistics].
+To calculate the descriptive statistics, you can run [`task.calculate_descriptive_statistics()`][mteb.AbsTask.calculate_descriptive_statistics]. 
+By default, this method caches the results and loads them from cache on subsequent calls. To recalculate the statistics (overwriting the cached results), use the `overwrite_results=True` parameter:
+
+```python
+task = MyTask()
+
+# First call - calculates and caches the statistics
+stats = task.calculate_descriptive_statistics()
+
+# Subsequent calls load from cache
+stats = task.calculate_descriptive_statistics()
+
+# Force recalculation and update the cache
+stats = task.calculate_descriptive_statistics(overwrite_results=True)
+```
 
 ### Submit a Pull Request
 

--- a/docs/contributing/adding_a_dataset.md
+++ b/docs/contributing/adding_a_dataset.md
@@ -481,20 +481,7 @@ Once you have your task you can create a pull request (PR) to the main repositor
 Before creating a pull request, it is important to calculate some descriptive statistics about the dataset. This is to ensure that the dataset is not too small, does not contain duplicates and that the documents are not too short. This is important to ensure that the dataset is of high quality and that it can be used to evaluate models in a meaningful way.
 
 To calculate the descriptive statistics, you can run [`task.calculate_descriptive_statistics()`][mteb.AbsTask.calculate_descriptive_statistics].
-By default, this method caches the results and loads them from cache on subsequent calls. To recalculate the statistics (overwriting the cached results), use the `overwrite_results=True` parameter:
-
-```python
-task = MyTask()
-
-# First call - calculates and caches the statistics
-stats = task.calculate_descriptive_statistics()
-
-# Subsequent calls load from cache
-stats = task.calculate_descriptive_statistics()
-
-# Force recalculation and update the cache
-stats = task.calculate_descriptive_statistics(overwrite_results=True)
-```
+By default, this method caches the results and loads them from cache on subsequent calls. To recalculate the statistics (overwriting the cached results), use the `overwrite_results=True`.
 
 ### Submit a Pull Request
 

--- a/mteb/abstasks/abstask.py
+++ b/mteb/abstasks/abstask.py
@@ -396,16 +396,15 @@ class AbsTask(ABC):  # noqa: PLR0904
             num_proc: Number of processes to use for loading the dataset and for parallel hash computation
                 across image/audio/video modalities.
 
-        Examples:
-                    >>> task = get_task("STS12")
-                    >>> # Load from cache if available
-                    >>> stats = task.calculate_descriptive_statistics()
-                    >>> # Force recalculation
-                    >>> stats = task.calculate_descriptive_statistics(overwrite_results=True)
-
-
         Returns:
             A dictionary containing descriptive statistics for each split.
+
+        Examples:
+            >>> task = get_task("STS12")
+            >>> # Load from cache if available
+            >>> stats = task.calculate_descriptive_statistics()
+            >>> # Force recalculation
+            >>> stats = task.calculate_descriptive_statistics(overwrite_results=True)
         """
         from mteb.abstasks import AbsTaskClassification
 

--- a/mteb/abstasks/abstask.py
+++ b/mteb/abstasks/abstask.py
@@ -413,10 +413,9 @@ class AbsTask(ABC):  # noqa: PLR0904
 
         if existing_stats is not None and not overwrite_results:
             logger.info(
-                f"Loaded descriptive statistics from cache for task '{self.metadata.name}'. "
+                f"Loaded metadata descriptive statistics from cache for task '{self.metadata.name}'. "
                 "To recalculate statistics, use calculate_descriptive_statistics(overwrite_results=True)."
             )
-            logger.info("Loading metadata descriptive statistics from cache.")
             return existing_stats
 
         if not self.data_loaded:

--- a/mteb/abstasks/abstask.py
+++ b/mteb/abstasks/abstask.py
@@ -390,8 +390,19 @@ class AbsTask(ABC):  # noqa: PLR0904
         """Calculates descriptive statistics from the dataset.
 
         Args:
-            overwrite_results: Whether to overwrite existing results. If False and results already exist, the existing results will be loaded from cache.
-            num_proc: Number of processes to use for loading the dataset and for parallel hash computation across image/audio/video modalities.
+            overwrite_results: Whether to recalculate and overwrite existing results.
+                If False and results already exist, the cached results will be loaded instead.
+                Use True to force recalculation.
+            num_proc: Number of processes to use for loading the dataset and for parallel hash computation
+                across image/audio/video modalities.
+
+        Examples:
+                    >>> task = get_task("STS12")
+                    >>> # Load from cache if available
+                    >>> stats = task.calculate_descriptive_statistics()
+                    >>> # Force recalculation
+                    >>> stats = task.calculate_descriptive_statistics(overwrite_results=True)
+
 
         Returns:
             A dictionary containing descriptive statistics for each split.
@@ -401,6 +412,10 @@ class AbsTask(ABC):  # noqa: PLR0904
         existing_stats = self.metadata.descriptive_stats
 
         if existing_stats is not None and not overwrite_results:
+            logger.info(
+                f"Loaded descriptive statistics from cache for task '{self.metadata.name}'. "
+                "To recalculate statistics, use calculate_descriptive_statistics(overwrite_results=True)."
+            )
             logger.info("Loading metadata descriptive statistics from cache.")
             return existing_stats
 

--- a/mteb/abstasks/abstask.py
+++ b/mteb/abstasks/abstask.py
@@ -401,7 +401,7 @@ class AbsTask(ABC):  # noqa: PLR0904
 
         Examples:
             >>> task = get_task("STS12")
-            >>> # Load from cache if available
+            >>> # Calculate desc. stats if not already calculated
             >>> stats = task.calculate_descriptive_statistics()
             >>> # Force recalculation
             >>> stats = task.calculate_descriptive_statistics(overwrite_results=True)


### PR DESCRIPTION
closes #4107
