### PR TITLE
model: Add ModelMeta for potion-code-16M-v2

### DIFF
--- a/mteb/models/model_implementations/model2vec_models.py
+++ b/mteb/models/model_implementations/model2vec_models.py
@@ -434,6 +434,36 @@ potion_multilingual_128m = ModelMeta(
     citation=MODEL2VEC_CITATION,
 )
 
+potion_code_16m_v2 = ModelMeta(
+    loader=SentenceTransformerEncoderWrapper,
+    name="minishlab/potion-code-16M-v2",
+    model_type=["dense"],
+    languages=["eng-Latn"],
+    open_weights=True,
+    revision="d3daf3e31f36d78f75913030b8bdf4a505d5b833",
+    release_date="2026-07-08",
+    n_parameters=16244992,
+    n_embedding_parameters=16244992,
+    memory_usage_mb=62,
+    max_tokens=np.inf,
+    embed_dim=256,
+    license="mit",
+    similarity_fn_name=ScoringFunction.COSINE,
+    framework=["NumPy", "Sentence Transformers", "safetensors"],
+    reference="https://huggingface.co/minishlab/potion-code-16M-v2",
+    use_instructions=False,
+    adapted_from="nomic-ai/CodeRankEmbed",
+    superseded_by=None,
+    training_datasets={"CoRNStack"},
+    public_training_code="https://github.com/MinishLab/model2vec",
+    public_training_data=(
+        "https://huggingface.co/collections/nomic-ai/cornstack; "
+        "https://huggingface.co/datasets/minishlab/tokenlearn-cornstack-docs-coderankembed-v2; "
+        "https://huggingface.co/datasets/minishlab/tokenlearn-cornstack-queries-coderankembed-v2"
+    ),
+    citation=MODEL2VEC_CITATION,
+)
+
 pubmed_bert_100k = ModelMeta(
     loader=Model2VecModel,
     name="NeuML/pubmedbert-base-embeddings-100K",


### PR DESCRIPTION
Hi!

This PR adds a model specification for [potion-base-16M-v2](https://huggingface.co/minishlab/potion-base-16M-v2), our latest static model specifically trained for code retrieval.

### Checklist
- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [x] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e., is available either as an API or the weights are publicly available to download
- [x] I reproduced results from the original paper (if applicable) on at least one benchmark, and I am including the results in the PR description.

## CoIR results

potion-code-16M-v2 evaluated on all 10 CoIR tasks (NDCG@10):

| Task | Score |
|---|---:|
| AppsRetrieval | 5.19 |
| CodeFeedbackMT | 38.02 |
| CodeFeedbackST | 53.22 |
| CodeSearchNetCCRetrieval | 48.67 |
| CodeTransOceanContest | 43.66 |
| CodeTransOceanDL | 32.64 |
| CosQA | 24.36 |
| COIRCodeSearchNetRetrieval | 73.68 |
| StackOverflowQA | 59.57 |
| SyntheticText2SQL | 44.07 |
| **Avg** | **42.31** |

