### PR TITLE
dataset: KorNLI

### DIFF
--- a/mteb/descriptive_stats/PairClassification/KorNLI.json
+++ b/mteb/descriptive_stats/PairClassification/KorNLI.json
@@ -1,0 +1,41 @@
+{
+    "test": {
+        "num_samples": 3340,
+        "unique_pairs": 3340,
+        "number_of_characters": 264368,
+        "text1_statistics": {
+            "total_text_length": 178196,
+            "min_text_length": 7,
+            "average_text_length": 53.35209580838323,
+            "max_text_length": 124,
+            "unique_texts": 1670
+        },
+        "image1_statistics": null,
+        "audio1_statistics": null,
+        "video1_statistics": null,
+        "text2_statistics": {
+            "total_text_length": 86172,
+            "min_text_length": 3,
+            "average_text_length": 25.8,
+            "max_text_length": 104,
+            "unique_texts": 3340
+        },
+        "image2_statistics": null,
+        "audio2_statistics": null,
+        "video2_statistics": null,
+        "labels_statistics": {
+            "min_labels_per_text": 1,
+            "average_label_per_text": 1.0,
+            "max_labels_per_text": 1,
+            "unique_labels": 2,
+            "labels": {
+                "0": {
+                    "count": 1670
+                },
+                "1": {
+                    "count": 1670
+                }
+            }
+        }
+    }
+}

--- a/mteb/tasks/pair_classification/kor/__init__.py
+++ b/mteb/tasks/pair_classification/kor/__init__.py
@@ -1,3 +1,4 @@
 from .klue_nli import KlueNLI
+from .kor_nli import KorNLI
 
-__all__ = ["KlueNLI"]
+__all__ = ["KlueNLI", "KorNLI"]

--- a/mteb/tasks/pair_classification/kor/kor_nli.py
+++ b/mteb/tasks/pair_classification/kor/kor_nli.py
@@ -1,0 +1,58 @@
+from mteb.abstasks.pair_classification import AbsTaskPairClassification
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class KorNLI(AbsTaskPairClassification):
+    metadata = TaskMetadata(
+        name="KorNLI",
+        dataset={
+            "path": "kakaobrain/kor_nli",
+            "name": "xnli",
+            "revision": "3e0e4626f66911b344c490c26e3cc07e6c3bb0f9",
+        },
+        description="Korean Natural Language Inference dataset (XNLI subset), where the "
+        "Korean-translated XNLI dev/test sets are used to determine textual entailment "
+        "between a premise and a hypothesis sentence. Part of KorNLI/KorSTS.",
+        reference="https://arxiv.org/abs/2004.03289",
+        type="PairClassification",
+        category="t2t",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["kor-Hang"],
+        main_score="max_ap",
+        date=("2018-01-01", "2020-04-07"),
+        domains=["Non-fiction", "Fiction", "Government", "Written"],
+        task_subtypes=["Textual Entailment"],
+        license="cc-by-sa-4.0",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        sample_creation="machine-translated and verified",
+        bibtex_citation=r"""
+@article{ham2020kornli,
+  author = {Ham, Jiyeon and Choe, Yo Joong and Park, Kyubyong and Choi, Ilji and Soh, Hyungjoon},
+  journal = {arXiv preprint arXiv:2004.03289},
+  title = {KorNLI and KorSTS: New Benchmark Datasets for Korean Natural Language Understanding},
+  year = {2020},
+}
+""",
+    )
+
+    def dataset_transform(
+        self,
+        num_proc: int | None = None,
+    ):
+        _dataset = {}
+        for split in self.metadata.eval_splits:
+            # keep labels 0=entailment and 2=contradiction, and map them as 1 and 0 for binary classification
+            hf_dataset = self.dataset[split].filter(lambda x: x["label"] in [0, 2])  # noqa: PLR6201
+            hf_dataset = hf_dataset.map(
+                lambda example: {"label": 0 if example["label"] == 2 else 1}
+            )
+            _dataset[split] = [
+                {
+                    "sentence1": hf_dataset["premise"],
+                    "sentence2": hf_dataset["hypothesis"],
+                    "labels": hf_dataset["label"],
+                }
+            ]
+        self.dataset = _dataset


### PR DESCRIPTION
close #4879

## Summary
This PR is a follow-up/extension related to #4870 to add an additional task for the Korean language. 

It implements the **KorNLI** (Korean Natural Language Inference) dataset to expand the evaluation coverage for `kor-Hang` in MTEB. This addition introduces the binary pair-classification task utilizing the machine-translated and verified XNLI test subsets, mapping `entailment` to 1 and `contradiction` to 0 following the standard setup.