### PR TITLE
Add vultr/VultronRetrieverFlash-Qwen3.5-0.8B

### DIFF
--- a/mteb/models/model_implementations/colqwen_models.py
+++ b/mteb/models/model_implementations/colqwen_models.py
@@ -745,3 +745,31 @@ vultron_prime_qwen35_8b = ModelMeta(
     training_datasets=VULTRON_PRIME_8B_TRAINING_DATA,
     extra_requirements_groups=["colpali_engine"],
 )
+
+vultron_flash_qwen35_0_8b = ModelMeta(
+    loader=ColQwen3_5Wrapper,
+    loader_kwargs=dict(
+        torch_dtype=torch.bfloat16,
+    ),
+    name="vultr/VultronRetrieverFlash-Qwen3.5-0.8B",
+    model_type=["late-interaction"],
+    languages=["eng-Latn", "fra-Latn", "deu-Latn", "spa-Latn", "ita-Latn", "por-Latn"],
+    revision="5d1a696e8e62f12508045a93543dfd0488ea3b77",
+    release_date="2026-06-21",
+    modalities=["image", "text"],
+    n_parameters=853_341_916,
+    n_embedding_parameters=254_279_680,  # vocab 248320 x hidden 1024 (token embedding matrix)
+    memory_usage_mb=1707,
+    max_tokens=262144,
+    embed_dim=320,
+    license="apache-2.0",
+    open_weights=True,
+    public_training_code=None,
+    public_training_data=None,
+    framework=["PyTorch", "ColPali", "safetensors"],
+    reference="https://huggingface.co/vultr/VultronRetrieverFlash-Qwen3.5-0.8B",
+    similarity_fn_name=ScoringFunction.MAX_SIM,
+    use_instructions=False,
+    training_datasets=VULTRON_PRIME_8B_TRAINING_DATA,  # 0.8B sibling, same training pool as the 8B Prime
+    extra_requirements_groups=["colpali_engine"],
+)


### PR DESCRIPTION
Adds a `ModelMeta` for **[vultr/VultronRetrieverFlash-Qwen3.5-0.8B](https://huggingface.co/vultr/VultronRetrieverFlash-Qwen3.5-0.8B)**, the 0.8B small-tier sibling of the already-registered `vultr/VultronRetrieverPrime-Qwen3.5-8B`.

- Late-interaction (ColBERT-style, MaxSim) visual document retriever, `ColQwen3_5` architecture, 320-dim multi-vector, image+text.
- Reuses the existing `ColQwen3_5Wrapper` verbatim (same loader as `colqwen3_5_v3` and the 8B Prime entry); `embed_dim=320` is set via `ModelMeta`, no wrapper change.
- Apache-2.0, 6 languages (en/fr/de/es/it/pt), base `Qwen/Qwen3.5-0.8B`.
- `training_datasets` is the same pool as the 8B Prime entry (`VULTRON_PRIME_8B_TRAINING_DATA`).

Official MTEB ViDoRe (late-interaction evaluator, dim 320 / 1792 visual tokens): **V1 0.8815 (ndcg@5) / V2 0.6036 (ndcg@5) / V3 0.5649 (ndcg@10)**.

The matching results PR (V1/V2/V3 task JSONs) to `embeddings-benchmark/results` follows once this merges, so the model name resolves via `get_model_meta`.