### PR TITLE
Fix #4368: Add CO₂ inference-cost estimate (gCO₂/Mtoken) to model metadata

### DIFF
--- a/mteb/api/schemas.py
+++ b/mteb/api/schemas.py
@@ -183,6 +183,19 @@ class TaskMetaSchema(_CamelModel):
         )
 
 
+class Co2EstimateSchema(_CamelModel):
+    """Estimated inference carbon cost with the assumptions behind it (for a badge + popover).
+
+    All figures are approximate and reflect benchmark conditions, not real-world deployment.
+    """
+
+    g_co2_per_million_tokens: float
+    active_parameters: int | None
+    benchmark_hardware: str
+    carbon_intensity_g_per_kwh: float
+    pue: float
+
+
 class ModelMetaSchema(_CamelModel):
     """Static model metadata; ``name`` is the canonical ``org/name`` HF identifier."""
 
@@ -204,6 +217,7 @@ class ModelMetaSchema(_CamelModel):
     languages: list[str] = Field(default_factory=list)
     citation: str | None = None
     memory_usage_mb: float | None = None
+    co2_estimate: Co2EstimateSchema | None = None
     license: str | None = None
     public_training_code: str | None = None
     public_training_data: str | None = None
@@ -253,6 +267,11 @@ class ModelMetaSchema(_CamelModel):
             memory_usage_mb=float(meta.memory_usage_mb)
             if meta.memory_usage_mb is not None
             else None,
+            co2_estimate=(
+                Co2EstimateSchema(**meta.co2_cost_estimate)
+                if meta.co2_cost_estimate is not None
+                else None
+            ),
             license=str(meta.license) if meta.license else None,
             public_training_code=str(meta.public_training_code)
             if meta.public_training_code

--- a/mteb/models/model_meta.py
+++ b/mteb/models/model_meta.py
@@ -161,6 +161,30 @@ OPEN_LICENSES: frozenset[str] = frozenset(
 )
 
 
+# --- CO2 inference-cost estimation ---------------------------------------------------
+# We estimate the inference carbon cost of a model as grams of CO2-equivalent per one
+# million tokens (gCO2eq / Mtoken). The estimate follows the linear energy model used by
+# EcoLogits (https://ecologits.ai/0.2/methodology/llm_inference/) and Luccioni et al.
+# (2024, https://arxiv.org/abs/2311.16863), so that figures are on roughly the same scale
+# as EcoLogits estimates for closed generative models:
+#
+#     energy_per_token (Wh) = CO2_ENERGY_ALPHA * active_params_billions + CO2_ENERGY_BETA
+#
+# The GPU energy is scaled by the datacenter PUE and multiplied by the grid carbon
+# intensity. All figures are approximate (prefixed with "~" when displayed) and reflect
+# *benchmark* conditions (a single reference GPU on an average grid), not any particular
+# real-world deployment. The coefficients are kept as module constants so they can be
+# refit on embedding-specific benchmark data in the future.
+CO2_ENERGY_ALPHA_WH_PER_TOKEN_PER_B_PARAM = 8.91e-5
+CO2_ENERGY_BETA_WH_PER_TOKEN = 1.43e-3
+# ADEME world-average grid carbon intensity, gCO2eq per kWh.
+CO2_CARBON_INTENSITY_G_PER_KWH = 400.0
+# Datacenter Power Usage Effectiveness.
+CO2_PUE = 1.2
+# Reference hardware the estimate is anchored to.
+CO2_BENCHMARK_HARDWARE = "A100 80GB"
+
+
 class ScoringFunction(HelpfulStrEnum):
     """The scoring function used by the models."""
 
@@ -317,6 +341,51 @@ class ModelMeta(BaseModel):  # noqa: PLR0904
         if self.n_parameters is not None and self.n_embedding_parameters is not None:
             return self.n_parameters - self.n_embedding_parameters
         return None
+
+    @property
+    def co2_cost_per_million_tokens(self) -> float | None:
+        """Estimated inference carbon cost in grams of CO2-equivalent per million tokens.
+
+        The estimate is derived from `n_active_parameters` using the linear energy model
+        described alongside the `CO2_ENERGY_ALPHA_WH_PER_TOKEN_PER_B_PARAM` constant, and
+        assumes the reference benchmark hardware (`CO2_BENCHMARK_HARDWARE`), an average grid
+        carbon intensity (`CO2_CARBON_INTENSITY_G_PER_KWH`) and datacenter overhead
+        (`CO2_PUE`). It is an approximation and reflects benchmark conditions rather than any
+        specific real-world deployment; treat it as a relative signal for model selection.
+
+        Returns:
+            The estimated gCO2eq / Mtoken, or None if the number of active parameters is unknown.
+        """
+        active = self.n_active_parameters
+        if active is None:
+            return None
+        active_billions = active / 1e9
+        energy_wh_per_token = (
+            CO2_ENERGY_ALPHA_WH_PER_TOKEN_PER_B_PARAM * active_billions
+            + CO2_ENERGY_BETA_WH_PER_TOKEN
+        )
+        # Wh/token -> kWh/Mtoken: multiply by 1e6 tokens then divide by 1000 Wh per kWh.
+        energy_kwh_per_million_tokens = energy_wh_per_token * 1e3
+        return energy_kwh_per_million_tokens * CO2_PUE * CO2_CARBON_INTENSITY_G_PER_KWH
+
+    @property
+    def co2_cost_estimate(self) -> dict[str, Any] | None:
+        """The CO2 inference-cost estimate together with the assumptions behind it.
+
+        Intended to back a compact badge (e.g. `~42 gCO₂ / Mtoken`) with a popover listing
+        the assumptions. Returns None when the estimate cannot be computed (unknown active
+        parameters). See `co2_cost_per_million_tokens` for the methodology.
+        """
+        value = self.co2_cost_per_million_tokens
+        if value is None:
+            return None
+        return {
+            "g_co2_per_million_tokens": value,
+            "active_parameters": self.n_active_parameters,
+            "benchmark_hardware": CO2_BENCHMARK_HARDWARE,
+            "carbon_intensity_g_per_kwh": CO2_CARBON_INTENSITY_G_PER_KWH,
+            "pue": CO2_PUE,
+        }
 
     @property
     def open_license(self) -> bool:

--- a/tests/test_models/test_model_meta.py
+++ b/tests/test_models/test_model_meta.py
@@ -216,6 +216,76 @@ def test_openness_non_open_license_not_counted():
     assert meta.openness_score == 2
 
 
+def _co2_meta(**overwrites) -> ModelMeta:
+    return ModelMeta.create_empty(
+        overwrites={"name": "test/co2", "revision": "test", **overwrites}
+    )
+
+
+def test_co2_cost_none_when_active_params_unknown():
+    meta = _co2_meta(n_parameters=None, n_embedding_parameters=None)
+    assert meta.n_active_parameters is None
+    assert meta.co2_cost_per_million_tokens is None
+    assert meta.co2_cost_estimate is None
+
+
+def test_co2_cost_matches_linear_model():
+    from mteb.models.model_meta import (
+        CO2_CARBON_INTENSITY_G_PER_KWH,
+        CO2_ENERGY_ALPHA_WH_PER_TOKEN_PER_B_PARAM,
+        CO2_ENERGY_BETA_WH_PER_TOKEN,
+        CO2_PUE,
+    )
+
+    # 1B active parameters (110M total minus 10M embedding would be too small; use explicit override)
+    meta = _co2_meta(n_active_parameters_override=1_000_000_000)
+    assert meta.n_active_parameters == 1_000_000_000
+
+    energy_wh_per_token = (
+        CO2_ENERGY_ALPHA_WH_PER_TOKEN_PER_B_PARAM * 1.0 + CO2_ENERGY_BETA_WH_PER_TOKEN
+    )
+    expected = energy_wh_per_token * 1e3 * CO2_PUE * CO2_CARBON_INTENSITY_G_PER_KWH
+    assert meta.co2_cost_per_million_tokens == pytest.approx(expected)
+
+
+def test_co2_cost_increases_with_active_parameters():
+    small = _co2_meta(n_active_parameters_override=100_000_000)
+    large = _co2_meta(n_active_parameters_override=7_000_000_000)
+    assert small.co2_cost_per_million_tokens < large.co2_cost_per_million_tokens
+
+
+def test_co2_cost_uses_active_not_total_parameters():
+    from mteb.models.model_meta import CO2_ENERGY_BETA_WH_PER_TOKEN
+
+    # n_active_parameters = n_parameters - n_embedding_parameters
+    meta = _co2_meta(n_parameters=110_000_000, n_embedding_parameters=10_000_000)
+    assert meta.n_active_parameters == 100_000_000
+
+    active_only = _co2_meta(n_active_parameters_override=100_000_000)
+    assert meta.co2_cost_per_million_tokens == pytest.approx(
+        active_only.co2_cost_per_million_tokens
+    )
+    # sanity: strictly positive and dominated by the fixed beta term for a small model
+    assert meta.co2_cost_per_million_tokens > CO2_ENERGY_BETA_WH_PER_TOKEN
+
+
+def test_co2_cost_estimate_reports_assumptions():
+    from mteb.models.model_meta import (
+        CO2_BENCHMARK_HARDWARE,
+        CO2_CARBON_INTENSITY_G_PER_KWH,
+        CO2_PUE,
+    )
+
+    meta = _co2_meta(n_active_parameters_override=1_000_000_000)
+    estimate = meta.co2_cost_estimate
+    assert estimate is not None
+    assert estimate["g_co2_per_million_tokens"] == meta.co2_cost_per_million_tokens
+    assert estimate["active_parameters"] == 1_000_000_000
+    assert estimate["benchmark_hardware"] == CO2_BENCHMARK_HARDWARE
+    assert estimate["carbon_intensity_g_per_kwh"] == CO2_CARBON_INTENSITY_G_PER_KWH
+    assert estimate["pue"] == CO2_PUE
+
+
 def test_model_name_without_prefix():
     with pytest.raises(ValueError):
         ModelMeta(


### PR DESCRIPTION
Closes #4368

## What

Adds an estimate of a model's inference carbon cost, expressed as grams of CO₂-equivalent per million tokens (gCO₂ / Mtoken), derived from its **active parameters**. This surfaces a model-selection signal (relative inference cost) that no other embedding leaderboard currently shows.

## Methodology

Follows the EcoLogits linear energy model referenced in the issue:

```
energy_per_token (Wh) = a · active_params_billions + b
```

The GPU energy is scaled by the datacenter PUE and multiplied by the grid carbon intensity. Using the EcoLogits coefficients keeps the figures on roughly the same scale as EcoLogits estimates for closed generative models, as suggested in the issue.

All assumptions are documented module constants in `mteb/models/model_meta.py` so they can be **refit on embedding-specific benchmark data** later:

- Energy coefficients `a`, `b`
- Carbon intensity — 400 gCO₂/kWh (ADEME world average)
- PUE — 1.2
- Benchmark hardware — A100 80GB

All figures are approximate (to be displayed with a `~` prefix) and reflect **benchmark conditions**, not any specific real-world deployment.

## API surface

- `ModelMeta.co2_cost_per_million_tokens` → the numeric estimate (`None` when active parameters are unknown).
- `ModelMeta.co2_cost_estimate` → the estimate plus the assumptions behind it, intended to back a compact badge with a popover (per the mockup in the issue).
- `Co2EstimateSchema` added to `ModelMetaSchema` so the leaderboard API exposes the estimate + assumptions to the frontend.

## Tests

Added unit tests in `tests/test_models/test_model_meta.py` covering the linear model, monotonicity in active parameters, use of active (not total) parameters, the reported assumptions, and the `None` case. All pass locally.

## Notes / follow-ups

- The rendered badge + popover UI lives in the SvelteKit frontend; this PR provides the backend estimate and API field it consumes.
- For closed models where active parameters are undisclosed, the estimate returns `None`; the EcoLogits-fallback / throughput-based estimation discussed in the issue can be layered on top later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)