### PR TITLE
fix: ModelMeta Validation

### DIFF
--- a/mteb/cache/result_cache.py
+++ b/mteb/cache/result_cache.py
@@ -37,7 +37,11 @@ from mteb.benchmarks.benchmark import Benchmark
 from mteb.benchmarks.get_benchmark import get_benchmark
 from mteb.models import ModelMeta
 from mteb.models.get_model_meta import get_model_metas
-from mteb.models.model_meta import _serialize_experiment_kwargs_to_name
+from mteb.models.model_implementations import MODEL_REGISTRY
+from mteb.models.model_meta import (
+    _get_loader_name,
+    _serialize_experiment_kwargs_to_name,
+)
 from mteb.results import BenchmarkResults, ModelResult, TaskResult
 from mteb.results.task_result import (
     _read_run_settings_from_file,
@@ -1080,8 +1084,21 @@ class ResultCache:
 
         try:
             with meta_file.open("r") as f:
-                meta_dict = f.read()
-            return ModelMeta.model_validate_json(meta_dict)
+                meta_dict = json.load(f)
+
+            # Resolve the string loader name back to the Callable registry object
+            loader_name = meta_dict.get("loader")
+            resolved_loader = None
+            if isinstance(loader_name, str):
+                for model_meta in MODEL_REGISTRY.values():
+                    if model_meta.loader is not None:
+                        name = _get_loader_name(model_meta.loader)  # type: ignore[arg-type]
+                        if name == loader_name:
+                            resolved_loader = model_meta.loader
+                            break
+
+            meta_dict["loader"] = resolved_loader
+            return ModelMeta.model_validate(meta_dict)
         except Exception as e:
             logger.warning(f"Failed to load ModelMeta from {meta_file}: {e}")
             return None

--- a/mteb/cache/result_cache.py
+++ b/mteb/cache/result_cache.py
@@ -37,11 +37,7 @@ from mteb.benchmarks.benchmark import Benchmark
 from mteb.benchmarks.get_benchmark import get_benchmark
 from mteb.models import ModelMeta
 from mteb.models.get_model_meta import get_model_metas
-from mteb.models.model_implementations import MODEL_REGISTRY
-from mteb.models.model_meta import (
-    _get_loader_name,
-    _serialize_experiment_kwargs_to_name,
-)
+from mteb.models.model_meta import _serialize_experiment_kwargs_to_name
 from mteb.results import BenchmarkResults, ModelResult, TaskResult
 from mteb.results.task_result import (
     _read_run_settings_from_file,
@@ -1084,21 +1080,8 @@ class ResultCache:
 
         try:
             with meta_file.open("r") as f:
-                meta_dict = json.load(f)
-
-            # Resolve the string loader name back to the Callable registry object
-            loader_name = meta_dict.get("loader")
-            resolved_loader = None
-            if isinstance(loader_name, str):
-                for model_meta in MODEL_REGISTRY.values():
-                    if model_meta.loader is not None:
-                        name = _get_loader_name(model_meta.loader)  # type: ignore[arg-type]
-                        if name == loader_name:
-                            resolved_loader = model_meta.loader
-                            break
-
-            meta_dict["loader"] = resolved_loader
-            return ModelMeta.model_validate(meta_dict)
+                meta_dict = f.read()
+            return ModelMeta.model_validate_json_resolved(meta_dict)
         except Exception as e:
             logger.warning(f"Failed to load ModelMeta from {meta_file}: {e}")
             return None

--- a/mteb/models/model_meta.py
+++ b/mteb/models/model_meta.py
@@ -414,6 +414,24 @@ class ModelMeta(BaseModel):  # noqa: PLR0904
             )
         return v
 
+    @classmethod
+    def model_validate_json_resolved(cls, json_data: str | bytes) -> ModelMeta:
+        """Validate JSON and resolve string loader if present."""
+        data = json.loads(json_data)
+        loader_name = data.get("loader")
+        resolved_loader = None
+        if isinstance(loader_name, str):
+            from mteb.models.model_implementations import MODEL_REGISTRY
+
+            for model_meta in MODEL_REGISTRY.values():
+                if model_meta.loader is not None:
+                    name = _get_loader_name(model_meta.loader)  # type: ignore[arg-type]
+                    if name == loader_name:
+                        resolved_loader = model_meta.loader
+                        break
+        data["loader"] = resolved_loader
+        return cls.model_validate(data)
+
     def __hash__(self) -> int:
         """Make ModelMeta hashable based on name, revision, experiment_kwargs and embed_dim.
 

--- a/mteb/models/model_meta.py
+++ b/mteb/models/model_meta.py
@@ -229,7 +229,7 @@ class ModelMeta(BaseModel):  # noqa: PLR0904
     model_config = ConfigDict(extra="forbid")
 
     # loaders
-    loader: Callable[..., MTEBModels] | None
+    loader: Callable[..., MTEBModels] | str | None
     loader_kwargs: dict[str, Any] = field(default_factory=dict)
     name: str | None
     revision: str | None
@@ -413,6 +413,23 @@ class ModelMeta(BaseModel):  # noqa: PLR0904
                 "Model name must be in the format 'organization/model_name'"
             )
         return v
+
+    @field_validator("loader", mode="before")
+    @classmethod
+    def _validate_loader(
+        cls, loader: Callable[..., MTEBModels] | str | None
+    ) -> Callable[..., MTEBModels] | str | None:
+        if isinstance(loader, str):
+            try:
+                from mteb.models.model_implementations import MODEL_REGISTRY
+
+                for model_meta in MODEL_REGISTRY.values():
+                    if model_meta.loader is not None:
+                        if _get_loader_name(model_meta.loader) == loader:
+                            return model_meta.loader
+            except Exception as e:
+                logger.debug("Failed to resolve loader %s: %s", loader, e)
+        return loader
 
     def __hash__(self) -> int:
         """Make ModelMeta hashable based on name, revision, experiment_kwargs and embed_dim.

--- a/mteb/models/model_meta.py
+++ b/mteb/models/model_meta.py
@@ -70,6 +70,7 @@ if TYPE_CHECKING:
     from mteb.abstasks import AbsTask
     from mteb.benchmarks.benchmark import Benchmark
     from mteb.cache import ResultCache
+    from mteb.models.models_protocols import EncoderProtocol
 
 
 logger = logging.getLogger(__name__)
@@ -172,12 +173,10 @@ class ScoringFunction(HelpfulStrEnum):
 
 
 def _get_loader_name(
-    loader: Callable[..., Any] | str | None,
+    loader: Callable[..., EncoderProtocol] | None,
 ) -> str | None:
     if loader is None:
         return None
-    if isinstance(loader, str):
-        return loader
     if hasattr(loader, "func"):  # partial class wrapper
         return str(loader.func.__name__)
     return str(loader.__name__)
@@ -230,7 +229,7 @@ class ModelMeta(BaseModel):  # noqa: PLR0904
     model_config = ConfigDict(extra="forbid")
 
     # loaders
-    loader: Callable[..., MTEBModels] | str | None
+    loader: Callable[..., MTEBModels] | None
     loader_kwargs: dict[str, Any] = field(default_factory=dict)
     name: str | None
     revision: str | None
@@ -415,23 +414,6 @@ class ModelMeta(BaseModel):  # noqa: PLR0904
             )
         return v
 
-    @field_validator("loader", mode="before")
-    @classmethod
-    def _validate_loader(
-        cls, loader: Callable[..., MTEBModels] | str | None
-    ) -> Callable[..., MTEBModels] | str | None:
-        if isinstance(loader, str):
-            try:
-                from mteb.models.model_implementations import MODEL_REGISTRY
-
-                for model_meta in MODEL_REGISTRY.values():
-                    if model_meta.loader is not None:
-                        if _get_loader_name(model_meta.loader) == loader:
-                            return model_meta.loader
-            except Exception as e:
-                logger.debug("Failed to resolve loader %s: %s", loader, e)
-        return loader
-
     def __hash__(self) -> int:
         """Make ModelMeta hashable based on name, revision, experiment_kwargs and embed_dim.
 
@@ -485,24 +467,10 @@ class ModelMeta(BaseModel):  # noqa: PLR0904
         if _self.name is None:
             raise ValueError("name is not set for ModelMeta. Cannot load model.")
 
-        loader = self._validate_loader(_self.loader)
-
-        if loader is None:
-            raise NotImplementedError(
-                "No model implementation is available for this model."
-            )
-
-        if isinstance(loader, str):
-            raise ValueError(
-                f"Loader '{loader}' for model '{_self.name}' could not be resolved to a callable. "
-                "Ensure the model is registered and its loader is available in the current environment."
-            )
-
+        loader = _self.loader
         name = _self.name
         revision = _self.revision
         updates: dict[str, Any] = {}
-        if loader != _self.loader:
-            updates["loader"] = loader
         base_exp_kwargs = (
             dict(_self.experiment_kwargs) if _self.experiment_kwargs else {}
         )

--- a/mteb/models/model_meta.py
+++ b/mteb/models/model_meta.py
@@ -70,7 +70,6 @@ if TYPE_CHECKING:
     from mteb.abstasks import AbsTask
     from mteb.benchmarks.benchmark import Benchmark
     from mteb.cache import ResultCache
-    from mteb.models.models_protocols import EncoderProtocol
 
 
 logger = logging.getLogger(__name__)
@@ -173,10 +172,12 @@ class ScoringFunction(HelpfulStrEnum):
 
 
 def _get_loader_name(
-    loader: Callable[..., EncoderProtocol] | None,
+    loader: Callable[..., Any] | str | None,
 ) -> str | None:
     if loader is None:
         return None
+    if isinstance(loader, str):
+        return loader
     if hasattr(loader, "func"):  # partial class wrapper
         return str(loader.func.__name__)
     return str(loader.__name__)
@@ -484,10 +485,24 @@ class ModelMeta(BaseModel):  # noqa: PLR0904
         if _self.name is None:
             raise ValueError("name is not set for ModelMeta. Cannot load model.")
 
-        loader = _self.loader
+        loader = self._validate_loader(_self.loader)
+
+        if loader is None:
+            raise NotImplementedError(
+                "No model implementation is available for this model."
+            )
+
+        if isinstance(loader, str):
+            raise ValueError(
+                f"Loader '{loader}' for model '{_self.name}' could not be resolved to a callable. "
+                "Ensure the model is registered and its loader is available in the current environment."
+            )
+
         name = _self.name
         revision = _self.revision
         updates: dict[str, Any] = {}
+        if loader != _self.loader:
+            updates["loader"] = loader
         base_exp_kwargs = (
             dict(_self.experiment_kwargs) if _self.experiment_kwargs else {}
         )

--- a/tests/test_models/test_model_meta.py
+++ b/tests/test_models/test_model_meta.py
@@ -1,3 +1,4 @@
+import json
 import re
 
 import pytest
@@ -571,3 +572,23 @@ def test_model_meta_no_auto_install_by_default(monkeypatch):
 
     with pytest.raises(ImportError):
         model_meta._check_requirements()
+
+
+def test_model_validate_json_resolved():
+    """Test that model_validate_json_resolved correctly parses JSON and resolves string loader to callable."""
+    original_meta = mteb.get_model_meta("google/siglip-base-patch16-224")
+    original_loader = original_meta.loader
+    assert original_loader is not None
+
+    meta_dict = original_meta.to_dict()
+    assert isinstance(meta_dict["loader"], str)
+    assert meta_dict["loader"] == "SiglipModelWrapper"
+
+    json_data = json.dumps(meta_dict)
+    parsed_meta = ModelMeta.model_validate_json_resolved(json_data)
+    assert parsed_meta.loader == original_loader
+
+    meta_dict["loader"] = "NonExistentModelWrapper"
+    json_data_unknown = json.dumps(meta_dict)
+    parsed_unknown = ModelMeta.model_validate_json_resolved(json_data_unknown)
+    assert parsed_unknown.loader is None


### PR DESCRIPTION
closes #4902.
Updated the signature of the `loader` to accept `str` along with `Callable[..., MTEBModels]` and added a field validator that will check if a string is provided. If a string is provided, it tries to match it against any registered loaders in `MODEL_REGISTRY` and dynamically resolve it back to the original Callable.
If it cannot find a registered loader or if `MODEL_REGISTRY` is not populated yet, it still allows the string value to pass validation safely.
It gave an error previously because, when saving model metadata in `model_meta.json`, it serializes `loader` to `string`. When calling `submit_results`, the code reads `model_meta.json` from the cache and attempts to reconstruct the ModelMeta object using `ModelMeta.model_validate_json()`, and during this, Pydantic expects loader to be `Callable` or `None`, but it is a `string` so it is giving an error.