### PR TITLE
model: update VultronRetrieverPrime-Qwen3.5-8B repo path to the vultr org

### DIFF
--- a/mteb/models/model_implementations/colqwen_models.py
+++ b/mteb/models/model_implementations/colqwen_models.py
@@ -723,7 +723,7 @@ vultron_prime_qwen35_8b = ModelMeta(
     loader_kwargs=dict(
         torch_dtype=torch.bfloat16,
     ),
-    name="athrael-soju/VultronRetrieverPrime-Qwen3.5-8B",
+    name="vultr/VultronRetrieverPrime-Qwen3.5-8B",
     model_type=["late-interaction"],
     languages=["eng-Latn", "fra-Latn", "deu-Latn", "spa-Latn", "ita-Latn", "por-Latn"],
     revision="e8f3104b743a04b0d5f715b67117d687ae99ce51",
@@ -739,7 +739,7 @@ vultron_prime_qwen35_8b = ModelMeta(
     public_training_code=None,
     public_training_data=None,
     framework=["PyTorch", "ColPali", "safetensors"],
-    reference="https://huggingface.co/athrael-soju/VultronRetrieverPrime-Qwen3.5-8B",
+    reference="https://huggingface.co/vultr/VultronRetrieverPrime-Qwen3.5-8B",
     similarity_fn_name=ScoringFunction.MAX_SIM,
     use_instructions=False,
     training_datasets=VULTRON_PRIME_8B_TRAINING_DATA,


### PR DESCRIPTION
The VultronRetrieverPrime-Qwen3.5-8B repository moved on the Hub from `athrael-soju/` to `vultr/`. This updates the `ModelMeta` `name` and `reference` to `vultr/VultronRetrieverPrime-Qwen3.5-8B`.

Revision `e8f3104b743a04b0d5f715b67117d687ae99ce51` is preserved across the transfer, so the existing results entry still matches the registered revision. A companion PR to `embeddings-benchmark/results` renames the results directory to `vultr__VultronRetrieverPrime-Qwen3.5-8B`.

No scores change.