### PR TITLE
Add vultr/VultronRetrieverCore-Qwen3.5-4.5B

### DIFF
--- a/mteb/models/model_implementations/colqwen_models.py
+++ b/mteb/models/model_implementations/colqwen_models.py
@@ -773,3 +773,31 @@ vultron_flash_qwen35_0_8b = ModelMeta(
     training_datasets=VULTRON_PRIME_8B_TRAINING_DATA,  # 0.8B sibling, same training pool as the 8B Prime
     extra_requirements_groups=["colpali_engine"],
 )
+
+vultron_core_qwen35_4b = ModelMeta(
+    loader=ColQwen3_5Wrapper,
+    loader_kwargs=dict(
+        torch_dtype=torch.bfloat16,
+    ),
+    name="vultr/VultronRetrieverCore-Qwen3.5-4.5B",
+    model_type=["late-interaction"],
+    languages=["eng-Latn", "fra-Latn", "deu-Latn", "spa-Latn", "ita-Latn", "por-Latn"],
+    revision="5b63301ce5a49993f9ec1cf36645840b8cbd8120",
+    release_date="2026-06-22",
+    modalities=["image", "text"],
+    n_parameters=4_540_085_056,
+    n_embedding_parameters=635_699_200,  # vocab 248320 x hidden 2560 (token embedding matrix)
+    memory_usage_mb=9080,
+    max_tokens=262144,
+    embed_dim=320,
+    license="apache-2.0",
+    open_weights=True,
+    public_training_code=None,
+    public_training_data=None,
+    framework=["PyTorch", "ColPali", "safetensors"],
+    reference="https://huggingface.co/vultr/VultronRetrieverCore-Qwen3.5-4.5B",
+    similarity_fn_name=ScoringFunction.MAX_SIM,
+    use_instructions=False,
+    training_datasets=VULTRON_PRIME_8B_TRAINING_DATA,  # 4B sibling, same training pool as Prime/Flash
+    extra_requirements_groups=["colpali_engine"],
+)


### PR DESCRIPTION
Adds the `ModelMeta` for `vultr/VultronRetrieverCore-Qwen3.5-4.5B`, the mid-tier of the VultronRetriever family (between the 0.8B Flash and the 8B Prime, both already in the registry).

4.5B ColQwen3.5 late-interaction retriever, MaxSim scoring, per-token embed dim 320. Official MTEB dim320/vt1792: ViDoRe V1 0.9221 / V2 0.6612 / V3 0.6372.

Same `ColQwen3_5Wrapper` loader and training-data provenance as the Prime/Flash entries. Results PR to follow.