### PR TITLE
Support porcessing images and text together for colpali models 

### DIFF
--- a/mteb/models/model_implementations/colpali_models.py
+++ b/mteb/models/model_implementations/colpali_models.py
@@ -72,7 +72,7 @@ class ColPaliEngineWrapper(AbsEncoder):
                 raise ValueError(
                     "The number of texts and images must have the same length"
                 )
-            fused_embeddings = text_embeddings + image_embeddings
+            fused_embeddings = torch.cat([text_embeddings, image_embeddings], dim=1)
             return fused_embeddings
         elif text_embeddings is not None:
             return text_embeddings


### PR DESCRIPTION
Make possible to run colpali based models on tasks like Vidore3*.v2 with images and texts as part of same data. Was used during https://github.com/embeddings-benchmark/results/pull/595