### PR TITLE
model: use text task prefixes for gemini-embedding-2; improve doc prefix

### DIFF
--- a/mteb/models/model_implementations/google_gemini.py
+++ b/mteb/models/model_implementations/google_gemini.py
@@ -54,6 +54,34 @@ MULTILINGUAL_EVALUATED_LANGUAGES = [
 # Prompt mapping for Gemini Embedding 2.
 # Task-type defaults are derived from MTEB metadata; per-task overrides
 # are from Google's recommended mapping in issue #4260.
+GEMINI_EMBEDDING_2_TEXT_PREFIXES = {
+    "RETRIEVAL_QUERY": "task: search result | query: {text}",
+    "QUESTION_ANSWERING": "task: question answering | query: {text}",
+    "FACT_VERIFICATION": "task: fact checking | query: {text}",
+    "CODE_RETRIEVAL_QUERY": "task: code retrieval | query: {text}",
+    "CLASSIFICATION": "task: classification | query: {text}",
+    "CLUSTERING": "task: clustering | query: {text}",
+    "SEMANTIC_SIMILARITY": "task: sentence similarity | query: {text}",
+}
+
+
+def _format_gemini_embedding_2_document(text: str, title: str | None = None) -> str:
+    return f"title: {title or 'none'} | text: {text}"
+
+
+def _format_gemini_embedding_2_text(
+    text: str,
+    google_task_type: str | None,
+    prompt_type: PromptType | None,
+    title: str | None = None,
+) -> str:
+    if prompt_type == PromptType.document:
+        return _format_gemini_embedding_2_document(text, title)
+    if google_task_type in GEMINI_EMBEDDING_2_TEXT_PREFIXES:
+        return GEMINI_EMBEDDING_2_TEXT_PREFIXES[google_task_type].format(text=text)
+    return text
+
+
 GEMINI_EMBEDDING_2_PROMPTS = {
     # Task-type defaults (derived from metadata)
     "Classification": "CLASSIFICATION",
@@ -169,16 +197,12 @@ class GoogleGeminiEmbeddingModel(AbsEncoder):
     def _embed(
         self,
         contents: list,
-        google_task_type: str | None = None,
         show_progress_bar: bool = False,
         batch_size: int = 32,
     ) -> np.ndarray:
         from google.genai.types import EmbedContentConfig
 
-        config = EmbedContentConfig(
-            taskType=google_task_type,
-            outputDimensionality=self.embed_dim,
-        )
+        config = EmbedContentConfig(outputDimensionality=self.embed_dim)
 
         async def run() -> list:
             semaphore = asyncio.Semaphore(batch_size)
@@ -266,16 +290,16 @@ class GoogleGeminiEmbeddingModel(AbsEncoder):
                         [text, Part.from_bytes(data=wav_bytes, mime_type="audio/wav")]
                     )
         elif has_text:
-            if has_title:
-                contents = []
-                for batch in inputs:
-                    for title, text in zip(batch["title"], batch["text"]):
-                        if title:
-                            contents.append(f"title: {title} | text: {text}")
-                        else:
-                            contents.append(text)
-            else:
-                contents = [text for batch in inputs for text in batch["text"]]
+            contents = []
+            for batch in inputs:
+                texts = batch["text"]
+                titles = batch["title"] if has_title else [None] * len(texts)
+                for text, title in zip(texts, titles):
+                    contents.append(
+                        _format_gemini_embedding_2_text(
+                            text, google_task_type, prompt_type, title
+                        )
+                    )
         elif has_image:
             contents = [img for batch in inputs for img in batch["image"]]
         elif has_audio:
@@ -291,7 +315,6 @@ class GoogleGeminiEmbeddingModel(AbsEncoder):
 
         return self._embed(
             contents,
-            google_task_type=google_task_type,
             show_progress_bar=show_progress_bar,
             batch_size=batch_size,
         )

--- a/tests/test_models/test_google_gemini.py
+++ b/tests/test_models/test_google_gemini.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import pytest
+
+from mteb.models.model_implementations.google_gemini import (
+    _format_gemini_embedding_2_text,
+)
+from mteb.types import PromptType
+
+
+@pytest.mark.parametrize(
+    ("google_task_type", "expected"),
+    [
+        ("RETRIEVAL_QUERY", "task: search result | query: example text"),
+        ("QUESTION_ANSWERING", "task: question answering | query: example text"),
+        ("FACT_VERIFICATION", "task: fact checking | query: example text"),
+        ("CLASSIFICATION", "task: classification | query: example text"),
+        ("CLUSTERING", "task: clustering | query: example text"),
+        ("SEMANTIC_SIMILARITY", "task: sentence similarity | query: example text"),
+    ],
+)
+def test_gemini_embedding_2_formats_task_prefixes(
+    google_task_type: str, expected: str
+) -> None:
+    assert (
+        _format_gemini_embedding_2_text(
+            "example text", google_task_type, PromptType.query
+        )
+        == expected
+    )
+
+
+def test_gemini_embedding_2_formats_documents_with_title() -> None:
+    assert (
+        _format_gemini_embedding_2_text(
+            "example text", "FACT_VERIFICATION", PromptType.document, "Example"
+        )
+        == "title: Example | text: example text"
+    )
+
+
+def test_gemini_embedding_2_formats_documents_without_title() -> None:
+    assert (
+        _format_gemini_embedding_2_text(
+            "example text", "FACT_VERIFICATION", PromptType.document
+        )
+        == "title: none | text: example text"
+    )
+
+
+def test_gemini_embedding_2_leaves_unknown_task_type_unchanged() -> None:
+    assert _format_gemini_embedding_2_text("example text", None, None) == "example text"


### PR DESCRIPTION
Two fixes:
1. Pass query/task prompts directly as text prefixes instead of through `taskType`. Ref: https://ai.google.dev/gemini-api/docs/embeddings#gemini-embedding-2. `taskType` is documented for `gemini-embedding-001`; `gemini-embedding-2` is recommended to directly format task prompts as text prefixes, e.g., `task: fact checking | query: {content}` for fact verification tasks; `task: sentence similarity | query: {content}` for STS etc.  
Note: I ran a small API check and verified that passing different `taskType` values leads to identical embeddings for `gemini-embedding-2`; so it's removed from `EmbedContentConfig`.
2. Format documents without titles as `title: none | text: {text}` to align with the official docs. In previous implementation, documents were only formatted when a title existed. 

Ran a few tasks before fix vs. after fix to validate:

  | Task |before | this PR | Δ |
  |---|---:|---:|---:|
  | ArguAna | 41.9210 | 78.7090 | +36.7880 |
  | Banking77Classification.v2 | 93.1242 | 93.3420 | +0.2178 |
  | BiorxivClusteringP2P.v2 | 51.8584 | 53.1959 | +1.3375 |
  | STS12 | 72.8689 | 81.1285 | +8.2596 |