### PR TITLE
add missing arXiv ID and update publication year for mFollowIR citations 

### DIFF
--- a/mteb/tasks/instruction_reranking/multilingual/m_follow_ir.py
+++ b/mteb/tasks/instruction_reranking/multilingual/m_follow_ir.py
@@ -168,9 +168,9 @@ class mFollowIRCrossLingual(AbsTaskRetrieval):  # noqa: N801
         bibtex_citation=r"""
 @article{weller2024mfollowir,
   author = {Weller, Orion and Chang, Benjamin and Yang, Eugene and Yarmohammadi, Mahsa and Barham, Sam and MacAvaney, Sean and Cohan, Arman and Soldaini, Luca and Van Durme, Benjamin and Lawrie, Dawn},
-  journal = {arXiv preprint TODO},
+  journal = {arXiv preprint arXiv:2501.19264},
   title = {{mFollowIR: a Multilingual Benchmark for Instruction Following in Retrieval}},
-  year = {2024},
+  year = {2025},
 }
 """,
     )
@@ -236,9 +236,9 @@ class mFollowIR(AbsTaskRetrieval):  # noqa: N801
         bibtex_citation=r"""
 @article{weller2024mfollowir,
   author = {Weller, Orion and Chang, Benjamin and Yang, Eugene and Yarmohammadi, Mahsa and Barham, Sam and MacAvaney, Sean and Cohan, Arman and Soldaini, Luca and Van Durme, Benjamin and Lawrie, Dawn},
-  journal = {arXiv preprint TODO},
+  journal = {arXiv preprint arXiv:2501.19264},
   title = {{mFollowIR: a Multilingual Benchmark for Instruction Following in Retrieval}},
-  year = {2024},
+  year = {2025},
 }
 """,
     )


### PR DESCRIPTION
### Description
This PR resolves an incomplete citation placeholder (`arXiv preprint TODO`) in the `mFollowIR` and `mFollowIRCrossLingual` tasks. 

**Changes made:**
- Replaced `arXiv preprint TODO` with the correct journal citation `arXiv preprint arXiv:2501.19264`.
- Updated the publication year from `2024` to `2025` to match the January publication date.

**Proof / Sources:**
- The original placeholder read: `mFollowIR: a Multilingual Benchmark for Instruction Following in Retrieval`.
- The published arXiv preprint for this exact title with matching authors can be found here: https://arxiv.org/abs/2501.19264

### Fixes
Fixes #4889