### PR TITLE
chore: fix Pydantic 2.11 deprecation warning

### DIFF
--- a/mteb/abstasks/task_metadata.py
+++ b/mteb/abstasks/task_metadata.py
@@ -581,7 +581,7 @@ class TaskMetadata(BaseModel):
         """
         return all(
             getattr(self, field_name) is not None
-            for field_name in self.model_fields
+            for field_name in self.__class__.model_fields
             if field_name
             not in ["prompt", "adapted_from", "contributed_by", "superseded_by"]  # noqa: PLR6201
         )


### PR DESCRIPTION
**Related Issue**: Closes #4892 

**Description**:
This PR addresses a Pydantic V2.11 deprecation warning in `TaskMetadata.is_filled()`. 

By replacing the instance-level access (`self.model_fields`) with class-level access (`self.__class__.model_fields`), this minor cleanup clears over 1,700 deprecation warnings from the `pytest` output and ensures compatibility for when Pydantic V3.0 is eventually released.