### PR TITLE
fix: probe trailing frames in resample_video

### DIFF
--- a/mteb/models/modality_collators.py
+++ b/mteb/models/modality_collators.py
@@ -224,9 +224,15 @@ class FramesCollator:
         # Retry on the actual call: decrement source count when trailing
         # frames fail to decode.
         n = video.metadata.num_frames
+        original_n = n
         while n > 0:
             try:
                 frames: torch.Tensor = video.get_frames_at(_indices(n)).data
+                if n < original_n:
+                    logger.warning(
+                        "Dropped %d undecodable trailing frame(s) from video",
+                        original_n - n,
+                    )
                 return frames
             except RuntimeError as e:
                 if "no more frames" not in str(e):

--- a/mteb/models/modality_collators.py
+++ b/mteb/models/modality_collators.py
@@ -205,45 +205,31 @@ class FramesCollator:
             num_frames: If set, select exactly this many frames uniformly
                 (fixed-sample mode).
         """
-        # Probe backwards: trailing frames may not decode.
-        num_source_frames = video.metadata.num_frames
-        while num_source_frames > 0:
+
+        def _indices(n_source: int) -> list[int]:
+            if num_frames is None and fps is None:
+                return list(range(n_source))
+            if num_frames is not None:
+                target = num_frames
+            else:
+                duration = video.metadata.end_stream_seconds
+                target = max(1, int(duration * fps))
+                if max_frames is not None:
+                    target = min(target, max_frames)
+            if num_frames is not None and n_source < target:
+                return (list(range(n_source)) * ((target // n_source) + 1))[:target]
+            step = max(1, n_source // target)
+            return list(range(0, n_source, step))[:target]
+
+        # Retry on the actual call: decrement source count when trailing
+        # frames fail to decode.
+        n = video.metadata.num_frames
+        while n > 0:
             try:
-                video.get_frame_at(num_source_frames - 1)
-                break
+                return cast("torch.Tensor", video.get_frames_at(_indices(n)).data)
             except Exception:
-                num_source_frames -= 1
-        if num_source_frames == 0:
-            raise RuntimeError("video has no decodable frames")
-
-        if num_frames is None and fps is None:
-            # No resampling: return all frames
-            frames = cast(
-                "torch.Tensor", video.get_frames_at(list(range(num_source_frames))).data
-            )
-            return frames
-
-        if num_frames is not None:
-            # Fixed-sample mode: always select exactly num_frames
-            target = num_frames
-        else:
-            # FPS-based mode: scale with duration
-            duration = video.metadata.end_stream_seconds
-            target = max(1, int(duration * fps))
-            if max_frames is not None:
-                target = min(target, max_frames)
-
-        if num_frames is not None and num_source_frames < target:
-            # Repeat frames to reach exactly ``num_frames``.
-            selected_frames = (
-                list(range(num_source_frames)) * ((target // num_source_frames) + 1)
-            )[:target]
-        else:
-            frame_step = max(1, num_source_frames // target)
-            selected_frames = list(range(0, num_source_frames, frame_step))[:target]
-        frames = video.get_frames_at(selected_frames).data
-        frames = cast("torch.Tensor", frames)
-        return frames
+                n -= 1
+        raise RuntimeError("video has no decodable frames")
 
 
 class VideoCollator:

--- a/mteb/models/modality_collators.py
+++ b/mteb/models/modality_collators.py
@@ -226,8 +226,9 @@ class FramesCollator:
         n = video.metadata.num_frames
         while n > 0:
             try:
-                return cast("torch.Tensor", video.get_frames_at(_indices(n)).data)
-            except Exception:
+                frames: torch.Tensor = video.get_frames_at(_indices(n)).data
+                return frames
+            except RuntimeError:
                 n -= 1
         raise RuntimeError("video has no decodable frames")
 

--- a/mteb/models/modality_collators.py
+++ b/mteb/models/modality_collators.py
@@ -228,7 +228,9 @@ class FramesCollator:
             try:
                 frames: torch.Tensor = video.get_frames_at(_indices(n)).data
                 return frames
-            except RuntimeError:
+            except RuntimeError as e:
+                if "no more frames" not in str(e):
+                    raise
                 n -= 1
         raise RuntimeError("video has no decodable frames")
 

--- a/mteb/models/modality_collators.py
+++ b/mteb/models/modality_collators.py
@@ -205,8 +205,16 @@ class FramesCollator:
             num_frames: If set, select exactly this many frames uniformly
                 (fixed-sample mode).
         """
-        # Guard against torchcodec.num_frames over-counting by 1.
-        num_source_frames = video.metadata.num_frames - 1
+        # Probe backwards: trailing frames may not decode.
+        num_source_frames = video.metadata.num_frames
+        while num_source_frames > 0:
+            try:
+                video.get_frame_at(num_source_frames - 1)
+                break
+            except Exception:
+                num_source_frames -= 1
+        if num_source_frames == 0:
+            raise RuntimeError("video has no decodable frames")
 
         if num_frames is None and fps is None:
             # No resampling: return all frames


### PR DESCRIPTION
Replace the unconditional -1 workaround with a backwards probe so healthy videos keep all frames and clips with multiple damaged trailing frames (e.g. HMDB51 AVIs) still decode.

If you add a model or a dataset, please add the corresponding checklist:

* [dataset checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_dataset/#submit-a-pull-request)
* [model checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_model/#submitting-your-model-as-a-pr)
