### PR TITLE
docs: Document evaluation request workflow

### DIFF
--- a/docs/contributing/adding_a_model.md
+++ b/docs/contributing/adding_a_model.md
@@ -12,6 +12,12 @@ The MTEB Leaderboard is available [here](https://huggingface.co/spaces/mteb/lead
 2. [Evaluate](../get_started/usage/get_started.md#evaluating-a-model) the desired model using `mteb` on the [benchmarks](../get_started/usage/selecting_tasks.md#selecting-a-benchmark)
 3. Push the results to the [results repository](https://github.com/embeddings-benchmark/results) via a PR. Once merged they will appear on the leaderboard after a day.
 
+!!! tip "Requesting an evaluation"
+
+    If you want a model to be evaluated but are not submitting the results yourself, open an [Evaluation Request](https://github.com/embeddings-benchmark/mteb/issues/new?template=eval_request.yaml) issue instead. Include the model link, the tasks or benchmarks you care about, whether the model already exists in MTEB, and whether you can help run the evaluation.
+
+    Maintainers generally prioritize evaluation requests for private subsets or cases where community contributors cannot run the benchmark directly. For public benchmarks, the fastest path is still to run the evaluation locally and submit the results PR.
+
 !!! info Submitting Evaluation Results
 
     This section contains info on how to submit a model implementation. If you wish to submit a model results see [submit results](./submitting_results.md).

--- a/docs/contributing/adding_a_model.md
+++ b/docs/contributing/adding_a_model.md
@@ -14,9 +14,9 @@ The MTEB Leaderboard is available [here](https://huggingface.co/spaces/mteb/lead
 
 !!! tip "Requesting an evaluation"
 
-    If you want a model to be evaluated but are not submitting the results yourself, open an [Evaluation Request](https://github.com/embeddings-benchmark/mteb/issues/new?template=eval_request.yaml) issue instead. Include the model link, the tasks or benchmarks you care about, whether the model already exists in MTEB, and whether you can help run the evaluation.
+    If you want a model to be evaluated but are not submitting the results yourself, open an [Evaluation Request](https://github.com/embeddings-benchmark/mteb/issues/new?template=eval_request.yaml) issue instead and fill out the required information.
 
-    Maintainers generally prioritize evaluation requests for private subsets or cases where community contributors cannot run the benchmark directly. For public benchmarks, the fastest path is still to run the evaluation locally and submit the results PR.
+    Maintainers prioritize evaluation requests for private subsets or cases where community contributors cannot run the benchmark directly. We aim to run a private evaluation within 7 working days of the request. For public benchmarks, the fastest path is still to run the evaluation locally and submit the results PR.
 
 !!! info Submitting Evaluation Results
 

--- a/docs/contributing/submitting_results.md
+++ b/docs/contributing/submitting_results.md
@@ -9,6 +9,8 @@ icon: lucide/upload
 
 The [`ResultCache`][mteb.cache.result_cache.ResultCache] class manages evaluation results locally and submits them to the [official results repository](https://github.com/embeddings-benchmark/results). Use it to cache results, avoid re-computation, and contribute results back to the community.
 
+If you want to request that a model be evaluated, rather than submitting results that you ran yourself, open an [Evaluation Request](https://github.com/embeddings-benchmark/mteb/issues/new?template=eval_request.yaml) issue.
+
 ## Loading Results
 
 For a full guide on loading and working with results — including filtering, dataframe conversion, and benchmark scoring — see [Loading Results](../get_started/usage/loading_results.md).


### PR DESCRIPTION
## Summary
- Link the existing Evaluation Request issue template from the model contribution guide.
- Clarify when to request an evaluation versus submitting locally run results.

Fixes #4734

## Validation
- `git diff --check`