### PR TITLE
Update run-leaderboard command to disable sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ leaderboard-test-all:
 
 run-leaderboard:
 	@echo "--- 🚀 Running leaderboard locally ---"
-	uv run --extra leaderboard python -m mteb leaderboard
+	uv run --no-sync --extra leaderboard python -m mteb leaderboard
 
 format-citations:
 	@echo "--- 🧹 Formatting citations ---"


### PR DESCRIPTION
Leaderboard can't build, because it can't build in hour quota https://github.com/embeddings-benchmark/mteb/issues/4724