### PR TITLE
fix por benchmark

### DIFF
--- a/mteb/benchmarks/benchmarks/benchmarks.py
+++ b/mteb/benchmarks/benchmarks/benchmarks.py
@@ -784,7 +784,7 @@ MTEB_PT = Benchmark(
     icon="https://raw.githubusercontent.com/lipis/flag-icons/260c91531be024944c6514130c5defb2ebb02b7d/flags/4x3/br.svg",
     tasks=MTEBTasks(
         get_tasks(
-            languages=["pt"],
+            languages=["por"],
             tasks=[
                 # STS (3)
                 "Assin2STS",


### PR DESCRIPTION
Fix benchmark language filter from https://github.com/embeddings-benchmark/mteb/pull/4801 CC @Lucas-Okamura

Currently it output:
```
Skipping task 'Assin2STS': no subsets match the language filter ['pt'].
/Users/samoed/Desktop/mteb/mteb/get_tasks.py:299: UserWarning: Skipping task 'Assin2STS': no subsets match the language filter ['pt'].
  log_once.warning(
Skipping task 'SICK-BR-STS': no subsets match the language filter ['pt'].
/Users/samoed/Desktop/mteb/mteb/get_tasks.py:299: UserWarning: Skipping task 'SICK-BR-STS': no subsets match the language filter ['pt'].
  log_once.warning(
Skipping task 'STSBenchmarkMultilingualSTS': no subsets match the language filter ['pt'].
/Users/samoed/Desktop/mteb/mteb/get_tasks.py:299: UserWarning: Skipping task 'STSBenchmarkMultilingualSTS': no subsets match the language filter ['pt'].
  log_once.warning(
Skipping task 'MassiveIntentClassification': no subsets match the language filter ['pt'].
/Users/samoed/Desktop/mteb/mteb/get_tasks.py:299: UserWarning: Skipping task 'MassiveIntentClassification': no subsets match the language filter ['pt'].
  log_once.warning(
Skipping task 'BrazilianToxicTweetsClassification': no subsets match the language filter ['pt'].
/Users/samoed/Desktop/mteb/mteb/get_tasks.py:299: UserWarning: Skipping task 'BrazilianToxicTweetsClassification': no subsets match the language filter ['pt'].
  log_once.warning(
Skipping task 'HateSpeechPortugueseClassification': no subsets match the language filter ['pt'].
/Users/samoed/Desktop/mteb/mteb/get_tasks.py:299: UserWarning: Skipping task 'HateSpeechPortugueseClassification': no subsets match the language filter ['pt'].
  log_once.warning(
Skipping task 'MultiLongDocReranking': no subsets match the language filter ['pt'].
/Users/samoed/Desktop/mteb/mteb/get_tasks.py:299: UserWarning: Skipping task 'MultiLongDocReranking': no subsets match the language filter ['pt'].
  log_once.warning(
Skipping task 'WikipediaRerankingMultilingual': no subsets match the language filter ['pt'].
/Users/samoed/Desktop/mteb/mteb/get_tasks.py:299: UserWarning: Skipping task 'WikipediaRerankingMultilingual': no subsets match the language filter ['pt'].
  log_once.warning(
Skipping task 'XGlueWPRReranking': no subsets match the language filter ['pt'].
/Users/samoed/Desktop/mteb/mteb/get_tasks.py:299: UserWarning: Skipping task 'XGlueWPRReranking': no subsets match the language filter ['pt'].
  log_once.warning(
Skipping task 'MultiLongDocRetrieval': no subsets match the language filter ['pt'].
/Users/samoed/Desktop/mteb/mteb/get_tasks.py:299: UserWarning: Skipping task 'MultiLongDocRetrieval': no subsets match the language filter ['pt'].
  log_once.warning(
Skipping task 'WikipediaRetrievalMultilingual': no subsets match the language filter ['pt'].
/Users/samoed/Desktop/mteb/mteb/get_tasks.py:299: UserWarning: Skipping task 'WikipediaRetrievalMultilingual': no subsets match the language filter ['pt'].
  log_once.warning(
```