### PR TITLE
fix: Add F2LLM-v2-80M as a reference model

### DIFF
--- a/tests/test_benchmarks/test_reference_models.py
+++ b/tests/test_benchmarks/test_reference_models.py
@@ -16,6 +16,7 @@ REFERENCE_MODELS = [
     "sentence-transformers/static-similarity-mrl-multilingual-v1",
     "minishlab/potion-multilingual-128M",
     "mteb/baseline-bm25s",
+    "codefuse-ai/F2LLM-v2-80M",
 ]
 
 # Models that implement SearchProtocol only (retrieval/reranking tasks)


### PR DESCRIPTION
The previous PR (https://github.com/embeddings-benchmark/mteb/pull/4381) was closed due to inactivity.

Now reference model coverage tests are all passed.

Closes https://github.com/embeddings-benchmark/mteb/issues/4321