### PR TITLE
fix: Make project releasablle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,21 +126,10 @@ vllm = ["vllm>=0.11.1"]
 transformers-v4 = ["transformers<5"]
 siglip = ["sentencepiece>=0.2.0","protobuf>=3.0.0"]
 qwen-vl = ["transformers>=4.57.0", "qwen-vl-utils>=0.0.14"]
-omnivinci = ["transformers==4.46.0", "torch==2.8.*", "einops>=0.8.0", "openai-whisper>=20240930", "soundfile>=0.13.1", "opencv-python-headless>=4.0.0", "kaldiio>=2.18.0", "decord>=0.6.0", "librosa>=0.10.0", "beartype>=0.18.0", "accelerate>=1.0.0", "s2wrapper @ git+https://github.com/bfshi/scaling_on_scales", "deepspeed>=0.9.0", "torchvision>=0.15.0", "torchaudio>=2.0.0", "torchcodec==0.7.0", "av>=10.0.0", "numpy>=1.23.0,<2.0.0", "flash-attn>=2.6.3"]
+# omnivinci = ["transformers==4.46.0", "torch==2.8.*", "einops>=0.8.0", "openai-whisper>=20240930", "soundfile>=0.13.1", "opencv-python-headless>=4.0.0", "kaldiio>=2.18.0", "decord>=0.6.0", "librosa>=0.10.0", "beartype>=0.18.0", "accelerate>=1.0.0", "s2wrapper @ git+https://github.com/bfshi/scaling_on_scales", "deepspeed>=0.9.0", "torchvision>=0.15.0", "torchaudio>=2.0.0", "torchcodec==0.7.0", "av>=10.0.0", "numpy>=1.23.0,<2.0.0", "flash-attn>=2.6.3"]
 qwen_omni_utils = ["qwen_omni_utils"]
 embeddinggemma = ["transformers>=4.56.0"]
-ebind = ["ebind @ git+https://github.com/encord-team/ebind@7909701e9372353ca678b9515f9f61cf87c83c71", "soundfile>=0.13.1", "transformers>=4.57.1,!=5.0.0"]
-
-
-
-
-
-
-
-
-
-
-
+# ebind = ["ebind @ git+https://github.com/encord-team/ebind@7909701e9372353ca678b9515f9f61cf87c83c71", "soundfile>=0.13.1", "transformers>=4.57.1,!=5.0.0"]
 
 
 
@@ -444,9 +433,9 @@ conflicts = [
         { extra = "muq" },
         { extra = "transformers-v4" },
         { extra = "qwen-vl" },
-        { extra = "omnivinci" },
+#        { extra = "omnivinci" },
         { extra = "embeddinggemma" },
-        { extra = "ebind" },
+#        { extra = "ebind" },
         { extra = "visrag-ret" }, # conflicting version of timm with blip2
     ],
 ]


### PR DESCRIPTION
  Currently on PYPI latest version of mteb is `2.12.30`. In the next commits, we added git dependencies which are actually not valid for publishing on pypi. Noticed by @AdnanElAssadi56. Summary of investigation:

  The actual failure (not the no-op run you originally linked) is:

  - **Run**: https://github.com/embeddings-benchmark/mteb/actions/runs/27025138385
  - **Failing step**: `Publish package distributions to PyPI` (step 7 of the `release` job)
  - Full chain of identical failures going back to 2026-04-30 visible at: https://github.com/embeddings-benchmark/mteb/actions/workflows/release.yml?query=is%3Afailure

  The 400 response body in the log says explicitly:
  > Can't have direct dependency: s2wrapper @ git+https://github.com/bfshi/scaling_on_scales ; extra == "omnivinci". See https://packaging.python.org/specifications/core-metadata for more information.

  ## PyPI side — where the rule lives

  PyPI itself doesn't have a glossy policy page; the rule is enforced in Warehouse (the PyPI server) source code:

  - **Warehouse validation code that emits the error**: [`warehouse/forklift/metadata.py`](https://github.com/pypi/warehouse/blob/82b725b339dd7b2d06a764b44129425f7c497c76/warehouse/forklift/metadata.py#L240-L247) — iterates `requires_dist`, and if `req.url is not None` it appends `InvalidMetadata("Can't have direct dependency: …")`.
  - **Tracking issue / policy discussion** (the canonical place users get pointed to): [pypi/warehouse#7136 — "Allow PEP 508 URL requirements in requires_dist"](https://github.com/pypi/warehouse/issues/7136) and the duplicate [#9404](https://github.com/pypi/warehouse/issues/9404).
  - **Spec the error links to**: [Core metadata specifications — `Requires-Dist`](https://packaging.python.org/en/latest/specifications/core-metadata/#requires-dist-multiple-use) (PyPA packaging docs). Combined with [PEP 440 §Direct references](https://peps.python.org/pep-0440/#direct-references), which notes:
    > Public index servers SHOULD NOT allow the use of direct references in uploaded distributions.

  That "SHOULD NOT" is what Warehouse implements as a hard reject.

  Sources:
  - [mteb release run 27025138385 (failing)](https://github.com/embeddings-benchmark/mteb/actions/runs/27025138385)
  - [warehouse/forklift/metadata.py — "Can't have direct dependency"](https://github.com/pypi/warehouse/blob/main/warehouse/forklift/metadata.py)
  - [pypi/warehouse#7136 — Allow PEP 508 URL requirements in requires_dist](https://github.com/pypi/warehouse/issues/7136)
  - [pypi/warehouse#9404 — Cannot upload with external dependency](https://github.com/pypi/warehouse/issues/9404)
  - [PyPA core-metadata spec — Requires-Dist](https://packaging.python.org/en/latest/specifications/core-metadata/#requires-dist-multiple-use)
  - [PEP 440 — Direct references](https://peps.python.org/pep-0440/#direct-references)