### PR TITLE
Add model: google/gemini-embedding-2 (GA)

### DIFF
--- a/mteb/models/model_implementations/google_gemini.py
+++ b/mteb/models/model_implementations/google_gemini.py
@@ -347,6 +347,35 @@ google_gemini_embedding_001 = ModelMeta(
     extra_requirements_groups=["vertexai"],
 )
 
+google_gemini_embedding_2 = ModelMeta(
+    loader=GoogleGeminiEmbeddingModel,  # type: ignore[call-arg]
+    loader_kwargs=dict(
+        model_prompts=GEMINI_EMBEDDING_2_PROMPTS,
+        embed_dim=3072,
+    ),
+    name="google/gemini-embedding-2",
+    model_type=["dense"],
+    languages=MULTILINGUAL_EVALUATED_LANGUAGES,
+    modalities=["audio", "image", "text"],
+    open_weights=False,
+    revision="1",
+    release_date="2026-04-22",
+    n_parameters=None,
+    n_embedding_parameters=None,
+    memory_usage_mb=None,
+    max_tokens=8192,
+    embed_dim=[768, 1536, 3072],
+    license=None,
+    reference="https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/embedding-2",
+    similarity_fn_name=ScoringFunction.COSINE,
+    framework=["API"],
+    use_instructions=True,
+    public_training_code=None,
+    public_training_data=None,
+    training_datasets=GECKO_TRAINING_DATA,
+    extra_requirements_groups=["google_genai"],
+)
+
 google_gemini_embedding_2_preview = ModelMeta(
     loader=GoogleGeminiEmbeddingModel,  # type: ignore[call-arg]
     loader_kwargs=dict(


### PR DESCRIPTION
This PR adds the GA release of Google's Gemini Embedding 2 model (`google/gemini-embedding-2`) to the MTEB model registry.

Closes #4749

**Key specs:**
- Model ID: `google/gemini-embedding-2`
- Modalities: text, image, audio
- Max tokens: 8,192
- Embedding dimensions: [768, 1536, 3072] (MRL support via output_dimensionality)
- Release date: 2026-04-22
- API-based (Google Generative AI SDK)
- Reuses the existing `GoogleGeminiEmbeddingModel` wrapper and `GEMINI_EMBEDDING_2_PROMPTS` infrastructure

**Changes:**
- Added `google_gemini_embedding_2` ModelMeta entry to `google_gemini.py`

The model shares the prompt structure and multimodal support with the existing `google/gemini-embedding-2-preview`, but has a significantly larger context window (8,192 vs 2,048 tokens).