### PR TITLE
Add topk-io/Iso-ModernColBERT model meta

### DIFF
--- a/mteb/models/model_implementations/pylate_models.py
+++ b/mteb/models/model_implementations/pylate_models.py
@@ -512,6 +512,42 @@ lightonai__gte_moderncolbert_v1 = ModelMeta(
     extra_requirements_groups=["pylate"],
 )
 
+topk_io__iso_moderncolbert = ModelMeta(
+    loader=MultiVectorModel,
+    name="topk-io/Iso-ModernColBERT",
+    model_type=["late-interaction"],
+    languages=[
+        "eng-Latn",
+    ],
+    open_weights=True,
+    revision="a43b93e62b11ff205b7f935c1ce2207bfed2d283",
+    public_training_code=None,
+    public_training_data="https://huggingface.co/datasets/lightonai/ms-marco-en-bge-gemma",
+    release_date="2026-05-27",
+    n_parameters=149015808,
+    n_embedding_parameters=38684160,
+    memory_usage_mb=568,
+    max_tokens=8192,
+    embed_dim=128,
+    license="apache-2.0",
+    similarity_fn_name=ScoringFunction.MAX_SIM,
+    framework=["PyLate", "ColBERT", "safetensors", "Sentence Transformers"],
+    reference="https://huggingface.co/topk-io/Iso-ModernColBERT",
+    use_instructions=False,
+    adapted_from="lightonai/GTE-ModernColBERT-v1",
+    superseded_by=None,
+    training_datasets={
+        "MSMARCO",
+    },
+    citation="""@misc{Iso-ModernColBERT,
+    title={Iso-ModernColBERT},
+    author={TopK},
+    url={https://huggingface.co/topk-io/Iso-ModernColBERT},
+    year={2026}
+}""",
+    extra_requirements_groups=["pylate"],
+)
+
 late_on_code_citation = """@misc{LateOn-Code,
   title  = {LateOn-Code: a Family of State-Of-The-Art Late Interaction Code Retrieval Models},
   author = {Chaffin, Antoine},


### PR DESCRIPTION
## Summary

Closes #4758.

Adds the `ModelMeta` entry for **`topk-io/Iso-ModernColBERT`** to
`mteb/models/model_implementations/pylate_models.py`.

Iso-ModernColBERT is a PyLate / ColBERT late-interaction (multi-vector) model —
an *isotropically corrected* version of `lightonai/GTE-ModernColBERT-v1` built
for faster `bf16` inference at near-identical accuracy. It loads via the same
`MultiVectorModel` loader as the other ModernColBERT entries.

## Metadata sources

All fields were taken from the model card + HF API (not guessed):

- **revision** `a43b93e62b11ff205b7f935c1ce2207bfed2d283` (current `main`)
- **license** `apache-2.0`, **languages** `eng-Latn`
- **adapted_from** `lightonai/GTE-ModernColBERT-v1` (HF `base_model`), so it
  shares its architecture: 149,015,808 params, 128-dim embeddings, 8192 tokens
- **public_training_data** `lightonai/ms-marco-en-bge-gemma` (card `datasets`)
- `release_date` from the repo creation date (2026-05-27)

## Verification

```python
from mteb.models.model_implementations import MODEL_REGISTRY
MODEL_REGISTRY["topk-io/Iso-ModernColBERT"]  # registers cleanly
```

- `ruff check` / `ruff format --check`: clean
- `pytest tests/test_models/test_model_meta.py -k "name_and_revision or hashable or without_prefix"`: **731 passed**
