### PR TITLE
Fix #4375: load MSR-VTT via standard retrieval format

### DIFF
--- a/mteb/abstasks/retrieval.py
+++ b/mteb/abstasks/retrieval.py
@@ -241,6 +241,10 @@ class AbsTaskRetrieval(AbsTask):
         eval_splits = self.eval_splits
         trust_remote_code = self.metadata.dataset.get("trust_remote_code", False)
         revision = self.metadata.dataset["revision"]
+        # A single repo can host several retrieval directions/tasks via named
+        # configs (e.g. ``<name>-queries`` / ``<name>-corpus`` / ``<name>-qrels``).
+        # Multilingual tasks derive the config from the language subset instead.
+        dataset_name = self.metadata.dataset.get("name")
 
         def _process_data(split: str, hf_subset: str = "default") -> None:
             """Helper function to load and process data for a given split and language"""
@@ -255,7 +259,7 @@ class AbsTaskRetrieval(AbsTask):
                 revision=revision,
                 trust_remote_code=trust_remote_code,
                 split=split,
-                config=hf_subset,
+                config=hf_subset if self.metadata.is_multilingual else dataset_name,
             ).load(
                 num_proc=num_proc,
             )

--- a/mteb/tasks/retrieval/eng/msr_vtt.py
+++ b/mteb/tasks/retrieval/eng/msr_vtt.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
-from datasets import load_dataset
-
 from mteb.abstasks.retrieval import AbsTaskRetrieval
-from mteb.abstasks.retrieval_dataset_loaders import RetrievalSplitData
 from mteb.abstasks.task_metadata import TaskMetadata
 
 _DATASET_PATH = "mteb/MSR-VTT"
+# The standard-format configs (``<direction>-queries`` / ``<direction>-corpus``
+# / ``<direction>-qrels``) are produced by
+# ``scripts/upload_msr_vtt_retrieval.py``. Update this revision after
+# reuploading the dataset so every direction loads through the standard
+# ``RetrievalDatasetLoader`` (see issue #4375).
 _DATASET_REVISION = "4661603cee25c1fd370e5478a2953203cf37155b"
 _BIBTEX = r"""
 @inproceedings{xu2016msrvtt,
@@ -18,44 +20,15 @@ _BIBTEX = r"""
 """
 
 
-def _load_msr_vtt(
-    task: AbsTaskRetrieval,
-    query_columns: list[str],
-    corpus_columns: list[str],
-) -> None:
-    """Shared loader for all MSR-VTT retrieval directions.
-
-    TODO: Reupload dataset in standard format and remove this custom load_data.
-    """
-    if task.data_loaded:
-        return
-    task.dataset = {"default": {}}
-    dataset = load_dataset(
-        task.metadata.dataset["path"],
-        revision=task.metadata.dataset["revision"],
-        split=task.metadata.eval_splits[0],
-    )
-    dataset = dataset.add_column("id", [str(i) for i in range(len(dataset))])
-
-    query = dataset.select_columns(["id"] + query_columns)
-    corpus = dataset.select_columns(["id"] + corpus_columns)
-    if "caption" in query_columns:
-        query = query.rename_column("caption", "text")
-    if "caption" in corpus_columns:
-        corpus = corpus.rename_column("caption", "text")
-
-    qrels = {str(i): {str(i): 1} for i in range(len(dataset))}
-    task.dataset["default"]["test"] = RetrievalSplitData(
-        queries=query, corpus=corpus, relevant_docs=qrels, top_ranked=None
-    )
-    task.data_loaded = True
-
-
 class MSRVTTV2T(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="MSRVTTV2T",
         description="A large video description dataset for bridging video and language. Used the msrvtt_ret_test1k retrieval split (879 examples).",
-        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        dataset={
+            "path": _DATASET_PATH,
+            "revision": _DATASET_REVISION,
+            "name": "MSRVTTV2T",
+        },
         type="Any2AnyRetrieval",
         eval_langs=["eng-Latn"],
         eval_splits=["test"],
@@ -75,15 +48,16 @@ class MSRVTTV2T(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
-        _load_msr_vtt(self, query_columns=["video"], corpus_columns=["caption"])
-
 
 class MSRVTTT2V(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="MSRVTTT2V",
         description="A large video description dataset for bridging video and language. Used the msrvtt_ret_test1k retrieval split (879 examples).",
-        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        dataset={
+            "path": _DATASET_PATH,
+            "revision": _DATASET_REVISION,
+            "name": "MSRVTTT2V",
+        },
         type="Any2AnyRetrieval",
         eval_langs=["eng-Latn"],
         eval_splits=["test"],
@@ -103,15 +77,16 @@ class MSRVTTT2V(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
-        _load_msr_vtt(self, query_columns=["caption"], corpus_columns=["video"])
-
 
 class MSRVTTVA2T(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="MSRVTTVA2T",
         description="A large video description dataset for bridging video and language. Used the msrvtt_ret_test1k retrieval split (879 examples).",
-        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        dataset={
+            "path": _DATASET_PATH,
+            "revision": _DATASET_REVISION,
+            "name": "MSRVTTVA2T",
+        },
         type="Any2AnyRetrieval",
         eval_langs=["eng-Latn"],
         eval_splits=["test"],
@@ -131,17 +106,16 @@ class MSRVTTVA2T(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
-        _load_msr_vtt(
-            self, query_columns=["video", "audio"], corpus_columns=["caption"]
-        )
-
 
 class MSRVTTT2VA(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="MSRVTTT2VA",
         description="A large video description dataset for bridging video and language. Used the msrvtt_ret_test1k retrieval split (879 examples).",
-        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        dataset={
+            "path": _DATASET_PATH,
+            "revision": _DATASET_REVISION,
+            "name": "MSRVTTT2VA",
+        },
         type="Any2AnyRetrieval",
         eval_langs=["eng-Latn"],
         eval_splits=["test"],
@@ -161,11 +135,6 @@ class MSRVTTT2VA(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
-        _load_msr_vtt(
-            self, query_columns=["caption"], corpus_columns=["video", "audio"]
-        )
-
 
 class MSRVTTV2A(AbsTaskRetrieval):
     metadata = TaskMetadata(
@@ -175,7 +144,11 @@ class MSRVTTV2A(AbsTaskRetrieval):
             "Tests cross-modal alignment between video frames and audio."
             " Used the msrvtt_ret_test1k retrieval split (879 examples)."
         ),
-        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        dataset={
+            "path": _DATASET_PATH,
+            "revision": _DATASET_REVISION,
+            "name": "MSRVTTV2A",
+        },
         type="Any2AnyRetrieval",
         eval_langs=["eng-Latn"],
         eval_splits=["test"],
@@ -195,9 +168,6 @@ class MSRVTTV2A(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
-        _load_msr_vtt(self, query_columns=["video"], corpus_columns=["audio"])
-
 
 class MSRVTTA2V(AbsTaskRetrieval):
     metadata = TaskMetadata(
@@ -207,7 +177,11 @@ class MSRVTTA2V(AbsTaskRetrieval):
             "Tests cross-modal alignment between audio and video frames."
             " Used the msrvtt_ret_test1k retrieval split (879 examples)."
         ),
-        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        dataset={
+            "path": _DATASET_PATH,
+            "revision": _DATASET_REVISION,
+            "name": "MSRVTTA2V",
+        },
         type="Any2AnyRetrieval",
         eval_langs=["eng-Latn"],
         eval_splits=["test"],
@@ -227,15 +201,16 @@ class MSRVTTA2V(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
-        _load_msr_vtt(self, query_columns=["audio"], corpus_columns=["video"])
-
 
 class MSRVTTVT2A(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="MSRVTTVT2A",
         description="A large video description dataset for bridging video and language. Used the msrvtt_ret_test1k retrieval split (879 examples).",
-        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        dataset={
+            "path": _DATASET_PATH,
+            "revision": _DATASET_REVISION,
+            "name": "MSRVTTVT2A",
+        },
         type="Any2AnyRetrieval",
         eval_langs=["eng-Latn"],
         eval_splits=["test"],
@@ -257,17 +232,16 @@ class MSRVTTVT2A(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
-        _load_msr_vtt(
-            self, query_columns=["video", "caption"], corpus_columns=["audio"]
-        )
-
 
 class MSRVTTAT2V(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="MSRVTTAT2V",
         description="A large video description dataset for bridging video and language. Used the msrvtt_ret_test1k retrieval split (879 examples).",
-        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        dataset={
+            "path": _DATASET_PATH,
+            "revision": _DATASET_REVISION,
+            "name": "MSRVTTAT2V",
+        },
         type="Any2AnyRetrieval",
         eval_langs=["eng-Latn"],
         eval_splits=["test"],
@@ -288,8 +262,3 @@ class MSRVTTAT2V(AbsTaskRetrieval):
         },
         is_beta=True,
     )
-
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
-        _load_msr_vtt(
-            self, query_columns=["audio", "caption"], corpus_columns=["video"]
-        )

--- a/scripts/upload_msr_vtt_retrieval.py
+++ b/scripts/upload_msr_vtt_retrieval.py
@@ -1,0 +1,113 @@
+"""Reupload the MSR-VTT retrieval dataset in the standard MTEB format.
+
+The source repo ``mteb/MSR-VTT`` ships a single flat ``test`` split with
+``video`` / ``audio`` / ``caption`` columns, which forced every MSR-VTT
+retrieval task to implement a custom ``load_data`` that materialised queries,
+corpus and qrels on the fly (see issue #4375).
+
+This script rebuilds the dataset so that a single repo hosts one set of
+``<direction>-queries`` / ``<direction>-corpus`` / ``<direction>-qrels`` configs
+per retrieval direction. Each MSR-VTT task then loads through the standard
+``RetrievalDatasetLoader`` by pointing ``dataset["name"]`` at its direction, and
+the custom loaders can be removed.
+
+Every direction is an identity mapping: row ``i`` on the query side is relevant
+to row ``i`` on the corpus side (879 examples, msrvtt_ret_test1k split).
+
+Usage:
+    python scripts/upload_msr_vtt_retrieval.py --owner mteb --token "$HF_TOKEN"
+    python scripts/upload_msr_vtt_retrieval.py --dry-run
+
+After uploading, update ``_DATASET_REVISION`` in
+``mteb/tasks/retrieval/eng/msr_vtt.py`` to the new commit hash.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+from datasets import Dataset, load_dataset
+
+_SOURCE_PATH = "mteb/MSR-VTT"
+_SOURCE_REVISION = "4661603cee25c1fd370e5478a2953203cf37155b"
+_SPLIT = "test"
+
+# direction name -> (query columns, corpus columns)
+# The source columns are ``video``, ``audio`` and ``caption``; ``caption`` is
+# renamed to ``text`` on whichever side it appears on so the standard loader
+# treats it as the text modality.
+DIRECTIONS: dict[str, tuple[list[str], list[str]]] = {
+    "MSRVTTV2T": (["video"], ["caption"]),
+    "MSRVTTT2V": (["caption"], ["video"]),
+    "MSRVTTVA2T": (["video", "audio"], ["caption"]),
+    "MSRVTTT2VA": (["caption"], ["video", "audio"]),
+    "MSRVTTV2A": (["video"], ["audio"]),
+    "MSRVTTA2V": (["audio"], ["video"]),
+    "MSRVTTVT2A": (["video", "caption"], ["audio"]),
+    "MSRVTTAT2V": (["audio", "caption"], ["video"]),
+}
+
+
+def _select(dataset: Dataset, columns: list[str]) -> Dataset:
+    """Select ``id`` + the requested modality columns, renaming caption->text."""
+    out = dataset.select_columns(["id"] + columns)
+    if "caption" in columns:
+        out = out.rename_column("caption", "text")
+    return out
+
+
+def build_configs(dataset: Dataset) -> dict[str, Dataset]:
+    """Build every ``<direction>-{queries,corpus,qrels}`` config."""
+    n = len(dataset)
+    ids = [str(i) for i in range(n)]
+    qrels = Dataset.from_dict({"query-id": ids, "corpus-id": ids, "score": [1] * n})
+
+    configs: dict[str, Dataset] = {}
+    for direction, (query_cols, corpus_cols) in DIRECTIONS.items():
+        configs[f"{direction}-queries"] = _select(dataset, query_cols)
+        configs[f"{direction}-corpus"] = _select(dataset, corpus_cols)
+        configs[f"{direction}-qrels"] = qrels
+    return configs
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--owner",
+        default="mteb",
+        help="HF user/org that will own the reuploaded repo.",
+    )
+    p.add_argument(
+        "--repo",
+        default="MSR-VTT",
+        help="Repo name (combined with --owner) to push to.",
+    )
+    p.add_argument(
+        "--token", default=None, help="HF access token (or use the HF_TOKEN env var)."
+    )
+    p.add_argument("--dry-run", action="store_true", help="Build but do not upload.")
+    args = p.parse_args()
+
+    token = args.token or os.environ.get("HF_TOKEN")
+    repo_id = f"{args.owner}/{args.repo}"
+
+    dataset = load_dataset(_SOURCE_PATH, revision=_SOURCE_REVISION, split=_SPLIT)
+    dataset = dataset.add_column("id", [str(i) for i in range(len(dataset))])
+    print(
+        f"Loaded {len(dataset)} rows from {_SOURCE_PATH}, columns={dataset.column_names}"
+    )
+
+    configs = build_configs(dataset)
+    for config_name, ds in configs.items():
+        if args.dry_run:
+            print(
+                f"  [dry-run] {config_name}: {len(ds)} rows, columns={ds.column_names}"
+            )
+            continue
+        ds.push_to_hub(repo_id, config_name=config_name, split=_SPLIT, token=token)
+        print(f"  -> {repo_id} [{config_name}] ({len(ds)} rows)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #4375

## What

The MSR-VTT retrieval tasks (`MSRVTTV2T`, `MSRVTTT2V`, `MSRVTTVA2T`, `MSRVTTT2VA`, `MSRVTTV2A`, `MSRVTTA2V`, `MSRVTTVT2A`, `MSRVTTAT2V`) each shipped a custom `load_data` (`_load_msr_vtt`) that materialised queries/corpus/qrels on the fly, because `mteb/MSR-VTT` was uploaded as a single flat `test` split with `video`/`audio`/`caption` columns rather than the standard retrieval format.

## Changes

- **`mteb/abstasks/retrieval.py`**: allow a single repo to host multiple retrieval directions via a `name` config in `dataset` (i.e. `<name>-queries` / `<name>-corpus` / `<name>-qrels`). For non-multilingual tasks, `load_data` now passes `dataset["name"]` through the standard `RetrievalDatasetLoader`. Tasks without a `name` key are unaffected (`config` resolves to `None`, exactly as before), and multilingual tasks keep deriving the config from the language subset.
- **`mteb/tasks/retrieval/eng/msr_vtt.py`**: remove the custom `_load_msr_vtt` loaders; each task now loads through the standard loader by pointing `dataset["name"]` at its direction.
- **`scripts/upload_msr_vtt_retrieval.py`**: script that rebuilds `mteb/MSR-VTT` into the standard format (8 directions × `queries`/`corpus`/`qrels` = 24 configs, identity qrels, `caption`→`text`).

## Follow-up required (maintainer with HF write access)

The dataset itself must be reuploaded before these tasks resolve at runtime. A maintainer with HF write access to the `mteb` org needs to:

1. Run `python scripts/upload_msr_vtt_retrieval.py --owner mteb --token "$HF_TOKEN"` (use `--dry-run` first to inspect the 24 configs).
2. Update `_DATASET_REVISION` in `mteb/tasks/retrieval/eng/msr_vtt.py` to the resulting commit hash.

`_DATASET_REVISION` is intentionally left at the current value with a comment. This PR should not be merged before that reupload, otherwise the eight tasks will fail to load (the standard-format configs do not yet exist at the current revision).

## Verification

- All 8 tasks instantiate, pass `TaskMetadata` validation, carry the correct `name` config, and now use the base `AbsTaskRetrieval.load_data`.
- The `name` config flows through `RetrievalDatasetLoader` as `<name>-queries` / `<name>-corpus` / `<name>-qrels`, matching the configs emitted by the upload script's `build_configs` (24 configs, `caption` renamed to `text`, identity qrels).
- `ruff check` / `ruff format --check` pass on all changed files.
