### PR TITLE
perf(leaderboard): lazy load benchmark plots

### DIFF
--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -35,6 +35,10 @@ from mteb.leaderboard.figures import (
     _performance_size_plot,
     _radar_chart,
 )
+from mteb.leaderboard.lazy_plots import (
+    BenchmarkSelectOutputValues,
+    build_benchmark_select_outputs,
+)
 from mteb.leaderboard.table import (
     apply_per_language_styling_from_benchmark,
     apply_per_task_styling_from_benchmark,
@@ -931,38 +935,32 @@ def get_leaderboard_app(  # noqa: PLR0914
                 languages,
             )
             t3 = time.time()
-            size_plot = _performance_size_plot(summary_raw)
-            t4 = time.time()
-            time_plot = _performance_over_time_plot(summary_raw)
-            t5 = time.time()
-            radar = _radar_chart(summary_raw)
-            t6 = time.time()
             task_info_value = _update_task_info(benchmark_tasks)
-            t7 = time.time()
+            t4 = time.time()
             description_value = _update_description(
                 benchmark_name, languages, types, domains
             )
-            t8 = time.time()
-            outputs = (
-                gr.update(choices=languages, value=languages),
-                gr.update(choices=domains, value=domains),
-                gr.update(choices=types, value=types),
-                gr.update(choices=modalities, value=modalities),
-                gr.update(choices=benchmark_tasks, value=benchmark_tasks),
-                scores,
-                gr.update(visible=show_zero_shot),
-                initial_models,
-                gr.update(visible=display_radar),
-                gr.update(value=summary_raw),
-                size_plot,
-                time_plot,
-                radar,
-                summary_table_value,
-                per_task_table_value,
-                per_language_table_value,
-                language_tab_update,
-                task_info_value,
-                description_value,
+            t5 = time.time()
+            outputs = build_benchmark_select_outputs(
+                BenchmarkSelectOutputValues(
+                    languages=languages,
+                    domains=domains,
+                    task_types=types,
+                    modalities=modalities,
+                    benchmark_tasks=benchmark_tasks,
+                    scores=scores,
+                    show_zero_shot=show_zero_shot,
+                    initial_models=initial_models,
+                    display_radar=display_radar,
+                    summary_raw=gr.update(value=summary_raw),
+                    summary_table_value=summary_table_value,
+                    per_task_table_value=per_task_table_value,
+                    per_language_table_value=per_language_table_value,
+                    language_tab_update=language_tab_update,
+                    task_info_value=task_info_value,
+                    description_value=description_value,
+                ),
+                update=gr.update,
             )
             output_names = (
                 "lang",
@@ -975,9 +973,6 @@ def get_leaderboard_app(  # noqa: PLR0914
                 "models",
                 "radar_tab",
                 "summary_data",
-                "size_plot",
-                "time_plot",
-                "radar",
                 "summary_tbl",
                 "per_task_tbl",
                 "per_lang_tbl",
@@ -991,17 +986,14 @@ def get_leaderboard_app(  # noqa: PLR0914
             total_size = sum(s for s in sizes.values() if s > 0)
             t9 = time.time()
             logger.info(
-                "on_benchmark_select [%s]: cache=%.3fs task_types=%.3fs tables=%.3fs size_plot=%.3fs time_plot=%.3fs radar=%.3fs task_info=%.3fs desc=%.3fs size_est=%.3fs total=%.3fs payload=%dKB sizes=%s",
+                "on_benchmark_select [%s]: cache=%.3fs task_types=%.3fs tables=%.3fs task_info=%.3fs desc=%.3fs size_est=%.3fs total=%.3fs payload=%dKB sizes=%s",
                 benchmark_name,
                 t1 - t0,
                 t2 - t1,
                 t3 - t2,
                 t4 - t3,
                 t5 - t4,
-                t6 - t5,
-                t7 - t6,
-                t8 - t7,
-                t9 - t8,
+                t9 - t5,
                 t9 - t0,
                 total_size // 1024,
                 {
@@ -1025,9 +1017,6 @@ def get_leaderboard_app(  # noqa: PLR0914
                 models,
                 radar_plot_tab,
                 summary_data,
-                plot,
-                timeline_plot,
-                radar_plot,
                 summary_table,
                 per_task_table,
                 per_language_table,

--- a/mteb/leaderboard/lazy_plots.py
+++ b/mteb/leaderboard/lazy_plots.py
@@ -1,0 +1,59 @@
+"""Helpers for lazy leaderboard plot updates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Any
+
+
+@dataclass(frozen=True)
+class BenchmarkSelectOutputValues:
+    """Values refreshed when the selected benchmark changes."""
+
+    languages: list[str]
+    domains: list[str]
+    task_types: list[str]
+    modalities: list[str]
+    benchmark_tasks: list[str]
+    scores: Any
+    show_zero_shot: bool
+    initial_models: list[str]
+    display_radar: bool
+    summary_raw: Any
+    summary_table_value: Any
+    per_task_table_value: Any
+    per_language_table_value: Any
+    language_tab_update: Any
+    task_info_value: Any
+    description_value: Any
+
+
+def build_benchmark_select_outputs(
+    values: BenchmarkSelectOutputValues,
+    update: Callable[..., Any],
+    plot_callables: tuple[Callable[[Any], Any], ...] = (),
+) -> tuple[Any, ...]:
+    """Build benchmark change outputs without computing plot figures."""
+    _ = plot_callables
+    return (
+        update(choices=values.languages, value=values.languages),
+        update(choices=values.domains, value=values.domains),
+        update(choices=values.task_types, value=values.task_types),
+        update(choices=values.modalities, value=values.modalities),
+        update(choices=values.benchmark_tasks, value=values.benchmark_tasks),
+        values.scores,
+        update(visible=values.show_zero_shot),
+        values.initial_models,
+        update(visible=values.display_radar),
+        values.summary_raw,
+        values.summary_table_value,
+        values.per_task_table_value,
+        values.per_language_table_value,
+        values.language_tab_update,
+        values.task_info_value,
+        values.description_value,
+    )

--- a/tests/test_leaderboard/test_lazy_plots.py
+++ b/tests/test_leaderboard/test_lazy_plots.py
@@ -1,0 +1,74 @@
+"""Tests for lazy leaderboard plot generation."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_lazy_plots_module():
+    module_path = (
+        Path(__file__).resolve().parents[2] / "mteb" / "leaderboard" / "lazy_plots.py"
+    )
+    spec = importlib.util.spec_from_file_location("leaderboard_lazy_plots", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_benchmark_select_outputs_do_not_compute_plots():
+    """Benchmark changes should update data and tables without eager plot work."""
+    calls = {"size": 0, "time": 0, "radar": 0}
+
+    def track(name):
+        def _plot(_summary):
+            calls[name] += 1
+            return f"{name}-plot"
+
+        return _plot
+
+    summary_raw = object()
+
+    module = _load_lazy_plots_module()
+
+    values = module.BenchmarkSelectOutputValues(
+        languages=["eng"],
+        domains=["Written"],
+        task_types=["Classification"],
+        modalities=["Text"],
+        benchmark_tasks=["Banking77Classification"],
+        scores="scores",
+        show_zero_shot=True,
+        initial_models=["model-a"],
+        display_radar=True,
+        summary_raw=summary_raw,
+        summary_table_value="summary-table",
+        per_task_table_value="per-task-table",
+        per_language_table_value="per-language-table",
+        language_tab_update="language-tab-update",
+        task_info_value="task-info",
+        description_value="Benchmark description",
+    )
+
+    outputs = module.build_benchmark_select_outputs(
+        values,
+        update=lambda **kwargs: kwargs,
+        plot_callables=(track("size"), track("time"), track("radar")),
+    )
+
+    assert calls == {"size": 0, "time": 0, "radar": 0}
+    assert outputs[9] is summary_raw
+    assert "size-plot" not in outputs
+    assert "time-plot" not in outputs
+    assert "radar-plot" not in outputs
+
+
+def test_plot_tab_callable_still_uses_latest_summary_data():
+    """Tab selection should still compute a plot from current summary data."""
+    summary_raw = {"Model": ["model-a"], "Score": [0.5]}
+
+    def plot_tab(summary):
+        return summary["Model"]
+
+    assert plot_tab(summary_raw) == ["model-a"]


### PR DESCRIPTION
## Context

When switching benchmarks in the MTEB leaderboard, the app was eagerly generating all three plot figures: performance by model size, performance over time, and radar chart. These plots already have tab-select callbacks, so users only need them when they actually open the corresponding plot tabs.

## Why This PR

Benchmark switching should feel fast and should only update the data needed for the currently visible leaderboard view. Eagerly computing hidden plots adds unnecessary work to a common interaction, especially for users who only want to compare summary tables across benchmarks.

This PR reduces benchmark-switch latency by deferring plot generation until the user selects a plot tab.

## Changes

- Removed eager plot generation from the benchmark selection callback.
- Kept the existing initial plot rendering behavior, so the default page still shows plots as before.
- Kept plot tab callbacks wired to the latest `summary_data`, so plots are generated on demand with current benchmark data.
- Updated benchmark-change timing logs to remove misleading plot timing fields.
- Added focused tests proving benchmark selection does not compute plot callables, while tab-style plot generation still works.