### PR TITLE
docs: add icon to hybrid model page

### DIFF
--- a/docs/get_started/advanced_usage/hybrid_model.md
+++ b/docs/get_started/advanced_usage/hybrid_model.md
@@ -1,3 +1,8 @@
+---
+title: "Hybrid model"
+icon: lucide/merge
+---
+
 ## Using a Hybrid Model
 
 MTEB provides a unified [`mteb.HybridSearch`][mteb.HybridSearch] wrapper that allows you to combine multiple retrievers and cross-encoders using different fusion strategies (e.g. Reciprocal Rank Fusion, Distribution-Based Score Fusion, or custom fusion functions).


### PR DESCRIPTION
The hybrid model documentation page was the only page under `docs/get_started/advanced_usage/` missing frontmatter. As a result it rendered without an icon in the docs navigation, looking out of place next to its siblings.

This adds a `title` and the `lucide/merge` icon (as suggested in the issue) to match the other pages in that section.

Closes #4895