### PR TITLE
leaderboard: Add MVEB to leaderboard menu

### DIFF
--- a/mteb/benchmarks/_leaderboard_menu.py
+++ b/mteb/benchmarks/_leaderboard_menu.py
@@ -60,6 +60,17 @@ GP_BENCHMARK_ENTRIES = [
                 ),
             ),
             MenuEntry(
+                "Video",
+                mteb.get_benchmarks(
+                    [
+                        "MVEB",
+                        "MVEB(video)",
+                        "MVEB(text, video)",
+                        "MVEB(beta, extended)",
+                    ]
+                ),
+            ),
+            MenuEntry(
                 "Domain-Specific ",
                 mteb.get_benchmarks(
                     [


### PR DESCRIPTION
Adds a Video MenuEntry under Multimodal containing the MVEB benchmark family (`MVEB`, `MVEB(video)`, `MVEB(text, video)`, `MVEB(beta, extended)`), mirroring how MAEB is exposed under Audio.

Supersedes #4752 (which was incorrectly based on `mveb-paper-latex-generation` — thanks @Samoed for the catch). Will merge cleanly once the MVEB benchmark names land on main via #4650.
