### PR TITLE
Fix HatefulMemes, SciMMIR, and Memotion retrieval tasks as they fail with TypeError

### DIFF
--- a/mteb/tasks/retrieval/eng/hateful_memes_i2t_retrieval.py
+++ b/mteb/tasks/retrieval/eng/hateful_memes_i2t_retrieval.py
@@ -29,6 +29,7 @@ def _load_data(path: str, splits: str, revision: str | None = None):
         remove_columns=[
             "split",
             "label",
+            "image",
         ],
     )
 
@@ -43,6 +44,7 @@ def _load_data(path: str, splits: str, revision: str | None = None):
             remove_columns=[
                 "split",
                 "label",
+                "text",
             ],
         )
         relevant_docs[split] = {}

--- a/mteb/tasks/retrieval/eng/hateful_memes_t2i_retrieval.py
+++ b/mteb/tasks/retrieval/eng/hateful_memes_t2i_retrieval.py
@@ -29,6 +29,7 @@ def _load_data(path: str, splits: str, revision: str | None = None):
         remove_columns=[
             "split",
             "label",
+            "text",
         ],
     )
 
@@ -43,6 +44,7 @@ def _load_data(path: str, splits: str, revision: str | None = None):
             remove_columns=[
                 "split",
                 "label",
+                "image",
             ],
         )
         relevant_docs[split] = {}

--- a/mteb/tasks/retrieval/eng/memotion_i2t_retrieval.py
+++ b/mteb/tasks/retrieval/eng/memotion_i2t_retrieval.py
@@ -42,6 +42,7 @@ def _load_data(path: str, splits: str, revision: str | None = None):
                     "offensive",
                     "motivational",
                     "sentiment",
+                    "image",
                 ],
             )
             for split in dataset_splits

--- a/mteb/tasks/retrieval/eng/memotion_t2i_retrieval.py
+++ b/mteb/tasks/retrieval/eng/memotion_t2i_retrieval.py
@@ -66,6 +66,7 @@ def _load_data(path: str, splits: str, revision: str | None = None):
                 "motivational",
                 "sentiment",
                 "text_corrected",
+                "image",
             ],
         )
 

--- a/mteb/tasks/retrieval/eng/sci_mmir_i2t_retrieval.py
+++ b/mteb/tasks/retrieval/eng/sci_mmir_i2t_retrieval.py
@@ -29,6 +29,7 @@ def _load_data(path: str, splits: str, revision: str | None = None):
                 "super_class",
                 "sub_class",
                 "split",
+                "image",
             ],
         )
 
@@ -44,6 +45,7 @@ def _load_data(path: str, splits: str, revision: str | None = None):
                 "super_class",
                 "sub_class",
                 "split",
+                "text",
             ],
         )
         relevant_docs[split] = {}

--- a/mteb/tasks/retrieval/eng/sci_mmir_t2i_retrieval.py
+++ b/mteb/tasks/retrieval/eng/sci_mmir_t2i_retrieval.py
@@ -29,6 +29,7 @@ def _load_data(path: str, splits: str, revision: str | None = None):
                 "super_class",
                 "sub_class",
                 "split",
+                "text",
             ],
         )
 
@@ -44,6 +45,7 @@ def _load_data(path: str, splits: str, revision: str | None = None):
                 "super_class",
                 "sub_class",
                 "split",
+                "image",
             ],
         )
         relevant_docs[split] = {}


### PR DESCRIPTION
Six retrieval tasks fail during evaluation: HatefulMemesI2TRetrieval, HatefulMemesT2IRetrieval, MemotionI2TRetrieval, MemotionT2IRetrieval, SciMMIRI2TRetrieval, SciMMIRT2IRetrieval.

Reproduction:

```python
import mteb
from mteb._create_dataloaders import create_dataloader
from mteb.types import PromptType

task = mteb.get_task("HatefulMemesI2TRetrieval")
task.load_data()

corpus_ds = task.corpus["test"]
print(corpus_ds.column_names)  # ['image', 'id', 'text', 'modality']

loader = create_dataloader(corpus_ds, task.metadata, prompt_type=PromptType.document, batch_size=4)
next(iter(loader))
# TypeError: default_collate: batch must contain tensors, numpy arrays, numbers,
#            dicts or lists; found <class 'PIL.PngImagePlugin.PngImageFile'>
```

From what I understand this happens because image columns are kept even though they're not needed, and when the text collator is created it's unable to `torch.stack()` PIL images and raises the TypeError. 

Fix: I'm proposing to explicitly drop the opposite-modality columns for these tasks. If you think there's another way that fixes the issue better I'm happy to implement it! 