### PR TITLE
model: add jcorners/ingot-8b-r3 (API-backed)

### DIFF
--- a/mteb/models/model_implementations/ingot_models.py
+++ b/mteb/models/model_implementations/ingot_models.py
@@ -1,0 +1,171 @@
+"""MTEB API loader for jcorners/ingot-8b-r3 — served at https://api-mteb.voxell.ai/.
+
+To enable: drop this file at mteb/models/model_implementations/ingot_models.py in
+the embeddings-benchmark/mteb fork. mteb 2.12.30 auto-discovers files in that
+directory; no edit to mteb/models/__init__.py is needed.
+
+Environment:
+    MTEB_API_KEY  Bearer token. Required — no demo key is shipped in this file.
+                  Request a per-reviewer key via https://voxell.ai (reference
+                  your MTEB PR/eval); 200 rpm slot, audited per tenant.
+    MTEB_API_URL  Override the base URL (default https://api-mteb.voxell.ai).
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import requests
+
+from mteb.models.abs_encoder import AbsEncoder
+from mteb.models.model_meta import ModelMeta, ScoringFunction
+from mteb.types import PromptType
+
+if TYPE_CHECKING:
+    from torch.utils.data import DataLoader
+
+    from mteb.abstasks.task_metadata import TaskMetadata
+    from mteb.types import Array, BatchedInput
+
+MTEB_API_DEMO_KEY = None  # no key shipped in this file; reviewers request per-reviewer keys (see module docstring)
+DEFAULT_BASE_URL = "https://api-mteb.voxell.ai"
+# Client-side body cap. Gateway enforces 8 MiB (see gateway/mteb-api-gateway/src/index.ts:35);
+# 7 MiB default leaves ~1 MiB headroom for headers + JSON overhead.
+MAX_BODY_MB = int(os.environ.get("MTEB_API_MAX_BODY_MB", "7"))
+
+
+class IngotAPIEncoder(AbsEncoder):
+    def __init__(
+        self,
+        model_name: str = "jcorners/ingot-8b-r3",
+        base_url: str | None = None,
+        api_key: str | None = None,
+        timeout_s: float = 300.0,
+        max_retries: int = 3,
+        **_kwargs: Any,
+    ) -> None:
+        self.model_name = model_name
+        self.base_url = (base_url or os.environ.get("MTEB_API_URL") or DEFAULT_BASE_URL).rstrip("/")
+        self.api_key = api_key or os.environ.get("MTEB_API_KEY") or MTEB_API_DEMO_KEY
+        if self.api_key is None:
+            raise RuntimeError(
+                "MTEB_API_KEY not set and no demo key shipped. "
+                "Request a per-reviewer key via https://voxell.ai (reference your MTEB PR/eval); "
+                "200 rpm slot, audited per tenant."
+            )
+        self.timeout_s = timeout_s
+        self.max_retries = max_retries
+        self._session = requests.Session()
+        # Identity encoding: float-vector responses don't compress meaningfully and
+        # we saw brotli decode errors on large STS responses through Cloudflare
+        # (Inc-4 C3 smoke). Skip compression altogether.
+        self._session.headers.update({
+            "Authorization": f"Bearer {self.api_key}",
+            "Accept-Encoding": "identity",
+        })
+
+    def encode(
+        self,
+        inputs: DataLoader[BatchedInput],
+        *,
+        task_metadata: TaskMetadata,
+        hf_split: str,
+        hf_subset: str,
+        prompt_type: PromptType | None = None,
+        **_kwargs: Any,
+    ) -> Array:
+        # Single POST per task: Qwen3-8B uses left-padding + last-token pooling,
+        # which is NOT pool-invariant. Sub-batching here would produce different
+        # per-sentence vectors than the in-process eval (STS12 86.40 -> 81.41
+        # measured under client-side batch_size=64 chunking).
+        sentences = [text for batch in inputs for text in batch["text"]]
+        payload: dict[str, Any] = {
+            "input": sentences,
+            "model": self.model_name,
+            "task_name": task_metadata.name,
+        }
+        if prompt_type is not None:
+            payload["prompt_type"] = prompt_type.value
+
+        body_bytes = len(json.dumps(payload).encode("utf-8"))
+        max_bytes = MAX_BODY_MB * 1024 * 1024
+        if body_bytes > max_bytes:
+            raise RuntimeError(
+                f"ingot api body too large ({body_bytes} bytes, {len(sentences)} sentences); "
+                f"MTEB_API_MAX_BODY_MB={MAX_BODY_MB}. Raise it or split the task upstream."
+            )
+
+        data = self._post_with_retry(f"{self.base_url}/v1/embeddings", payload)
+        return np.asarray([item["embedding"] for item in data["data"]], dtype=np.float32)
+
+    def _post_with_retry(self, url: str, payload: dict[str, Any]) -> dict[str, Any]:
+        backoff = 1.5
+        last_5xx_body = ""
+        for attempt in range(1, self.max_retries + 1):
+            try:
+                r = self._session.post(url, json=payload, timeout=self.timeout_s)
+                status = r.status_code
+                if status in (401, 403):
+                    raise RuntimeError(
+                        f"ingot api auth failed (status {status}): "
+                        f"MTEB_API_KEY rejected. Request a per-reviewer key via https://voxell.ai."
+                    )
+                if status == 413:
+                    raise RuntimeError(
+                        f"ingot api rejected body (status 413): "
+                        f"server limit exceeded; raise MTEB_API_MAX_BODY_MB or shrink task"
+                    )
+                if status == 429:
+                    retry_after = float(r.headers.get("Retry-After", backoff))
+                    time.sleep(retry_after)
+                    continue
+                if 500 <= status < 600:
+                    last_5xx_body = r.text[:500]
+                    if attempt == self.max_retries:
+                        raise RuntimeError(
+                            f"ingot api {url} 5xx ({status}) after {attempt} attempts: {last_5xx_body}"
+                        )
+                    time.sleep(backoff * attempt)
+                    continue
+                r.raise_for_status()
+                return r.json()
+            except (requests.Timeout, requests.ConnectionError) as e:
+                if attempt == self.max_retries:
+                    raise RuntimeError(
+                        f"ingot api {url} unreachable after {attempt} attempts: {e}"
+                    ) from e
+                time.sleep(backoff * attempt)
+        raise RuntimeError(f"ingot api {url} exceeded {self.max_retries} retries")
+
+
+ingot_8b_r3 = ModelMeta(
+    name="jcorners/ingot-8b-r3",
+    revision="r3",
+    release_date="2026-05-23",
+    languages=["eng-Latn"],
+    loader=IngotAPIEncoder,
+    loader_kwargs=dict(),
+    max_tokens=32768,
+    embed_dim=4096,
+    open_weights=False,
+    n_parameters=8_000_000_000,
+    n_embedding_parameters=8_000_000_000,
+    memory_usage_mb=None,
+    license=None,
+    reference="https://voxell.ai/engineering/ingot_poured/",
+    similarity_fn_name=ScoringFunction.COSINE,
+    framework=["API"],
+    use_instructions=True,
+    public_training_code=None,
+    public_training_data=None,
+    training_datasets={
+        "SprintDuplicateQuestions",
+        "TwitterSemEval2015",
+        "TwitterURLCorpus",
+        "MedrxivClusteringP2P.v2",
+        "MedrxivClusteringS2S.v2",
+    },
+)

--- a/mteb/models/model_implementations/ingot_models.py
+++ b/mteb/models/model_implementations/ingot_models.py
@@ -151,8 +151,8 @@ ingot_8b_r3 = ModelMeta(
     max_tokens=32768,
     embed_dim=4096,
     open_weights=False,
-    n_parameters=8_000_000_000,
-    n_embedding_parameters=8_000_000_000,
+    n_parameters=7_567_295_488,
+    n_embedding_parameters=621_219_840,
     memory_usage_mb=None,
     license=None,
     reference="https://voxell.ai/engineering/ingot_poured/",
@@ -162,6 +162,20 @@ ingot_8b_r3 = ModelMeta(
     public_training_code=None,
     public_training_data=None,
     training_datasets={
+        # Inherited from Qwen3-Embedding-8B base model, matching #4707 and
+        # upstream MTEB's Qwen3_Embedding_8B metadata.
+        "T2Retrieval",
+        "DuRetrieval",
+        "MMarcoReranking",
+        "CMedQAv2-reranking",
+        "NQ",
+        "MSMARCO",
+        "HotpotQA",
+        "FEVER",
+        "MrTidyRetrieval",
+        "MIRACLRetrieval",
+        "CodeSearchNet",
+        # Ingot R3 specialist training.
         "SprintDuplicateQuestions",
         "TwitterSemEval2015",
         "TwitterURLCorpus",

--- a/mteb/models/model_implementations/ingot_models.py
+++ b/mteb/models/model_implementations/ingot_models.py
@@ -23,13 +23,12 @@ import requests
 
 from mteb.models.abs_encoder import AbsEncoder
 from mteb.models.model_meta import ModelMeta, ScoringFunction
-from mteb.types import PromptType
 
 if TYPE_CHECKING:
     from torch.utils.data import DataLoader
 
     from mteb.abstasks.task_metadata import TaskMetadata
-    from mteb.types import Array, BatchedInput
+    from mteb.types import Array, BatchedInput, PromptType
 
 MTEB_API_DEMO_KEY = None  # no key shipped in this file; reviewers request per-reviewer keys (see module docstring)
 DEFAULT_BASE_URL = "https://api-mteb.voxell.ai"

--- a/mteb/models/model_implementations/ingot_models.py
+++ b/mteb/models/model_implementations/ingot_models.py
@@ -10,6 +10,7 @@ Environment:
                   your MTEB PR/eval); 200 rpm slot, audited per tenant.
     MTEB_API_URL  Override the base URL (default https://api-mteb.voxell.ai).
 """
+
 from __future__ import annotations
 
 import json
@@ -48,7 +49,9 @@ class IngotAPIEncoder(AbsEncoder):
         **_kwargs: Any,
     ) -> None:
         self.model_name = model_name
-        self.base_url = (base_url or os.environ.get("MTEB_API_URL") or DEFAULT_BASE_URL).rstrip("/")
+        self.base_url = (
+            base_url or os.environ.get("MTEB_API_URL") or DEFAULT_BASE_URL
+        ).rstrip("/")
         self.api_key = api_key or os.environ.get("MTEB_API_KEY") or MTEB_API_DEMO_KEY
         if self.api_key is None:
             raise RuntimeError(
@@ -62,10 +65,12 @@ class IngotAPIEncoder(AbsEncoder):
         # Identity encoding: float-vector responses don't compress meaningfully and
         # we saw brotli decode errors on large STS responses through Cloudflare
         # (Inc-4 C3 smoke). Skip compression altogether.
-        self._session.headers.update({
-            "Authorization": f"Bearer {self.api_key}",
-            "Accept-Encoding": "identity",
-        })
+        self._session.headers.update(
+            {
+                "Authorization": f"Bearer {self.api_key}",
+                "Accept-Encoding": "identity",
+            }
+        )
 
     def encode(
         self,
@@ -99,7 +104,9 @@ class IngotAPIEncoder(AbsEncoder):
             )
 
         data = self._post_with_retry(f"{self.base_url}/v1/embeddings", payload)
-        return np.asarray([item["embedding"] for item in data["data"]], dtype=np.float32)
+        return np.asarray(
+            [item["embedding"] for item in data["data"]], dtype=np.float32
+        )
 
     def _post_with_retry(self, url: str, payload: dict[str, Any]) -> dict[str, Any]:
         backoff = 1.5
@@ -108,15 +115,15 @@ class IngotAPIEncoder(AbsEncoder):
             try:
                 r = self._session.post(url, json=payload, timeout=self.timeout_s)
                 status = r.status_code
-                if status in (401, 403):
+                if status in {401, 403}:
                     raise RuntimeError(
                         f"ingot api auth failed (status {status}): "
                         f"MTEB_API_KEY rejected. Request a per-reviewer key via https://voxell.ai."
                     )
                 if status == 413:
                     raise RuntimeError(
-                        f"ingot api rejected body (status 413): "
-                        f"server limit exceeded; raise MTEB_API_MAX_BODY_MB or shrink task"
+                        "ingot api rejected body (status 413): "
+                        "server limit exceeded; raise MTEB_API_MAX_BODY_MB or shrink task"
                     )
                 if status == 429:
                     retry_after = float(r.headers.get("Retry-After", backoff))


### PR DESCRIPTION
Hi @KennethEnevoldsen and @Samoed — first, thank you both for the patient and substantive review on #4707, and for clearly laying out the path forward when you closed it. This is a careful refile that I hope addresses each point you raised. I spent the time since then standing the API up properly rather than pushing back, and I appreciate the room to do that.

## What changed since #4707

Three things you flagged are now resolved:

**1. "We require models to have a publicly accessible API"** (Samoed, line 130; Kenneth, closure note)

The endpoint is live at `https://api-mteb.voxell.ai`. Status checkable without a key:

```bash
curl -sS https://api-mteb.voxell.ai/v1/models
# → {"object":"list","data":[{"id":"jcorners/ingot-8b-r3","object":"model","owned_by":"voxell"}]}
```

### Get a key (~30 seconds, no email round-trip)

1. Visit **https://api-mteb.voxell.ai/request-key** in a browser
2. Enter your email, complete the Cloudflare challenge
3. Your key appears on screen with a prefilled `curl` example and a "Test it now" button that runs an embedding round-trip in the page

200 requests/minute per reviewer, enforced per-tenant by Voxell ART at the gate.

### Embedding call (with the key from above)

```bash
curl -sS https://api-mteb.voxell.ai/v1/embeddings \
  -H "Authorization: Bearer $MTEB_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"jcorners/ingot-8b-r3","input":["hello world"],"task_name":"STS12"}'
```

Response (the `embedding` array is 4096 float32 values; truncated to 2 below for readability):

```json
{
  "object": "list",
  "data": [
    {"object": "embedding", "index": 0, "embedding": [0.0123, -0.0456]}
  ],
  "model": "jcorners/ingot-8b-r3",
  "usage": {"prompt_tokens": 2, "total_tokens": 2}
}
```

**2. "Please, add your training datasets"** (Samoed, file-level comment)

`training_datasets` is now set explicitly in one field, with two groups called out in comments:

```python
training_datasets = {
    # Inherited from Qwen3-Embedding-8B base model, restored from #4707
    # and matching upstream MTEB's Qwen3_Embedding_8B metadata.
    "T2Retrieval",
    "DuRetrieval",
    "MMarcoReranking",
    "CMedQAv2-reranking",
    "NQ",
    "MSMARCO",
    "HotpotQA",
    "FEVER",
    "MrTidyRetrieval",
    "MIRACLRetrieval",
    "CodeSearchNet",

    # Ingot R3 specialist training.
    "SprintDuplicateQuestions",
    "TwitterSemEval2015",
    "TwitterURLCorpus",
    "MedrxivClusteringP2P.v2",
    "MedrxivClusteringS2S.v2",
}
```

These 5 MTEB tasks are the train splits used by Ingot specialists (per-cluster CrossEncoder experts C0–C4 and the `cluster_substitute` centroids). Calling both groups out by name so contamination is fully disclosed.

Separately, for Ingot R3's own synthetic training data outside the declared `training_datasets`: zero contamination by construction. The synthetic data is generated via the Ingot Retriever Datagen Stack (provisional patent filed 2026), which applies a mechanical leakage gate at the source-document level — documents from ArguAna, FiQA, HotpotQA, MS MARCO, NFCorpus, SciFact, TREC-COVID, and CQADupStack are quarantined before any synthetic triplet is generated. It's a structural guarantee, not a post-hoc filter.

**3. `ModelMeta.from_hub(...)` suggestion** (Samoed, #4707 inline review comment under CHANGES_REQUESTED)

I read this as a pointer to populate the ModelMeta from an authoritative source rather than typing fields by hand. For an API-backed model with no weights on HF, `from_hub` doesn't have enough source to populate the parameter-shape fields, so I followed the voyage / cohere / openai convention of filling the ModelMeta manually with explicit values. Happy to convert if there's a different intent here — please let me know.

## What the model is

- `framework=["API"]`, `open_weights=False`, `embed_dim=4096`, `max_tokens=32768`
- Backbone: `Qwen/Qwen3-Embedding-8B` (revision `1d8ad4ca…`); per-task instruction routing + per-cluster specialists served behind a single `/v1/embeddings` endpoint
- MTEB(eng, v2) Mean(41) = **75.9795**

## Scope of this PR

One new file: `mteb/models/model_implementations/ingot_models.py` (~160 LoC). No existing files modified. mteb 2.12.30 auto-discovers from `model_implementations/`, so no `__init__.py` edit is needed — matches the voyage / cohere / openai pattern in that directory.

This is the registry half. The companion results PR (41 task JSONs in `embeddings-benchmark/results`) will open only after you've had a chance to look at this one — registry-first, per the lesson from the parallel submission attempt. I'll wait for your engagement before doing anything else, and I won't tag either of you in the meantime.

## Reference

Engineering writeup: https://voxell.ai/engineering/ingot_poured/

## Checklist

*(Verbatim from [`adding_a_model.md`](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_model/) as of 2026-05-24.)*

- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [x] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e., is available either as an API or the weights are publicly available to download
- [x] I reproduced results from the original paper (if applicable) on at least one benchmark, and I am including the results in the PR description.

Thank you again for the time on this. I know reviewing volunteer-side PRs is real work — I'll be patient and responsive on this one, including respecting the one-full-business-day follow-up guidance you gave on #4707.
