### PR TITLE
Add VultronRetrieverPrime-Qwen3.5-8B ModelMeta

### DIFF
--- a/mteb/models/model_implementations/colqwen_models.py
+++ b/mteb/models/model_implementations/colqwen_models.py
@@ -697,3 +697,51 @@ colturk_vdr_4b = ModelMeta(
     extra_requirements_groups=["colpali_engine"],
     adapted_from="Qwen/Qwen3-VL-4B-Instruct",
 )
+
+VULTRON_PRIME_8B_TRAINING_DATA = {
+    # from https://huggingface.co/datasets/vidore/colpali_train_set
+    "VidoreDocVQARetrieval",
+    "VidoreInfoVQARetrieval",
+    "VidoreTatdqaRetrieval",
+    "VidoreArxivQARetrieval",
+    # from https://huggingface.co/datasets/Metric-AI/tabfquad_train_set
+    "VidoreTabfquadRetrieval",
+    # from https://huggingface.co/datasets/llamaindex/vdr-multilingual-train
+    "VDRMultilingualRetrieval",
+    # from https://huggingface.co/datasets/openbmb/VisRAG-Ret-Train-Synthetic-data
+    "VisRAG-Ret-Train-Synthetic-data",
+    # from https://huggingface.co/datasets/openbmb/VisRAG-Ret-Train-In-domain-data
+    "VisRAG-Ret-Train-In-domain-data",
+    # from https://huggingface.co/datasets/HuggingFaceM4/Docmatix (IR adaptation)
+    "docmatix-ir",
+    # wiki-ss + Natural Questions document-screenshot retrieval
+    "wiki-ss-nq",
+}
+
+vultron_prime_qwen35_8b = ModelMeta(
+    loader=ColQwen3_5Wrapper,
+    loader_kwargs=dict(
+        torch_dtype=torch.bfloat16,
+    ),
+    name="athrael-soju/VultronRetrieverPrime-Qwen3.5-8B",
+    model_type=["late-interaction"],
+    languages=["eng-Latn", "fra-Latn", "deu-Latn", "spa-Latn", "ita-Latn", "por-Latn"],
+    revision="e8f3104b743a04b0d5f715b67117d687ae99ce51",
+    release_date="2026-06-18",
+    modalities=["image", "text"],
+    n_parameters=8_394_006_064,
+    n_embedding_parameters=1_017_118_720,  # vocab 248320 x hidden 4096 (token embedding matrix)
+    memory_usage_mb=16788,
+    max_tokens=262144,
+    embed_dim=320,
+    license="apache-2.0",
+    open_weights=True,
+    public_training_code=None,
+    public_training_data=None,
+    framework=["PyTorch", "ColPali", "safetensors"],
+    reference="https://huggingface.co/athrael-soju/VultronRetrieverPrime-Qwen3.5-8B",
+    similarity_fn_name=ScoringFunction.MAX_SIM,
+    use_instructions=False,
+    training_datasets=VULTRON_PRIME_8B_TRAINING_DATA,
+    extra_requirements_groups=["colpali_engine"],
+)


### PR DESCRIPTION
Adds a `ModelMeta` for [`athrael-soju/VultronRetrieverPrime-Qwen3.5-8B`](https://huggingface.co/athrael-soju/VultronRetrieverPrime-Qwen3.5-8B), a late-interaction (ColBERT-style MaxSim) visual document retriever.

- **Architecture:** ColQwen3.5 (Qwen3.5-VL backbone), multi-vector, `embed_dim` 320, image+text
- **Size:** 8.4B params, Apache-2.0, 6 languages (eng/fra/deu/spa/ita/por)
- **Loader:** reuses the existing `ColQwen3_5Wrapper` (no wrapper change); `extra_requirements_groups=["colpali_engine"]`
- **Revision:** `e8f3104b743a04b0d5f715b67117d687ae99ce51` (public, open weights on HF)

Official ViDoRe scores (ndcg@5 / ndcg@5 / ndcg@10): **V1 0.9208 / V2 0.6818 / V3 0.6472**.

The matching results PR to `embeddings-benchmark/results` will follow once this is merged (the results `name` needs the registered `ModelMeta` to resolve).