### PR TITLE
Fix Querit model implementation: Supplementing the base model information of the Querit/Querit-4B

### DIFF
--- a/mteb/models/model_implementations/querit_models.py
+++ b/mteb/models/model_implementations/querit_models.py
@@ -237,6 +237,7 @@ Querit_Reranker_A0_6B = ModelMeta(
     reference="https://huggingface.co/Querit/Querit",
     similarity_fn_name=None,
     training_datasets=querit_reranker_training_data,
+    adapted_from="Qwen/Qwen3-Embedding-4B",
     license="apache-2.0",
     framework=["PyTorch"],
     use_instructions=None,

--- a/mteb/models/model_implementations/querit_models.py
+++ b/mteb/models/model_implementations/querit_models.py
@@ -217,7 +217,7 @@ querit_reranker_training_data = {
     "T2Reranking",  # https://huggingface.co/datasets/THUIR/T2Ranking & The corpus and queries that overlap with mteb/T2Reranking have been removed.
 }
 
-Querit_Reranker_A0_6B = ModelMeta(
+Querit_Reranker_A0_4B = ModelMeta(
     loader=QueritWrapper,
     loader_kwargs={
         "fp_options": "bfloat16",
@@ -237,7 +237,6 @@ Querit_Reranker_A0_6B = ModelMeta(
     reference="https://huggingface.co/Querit/Querit",
     similarity_fn_name=None,
     training_datasets=querit_reranker_training_data,
-    adapted_from="Qwen/Qwen3-Embedding-4B",
     license="apache-2.0",
     framework=["PyTorch"],
     use_instructions=None,
@@ -265,6 +264,7 @@ Querit_Reranker_4B = ModelMeta(
     reference="https://huggingface.co/Querit/Querit-4B",
     similarity_fn_name=None,
     training_datasets=querit_reranker_training_data,
+    adapted_from="Qwen/Qwen3-Embedding-4B",
     license="apache-2.0",
     framework=["PyTorch"],
     use_instructions=None,


### PR DESCRIPTION
Supplement the base model information of the Querit/Querit-4B and modify the ModelMeta Entry according to the actual activation parameters of Querit/Querit.
- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [x] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e., is available either as an API or the weights are publicly available to download