### PR TITLE
fix: revision of ingot-8b-r3 to follow single-char API convention (r3 → 3)

### DIFF
--- a/mteb/models/model_implementations/ingot_models.py
+++ b/mteb/models/model_implementations/ingot_models.py
@@ -149,7 +149,7 @@ class IngotAPIEncoder(AbsEncoder):
 
 ingot_8b_r3 = ModelMeta(
     name="jcorners/ingot-8b-r3",
-    revision="r3",
+    revision="3",
     release_date="2026-05-23",
     languages=["eng-Latn"],
     loader=IngotAPIEncoder,


### PR DESCRIPTION
The merged ModelMeta declares revision="r3", but every other API model in the registry uses a single-character revision, and the results repo's test_revision_is_specified_for_new_additions requires a 40-char SHA or len==1. This aligns it to "3" so the model meta matches the API-version  convention and links to the results submission in  embeddings-benchmark/results#558.
