### PR TITLE
Fix empty leaderboard task info

### DIFF
--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -50,6 +50,15 @@ event_logger = EventLogger()
 
 LANGUAGE: list[str] = list({l for t in mteb.get_tasks() for l in t.metadata.languages})
 MODEL_TYPE_CHOICES = list(get_args(MODEL_TYPES))
+_TASK_INFO_COLUMNS = [
+    "Task Name",
+    "Task Type",
+    "Languages",
+    "Domains",
+    "Metric",
+    "Modality",
+    "Public",
+]
 
 
 def _produce_benchmark_link(benchmark_name: str, request: gr.Request) -> str:
@@ -120,8 +129,11 @@ def _format_list(props: list[str]):
     return ", ".join(props)
 
 
-def _update_task_info(task_names: str) -> pd.DataFrame:
+def _update_task_info(task_names: list[str]) -> pd.DataFrame:
     t0 = time.time()
+    if not task_names:
+        return pd.DataFrame(columns=_TASK_INFO_COLUMNS)
+
     tasks = mteb.get_tasks(tasks=task_names)
     t1 = time.time()
     df = tasks.to_dataframe(

--- a/tests/test_leaderboard/test_leaderboard.py
+++ b/tests/test_leaderboard/test_leaderboard.py
@@ -14,6 +14,32 @@ TIMEOUT = 300
 pytest.importorskip("gradio", reason="Gradio not installed")
 
 
+def test_update_task_info_returns_empty_dataframe_for_empty_task_selection():
+    from mteb.leaderboard.app import _update_task_info
+
+    df = _update_task_info([])
+
+    assert df.empty
+    assert list(df.columns) == [
+        "Task Name",
+        "Task Type",
+        "Languages",
+        "Domains",
+        "Metric",
+        "Modality",
+        "Public",
+    ]
+
+
+def test_update_task_info_returns_selected_task():
+    from mteb.leaderboard.app import _update_task_info
+
+    df = _update_task_info(["STS12"])
+
+    assert len(df.index) == 1
+    assert "STS12" in df.loc[0, "Task Name"]
+
+
 def run_leaderboard_app():
     """Function to launch the leaderboard app."""
     # Set up logging for subprocess


### PR DESCRIPTION
This PR fixes a leaderboard issue where clearing the Task selection caused the Task information table to show all tasks. The root cause is that `_update_task_info([])` passed an empty list to `mteb.get_tasks`, where an empty list is treated like no task filter. The fix handles the empty selection locally in the leaderboard by returning an empty DataFrame with the expected schema, avoiding any change to the public `mteb.get_tasks` API. It also adds tests for both empty and normal task selections.