### PR TITLE
bidirlm-omni: default audio max_samples to 30s at 16kHz

### DIFF
--- a/mteb/models/model_implementations/bidirlm_omni_models.py
+++ b/mteb/models/model_implementations/bidirlm_omni_models.py
@@ -92,7 +92,7 @@ class BidirLMOmniEncoder(AbsEncoder):
         fps: float | None = 2.0,
         max_frames: int | None = 64,
         num_frames: int | None = None,
-        max_samples: int | None = None,
+        max_samples: int | None = 30 * 16_000,
         **kwargs: Any,
     ) -> None:
         from transformers import AutoVideoProcessor


### PR DESCRIPTION
If you add a model or a dataset, please add the corresponding checklist:

* [dataset checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_dataset/#submit-a-pull-request)
* [model checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_model/#submitting-your-model-as-a-pr)
