### PR TITLE
InjongoIntent: dropped eng config

### DIFF
--- a/mteb/tasks/classification/multilingual/injongo_intent.py
+++ b/mteb/tasks/classification/multilingual/injongo_intent.py
@@ -43,7 +43,7 @@ class InjongoIntent(AbsTaskClassification):
             "xho": ["xho-Latn"],
             "yor": ["yor-Latn"],
             "zul": ["zul-Latn"],
-           # "eng": ["eng-Latn"],
+            # "eng": ["eng-Latn"],
         },
         main_score="accuracy",
         date=("2024-02-13", "2025-02-13"),

--- a/mteb/tasks/classification/multilingual/injongo_intent.py
+++ b/mteb/tasks/classification/multilingual/injongo_intent.py
@@ -43,7 +43,7 @@ class InjongoIntent(AbsTaskClassification):
             "xho": ["xho-Latn"],
             "yor": ["yor-Latn"],
             "zul": ["zul-Latn"],
-            "eng": ["eng-Latn"],
+           # "eng": ["eng-Latn"],
         },
         main_score="accuracy",
         date=("2024-02-13", "2025-02-13"),


### PR DESCRIPTION
Issue:
The mteb/InjongoIntent mirror is missing the test split for the "eng" config specifically, so the loader raises "Instruction "test" corresponds to no data!" when materializing splits. All 16 African-language configs are intact (full train/validation/test) only English is broken. This is also why the task works on AfriMTEB-Lite, since Lite's language filter excludes English and never hits the broken config.


Fix:
We remove the "eng" config from eval_langs, so the task loads the 16 working African-language configs, which are the main focus of the task.

