### PR TITLE
Fix task crashes in EBind (short audio)

### DIFF
--- a/mteb/models/model_implementations/ebind_models.py
+++ b/mteb/models/model_implementations/ebind_models.py
@@ -64,12 +64,19 @@ class EBindWrapper(AbsEncoder):
 
     def _process_audio_batch(self, audio_items: list) -> torch.Tensor:
         """Process a batch of audio items via temp WAV files (IBAudioProcessor requires paths)."""
+        import numpy as np
         import soundfile as sf
 
         audio_tensors = []
         for item in audio_items:
+            array = np.asarray(item["array"])
+            sr = item["sampling_rate"]
+            # pad clips shorter than the mel-spectrogram window
+            min_samples = max(int(sr * 0.5), 1)
+            if array.shape[0] < min_samples:
+                array = np.pad(array, (0, min_samples - array.shape[0]))
             with tempfile.NamedTemporaryFile(suffix=".wav", delete=True) as tmp:
-                sf.write(tmp.name, item["array"], item["sampling_rate"])
+                sf.write(tmp.name, array, sr)
                 audio_tensors.append(self.processor.processors["audio"](tmp.name))
         return torch.stack(audio_tensors).to(self.device)
 


### PR DESCRIPTION
EBind:  MridinghamTonic crashes on a very short audio clip
A clip shorter than ImageBind's mel-spectrogram STFT window (400 samples @ 16k Hz, ~25ms) raises inside `IBAudioProcessor`, which swallows the exception to `None`; `torch.stack` then fails for the whole batch:

(MridinghamTonic contains a ~23ms clip → 368 samples, below the 400 window.)