### PR TITLE
fix filter by model size

### DIFF
--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -582,9 +582,7 @@ def get_leaderboard_app(  # noqa: PLR0914
 
     logger.info("Step 5/6: Creating Gradio components...")
     component_start = time.time()
-    default_languages = sorted(
-        default_pl_df["language"].explode().drop_nulls().unique().to_list()
-    )
+    default_languages = sorted(_benchmark_full_languages(default_benchmark.name))
     default_task_types = sorted(
         {
             _TASKS_REGISTRY[t].metadata.type


### PR DESCRIPTION
  Close https://github.com/embeddings-benchmark/mteb/issues/4793

  mteb/leaderboard/app.py:594-596 initialized default_languages from the polars language column (full codes like "eng-Latn"), while every consumer (update_scores_on_lang_change, update_tables, and _cache_on_benchmark_select) treats lang_select values as 3-letter codes
  ("eng").

  Consequences in update_tables:
  1. set(languages).issuperset(_benchmark_full_languages(...)) always returned False (full vs 3-letter), so the "skip when all selected" optimization never kicked in.
  2. The mask pl.element().str.split("-").list.first().is_in(lang_set) split each row's "eng-Latn" to "eng" and looked it up against the full-code lang_set — matching zero rows.

  Initial render dodged it (no update_tables); any filter click triggered the broken language filter → empty table.
