### PR TITLE
model: add Verm1ion/ColTurk-VDR-Qwen3VL-4B-v1.0

### DIFF
--- a/mteb/models/model_implementations/colqwen_models.py
+++ b/mteb/models/model_implementations/colqwen_models.py
@@ -680,7 +680,7 @@ colturk_vdr_4b = ModelMeta(
     release_date="2026-06-11",
     modalities=["image", "text"],
     n_parameters=4_505_515_136,
-    n_embedding_parameters=None,
+    n_embedding_parameters=388_956_160,
     memory_usage_mb=8593,
     max_tokens=262144,
     embed_dim=128,
@@ -695,4 +695,5 @@ colturk_vdr_4b = ModelMeta(
     training_datasets=COLPALI_TRAINING_DATA,
     citation=COLTURK_CITATION,
     extra_requirements_groups=["colpali_engine"],
+    adapted_from="Qwen/Qwen3-VL-4B-Instruct",
 )

--- a/mteb/models/model_implementations/colqwen_models.py
+++ b/mteb/models/model_implementations/colqwen_models.py
@@ -635,3 +635,64 @@ colqwen3_5_v3 = ModelMeta(
     training_datasets=COLQWEN35_V3_TRAINING_DATA,
     extra_requirements_groups=["colpali_engine"],
 )
+
+
+class ColQwen3EngineWrapper(ColPaliEngineWrapper):
+    """Wrapper for colpali_engine ColQwen3 models (merged full checkpoints)."""
+
+    def __init__(
+        self,
+        model_name: str = "Verm1ion/ColTurk-VDR-Qwen3VL-4B-v1.0",
+        revision: str | None = None,
+        device: str | None = None,
+        **kwargs,
+    ):
+        from colpali_engine.models import ColQwen3, ColQwen3Processor
+
+        super().__init__(
+            model_name=model_name,
+            model_class=ColQwen3,
+            processor_class=ColQwen3Processor,
+            revision=revision,
+            device=device,
+            **kwargs,
+        )
+
+
+COLTURK_CITATION = """
+@misc{karatay2026colturkvdr,
+  title={ColTurk-VDR: A Late-Interaction Visual Document Retriever on Qwen3-VL-4B},
+  author={Karatay, Mert},
+  year={2026},
+  url={https://github.com/Verm1lion/ColTurk-VDR}
+}
+"""
+
+colturk_vdr_4b = ModelMeta(
+    loader=ColQwen3EngineWrapper,
+    loader_kwargs=dict(
+        torch_dtype=torch.bfloat16,
+    ),
+    name="Verm1ion/ColTurk-VDR-Qwen3VL-4B-v1.0",
+    model_type=["late-interaction"],
+    languages=["eng-Latn", "fra-Latn"],
+    revision="d56c7bbc278ba2fe4ac1c255fb0e55dd46b40bad",
+    release_date="2026-06-11",
+    modalities=["image", "text"],
+    n_parameters=4_505_515_136,
+    n_embedding_parameters=None,
+    memory_usage_mb=8593,
+    max_tokens=262144,
+    embed_dim=128,
+    license="apache-2.0",
+    open_weights=True,
+    public_training_code="https://github.com/Verm1lion/ColTurk-VDR",
+    public_training_data="https://huggingface.co/datasets/manu/colpali-queries",
+    framework=["ColPali", "safetensors"],
+    reference="https://huggingface.co/Verm1ion/ColTurk-VDR-Qwen3VL-4B-v1.0",
+    similarity_fn_name=ScoringFunction.MAX_SIM,
+    use_instructions=True,
+    training_datasets=COLPALI_TRAINING_DATA,
+    citation=COLTURK_CITATION,
+    extra_requirements_groups=["colpali_engine"],
+)


### PR DESCRIPTION
Adds **ColTurk-VDR-Qwen3VL-4B-v1.0** — a ColBERT-style late-interaction visual document retriever built on `Qwen/Qwen3-VL-4B-Instruct` (LoRA r=32, published as merged full weights; colpali-engine `ColQwen3` architecture, Apache-2.0, open weights, public training code and data).

Since the model is a colpali-engine-native checkpoint (not a `trust_remote_code` repo), this PR also adds a small `ColQwen3EngineWrapper` that mirrors the existing `ColQwen2_5Wrapper` pattern (delegates to `colpali_engine.models.ColQwen3` / `ColQwen3Processor` via `ColPaliEngineWrapper`).

**ViDoRe V3 results** (8 public retrieval tasks, full corpus, all queries, MaxSim) — mean **NDCG@10 = 0.5584**:

| Task | NDCG@10 |
|---|---|
| Vidore3ComputerScienceRetrieval | 0.7306 |
| Vidore3EnergyRetrieval | 0.6238 |
| Vidore3PharmaceuticalsRetrieval | 0.6156 |
| Vidore3FinanceEnRetrieval | 0.5851 |
| Vidore3HrRetrieval | 0.5463 |
| Vidore3IndustrialRetrieval | 0.4624 |
| Vidore3PhysicsRetrieval | 0.4564 |
| Vidore3FinanceFrRetrieval | 0.4467 |

Eval code & raw result JSONs (with seeded bootstrap 95% CIs): https://github.com/Verm1lion/ColTurk-VDR — results PR: embeddings-benchmark/results#565 · private-split request: #4797.

- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [x] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e., is available either as an API or the weights are publicly available to download
- [x] I reproduced results from the original paper (if applicable) on at least one benchmark, and I am including the results in the PR description.

Notes for reviewers:
- The wrapper's load path (`ColQwen3.from_pretrained` + `ColQwen3Processor.from_pretrained` on the published repo) was smoke-verified end-to-end on the exact revision pinned in the ModelMeta.
- The results above were produced with the published self-contained harness (identical loading + MaxSim over the full corpora, all queries). Happy to re-run anything via `mteb.evaluate` on request.
- Training data (the ColPali train set) vs. ViDoRe V3 contamination was checked empirically (perceptual-hash scan over train images x V3 corpora: 0 exact duplicates; report in the linked repo).
