### PR TITLE
polish MVEB leaderboard names + icons

### DIFF
--- a/mteb/benchmarks/benchmarks/benchmarks.py
+++ b/mteb/benchmarks/benchmarks/benchmarks.py
@@ -3272,7 +3272,7 @@ MVEB = Benchmark(
     name="MVEB(beta)",
     aliases=["MVEB"],
     display_name="MVEB",
-    icon="https://raw.githubusercontent.com/DennisSuitters/LibreICONS/master/svg/libre-gui-activity.svg",
+    icon="https://github.com/DennisSuitters/LibreICONS/raw/2d2172d15e3c6ca03c018629d60050e4b99e5c55/svg-color/libre-gui-video.svg",
     tasks=get_tasks(
         tasks=[
             # Any2AnyRetrieval (10)
@@ -3316,8 +3316,8 @@ MVEB = Benchmark(
 MVEB_TEXT_VIDEO = Benchmark(
     name="MVEB(text, video, beta)",
     aliases=["MVEB(text, video)"],
-    display_name="Text+Video",
-    icon="https://raw.githubusercontent.com/DennisSuitters/LibreICONS/master/svg/libre-gui-activity.svg",
+    display_name="MVEB Video-Text",
+    icon="https://github.com/DennisSuitters/LibreICONS/raw/2d2172d15e3c6ca03c018629d60050e4b99e5c55/svg-color/libre-gui-video.svg",
     tasks=get_tasks(
         tasks=[
             # Any2AnyRetrieval (8)
@@ -3357,8 +3357,8 @@ MVEB_TEXT_VIDEO = Benchmark(
 MVEB_VIDEO = Benchmark(
     name="MVEB(video, beta)",
     aliases=["MVEB(video)"],
-    display_name="Video",
-    icon="https://raw.githubusercontent.com/DennisSuitters/LibreICONS/master/svg/libre-gui-activity.svg",
+    display_name="MVEB Video-Only",
+    icon="https://github.com/DennisSuitters/LibreICONS/raw/2d2172d15e3c6ca03c018629d60050e4b99e5c55/svg-color/libre-gui-video.svg",
     tasks=get_tasks(
         tasks=[
             # VideoClassification (6)


### PR DESCRIPTION
- display_name: "Video" -> "MVEB Video", "Text+Video" -> "MVEB Text+Video" so the leaderboard entries read clearly out of context (MVEB(beta) stays "MVEB").
- icon: switch the three displayed MVEB benchmarks from the monochrome, unpinned master/svg/libre-gui-activity icon to the colored, commit-pinned svg-color/libre-gui-video icon, matching the convention used by the other benchmarks.

If you add a model or a dataset, please add the corresponding checklist:

* [dataset checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_dataset/#submit-a-pull-request)
* [model checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_model/#submitting-your-model-as-a-pr)
