### PR TITLE
Update Querit model implementation: Supplementing the citation information of Querit

### DIFF
--- a/mteb/models/model_implementations/querit_models.py
+++ b/mteb/models/model_implementations/querit_models.py
@@ -217,6 +217,16 @@ querit_reranker_training_data = {
     "T2Reranking",  # https://huggingface.co/datasets/THUIR/T2Ranking & The corpus and queries that overlap with mteb/T2Reranking have been removed.
 }
 
+QUERIT_CITATION = """@misc{zhong2026queritrerankertrainingcompactmultilingual,
+      title={Querit-Reranker: Training Compact Multilingual Rerankers via Efficient Label-Free Distribution Adaptation}, 
+      author={Yunfei Zhong and Jun Yang and Wei Huang and Yinqiong Cai and Haosheng Qian and Yixing Fan and Ruqing Zhang and Lixin Su and Daiting Shi and Jiafeng Guo},
+      year={2026},
+      eprint={2606.19037},
+      archivePrefix={arXiv},
+      primaryClass={cs.IR},
+      url={https://arxiv.org/abs/2606.19037}, 
+}"""
+
 Querit_Reranker_A0_4B = ModelMeta(
     loader=QueritWrapper,
     loader_kwargs={
@@ -242,7 +252,7 @@ Querit_Reranker_A0_4B = ModelMeta(
     use_instructions=None,
     public_training_code=None,
     public_training_data=None,
-    citation=None,
+    citation=QUERIT_CITATION,
 )
 
 Querit_Reranker_4B = ModelMeta(
@@ -270,5 +280,5 @@ Querit_Reranker_4B = ModelMeta(
     use_instructions=None,
     public_training_code=None,
     public_training_data=None,
-    citation=None,
+    citation=QUERIT_CITATION,
 )


### PR DESCRIPTION
Supplement the citation information for Querit/Querit and Querit/Querit-4B.
- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [x] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e., is available either as an API or the weights are publicly available to download