### PR TITLE
[MVEB] Add STARBench video-centric QA task

### DIFF
--- a/mteb/descriptive_stats/VideoCentricQA/STARBenchFeasibilityVideoAudioCentricQA.json
+++ b/mteb/descriptive_stats/VideoCentricQA/STARBenchFeasibilityVideoAudioCentricQA.json
@@ -1,0 +1,103 @@
+{
+    "test": {
+        "num_samples": 2450,
+        "number_of_characters": 63397,
+        "documents_text_statistics": {
+            "total_text_length": 34115,
+            "min_text_length": 8,
+            "average_text_length": 17.40561224489796,
+            "max_text_length": 30,
+            "unique_texts": 170
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 29282,
+            "min_text_length": 48,
+            "average_text_length": 59.75918367346939,
+            "max_text_length": 82,
+            "unique_texts": 87
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": {
+            "total_duration_seconds": 16885.9114375,
+            "min_duration_seconds": 11.42425,
+            "average_duration_seconds": 34.461043749999995,
+            "max_duration_seconds": 73.23575,
+            "unique_audios": 181,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 490
+            }
+        },
+        "queries_video_statistics": {
+            "total_duration_seconds": 16875.11922828968,
+            "total_frames": 443286,
+            "min_width": 270,
+            "average_width": 416.53469387755104,
+            "max_width": 480,
+            "min_height": 268,
+            "average_height": 357.19591836734696,
+            "max_height": 480,
+            "min_duration_seconds": 11.4114,
+            "average_duration_seconds": 34.43901883324425,
+            "max_duration_seconds": 73.23271795252776,
+            "unique_videos": 181,
+            "average_fps": 26.32857142857143,
+            "fps": {
+                "30": 293,
+                "6": 12,
+                "29": 34,
+                "17": 20,
+                "25": 32,
+                "24": 63,
+                "15": 5,
+                "10": 1,
+                "11": 6,
+                "19": 2,
+                "28": 1,
+                "9": 6,
+                "8": 11,
+                "7": 2,
+                "14": 2
+            },
+            "min_resolution": [
+                480,
+                268
+            ],
+            "average_resolution": [
+                416.53469387755104,
+                357.19591836734696
+            ],
+            "max_resolution": [
+                392,
+                480
+            ],
+            "resolutions": {
+                "480x360": 93,
+                "480x270": 226,
+                "320x480": 20,
+                "270x480": 121,
+                "360x480": 20,
+                "392x480": 1,
+                "480x320": 2,
+                "480x268": 2,
+                "480x318": 5
+            }
+        },
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 490,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 490
+        },
+        "top_ranked_statistics": {
+            "num_top_ranked": 1960,
+            "min_top_ranked_per_query": 4,
+            "average_top_ranked_per_query": 4.0,
+            "max_top_ranked_per_query": 4
+        }
+    }
+}

--- a/mteb/descriptive_stats/VideoCentricQA/STARBenchFeasibilityVideoCentricQA.json
+++ b/mteb/descriptive_stats/VideoCentricQA/STARBenchFeasibilityVideoCentricQA.json
@@ -1,0 +1,93 @@
+{
+    "test": {
+        "num_samples": 2450,
+        "number_of_characters": 63397,
+        "documents_text_statistics": {
+            "total_text_length": 34115,
+            "min_text_length": 8,
+            "average_text_length": 17.40561224489796,
+            "max_text_length": 30,
+            "unique_texts": 170
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 29282,
+            "min_text_length": 48,
+            "average_text_length": 59.75918367346939,
+            "max_text_length": 82,
+            "unique_texts": 87
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": {
+            "total_duration_seconds": 16875.11922828968,
+            "total_frames": 443286,
+            "min_width": 270,
+            "average_width": 416.53469387755104,
+            "max_width": 480,
+            "min_height": 268,
+            "average_height": 357.19591836734696,
+            "max_height": 480,
+            "min_duration_seconds": 11.4114,
+            "average_duration_seconds": 34.43901883324425,
+            "max_duration_seconds": 73.23271795252776,
+            "unique_videos": 181,
+            "average_fps": 26.32857142857143,
+            "fps": {
+                "30": 293,
+                "6": 12,
+                "29": 34,
+                "17": 20,
+                "25": 32,
+                "24": 63,
+                "15": 5,
+                "10": 1,
+                "11": 6,
+                "19": 2,
+                "28": 1,
+                "9": 6,
+                "8": 11,
+                "7": 2,
+                "14": 2
+            },
+            "min_resolution": [
+                480,
+                268
+            ],
+            "average_resolution": [
+                416.53469387755104,
+                357.19591836734696
+            ],
+            "max_resolution": [
+                392,
+                480
+            ],
+            "resolutions": {
+                "480x360": 93,
+                "480x270": 226,
+                "320x480": 20,
+                "270x480": 121,
+                "360x480": 20,
+                "392x480": 1,
+                "480x320": 2,
+                "480x268": 2,
+                "480x318": 5
+            }
+        },
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 490,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 490
+        },
+        "top_ranked_statistics": {
+            "num_top_ranked": 1960,
+            "min_top_ranked_per_query": 4,
+            "average_top_ranked_per_query": 4.0,
+            "max_top_ranked_per_query": 4
+        }
+    }
+}

--- a/mteb/descriptive_stats/VideoCentricQA/STARBenchInteractionVideoAudioCentricQA.json
+++ b/mteb/descriptive_stats/VideoCentricQA/STARBenchInteractionVideoAudioCentricQA.json
@@ -1,0 +1,119 @@
+{
+    "test": {
+        "num_samples": 11990,
+        "number_of_characters": 268927,
+        "documents_text_statistics": {
+            "total_text_length": 129856,
+            "min_text_length": 4,
+            "average_text_length": 13.537948290241868,
+            "max_text_length": 30,
+            "unique_texts": 114
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 139071,
+            "min_text_length": 36,
+            "average_text_length": 57.99457881567973,
+            "max_text_length": 104,
+            "unique_texts": 189
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": {
+            "total_duration_seconds": 72687.3125,
+            "min_duration_seconds": 4.416,
+            "average_duration_seconds": 30.31163990825688,
+            "max_duration_seconds": 81.15375,
+            "unique_audios": 858,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 2398
+            }
+        },
+        "queries_video_statistics": {
+            "total_duration_seconds": 72637.0293360407,
+            "total_frames": 1884767,
+            "min_width": 270,
+            "average_width": 425.95663052543784,
+            "max_width": 480,
+            "min_height": 266,
+            "average_height": 353.279399499583,
+            "max_height": 480,
+            "min_duration_seconds": 4.345403899721449,
+            "average_duration_seconds": 30.29067111594691,
+            "max_duration_seconds": 81.13324601916317,
+            "unique_videos": 858,
+            "average_fps": 25.97414512093411,
+            "fps": {
+                "18": 13,
+                "17": 142,
+                "15": 110,
+                "30": 1322,
+                "6": 57,
+                "11": 18,
+                "14": 24,
+                "23": 5,
+                "25": 164,
+                "9": 9,
+                "24": 300,
+                "16": 13,
+                "27": 4,
+                "8": 19,
+                "21": 6,
+                "7": 7,
+                "29": 94,
+                "26": 10,
+                "50": 4,
+                "20": 17,
+                "60": 14,
+                "19": 5,
+                "120": 2,
+                "28": 12,
+                "10": 24,
+                "12": 3
+            },
+            "min_resolution": [
+                480,
+                266
+            ],
+            "average_resolution": [
+                425.95663052543784,
+                353.279399499583
+            ],
+            "max_resolution": [
+                480,
+                392
+            ],
+            "resolutions": {
+                "320x480": 125,
+                "480x270": 1057,
+                "480x320": 29,
+                "270x480": 426,
+                "480x360": 517,
+                "360x480": 149,
+                "272x480": 10,
+                "480x272": 23,
+                "480x266": 3,
+                "480x318": 34,
+                "480x268": 17,
+                "480x392": 2,
+                "480x352": 4,
+                "392x480": 2
+            }
+        },
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 2398,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 2398
+        },
+        "top_ranked_statistics": {
+            "num_top_ranked": 9592,
+            "min_top_ranked_per_query": 4,
+            "average_top_ranked_per_query": 4.0,
+            "max_top_ranked_per_query": 4
+        }
+    }
+}

--- a/mteb/descriptive_stats/VideoCentricQA/STARBenchInteractionVideoCentricQA.json
+++ b/mteb/descriptive_stats/VideoCentricQA/STARBenchInteractionVideoCentricQA.json
@@ -1,0 +1,109 @@
+{
+    "test": {
+        "num_samples": 11990,
+        "number_of_characters": 268927,
+        "documents_text_statistics": {
+            "total_text_length": 129856,
+            "min_text_length": 4,
+            "average_text_length": 13.537948290241868,
+            "max_text_length": 30,
+            "unique_texts": 114
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 139071,
+            "min_text_length": 36,
+            "average_text_length": 57.99457881567973,
+            "max_text_length": 104,
+            "unique_texts": 189
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": {
+            "total_duration_seconds": 72637.0293360407,
+            "total_frames": 1884767,
+            "min_width": 270,
+            "average_width": 425.95663052543784,
+            "max_width": 480,
+            "min_height": 266,
+            "average_height": 353.279399499583,
+            "max_height": 480,
+            "min_duration_seconds": 4.345403899721449,
+            "average_duration_seconds": 30.29067111594691,
+            "max_duration_seconds": 81.13324601916317,
+            "unique_videos": 858,
+            "average_fps": 25.97414512093411,
+            "fps": {
+                "18": 13,
+                "17": 142,
+                "15": 110,
+                "30": 1322,
+                "6": 57,
+                "11": 18,
+                "14": 24,
+                "23": 5,
+                "25": 164,
+                "9": 9,
+                "24": 300,
+                "16": 13,
+                "27": 4,
+                "8": 19,
+                "21": 6,
+                "7": 7,
+                "29": 94,
+                "26": 10,
+                "50": 4,
+                "20": 17,
+                "60": 14,
+                "19": 5,
+                "120": 2,
+                "28": 12,
+                "10": 24,
+                "12": 3
+            },
+            "min_resolution": [
+                480,
+                266
+            ],
+            "average_resolution": [
+                425.95663052543784,
+                353.279399499583
+            ],
+            "max_resolution": [
+                480,
+                392
+            ],
+            "resolutions": {
+                "320x480": 125,
+                "480x270": 1057,
+                "480x320": 29,
+                "270x480": 426,
+                "480x360": 517,
+                "360x480": 149,
+                "272x480": 10,
+                "480x272": 23,
+                "480x266": 3,
+                "480x318": 34,
+                "480x268": 17,
+                "480x392": 2,
+                "480x352": 4,
+                "392x480": 2
+            }
+        },
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 2398,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 2398
+        },
+        "top_ranked_statistics": {
+            "num_top_ranked": 9592,
+            "min_top_ranked_per_query": 4,
+            "average_top_ranked_per_query": 4.0,
+            "max_top_ranked_per_query": 4
+        }
+    }
+}

--- a/mteb/descriptive_stats/VideoCentricQA/STARBenchPredictionVideoAudioCentricQA.json
+++ b/mteb/descriptive_stats/VideoCentricQA/STARBenchPredictionVideoAudioCentricQA.json
@@ -1,0 +1,110 @@
+{
+    "test": {
+        "num_samples": 3120,
+        "number_of_characters": 66453,
+        "documents_text_statistics": {
+            "total_text_length": 29483,
+            "min_text_length": 4,
+            "average_text_length": 11.81209935897436,
+            "max_text_length": 30,
+            "unique_texts": 122
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 36970,
+            "min_text_length": 29,
+            "average_text_length": 59.24679487179487,
+            "max_text_length": 87,
+            "unique_texts": 130
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": {
+            "total_duration_seconds": 20103.5123125,
+            "min_duration_seconds": 7.52325,
+            "average_duration_seconds": 32.21716716746795,
+            "max_duration_seconds": 81.15375,
+            "unique_audios": 305,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 624
+            }
+        },
+        "queries_video_statistics": {
+            "total_duration_seconds": 20084.427770144903,
+            "total_frames": 523087,
+            "min_width": 270,
+            "average_width": 419.4647435897436,
+            "max_width": 480,
+            "min_height": 266,
+            "average_height": 356.01602564102564,
+            "max_height": 480,
+            "min_duration_seconds": 7.521299254526092,
+            "average_duration_seconds": 32.186582964975806,
+            "max_duration_seconds": 81.13324601916317,
+            "unique_videos": 305,
+            "average_fps": 26.099358974358974,
+            "fps": {
+                "18": 8,
+                "30": 376,
+                "11": 16,
+                "15": 15,
+                "17": 27,
+                "6": 19,
+                "25": 35,
+                "24": 65,
+                "8": 8,
+                "21": 3,
+                "50": 2,
+                "16": 2,
+                "29": 28,
+                "20": 4,
+                "19": 3,
+                "10": 2,
+                "28": 5,
+                "26": 1,
+                "9": 4,
+                "23": 1
+            },
+            "min_resolution": [
+                480,
+                266
+            ],
+            "average_resolution": [
+                419.4647435897436,
+                356.01602564102564
+            ],
+            "max_resolution": [
+                480,
+                360
+            ],
+            "resolutions": {
+                "320x480": 34,
+                "480x270": 277,
+                "270x480": 131,
+                "480x320": 5,
+                "480x360": 112,
+                "272x480": 3,
+                "360x480": 35,
+                "480x272": 5,
+                "480x268": 6,
+                "480x318": 15,
+                "480x266": 1
+            }
+        },
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 624,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 624
+        },
+        "top_ranked_statistics": {
+            "num_top_ranked": 2496,
+            "min_top_ranked_per_query": 4,
+            "average_top_ranked_per_query": 4.0,
+            "max_top_ranked_per_query": 4
+        }
+    }
+}

--- a/mteb/descriptive_stats/VideoCentricQA/STARBenchPredictionVideoCentricQA.json
+++ b/mteb/descriptive_stats/VideoCentricQA/STARBenchPredictionVideoCentricQA.json
@@ -1,0 +1,100 @@
+{
+    "test": {
+        "num_samples": 3120,
+        "number_of_characters": 66453,
+        "documents_text_statistics": {
+            "total_text_length": 29483,
+            "min_text_length": 4,
+            "average_text_length": 11.81209935897436,
+            "max_text_length": 30,
+            "unique_texts": 122
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 36970,
+            "min_text_length": 29,
+            "average_text_length": 59.24679487179487,
+            "max_text_length": 87,
+            "unique_texts": 130
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": {
+            "total_duration_seconds": 20084.427770144903,
+            "total_frames": 523087,
+            "min_width": 270,
+            "average_width": 419.4647435897436,
+            "max_width": 480,
+            "min_height": 266,
+            "average_height": 356.01602564102564,
+            "max_height": 480,
+            "min_duration_seconds": 7.521299254526092,
+            "average_duration_seconds": 32.186582964975806,
+            "max_duration_seconds": 81.13324601916317,
+            "unique_videos": 305,
+            "average_fps": 26.099358974358974,
+            "fps": {
+                "18": 8,
+                "30": 376,
+                "11": 16,
+                "15": 15,
+                "17": 27,
+                "6": 19,
+                "25": 35,
+                "24": 65,
+                "8": 8,
+                "21": 3,
+                "50": 2,
+                "16": 2,
+                "29": 28,
+                "20": 4,
+                "19": 3,
+                "10": 2,
+                "28": 5,
+                "26": 1,
+                "9": 4,
+                "23": 1
+            },
+            "min_resolution": [
+                480,
+                266
+            ],
+            "average_resolution": [
+                419.4647435897436,
+                356.01602564102564
+            ],
+            "max_resolution": [
+                480,
+                360
+            ],
+            "resolutions": {
+                "320x480": 34,
+                "480x270": 277,
+                "270x480": 131,
+                "480x320": 5,
+                "480x360": 112,
+                "272x480": 3,
+                "360x480": 35,
+                "480x272": 5,
+                "480x268": 6,
+                "480x318": 15,
+                "480x266": 1
+            }
+        },
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 624,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 624
+        },
+        "top_ranked_statistics": {
+            "num_top_ranked": 2496,
+            "min_top_ranked_per_query": 4,
+            "average_top_ranked_per_query": 4.0,
+            "max_top_ranked_per_query": 4
+        }
+    }
+}

--- a/mteb/descriptive_stats/VideoCentricQA/STARBenchSequenceVideoAudioCentricQA.json
+++ b/mteb/descriptive_stats/VideoCentricQA/STARBenchSequenceVideoAudioCentricQA.json
@@ -1,0 +1,119 @@
+{
+    "test": {
+        "num_samples": 17930,
+        "number_of_characters": 351711,
+        "documents_text_statistics": {
+            "total_text_length": 121405,
+            "min_text_length": 4,
+            "average_text_length": 8.463817624093698,
+            "max_text_length": 30,
+            "unique_texts": 110
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 230306,
+            "min_text_length": 44,
+            "average_text_length": 64.22364751812604,
+            "max_text_length": 87,
+            "unique_texts": 549
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": {
+            "total_duration_seconds": 111533.0329375,
+            "min_duration_seconds": 5.921125,
+            "average_duration_seconds": 31.102351627858337,
+            "max_duration_seconds": 81.15375,
+            "unique_audios": 699,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 3586
+            }
+        },
+        "queries_video_statistics": {
+            "total_duration_seconds": 111447.10303689567,
+            "total_frames": 2921368,
+            "min_width": 270,
+            "average_width": 426.4116006692694,
+            "max_width": 480,
+            "min_height": 266,
+            "average_height": 352.0078081427775,
+            "max_height": 480,
+            "min_duration_seconds": 5.9059,
+            "average_duration_seconds": 31.078389023116472,
+            "max_duration_seconds": 81.13324601916317,
+            "unique_videos": 699,
+            "average_fps": 26.199386503067483,
+            "fps": {
+                "18": 24,
+                "17": 217,
+                "15": 155,
+                "30": 2060,
+                "6": 69,
+                "11": 42,
+                "14": 16,
+                "24": 417,
+                "25": 216,
+                "9": 11,
+                "16": 19,
+                "8": 22,
+                "21": 12,
+                "7": 15,
+                "29": 131,
+                "50": 10,
+                "20": 15,
+                "60": 23,
+                "10": 52,
+                "12": 3,
+                "28": 17,
+                "26": 9,
+                "23": 19,
+                "27": 6,
+                "19": 3,
+                "120": 3
+            },
+            "min_resolution": [
+                480,
+                266
+            ],
+            "average_resolution": [
+                426.4116006692694,
+                352.0078081427775
+            ],
+            "max_resolution": [
+                392,
+                480
+            ],
+            "resolutions": {
+                "320x480": 196,
+                "480x270": 1589,
+                "270x480": 616,
+                "480x360": 719,
+                "360x480": 221,
+                "480x320": 54,
+                "272x480": 22,
+                "480x272": 39,
+                "480x268": 33,
+                "480x266": 10,
+                "392x480": 4,
+                "480x318": 77,
+                "480x392": 3,
+                "480x352": 3
+            }
+        },
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 3586,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 3586
+        },
+        "top_ranked_statistics": {
+            "num_top_ranked": 14344,
+            "min_top_ranked_per_query": 4,
+            "average_top_ranked_per_query": 4.0,
+            "max_top_ranked_per_query": 4
+        }
+    }
+}

--- a/mteb/descriptive_stats/VideoCentricQA/STARBenchSequenceVideoCentricQA.json
+++ b/mteb/descriptive_stats/VideoCentricQA/STARBenchSequenceVideoCentricQA.json
@@ -1,0 +1,109 @@
+{
+    "test": {
+        "num_samples": 17930,
+        "number_of_characters": 351711,
+        "documents_text_statistics": {
+            "total_text_length": 121405,
+            "min_text_length": 4,
+            "average_text_length": 8.463817624093698,
+            "max_text_length": 30,
+            "unique_texts": 110
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 230306,
+            "min_text_length": 44,
+            "average_text_length": 64.22364751812604,
+            "max_text_length": 87,
+            "unique_texts": 549
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": {
+            "total_duration_seconds": 111447.10303689567,
+            "total_frames": 2921368,
+            "min_width": 270,
+            "average_width": 426.4116006692694,
+            "max_width": 480,
+            "min_height": 266,
+            "average_height": 352.0078081427775,
+            "max_height": 480,
+            "min_duration_seconds": 5.9059,
+            "average_duration_seconds": 31.078389023116472,
+            "max_duration_seconds": 81.13324601916317,
+            "unique_videos": 699,
+            "average_fps": 26.199386503067483,
+            "fps": {
+                "18": 24,
+                "17": 217,
+                "15": 155,
+                "30": 2060,
+                "6": 69,
+                "11": 42,
+                "14": 16,
+                "24": 417,
+                "25": 216,
+                "9": 11,
+                "16": 19,
+                "8": 22,
+                "21": 12,
+                "7": 15,
+                "29": 131,
+                "50": 10,
+                "20": 15,
+                "60": 23,
+                "10": 52,
+                "12": 3,
+                "28": 17,
+                "26": 9,
+                "23": 19,
+                "27": 6,
+                "19": 3,
+                "120": 3
+            },
+            "min_resolution": [
+                480,
+                266
+            ],
+            "average_resolution": [
+                426.4116006692694,
+                352.0078081427775
+            ],
+            "max_resolution": [
+                392,
+                480
+            ],
+            "resolutions": {
+                "320x480": 196,
+                "480x270": 1589,
+                "270x480": 616,
+                "480x360": 719,
+                "360x480": 221,
+                "480x320": 54,
+                "272x480": 22,
+                "480x272": 39,
+                "480x268": 33,
+                "480x266": 10,
+                "392x480": 4,
+                "480x318": 77,
+                "480x392": 3,
+                "480x352": 3
+            }
+        },
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 3586,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 3586
+        },
+        "top_ranked_statistics": {
+            "num_top_ranked": 14344,
+            "min_top_ranked_per_query": 4,
+            "average_top_ranked_per_query": 4.0,
+            "max_top_ranked_per_query": 4
+        }
+    }
+}

--- a/mteb/tasks/multichoice/eng/__init__.py
+++ b/mteb/tasks/multichoice/eng/__init__.py
@@ -18,6 +18,7 @@ from .perception_test import (
     PerceptionTestVideoAudioCentricQA,
     PerceptionTestVideoCentricQA,
 )
+from .star_bench import STARBenchVideoAudioCentricQA, STARBenchVideoCentricQA
 from .video_mme import VideoMMEShortVideoAudioCentricQA, VideoMMEShortVideoCentricQA
 from .worldqa import WorldQAVideoAudioCentricQA, WorldQAVideoCentricQA
 from .worldsense import WorldSense1MinVideoAudioCentricQA, WorldSense1MinVideoCentricQA
@@ -43,6 +44,8 @@ __all__ = [
     "OmniVideoBenchVideoCentricQA",
     "PerceptionTestVideoAudioCentricQA",
     "PerceptionTestVideoCentricQA",
+    "STARBenchVideoAudioCentricQA",
+    "STARBenchVideoCentricQA",
     "VideoMMEShortVideoAudioCentricQA",
     "VideoMMEShortVideoCentricQA",
     "WorldQAVideoAudioCentricQA",

--- a/mteb/tasks/multichoice/eng/__init__.py
+++ b/mteb/tasks/multichoice/eng/__init__.py
@@ -18,7 +18,16 @@ from .perception_test import (
     PerceptionTestVideoAudioCentricQA,
     PerceptionTestVideoCentricQA,
 )
-from .star_bench import STARBenchVideoAudioCentricQA, STARBenchVideoCentricQA
+from .star_bench import (
+    STARBenchFeasibilityVideoAudioCentricQA,
+    STARBenchFeasibilityVideoCentricQA,
+    STARBenchInteractionVideoAudioCentricQA,
+    STARBenchInteractionVideoCentricQA,
+    STARBenchPredictionVideoAudioCentricQA,
+    STARBenchPredictionVideoCentricQA,
+    STARBenchSequenceVideoAudioCentricQA,
+    STARBenchSequenceVideoCentricQA,
+)
 from .video_mme import VideoMMEShortVideoAudioCentricQA, VideoMMEShortVideoCentricQA
 from .worldqa import WorldQAVideoAudioCentricQA, WorldQAVideoCentricQA
 from .worldsense import WorldSense1MinVideoAudioCentricQA, WorldSense1MinVideoCentricQA
@@ -44,8 +53,14 @@ __all__ = [
     "OmniVideoBenchVideoCentricQA",
     "PerceptionTestVideoAudioCentricQA",
     "PerceptionTestVideoCentricQA",
-    "STARBenchVideoAudioCentricQA",
-    "STARBenchVideoCentricQA",
+    "STARBenchFeasibilityVideoAudioCentricQA",
+    "STARBenchFeasibilityVideoCentricQA",
+    "STARBenchInteractionVideoAudioCentricQA",
+    "STARBenchInteractionVideoCentricQA",
+    "STARBenchPredictionVideoAudioCentricQA",
+    "STARBenchPredictionVideoCentricQA",
+    "STARBenchSequenceVideoAudioCentricQA",
+    "STARBenchSequenceVideoCentricQA",
     "VideoMMEShortVideoAudioCentricQA",
     "VideoMMEShortVideoCentricQA",
     "WorldQAVideoAudioCentricQA",

--- a/mteb/tasks/multichoice/eng/star_bench.py
+++ b/mteb/tasks/multichoice/eng/star_bench.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from datasets import Dataset, concatenate_datasets, load_dataset
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.retrieval_dataset_loaders import RetrievalSplitData
+from mteb.abstasks.task_metadata import TaskMetadata
+
+_CONFIGS = ["feasibility", "interaction", "prediction", "sequence"]
+
+
+class STARBenchVideoCentricQA(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="STARBenchVideoCentricQA",
+        description="STAR (Situated Reasoning in Real-World Videos) is a video question answering benchmark covering four question types: Interaction, Sequence, Prediction, and Feasibility. Each example pairs a video with a situated question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate.",
+        reference="https://arxiv.org/abs/2301.08059",
+        dataset={
+            "path": "mteb/star_bench_val",
+            "revision": "0f34df8b497e64bcb4385de99de19dd54c36a788",
+        },
+        type="VideoCentricQA",
+        category="vt2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2023-01-19", "2023-01-19"),
+        domains=["Web"],
+        task_subtypes=["Question answering"],
+        license="cc-by-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video", "text"],
+        sample_creation="found",
+        is_beta=True,
+        bibtex_citation=r"""
+@inproceedings{wu2024star,
+  author = {Wu, Bo and Yu, Shoubin and Chen, Zhenfang and Tenenbaum, Joshua B and Gan, Chuang},
+  booktitle = {Advances in Neural Information Processing Systems},
+  title = {STAR: Situated Reasoning in Real-World Videos},
+  year = {2024},
+}
+""",
+    )
+
+    def load_data(self, **kwargs) -> None:
+        if self.data_loaded:
+            return
+        self.dataset = {"default": {}}
+        for split in self.metadata.eval_splits:
+            splits = []
+            for cfg in _CONFIGS:
+                splits.append(
+                    load_dataset(
+                        self.metadata.dataset["path"],
+                        cfg,
+                        revision=self.metadata.dataset["revision"],
+                        split=split,
+                    )
+                )
+            ds = concatenate_datasets(splits)
+            ds = ds.add_column("id", [f"q{i}" for i in range(len(ds))])
+
+            queries = ds.select_columns(["id", "question", "video"]).rename_column(
+                "question", "text"
+            )
+
+            corpus_rows: list[dict] = []
+            relevant_docs: dict[str, dict[str, int]] = {}
+            top_ranked: dict[str, list[str]] = {}
+            for row in ds.select_columns(["id", "candidates", "answer"]):
+                qid = row["id"]
+                answer = row["answer"]
+                top_ranked[qid] = []
+                for j, candidate in enumerate(row["candidates"]):
+                    doc_id = f"{qid}_c{j}"
+                    corpus_rows.append({"id": doc_id, "text": candidate})
+                    top_ranked[qid].append(doc_id)
+                    if candidate == answer:
+                        relevant_docs[qid] = {doc_id: 1}
+
+            corpus = Dataset.from_list(corpus_rows)
+            self.dataset["default"][split] = RetrievalSplitData(
+                queries=queries,
+                corpus=corpus,
+                relevant_docs=relevant_docs,
+                top_ranked=top_ranked,
+            )
+        self.data_loaded = True
+
+
+class STARBenchVideoAudioCentricQA(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="STARBenchVideoAudioCentricQA",
+        description="STAR (Situated Reasoning in Real-World Videos) is a video question answering benchmark covering four question types: Interaction, Sequence, Prediction, and Feasibility. Each example pairs a video with audio and a situated question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, audio, question) tuple, retrieve the correct candidate.",
+        reference="https://arxiv.org/abs/2301.08059",
+        dataset={
+            "path": "mteb/star_bench_val",
+            "revision": "0f34df8b497e64bcb4385de99de19dd54c36a788",
+        },
+        type="VideoCentricQA",
+        category="vat2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2023-01-19", "2023-01-19"),
+        domains=["Web"],
+        task_subtypes=["Question answering"],
+        license="cc-by-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video", "audio", "text"],
+        sample_creation="found",
+        is_beta=True,
+        bibtex_citation=r"""
+@inproceedings{wu2024star,
+  author = {Wu, Bo and Yu, Shoubin and Chen, Zhenfang and Tenenbaum, Joshua B and Gan, Chuang},
+  booktitle = {Advances in Neural Information Processing Systems},
+  title = {STAR: Situated Reasoning in Real-World Videos},
+  year = {2024},
+}
+""",
+    )
+
+    def load_data(self, **kwargs) -> None:
+        if self.data_loaded:
+            return
+        self.dataset = {"default": {}}
+        for split in self.metadata.eval_splits:
+            splits = []
+            for cfg in _CONFIGS:
+                splits.append(
+                    load_dataset(
+                        self.metadata.dataset["path"],
+                        cfg,
+                        revision=self.metadata.dataset["revision"],
+                        split=split,
+                    )
+                )
+            ds = concatenate_datasets(splits)
+            ds = ds.add_column("id", [f"q{i}" for i in range(len(ds))])
+
+            queries = ds.select_columns(
+                ["id", "question", "video", "audio"]
+            ).rename_column("question", "text")
+
+            corpus_rows: list[dict] = []
+            relevant_docs: dict[str, dict[str, int]] = {}
+            top_ranked: dict[str, list[str]] = {}
+            for row in ds.select_columns(["id", "candidates", "answer"]):
+                qid = row["id"]
+                answer = row["answer"]
+                top_ranked[qid] = []
+                for j, candidate in enumerate(row["candidates"]):
+                    doc_id = f"{qid}_c{j}"
+                    corpus_rows.append({"id": doc_id, "text": candidate})
+                    top_ranked[qid].append(doc_id)
+                    if candidate == answer:
+                        relevant_docs[qid] = {doc_id: 1}
+
+            corpus = Dataset.from_list(corpus_rows)
+            self.dataset["default"][split] = RetrievalSplitData(
+                queries=queries,
+                corpus=corpus,
+                relevant_docs=relevant_docs,
+                top_ranked=top_ranked,
+            )
+        self.data_loaded = True

--- a/mteb/tasks/multichoice/eng/star_bench.py
+++ b/mteb/tasks/multichoice/eng/star_bench.py
@@ -1,29 +1,72 @@
 from __future__ import annotations
 
-from datasets import Dataset, concatenate_datasets, load_dataset
+from datasets import Dataset, load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.retrieval_dataset_loaders import RetrievalSplitData
 from mteb.abstasks.task_metadata import TaskMetadata
 
-_CONFIGS = ["feasibility", "interaction", "prediction", "sequence"]
+_BIBTEX = r"""
+@inproceedings{wu2024star,
+  author = {Wu, Bo and Yu, Shoubin and Chen, Zhenfang and Tenenbaum, Joshua B and Gan, Chuang},
+  booktitle = {Advances in Neural Information Processing Systems},
+  title = {STAR: Situated Reasoning in Real-World Videos},
+  year = {2024},
+}
+"""
+
+_DATASET = {
+    "path": "mteb/star_bench_val",
+    "revision": "0f34df8b497e64bcb4385de99de19dd54c36a788",
+}
+
+_DATE = ("2023-01-19", "2023-01-19")
 
 
-class STARBenchVideoCentricQA(AbsTaskRetrieval):
+def _load_split(path, revision, config, split, modalities):
+    ds = load_dataset(path, config, revision=revision, split=split)
+    ds = ds.add_column("id", [f"q{i}" for i in range(len(ds))])
+
+    query_cols = ["id", "question", "video"]
+    if "audio" in modalities:
+        query_cols.append("audio")
+    queries = ds.select_columns(query_cols).rename_column("question", "text")
+
+    corpus_rows: list[dict] = []
+    relevant_docs: dict[str, dict[str, int]] = {}
+    top_ranked: dict[str, list[str]] = {}
+    for row in ds.select_columns(["id", "candidates", "answer"]):
+        qid = row["id"]
+        answer = row["answer"]
+        top_ranked[qid] = []
+        for j, candidate in enumerate(row["candidates"]):
+            doc_id = f"{qid}_c{j}"
+            corpus_rows.append({"id": doc_id, "text": candidate})
+            top_ranked[qid].append(doc_id)
+            if candidate == answer:
+                relevant_docs[qid] = {doc_id: 1}
+
+    corpus = Dataset.from_list(corpus_rows)
+    return RetrievalSplitData(
+        queries=queries,
+        corpus=corpus,
+        relevant_docs=relevant_docs,
+        top_ranked=top_ranked,
+    )
+
+
+class STARBenchFeasibilityVideoCentricQA(AbsTaskRetrieval):
     metadata = TaskMetadata(
-        name="STARBenchVideoCentricQA",
-        description="STAR (Situated Reasoning in Real-World Videos) is a video question answering benchmark covering four question types: Interaction, Sequence, Prediction, and Feasibility. Each example pairs a video with a situated question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate.",
+        name="STARBenchFeasibilityVideoCentricQA",
+        description="STAR Feasibility subset: questions asking whether an action is feasible given the video context. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate.",
         reference="https://arxiv.org/abs/2301.08059",
-        dataset={
-            "path": "mteb/star_bench_val",
-            "revision": "0f34df8b497e64bcb4385de99de19dd54c36a788",
-        },
+        dataset=_DATASET,
         type="VideoCentricQA",
         category="vt2t",
         eval_splits=["test"],
         eval_langs=["eng-Latn"],
         main_score="accuracy",
-        date=("2023-01-19", "2023-01-19"),
+        date=_DATE,
         domains=["Web"],
         task_subtypes=["Question answering"],
         license="cc-by-4.0",
@@ -32,14 +75,7 @@ class STARBenchVideoCentricQA(AbsTaskRetrieval):
         modalities=["video", "text"],
         sample_creation="found",
         is_beta=True,
-        bibtex_citation=r"""
-@inproceedings{wu2024star,
-  author = {Wu, Bo and Yu, Shoubin and Chen, Zhenfang and Tenenbaum, Joshua B and Gan, Chuang},
-  booktitle = {Advances in Neural Information Processing Systems},
-  title = {STAR: Situated Reasoning in Real-World Videos},
-  year = {2024},
-}
-""",
+        bibtex_citation=_BIBTEX,
     )
 
     def load_data(self, **kwargs) -> None:
@@ -47,62 +83,24 @@ class STARBenchVideoCentricQA(AbsTaskRetrieval):
             return
         self.dataset = {"default": {}}
         for split in self.metadata.eval_splits:
-            splits = []
-            for cfg in _CONFIGS:
-                splits.append(
-                    load_dataset(
-                        self.metadata.dataset["path"],
-                        cfg,
-                        revision=self.metadata.dataset["revision"],
-                        split=split,
-                    )
-                )
-            ds = concatenate_datasets(splits)
-            ds = ds.add_column("id", [f"q{i}" for i in range(len(ds))])
-
-            queries = ds.select_columns(["id", "question", "video"]).rename_column(
-                "question", "text"
-            )
-
-            corpus_rows: list[dict] = []
-            relevant_docs: dict[str, dict[str, int]] = {}
-            top_ranked: dict[str, list[str]] = {}
-            for row in ds.select_columns(["id", "candidates", "answer"]):
-                qid = row["id"]
-                answer = row["answer"]
-                top_ranked[qid] = []
-                for j, candidate in enumerate(row["candidates"]):
-                    doc_id = f"{qid}_c{j}"
-                    corpus_rows.append({"id": doc_id, "text": candidate})
-                    top_ranked[qid].append(doc_id)
-                    if candidate == answer:
-                        relevant_docs[qid] = {doc_id: 1}
-
-            corpus = Dataset.from_list(corpus_rows)
-            self.dataset["default"][split] = RetrievalSplitData(
-                queries=queries,
-                corpus=corpus,
-                relevant_docs=relevant_docs,
-                top_ranked=top_ranked,
+            self.dataset["default"][split] = _load_split(
+                _DATASET["path"], _DATASET["revision"], "feasibility", split, ["video", "text"]
             )
         self.data_loaded = True
 
 
-class STARBenchVideoAudioCentricQA(AbsTaskRetrieval):
+class STARBenchFeasibilityVideoAudioCentricQA(AbsTaskRetrieval):
     metadata = TaskMetadata(
-        name="STARBenchVideoAudioCentricQA",
-        description="STAR (Situated Reasoning in Real-World Videos) is a video question answering benchmark covering four question types: Interaction, Sequence, Prediction, and Feasibility. Each example pairs a video with audio and a situated question and multiple candidate answers. The task is formulated as multiple-choice retrieval: given the (video, audio, question) tuple, retrieve the correct candidate.",
+        name="STARBenchFeasibilityVideoAudioCentricQA",
+        description="STAR Feasibility subset: questions asking whether an action is feasible given the video context. The task is formulated as multiple-choice retrieval: given the (video, audio, question) tuple, retrieve the correct candidate.",
         reference="https://arxiv.org/abs/2301.08059",
-        dataset={
-            "path": "mteb/star_bench_val",
-            "revision": "0f34df8b497e64bcb4385de99de19dd54c36a788",
-        },
+        dataset=_DATASET,
         type="VideoCentricQA",
         category="vat2t",
         eval_splits=["test"],
         eval_langs=["eng-Latn"],
         main_score="accuracy",
-        date=("2023-01-19", "2023-01-19"),
+        date=_DATE,
         domains=["Web"],
         task_subtypes=["Question answering"],
         license="cc-by-4.0",
@@ -111,14 +109,7 @@ class STARBenchVideoAudioCentricQA(AbsTaskRetrieval):
         modalities=["video", "audio", "text"],
         sample_creation="found",
         is_beta=True,
-        bibtex_citation=r"""
-@inproceedings{wu2024star,
-  author = {Wu, Bo and Yu, Shoubin and Chen, Zhenfang and Tenenbaum, Joshua B and Gan, Chuang},
-  booktitle = {Advances in Neural Information Processing Systems},
-  title = {STAR: Situated Reasoning in Real-World Videos},
-  year = {2024},
-}
-""",
+        bibtex_citation=_BIBTEX,
     )
 
     def load_data(self, **kwargs) -> None:
@@ -126,42 +117,211 @@ class STARBenchVideoAudioCentricQA(AbsTaskRetrieval):
             return
         self.dataset = {"default": {}}
         for split in self.metadata.eval_splits:
-            splits = []
-            for cfg in _CONFIGS:
-                splits.append(
-                    load_dataset(
-                        self.metadata.dataset["path"],
-                        cfg,
-                        revision=self.metadata.dataset["revision"],
-                        split=split,
-                    )
-                )
-            ds = concatenate_datasets(splits)
-            ds = ds.add_column("id", [f"q{i}" for i in range(len(ds))])
+            self.dataset["default"][split] = _load_split(
+                _DATASET["path"], _DATASET["revision"], "feasibility", split, ["video", "audio", "text"]
+            )
+        self.data_loaded = True
 
-            queries = ds.select_columns(
-                ["id", "question", "video", "audio"]
-            ).rename_column("question", "text")
 
-            corpus_rows: list[dict] = []
-            relevant_docs: dict[str, dict[str, int]] = {}
-            top_ranked: dict[str, list[str]] = {}
-            for row in ds.select_columns(["id", "candidates", "answer"]):
-                qid = row["id"]
-                answer = row["answer"]
-                top_ranked[qid] = []
-                for j, candidate in enumerate(row["candidates"]):
-                    doc_id = f"{qid}_c{j}"
-                    corpus_rows.append({"id": doc_id, "text": candidate})
-                    top_ranked[qid].append(doc_id)
-                    if candidate == answer:
-                        relevant_docs[qid] = {doc_id: 1}
+class STARBenchInteractionVideoCentricQA(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="STARBenchInteractionVideoCentricQA",
+        description="STAR Interaction subset: questions about human-object interactions observed in the video. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate.",
+        reference="https://arxiv.org/abs/2301.08059",
+        dataset=_DATASET,
+        type="VideoCentricQA",
+        category="vt2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=_DATE,
+        domains=["Web"],
+        task_subtypes=["Question answering"],
+        license="cc-by-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video", "text"],
+        sample_creation="found",
+        is_beta=True,
+        bibtex_citation=_BIBTEX,
+    )
 
-            corpus = Dataset.from_list(corpus_rows)
-            self.dataset["default"][split] = RetrievalSplitData(
-                queries=queries,
-                corpus=corpus,
-                relevant_docs=relevant_docs,
-                top_ranked=top_ranked,
+    def load_data(self, **kwargs) -> None:
+        if self.data_loaded:
+            return
+        self.dataset = {"default": {}}
+        for split in self.metadata.eval_splits:
+            self.dataset["default"][split] = _load_split(
+                _DATASET["path"], _DATASET["revision"], "interaction", split, ["video", "text"]
+            )
+        self.data_loaded = True
+
+
+class STARBenchInteractionVideoAudioCentricQA(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="STARBenchInteractionVideoAudioCentricQA",
+        description="STAR Interaction subset: questions about human-object interactions observed in the video. The task is formulated as multiple-choice retrieval: given the (video, audio, question) tuple, retrieve the correct candidate.",
+        reference="https://arxiv.org/abs/2301.08059",
+        dataset=_DATASET,
+        type="VideoCentricQA",
+        category="vat2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=_DATE,
+        domains=["Web"],
+        task_subtypes=["Question answering"],
+        license="cc-by-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video", "audio", "text"],
+        sample_creation="found",
+        is_beta=True,
+        bibtex_citation=_BIBTEX,
+    )
+
+    def load_data(self, **kwargs) -> None:
+        if self.data_loaded:
+            return
+        self.dataset = {"default": {}}
+        for split in self.metadata.eval_splits:
+            self.dataset["default"][split] = _load_split(
+                _DATASET["path"], _DATASET["revision"], "interaction", split, ["video", "audio", "text"]
+            )
+        self.data_loaded = True
+
+
+class STARBenchPredictionVideoCentricQA(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="STARBenchPredictionVideoCentricQA",
+        description="STAR Prediction subset: questions requiring prediction of what will happen next given the video context. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate.",
+        reference="https://arxiv.org/abs/2301.08059",
+        dataset=_DATASET,
+        type="VideoCentricQA",
+        category="vt2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=_DATE,
+        domains=["Web"],
+        task_subtypes=["Question answering"],
+        license="cc-by-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video", "text"],
+        sample_creation="found",
+        is_beta=True,
+        bibtex_citation=_BIBTEX,
+    )
+
+    def load_data(self, **kwargs) -> None:
+        if self.data_loaded:
+            return
+        self.dataset = {"default": {}}
+        for split in self.metadata.eval_splits:
+            self.dataset["default"][split] = _load_split(
+                _DATASET["path"], _DATASET["revision"], "prediction", split, ["video", "text"]
+            )
+        self.data_loaded = True
+
+
+class STARBenchPredictionVideoAudioCentricQA(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="STARBenchPredictionVideoAudioCentricQA",
+        description="STAR Prediction subset: questions requiring prediction of what will happen next given the video context. The task is formulated as multiple-choice retrieval: given the (video, audio, question) tuple, retrieve the correct candidate.",
+        reference="https://arxiv.org/abs/2301.08059",
+        dataset=_DATASET,
+        type="VideoCentricQA",
+        category="vat2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=_DATE,
+        domains=["Web"],
+        task_subtypes=["Question answering"],
+        license="cc-by-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video", "audio", "text"],
+        sample_creation="found",
+        is_beta=True,
+        bibtex_citation=_BIBTEX,
+    )
+
+    def load_data(self, **kwargs) -> None:
+        if self.data_loaded:
+            return
+        self.dataset = {"default": {}}
+        for split in self.metadata.eval_splits:
+            self.dataset["default"][split] = _load_split(
+                _DATASET["path"], _DATASET["revision"], "prediction", split, ["video", "audio", "text"]
+            )
+        self.data_loaded = True
+
+
+class STARBenchSequenceVideoCentricQA(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="STARBenchSequenceVideoCentricQA",
+        description="STAR Sequence subset: questions about the temporal order of actions in the video. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate.",
+        reference="https://arxiv.org/abs/2301.08059",
+        dataset=_DATASET,
+        type="VideoCentricQA",
+        category="vt2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=_DATE,
+        domains=["Web"],
+        task_subtypes=["Question answering"],
+        license="cc-by-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video", "text"],
+        sample_creation="found",
+        is_beta=True,
+        bibtex_citation=_BIBTEX,
+    )
+
+    def load_data(self, **kwargs) -> None:
+        if self.data_loaded:
+            return
+        self.dataset = {"default": {}}
+        for split in self.metadata.eval_splits:
+            self.dataset["default"][split] = _load_split(
+                _DATASET["path"], _DATASET["revision"], "sequence", split, ["video", "text"]
+            )
+        self.data_loaded = True
+
+
+class STARBenchSequenceVideoAudioCentricQA(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="STARBenchSequenceVideoAudioCentricQA",
+        description="STAR Sequence subset: questions about the temporal order of actions in the video. The task is formulated as multiple-choice retrieval: given the (video, audio, question) tuple, retrieve the correct candidate.",
+        reference="https://arxiv.org/abs/2301.08059",
+        dataset=_DATASET,
+        type="VideoCentricQA",
+        category="vat2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=_DATE,
+        domains=["Web"],
+        task_subtypes=["Question answering"],
+        license="cc-by-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video", "audio", "text"],
+        sample_creation="found",
+        is_beta=True,
+        bibtex_citation=_BIBTEX,
+    )
+
+    def load_data(self, **kwargs) -> None:
+        if self.data_loaded:
+            return
+        self.dataset = {"default": {}}
+        for split in self.metadata.eval_splits:
+            self.dataset["default"][split] = _load_split(
+                _DATASET["path"], _DATASET["revision"], "sequence", split, ["video", "audio", "text"]
             )
         self.data_loaded = True

--- a/mteb/tasks/multichoice/eng/star_bench.py
+++ b/mteb/tasks/multichoice/eng/star_bench.py
@@ -84,7 +84,11 @@ class STARBenchFeasibilityVideoCentricQA(AbsTaskRetrieval):
         self.dataset = {"default": {}}
         for split in self.metadata.eval_splits:
             self.dataset["default"][split] = _load_split(
-                _DATASET["path"], _DATASET["revision"], "feasibility", split, ["video", "text"]
+                _DATASET["path"],
+                _DATASET["revision"],
+                "feasibility",
+                split,
+                ["video", "text"],
             )
         self.data_loaded = True
 
@@ -118,7 +122,11 @@ class STARBenchFeasibilityVideoAudioCentricQA(AbsTaskRetrieval):
         self.dataset = {"default": {}}
         for split in self.metadata.eval_splits:
             self.dataset["default"][split] = _load_split(
-                _DATASET["path"], _DATASET["revision"], "feasibility", split, ["video", "audio", "text"]
+                _DATASET["path"],
+                _DATASET["revision"],
+                "feasibility",
+                split,
+                ["video", "audio", "text"],
             )
         self.data_loaded = True
 
@@ -152,7 +160,11 @@ class STARBenchInteractionVideoCentricQA(AbsTaskRetrieval):
         self.dataset = {"default": {}}
         for split in self.metadata.eval_splits:
             self.dataset["default"][split] = _load_split(
-                _DATASET["path"], _DATASET["revision"], "interaction", split, ["video", "text"]
+                _DATASET["path"],
+                _DATASET["revision"],
+                "interaction",
+                split,
+                ["video", "text"],
             )
         self.data_loaded = True
 
@@ -186,7 +198,11 @@ class STARBenchInteractionVideoAudioCentricQA(AbsTaskRetrieval):
         self.dataset = {"default": {}}
         for split in self.metadata.eval_splits:
             self.dataset["default"][split] = _load_split(
-                _DATASET["path"], _DATASET["revision"], "interaction", split, ["video", "audio", "text"]
+                _DATASET["path"],
+                _DATASET["revision"],
+                "interaction",
+                split,
+                ["video", "audio", "text"],
             )
         self.data_loaded = True
 
@@ -220,7 +236,11 @@ class STARBenchPredictionVideoCentricQA(AbsTaskRetrieval):
         self.dataset = {"default": {}}
         for split in self.metadata.eval_splits:
             self.dataset["default"][split] = _load_split(
-                _DATASET["path"], _DATASET["revision"], "prediction", split, ["video", "text"]
+                _DATASET["path"],
+                _DATASET["revision"],
+                "prediction",
+                split,
+                ["video", "text"],
             )
         self.data_loaded = True
 
@@ -254,7 +274,11 @@ class STARBenchPredictionVideoAudioCentricQA(AbsTaskRetrieval):
         self.dataset = {"default": {}}
         for split in self.metadata.eval_splits:
             self.dataset["default"][split] = _load_split(
-                _DATASET["path"], _DATASET["revision"], "prediction", split, ["video", "audio", "text"]
+                _DATASET["path"],
+                _DATASET["revision"],
+                "prediction",
+                split,
+                ["video", "audio", "text"],
             )
         self.data_loaded = True
 
@@ -288,7 +312,11 @@ class STARBenchSequenceVideoCentricQA(AbsTaskRetrieval):
         self.dataset = {"default": {}}
         for split in self.metadata.eval_splits:
             self.dataset["default"][split] = _load_split(
-                _DATASET["path"], _DATASET["revision"], "sequence", split, ["video", "text"]
+                _DATASET["path"],
+                _DATASET["revision"],
+                "sequence",
+                split,
+                ["video", "text"],
             )
         self.data_loaded = True
 
@@ -322,6 +350,10 @@ class STARBenchSequenceVideoAudioCentricQA(AbsTaskRetrieval):
         self.dataset = {"default": {}}
         for split in self.metadata.eval_splits:
             self.dataset["default"][split] = _load_split(
-                _DATASET["path"], _DATASET["revision"], "sequence", split, ["video", "audio", "text"]
+                _DATASET["path"],
+                _DATASET["revision"],
+                "sequence",
+                split,
+                ["video", "audio", "text"],
             )
         self.data_loaded = True


### PR DESCRIPTION
Add STARBenchVideoCentricQA (vt2t) and STARBenchVideoAudioCentricQA (vat2t) tasks for the STAR (Situated Reasoning in Real-World Videos) benchmark. The dataset has 4 question types (feasibility, interaction, prediction, sequence) totaling ~7100 examples. Both classes follow the standard AbsTaskRetrieval + RetrievalSplitData pattern.

For question by @Samoed : We combine all 4 configs into one task so models are evaluated on the full STAR benchmark holistically : the same approach used by OmniVideoBench (16 subsets combined). Happy to split if preferred.