### PR TITLE
dataset: add cleaned STSBenchmark v2

### DIFF
--- a/mteb/descriptive_stats/STS/STSBenchmark.v2.json
+++ b/mteb/descriptive_stats/STS/STSBenchmark.v2.json
@@ -1,0 +1,62 @@
+{
+    "validation": {
+        "num_samples": 1485,
+        "number_of_characters": 191208,
+        "unique_pairs": 1485,
+        "text1_statistics": {
+            "total_text_length": 96014,
+            "min_text_length": 12,
+            "average_text_length": 64.65589225589225,
+            "max_text_length": 200,
+            "unique_texts": 1467
+        },
+        "text2_statistics": {
+            "total_text_length": 95194,
+            "min_text_length": 17,
+            "average_text_length": 64.1037037037037,
+            "max_text_length": 186,
+            "unique_texts": 1462
+        },
+        "image1_statistics": null,
+        "image2_statistics": null,
+        "audio1_statistics": null,
+        "audio2_statistics": null,
+        "video1_statistics": null,
+        "video2_statistics": null,
+        "label_statistics": {
+            "min_score": 0.0,
+            "avg_score": 2.3586123456790116,
+            "max_score": 5.0
+        }
+    },
+    "test": {
+        "num_samples": 1362,
+        "number_of_characters": 146713,
+        "unique_pairs": 1362,
+        "text1_statistics": {
+            "total_text_length": 73513,
+            "min_text_length": 16,
+            "average_text_length": 53.97430249632893,
+            "max_text_length": 215,
+            "unique_texts": 1246
+        },
+        "text2_statistics": {
+            "total_text_length": 73200,
+            "min_text_length": 13,
+            "average_text_length": 53.74449339207048,
+            "max_text_length": 199,
+            "unique_texts": 1326
+        },
+        "image1_statistics": null,
+        "image2_statistics": null,
+        "audio1_statistics": null,
+        "audio2_statistics": null,
+        "video1_statistics": null,
+        "video2_statistics": null,
+        "label_statistics": {
+            "min_score": 0.0,
+            "avg_score": 2.6059757709251117,
+            "max_score": 5.0
+        }
+    }
+}

--- a/mteb/tasks/sts/eng/__init__.py
+++ b/mteb/tasks/sts/eng/__init__.py
@@ -13,7 +13,7 @@ from .sts15_sts import STS15STS
 from .sts15_visual_sts import STS15VisualSTS
 from .sts16_sts import STS16STS
 from .sts16_visual_sts import STS16VisualSTS
-from .sts_benchmark_sts import STSBenchmarkSTS
+from .sts_benchmark_sts import STSBenchmarkSTS, STSBenchmarkSTSV2
 
 __all__ = [
     "HUMESICKR",
@@ -31,5 +31,6 @@ __all__ = [
     "STS15VisualSTS",
     "STS16VisualSTS",
     "STSBenchmarkSTS",
+    "STSBenchmarkSTSV2",
     "SickrSTS",
 ]

--- a/mteb/tasks/sts/eng/sts_benchmark_sts.py
+++ b/mteb/tasks/sts/eng/sts_benchmark_sts.py
@@ -1,6 +1,11 @@
 from mteb.abstasks.sts import AbsTaskSTS
 from mteb.abstasks.task_metadata import TaskMetadata
 
+_STS_BENCHMARK_DATASET = {
+    "path": "mteb/stsbenchmark-sts",
+    "revision": "b0fddb56ed78048fa8b90373c8a3cfc37b684831",
+}
+
 
 class STSBenchmarkSTS(AbsTaskSTS):
     min_score = 0
@@ -8,10 +13,7 @@ class STSBenchmarkSTS(AbsTaskSTS):
 
     metadata = TaskMetadata(
         name="STSBenchmark",
-        dataset={
-            "path": "mteb/stsbenchmark-sts",
-            "revision": "b0fddb56ed78048fa8b90373c8a3cfc37b684831",
-        },
+        dataset=_STS_BENCHMARK_DATASET,
         description="Semantic Textual Similarity Benchmark (STSbenchmark) dataset.",
         reference="https://github.com/PhilipMay/stsb-multi-mt/",
         type="STS",
@@ -35,7 +37,66 @@ class STSBenchmarkSTS(AbsTaskSTS):
   year = {2021},
 }
 """,
+        superseded_by="STSBenchmark.v2",
     )
 
     min_score = 0
     max_score = 5
+
+
+class STSBenchmarkSTSV2(AbsTaskSTS):
+    min_score = 0
+    max_score = 5
+
+    metadata = TaskMetadata(
+        name="STSBenchmark.v2",
+        dataset=_STS_BENCHMARK_DATASET,
+        description="Semantic Textual Similarity Benchmark (STSbenchmark) dataset. This version removes duplicate sentence pairs from the validation and test splits when the same order-insensitive pair appears more than once in an evaluation split or appears in another split.",
+        reference="https://github.com/PhilipMay/stsb-multi-mt/",
+        type="STS",
+        category="t2t",
+        modalities=["text"],
+        eval_splits=["validation", "test"],
+        eval_langs=["eng-Latn"],
+        main_score="cosine_spearman",
+        date=("2021-01-01", "2021-12-31"),  # publication year
+        domains=["Blog", "News", "Written"],
+        task_subtypes=[],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="machine-translated and verified",
+        bibtex_citation=r"""
+@inproceedings{huggingface:dataset:stsb_multi_mt,
+  author = {Philip May},
+  title = {Machine translated multilingual STS benchmark dataset.},
+  url = {https://github.com/PhilipMay/stsb-multi-mt},
+  year = {2021},
+}
+""",
+        adapted_from=["STSBenchmark"],
+    )
+
+    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+        def normalized_pair(row) -> tuple[str, str]:
+            pair = (row["sentence1"], row["sentence2"])
+            return pair if pair[0] <= pair[1] else (pair[1], pair[0])
+
+        split_pair_counts: dict[tuple[str, str], dict[str, int]] = {}
+        for split, dataset in self.dataset.items():
+            for row in dataset:
+                key = normalized_pair(row)
+                split_pair_counts.setdefault(key, {})
+                split_pair_counts[key][split] = split_pair_counts[key].get(split, 0) + 1
+
+        eval_splits = ("validation", "test")
+        for split in eval_splits:
+            duplicate_eval_pairs = {
+                key
+                for key, counts in split_pair_counts.items()
+                if split in counts and (counts[split] > 1 or len(counts) > 1)
+            }
+            self.dataset[split] = self.dataset[split].filter(
+                lambda row: normalized_pair(row) not in duplicate_eval_pairs,
+                num_proc=num_proc,
+            )

--- a/mteb/tasks/sts/eng/sts_benchmark_sts.py
+++ b/mteb/tasks/sts/eng/sts_benchmark_sts.py
@@ -1,11 +1,6 @@
 from mteb.abstasks.sts import AbsTaskSTS
 from mteb.abstasks.task_metadata import TaskMetadata
 
-_STS_BENCHMARK_DATASET = {
-    "path": "mteb/stsbenchmark-sts",
-    "revision": "b0fddb56ed78048fa8b90373c8a3cfc37b684831",
-}
-
 
 class STSBenchmarkSTS(AbsTaskSTS):
     min_score = 0
@@ -13,7 +8,10 @@ class STSBenchmarkSTS(AbsTaskSTS):
 
     metadata = TaskMetadata(
         name="STSBenchmark",
-        dataset=_STS_BENCHMARK_DATASET,
+        dataset={
+            "path": "mteb/stsbenchmark-sts",
+            "revision": "b0fddb56ed78048fa8b90373c8a3cfc37b684831",
+        },
         description="Semantic Textual Similarity Benchmark (STSbenchmark) dataset.",
         reference="https://github.com/PhilipMay/stsb-multi-mt/",
         type="STS",
@@ -50,7 +48,10 @@ class STSBenchmarkSTSV2(AbsTaskSTS):
 
     metadata = TaskMetadata(
         name="STSBenchmark.v2",
-        dataset=_STS_BENCHMARK_DATASET,
+        dataset={
+            "path": "mteb/STSBenchmarkv2",
+            "revision": "93b628c3969a75e76727db2b7ee252e53e96268d",
+        },
         description="Semantic Textual Similarity Benchmark (STSbenchmark) dataset. This version removes duplicate sentence pairs from the validation and test splits when the same order-insensitive pair appears more than once in an evaluation split or appears in another split.",
         reference="https://github.com/PhilipMay/stsb-multi-mt/",
         type="STS",
@@ -76,27 +77,3 @@ class STSBenchmarkSTSV2(AbsTaskSTS):
 """,
         adapted_from=["STSBenchmark"],
     )
-
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
-        def normalized_pair(row) -> tuple[str, str]:
-            pair = (row["sentence1"], row["sentence2"])
-            return pair if pair[0] <= pair[1] else (pair[1], pair[0])
-
-        split_pair_counts: dict[tuple[str, str], dict[str, int]] = {}
-        for split, dataset in self.dataset.items():
-            for row in dataset:
-                key = normalized_pair(row)
-                split_pair_counts.setdefault(key, {})
-                split_pair_counts[key][split] = split_pair_counts[key].get(split, 0) + 1
-
-        eval_splits = ("validation", "test")
-        for split in eval_splits:
-            duplicate_eval_pairs = {
-                key
-                for key, counts in split_pair_counts.items()
-                if split in counts and (counts[split] > 1 or len(counts) > 1)
-            }
-            self.dataset[split] = self.dataset[split].filter(
-                lambda row: normalized_pair(row) not in duplicate_eval_pairs,
-                num_proc=num_proc,
-            )


### PR DESCRIPTION
## Summary

Adds `STSBenchmark.v2` as a cleaned version of `STSBenchmark` for #4798.

The original task is kept unchanged for score comparability and marked with `superseded_by="STSBenchmark.v2"`. The v2 task uses the same pinned HF dataset revision, then applies a conservative runtime transform over the evaluation splits.

Cleaning policy:

- use an order-insensitive normalized pair key, so `(sentence1, sentence2)` and `(sentence2, sentence1)` are treated as the same STS pair;
- remove validation/test rows when the normalized pair appears in another split, including train;
- remove validation/test rows when the normalized pair appears more than once inside that eval split;
- leave the train split unchanged.

Resulting eval split sizes:

- validation: 1,500 -> 1,485, with 1,485 unique normalized pairs
- test: 1,379 -> 1,362, with 1,362 unique normalized pairs

The cleanup is order-insensitive and split-aware, so the v2 task removes more than same-row duplicates while keeping the original task available for score comparability.

## Tests

- `/Users/jeremy/.local/bin/uv run ruff check mteb/tasks/sts/eng/sts_benchmark_sts.py mteb/tasks/sts/eng/__init__.py`
- `/Users/jeremy/.local/bin/uv run pytest tests/test_tasks/test_metadata.py tests/test_tasks/test_task_quality.py tests/test_get_tasks.py -q`
- regenerated the `STSBenchmark.v2` descriptive stats with `overwrite_results=True`

Closes #4798