### PR TITLE
fix: Load aggregated results from task results

### DIFF
--- a/mteb/evaluate.py
+++ b/mteb/evaluate.py
@@ -404,7 +404,7 @@ def evaluate(  # noqa: PLR0913, PLR0914
                 tasks, meta, cache, agg_strategy
             )
         except Exception:
-            if agg_strategy != OverwriteStrategy.ONLY_CACHE:
+            if agg_strategy == OverwriteStrategy.NEVER:
                 raise
             existing_results = None
             missing_eval = dict.fromkeys(tasks.eval_splits, tasks.hf_subsets)

--- a/mteb/evaluate.py
+++ b/mteb/evaluate.py
@@ -407,7 +407,7 @@ def evaluate(  # noqa: PLR0913, PLR0914
             if agg_strategy != OverwriteStrategy.ONLY_CACHE:
                 raise
             existing_results = None
-            missing_eval = True
+            missing_eval = dict.fromkeys(tasks.eval_splits, tasks.hf_subsets)
 
         if (
             existing_results

--- a/mteb/evaluate.py
+++ b/mteb/evaluate.py
@@ -287,11 +287,14 @@ def _check_cache(
 
     if (
         existing_results
-        and overwrite_strategy
-        not in (OverwriteStrategy.ALWAYS, OverwriteStrategy.NEVER)  # noqa: PLR6201
+        and overwrite_strategy != OverwriteStrategy.ALWAYS
         and (
-            not _requires_merge(task, existing_results)
-            or existing_results.is_mergeable(task)
+            overwrite_strategy
+            in [OverwriteStrategy.NEVER, OverwriteStrategy.ONLY_CACHE]  # noqa: PLR6201
+            or (
+                not _requires_merge(task, existing_results)
+                or existing_results.is_mergeable(task)
+            )
         )
     ):
         missing_eval = existing_results.get_missing_evaluations(task)
@@ -304,13 +307,15 @@ def _check_cache(
         OverwriteStrategy.ONLY_CACHE,
     ]:
         if existing_results is None:
+            if overwrite_strategy == OverwriteStrategy.ONLY_CACHE:
+                raise ValueError(
+                    f"overwrite_strategy is set to '{overwrite_strategy.value}' but no results found in cache for task {task.metadata.name}."
+                )
+        else:
             raise ValueError(
-                f"overwrite_strategy is set to '{overwrite_strategy.value}' but no results found in cache for task {task.metadata.name}."
+                f"overwrite_strategy is set to '{overwrite_strategy.value}' and the results file exists for task {task.metadata.name}. "
+                + f"However there are the following missing splits (and subsets): {missing_eval}. To rerun these set overwrite_strategy to 'only-missing'."
             )
-        raise ValueError(
-            f"overwrite_strategy is set to '{overwrite_strategy.value}' and the results file exists for task {task.metadata.name}. "
-            + f"However there are the following missing splits (and subsets): {missing_eval}. To rerun these set overwrite_strategy to 'only-missing'."
-        )
 
     return existing_results, missing_eval
 
@@ -394,7 +399,15 @@ def evaluate(  # noqa: PLR0913, PLR0914
     # AbsTaskAggregate is a special case where we have to run multiple tasks and combine the results
     if isinstance(tasks, AbsTaskAggregate):
         agg_strategy = OverwriteStrategy.from_str(overwrite_strategy)
-        existing_results, missing_eval = _check_cache(tasks, meta, cache, agg_strategy)
+        try:
+            existing_results, missing_eval = _check_cache(
+                tasks, meta, cache, agg_strategy
+            )
+        except Exception:
+            if agg_strategy != OverwriteStrategy.ONLY_CACHE:
+                raise
+            existing_results = None
+            missing_eval = True
 
         if (
             existing_results
@@ -426,7 +439,7 @@ def evaluate(  # noqa: PLR0913, PLR0914
         combined_results = tasks.combine_task_results(results.task_results)
 
         if existing_results:
-            combined_results = combined_results.merge(existing_results)
+            combined_results = existing_results.merge(combined_results)
 
         if cache:
             cache.save_to_cache(

--- a/mteb/evaluate.py
+++ b/mteb/evaluate.py
@@ -394,16 +394,16 @@ def evaluate(  # noqa: PLR0913, PLR0914
 
     model, meta, model_name, model_revision = _sanitize_model(model)
     _check_model_modalities(meta, tasks)
+    overwrite_strategy = OverwriteStrategy.from_str(overwrite_strategy)
 
     # AbsTaskAggregate is a special case where we have to run multiple tasks and combine the results
     if isinstance(tasks, AbsTaskAggregate):
-        agg_strategy = OverwriteStrategy.from_str(overwrite_strategy)
         try:
             existing_results, missing_eval = _check_cache(
-                tasks, meta, cache, agg_strategy
+                tasks, meta, cache, overwrite_strategy
             )
         except Exception:
-            if agg_strategy == OverwriteStrategy.NEVER:
+            if overwrite_strategy == OverwriteStrategy.NEVER:
                 raise
             existing_results = None
             missing_eval = dict.fromkeys(tasks.eval_splits, tasks.hf_subsets)
@@ -411,7 +411,7 @@ def evaluate(  # noqa: PLR0913, PLR0914
         if (
             existing_results
             and not missing_eval
-            and agg_strategy != OverwriteStrategy.ALWAYS
+            and overwrite_strategy != OverwriteStrategy.ALWAYS
         ):
             logger.info(
                 f"Results for {tasks.metadata.name} already exist in cache. Skipping evaluation and loading results."
@@ -489,7 +489,6 @@ def evaluate(  # noqa: PLR0913, PLR0914
             exceptions=exceptions,
         )
 
-    overwrite_strategy = OverwriteStrategy.from_str(overwrite_strategy)
     existing_results, missing_eval = _check_cache(task, meta, cache, overwrite_strategy)
 
     if (

--- a/mteb/evaluate.py
+++ b/mteb/evaluate.py
@@ -285,27 +285,26 @@ def _check_cache(
         if cache_results:
             existing_results = cache_results
 
+    dont_overwrite = overwrite_strategy in {
+        OverwriteStrategy.NEVER,
+        OverwriteStrategy.ONLY_CACHE,
+    }
+    is_mergable = existing_results is not None and (
+        not _requires_merge(task, existing_results)
+        or existing_results.is_mergeable(task)
+    )
+
     if (
         existing_results
         and overwrite_strategy != OverwriteStrategy.ALWAYS
-        and (
-            overwrite_strategy
-            in [OverwriteStrategy.NEVER, OverwriteStrategy.ONLY_CACHE]  # noqa: PLR6201
-            or (
-                not _requires_merge(task, existing_results)
-                or existing_results.is_mergeable(task)
-            )
-        )
+        and (dont_overwrite or is_mergable)
     ):
         missing_eval = existing_results.get_missing_evaluations(task)
     else:
         missing_eval = dict.fromkeys(task.eval_splits, task.hf_subsets)
         existing_results = None
 
-    if missing_eval and overwrite_strategy in [  # noqa: PLR6201
-        OverwriteStrategy.NEVER,
-        OverwriteStrategy.ONLY_CACHE,
-    ]:
+    if missing_eval and dont_overwrite:
         if existing_results is None:
             if overwrite_strategy == OverwriteStrategy.ONLY_CACHE:
                 raise ValueError(

--- a/mteb/evaluate.py
+++ b/mteb/evaluate.py
@@ -272,6 +272,49 @@ def _requires_merge(task: AbsTask, existing_results: TaskResult) -> bool:
     return False
 
 
+def _check_cache(
+    task: AbsTask,
+    meta: ModelMeta,
+    cache: ResultCache | None,
+    overwrite_strategy: OverwriteStrategy,
+) -> tuple[TaskResult | None, dict[str, list[str]]]:
+    """Load cached results, handle early skipping if up-to-date, or validate compatibility."""
+    existing_results: TaskResult | None = None
+    if cache and overwrite_strategy != OverwriteStrategy.ALWAYS:
+        cache_results = cache.load_task_result(task.metadata.name, meta)
+        if cache_results:
+            existing_results = cache_results
+
+    if (
+        existing_results
+        and overwrite_strategy
+        not in (OverwriteStrategy.ALWAYS, OverwriteStrategy.NEVER)  # noqa: PLR6201
+        and (
+            not _requires_merge(task, existing_results)
+            or existing_results.is_mergeable(task)
+        )
+    ):
+        missing_eval = existing_results.get_missing_evaluations(task)
+    else:
+        missing_eval = dict.fromkeys(task.eval_splits, task.hf_subsets)
+        existing_results = None
+
+    if missing_eval and overwrite_strategy in [  # noqa: PLR6201
+        OverwriteStrategy.NEVER,
+        OverwriteStrategy.ONLY_CACHE,
+    ]:
+        if existing_results is None:
+            raise ValueError(
+                f"overwrite_strategy is set to '{overwrite_strategy.value}' but no results found in cache for task {task.metadata.name}."
+            )
+        raise ValueError(
+            f"overwrite_strategy is set to '{overwrite_strategy.value}' and the results file exists for task {task.metadata.name}. "
+            + f"However there are the following missing splits (and subsets): {missing_eval}. To rerun these set overwrite_strategy to 'only-missing'."
+        )
+
+    return existing_results, missing_eval
+
+
 def evaluate(  # noqa: PLR0913, PLR0914
     model: ModelMeta | MTEBModels | SentenceTransformer | CrossEncoder,
     tasks: AbsTask | Iterable[AbsTask],
@@ -350,6 +393,23 @@ def evaluate(  # noqa: PLR0913, PLR0914
 
     # AbsTaskAggregate is a special case where we have to run multiple tasks and combine the results
     if isinstance(tasks, AbsTaskAggregate):
+        agg_strategy = OverwriteStrategy.from_str(overwrite_strategy)
+        existing_results, missing_eval = _check_cache(tasks, meta, cache, agg_strategy)
+
+        if (
+            existing_results
+            and not missing_eval
+            and agg_strategy != OverwriteStrategy.ALWAYS
+        ):
+            logger.info(
+                f"Results for {tasks.metadata.name} already exist in cache. Skipping evaluation and loading results."
+            )
+            return ModelResult(
+                model_name=model_name,
+                model_revision=model_revision,
+                task_results=[existing_results],
+            )
+
         results = evaluate(
             model,
             tasks.metadata.tasks,
@@ -364,6 +424,10 @@ def evaluate(  # noqa: PLR0913, PLR0914
             num_proc=num_proc,
         )
         combined_results = tasks.combine_task_results(results.task_results)
+
+        if existing_results:
+            combined_results = combined_results.merge(existing_results)
+
         if cache:
             cache.save_to_cache(
                 combined_results,
@@ -375,6 +439,7 @@ def evaluate(  # noqa: PLR0913, PLR0914
             model_name=results.model_name,
             model_revision=results.model_revision,
             task_results=[combined_results],
+            exceptions=results.exceptions,
         )
 
     if isinstance(tasks, AbsTask):
@@ -413,27 +478,7 @@ def evaluate(  # noqa: PLR0913, PLR0914
         )
 
     overwrite_strategy = OverwriteStrategy.from_str(overwrite_strategy)
-
-    existing_results: TaskResult | None = None
-    if cache and overwrite_strategy != OverwriteStrategy.ALWAYS:
-        cache_results = cache.load_task_result(task.metadata.name, meta)
-        if cache_results:
-            existing_results = cache_results
-
-    if (
-        existing_results
-        and overwrite_strategy
-        not in (OverwriteStrategy.ALWAYS, OverwriteStrategy.NEVER)  # noqa: PLR6201
-        and (
-            not _requires_merge(task, existing_results)
-            or existing_results.is_mergeable(task)
-        )
-    ):
-        missing_eval = existing_results.get_missing_evaluations(task)
-    else:
-        missing_eval = dict.fromkeys(task.eval_splits, task.hf_subsets)
-        # Will be fully recomputed so we set it to None to avoid merging:
-        existing_results = None
+    existing_results, missing_eval = _check_cache(task, meta, cache, overwrite_strategy)
 
     if (
         existing_results
@@ -449,19 +494,6 @@ def evaluate(  # noqa: PLR0913, PLR0914
             model_revision=model_revision,
             task_results=[existing_results],
         )
-    if missing_eval and overwrite_strategy in [  # noqa: PLR6201
-        OverwriteStrategy.NEVER,
-        OverwriteStrategy.ONLY_CACHE,
-    ]:
-        if existing_results is None:
-            raise ValueError(
-                f"overwrite_strategy is set to '{overwrite_strategy.value}' but no results found in cache for task {task.metadata.name}."
-            )
-        raise ValueError(
-            f"overwrite_strategy is set to '{overwrite_strategy.value}' and the results file exists for task {task.metadata.name}. "
-            + f"However there are the following missing splits (and subsets): {missing_eval}. To rerun these set overwrite_strategy to 'only-missing'."
-        )
-
     if existing_results:
         logger.info(
             f"Found existing results for {task.metadata.name}, only running missing splits (subsets): {missing_eval}"

--- a/mteb/evaluate.py
+++ b/mteb/evaluate.py
@@ -296,9 +296,7 @@ def _check_cache(
     # Load results from the cache if the overwrite strategy allows it
     existing_results: TaskResult | None = None
     if cache and overwrite_strategy != OverwriteStrategy.ALWAYS:
-        cache_results = cache.load_task_result(task.metadata.name, meta)
-        if cache_results:
-            existing_results = cache_results
+        existing_results = cache.load_task_result(task.metadata.name, meta)
 
     dont_overwrite = overwrite_strategy in {
         OverwriteStrategy.NEVER,
@@ -306,17 +304,13 @@ def _check_cache(
     }
 
     # Check if the cached results are compatible/mergeable with the current task definition
-    is_mergable = existing_results is not None and (
+    is_mergeable = existing_results is not None and (
         not _requires_merge(task, existing_results)
         or existing_results.is_mergeable(task)
     )
 
     # Determine missing splits and subsets
-    if (
-        existing_results
-        and overwrite_strategy != OverwriteStrategy.ALWAYS
-        and (dont_overwrite or is_mergable)
-    ):
+    if existing_results and (dont_overwrite or is_mergeable):
         # Cache exists and is compatible, compute missing evaluations to potentially resume
         missing_eval = existing_results.get_missing_evaluations(task)
     else:

--- a/mteb/evaluate.py
+++ b/mteb/evaluate.py
@@ -306,15 +306,22 @@ def _check_cache(
 
     if missing_eval and dont_overwrite:
         if existing_results is None:
-            if overwrite_strategy == OverwriteStrategy.ONLY_CACHE:
+            if (
+                not isinstance(task, AbsTaskAggregate)
+                and overwrite_strategy == OverwriteStrategy.ONLY_CACHE
+            ):
                 raise ValueError(
                     f"overwrite_strategy is set to '{overwrite_strategy.value}' but no results found in cache for task {task.metadata.name}."
                 )
-        else:
+        elif (
+            not isinstance(task, AbsTaskAggregate)
+            or overwrite_strategy == OverwriteStrategy.NEVER
+        ):
             raise ValueError(
                 f"overwrite_strategy is set to '{overwrite_strategy.value}' and the results file exists for task {task.metadata.name}. "
                 + f"However there are the following missing splits (and subsets): {missing_eval}. To rerun these set overwrite_strategy to 'only-missing'."
             )
+        existing_results = None
 
     return existing_results, missing_eval
 
@@ -398,15 +405,9 @@ def evaluate(  # noqa: PLR0913, PLR0914
 
     # AbsTaskAggregate is a special case where we have to run multiple tasks and combine the results
     if isinstance(tasks, AbsTaskAggregate):
-        try:
-            existing_results, missing_eval = _check_cache(
-                tasks, meta, cache, overwrite_strategy
-            )
-        except Exception:
-            if overwrite_strategy == OverwriteStrategy.NEVER:
-                raise
-            existing_results = None
-            missing_eval = dict.fromkeys(tasks.eval_splits, tasks.hf_subsets)
+        existing_results, missing_eval = _check_cache(
+            tasks, meta, cache, overwrite_strategy
+        )
 
         if (
             existing_results

--- a/mteb/evaluate.py
+++ b/mteb/evaluate.py
@@ -278,7 +278,22 @@ def _check_cache(
     cache: ResultCache | None,
     overwrite_strategy: OverwriteStrategy,
 ) -> tuple[TaskResult | None, dict[str, list[str]]]:
-    """Load cached results, handle early skipping if up-to-date, or validate compatibility."""
+    """Load cached results, handle early skipping if up-to-date, or validate compatibility.
+
+    Args:
+        task: The task to evaluate.
+        meta: Metadata of the model being evaluated.
+        cache: The cache database or file system layer.
+        overwrite_strategy: The strategy to handle existing cache results.
+
+    Returns:
+        A tuple containing:
+            - The cached TaskResult if it is compatible and we want to resume/skip.
+              Returns None if we need to re-run from scratch.
+            - A dictionary mapping evaluation split names to a list of missing subset names.
+              Returns an empty dict if no splits or subsets are missing.
+    """
+    # Load results from the cache if the overwrite strategy allows it
     existing_results: TaskResult | None = None
     if cache and overwrite_strategy != OverwriteStrategy.ALWAYS:
         cache_results = cache.load_task_result(task.metadata.name, meta)
@@ -289,23 +304,32 @@ def _check_cache(
         OverwriteStrategy.NEVER,
         OverwriteStrategy.ONLY_CACHE,
     }
+
+    # Check if the cached results are compatible/mergeable with the current task definition
     is_mergable = existing_results is not None and (
         not _requires_merge(task, existing_results)
         or existing_results.is_mergeable(task)
     )
 
+    # Determine missing splits and subsets
     if (
         existing_results
         and overwrite_strategy != OverwriteStrategy.ALWAYS
         and (dont_overwrite or is_mergable)
     ):
+        # Cache exists and is compatible, compute missing evaluations to potentially resume
         missing_eval = existing_results.get_missing_evaluations(task)
     else:
+        # Cache is missing, incompatible, or we are forcing an overwrite: re-run all splits/subsets
         missing_eval = dict.fromkeys(task.eval_splits, task.hf_subsets)
         existing_results = None
 
+    # Enforce dont_overwrite constraints (NEVER and ONLY_CACHE strategies)
     if missing_eval and dont_overwrite:
         if existing_results is None:
+            # Cache is completely missing (or incompatible)
+            # - For normal tasks, ONLY_CACHE strategy must raise ValueError since it cannot evaluate.
+            # - For AbsTaskAggregate, we don't raise here; it will fall back to evaluating subtasks recursively.
             if (
                 not isinstance(task, AbsTaskAggregate)
                 and overwrite_strategy == OverwriteStrategy.ONLY_CACHE
@@ -313,6 +337,10 @@ def _check_cache(
                 raise ValueError(
                     f"overwrite_strategy is set to '{overwrite_strategy.value}' but no results found in cache for task {task.metadata.name}."
                 )
+        # Cache results file exists but some splits/subsets are missing
+        # - For normal tasks, raising ValueError prevents silent overwrite under NEVER or ONLY_CACHE.
+        # - For AbsTaskAggregate, NEVER must raise to prevent overwriting the existing incomplete result file,
+        #   but ONLY_CACHE skips raising here to allow merging cached subtask results.
         elif (
             not isinstance(task, AbsTaskAggregate)
             or overwrite_strategy == OverwriteStrategy.NEVER

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -101,6 +101,16 @@ def test_evaluate_with_cache(
         "main score should match the expected value"
     )
 
+    # test cache never strategy
+    never_results = mteb.evaluate(model, task, cache=cache, overwrite_strategy="never")
+    assert never_results[0].get_score() == expected_score
+
+    cache_empty = ResultCache(tmp_path / "empty")
+    results_empty = mteb.evaluate(
+        model, task, cache=cache_empty, overwrite_strategy="never"
+    )
+    assert len(results_empty.task_results) == 1
+
 
 @pytest.mark.parametrize(
     "model, task, expected_score,splits",
@@ -227,20 +237,33 @@ def test_evaluate_aggregated_task():
 
 
 def test_evaluate_aggregated_task_with_cache(tmp_path):
+    """Test evaluating an aggregate task with caching.
+
+    Verifies both that:
+    1. If the aggregate file is missing but all sub-tasks are cached, it falls back
+       to combining the cached subtask results under ONLY_CACHE strategy.
+    2. Once the aggregate file is generated and saved, it can be loaded directly
+       on subsequent runs without re-evaluating or calling fallback.
+    """
     model = mteb.get_model("mteb/baseline-random-encoder")
     task = MockAggregatedTask()
     cache = ResultCache(tmp_path)
 
-    results = mteb.evaluate(model, task, cache=cache)
-    assert len(results.task_results) == 1
-    score1 = results.task_results[0].get_score()
+    for subtask in task.metadata.tasks:
+        mteb.evaluate(model, subtask, cache=cache)
 
     path = cache.get_task_result_path(
         task.metadata.name,
-        results.model_name.replace("/", "__"),
-        results.model_revision,
+        model.mteb_model_meta.model_name_as_path(),
+        model.mteb_model_meta.revision,
     )
-    assert path.exists() and path.is_file()
+    assert not path.exists()
+
+    results = mteb.evaluate(model, task, cache=cache, overwrite_strategy="only-cache")
+    assert len(results.task_results) == 1
+    score1 = results.task_results[0].get_score()
+    assert path.exists()
+
     cached_results = mteb.evaluate(
         model, task, cache=cache, overwrite_strategy="only-cache"
     )

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -243,11 +243,13 @@ def test_evaluate_aggregated_task_with_cache(tmp_path):
     1. If the aggregate file is missing but all sub-tasks are cached, it falls back
        to combining the cached subtask results under ONLY_CACHE strategy.
     2. Once the aggregate file is generated and saved, it can be loaded directly
-       on subsequent runs without re-evaluating or calling fallback.
+       on subsequent runs without re-evaluating or calling fallback (verified
+       by deleting the individual sub-task cache files prior to the second call).
     """
     model = mteb.get_model("mteb/baseline-random-encoder")
     task = MockAggregatedTask()
     cache = ResultCache(tmp_path)
+    # evaluate tasks individually
     mteb.evaluate(model, task.metadata.tasks, cache=cache)
 
     path = cache.get_task_result_path(
@@ -256,11 +258,21 @@ def test_evaluate_aggregated_task_with_cache(tmp_path):
         model.mteb_model_meta.revision,
     )
     assert not path.exists()
-
+    # should be able to load results even if aggregated task results do not exist
     results = mteb.evaluate(model, task, cache=cache, overwrite_strategy="only-cache")
     assert len(results.task_results) == 1
     score1 = results.task_results[0].get_score()
     assert path.exists()
+
+    # Delete individual sub-task cache files to ensure we load from the aggregate file
+    for subtask in task.metadata.tasks:
+        sub_path = cache.get_task_result_path(
+            subtask.metadata.name,
+            model.mteb_model_meta.model_name_as_path(),
+            model.mteb_model_meta.revision,
+        )
+        sub_path.unlink()
+        assert not sub_path.exists()
 
     cached_results = mteb.evaluate(
         model, task, cache=cache, overwrite_strategy="only-cache"

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -248,9 +248,7 @@ def test_evaluate_aggregated_task_with_cache(tmp_path):
     model = mteb.get_model("mteb/baseline-random-encoder")
     task = MockAggregatedTask()
     cache = ResultCache(tmp_path)
-
-    for subtask in task.metadata.tasks:
-        mteb.evaluate(model, subtask, cache=cache)
+    mteb.evaluate(model, task.metadata.tasks, cache=cache)
 
     path = cache.get_task_result_path(
         task.metadata.name,

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -226,6 +226,28 @@ def test_evaluate_aggregated_task():
     mteb.evaluate(model, task, cache=None)
 
 
+def test_evaluate_aggregated_task_with_cache(tmp_path):
+    model = mteb.get_model("mteb/baseline-random-encoder")
+    task = MockAggregatedTask()
+    cache = ResultCache(tmp_path)
+
+    results = mteb.evaluate(model, task, cache=cache)
+    assert len(results.task_results) == 1
+    score1 = results.task_results[0].get_score()
+
+    path = cache.get_task_result_path(
+        task.metadata.name,
+        results.model_name.replace("/", "__"),
+        results.model_revision,
+    )
+    assert path.exists() and path.is_file()
+    cached_results = mteb.evaluate(
+        model, task, cache=cache, overwrite_strategy="only-cache"
+    )
+    assert len(cached_results.task_results) == 1
+    assert cached_results.task_results[0].get_score() == pytest.approx(score1)
+
+
 def test_run_private_task_warning(caplog):
     """Test that a warning is correctly logged in an attempt run a private dataset is made"""
     task = mteb.get_task("Code1Retrieval")

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -101,15 +101,53 @@ def test_evaluate_with_cache(
         "main score should match the expected value"
     )
 
-    # test cache never strategy
-    never_results = mteb.evaluate(model, task, cache=cache, overwrite_strategy="never")
-    assert never_results[0].get_score() == expected_score
 
+def test_evaluate_with_overwrite_strategy_never(tmp_path: Path):
+    model = MockSentenceTransformer()
+    task = MockClassificationTask()
+    cache = ResultCache(tmp_path)
+
+    # First run should run evaluation and write to cache
+    results = mteb.evaluate(model, task, cache=cache, co2_tracker=False)
+    path = cache.get_task_result_path(
+        task.metadata.name,
+        results.model_name.replace("/", "__"),
+        results.model_revision,
+    )
+    assert path.exists(), "cache file should be written"
+    with Path(path).open("r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    dummy_score = 999.0
+    data["scores"]["test"][0]["main_score"] = dummy_score
+
+    with Path(path).open("w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+    initial_mtime = path.stat().st_mtime
+
+    # Second run with "never" should load from cache and NOT overwrite it
+    never_results = mteb.evaluate(
+        model, task, cache=cache, overwrite_strategy="never", co2_tracker=False
+    )
+
+    assert never_results[0].get_score() == dummy_score
+    assert path.stat().st_mtime == initial_mtime
+    with Path(path).open("r", encoding="utf-8") as f:
+        assert json.load(f)["scores"]["test"][0]["main_score"] == dummy_score
+
+    # Third run with an empty cache should run and write to cache
     cache_empty = ResultCache(tmp_path / "empty")
     results_empty = mteb.evaluate(
-        model, task, cache=cache_empty, overwrite_strategy="never"
+        model, task, cache=cache_empty, overwrite_strategy="never", co2_tracker=False
     )
     assert len(results_empty.task_results) == 1
+    empty_path = cache_empty.get_task_result_path(
+        task.metadata.name,
+        results_empty.model_name.replace("/", "__"),
+        results_empty.model_revision,
+    )
+    assert empty_path.exists()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -119,7 +119,9 @@ def test_evaluate_with_overwrite_strategy_never(tmp_path: Path):
         data = json.load(f)
 
     dummy_score = 999.0
-    data["scores"]["test"][0]["main_score"] = dummy_score
+    for split in data["scores"]:
+        for score_dict in data["scores"][split]:
+            score_dict["main_score"] = dummy_score
 
     with Path(path).open("w", encoding="utf-8") as f:
         json.dump(data, f)


### PR DESCRIPTION
closes #3974 

This PR adds `_check_cache()` to prevent crashes when no cached results exist. It fixes `NEVER` and `ONLY_CACHE` strategies to correctly retain cached results and only raise errors when missing evaluations are actually detected and ensure new evaluations merge into cached results without being overwritten.