### PR TITLE
fix: reconstruct main_score for legacy reranking and pair-classification results

### DIFF
--- a/mteb/results/task_result.py
+++ b/mteb/results/task_result.py
@@ -502,7 +502,7 @@ class TaskResult(BaseModel):  # noqa: PLR0904
                     main_score, subset_scores
                 )
                 if reconstructed is not None:
-                    subset_scores["main_score"] = reconstructed
+                    subset_scores["main_score"] = reconstructed  # type: ignore[index]
                 else:
                     log_once.warning(f"Main score {main_score} not found in scores")
 

--- a/mteb/results/task_result.py
+++ b/mteb/results/task_result.py
@@ -127,6 +127,43 @@ renamed_tasks = {
 }
 
 
+def _reconstruct_legacy_main_score(main_score: str, scores: ScoresDict) -> Score | None:
+    """Reconstruct a task's ``main_score`` from legacy metric names.
+
+    Result files from before the reranking and pair-classification evaluators were
+    migrated to the retrieval-based metrics stored their scores under different
+    names, so the current ``main_score`` is absent (see issue #4333):
+
+    - Reranking stored ``map``/``mrr`` instead of ``map_at_1000``/``mrr_at_10``.
+    - Pair classification stored per-similarity metrics (e.g. ``cosine_ap``) but not
+      the ``max_*`` aggregate.
+
+    Returns the reconstructed score, or ``None`` if it cannot be derived.
+    """
+    # Reranking: the legacy `map`/`mrr` correspond to today's `*map_at_k` / `*mrr_at_k`
+    # main scores (e.g. `map_at_1000`, `max_over_subqueries_map_at_1000`), which are
+    # computed the same way. Checked before the pair-classification branch below so
+    # that a `max_over_subqueries_*` main score is not mistaken for a `max_*` aggregate.
+    for legacy in ("map", "mrr"):
+        legacy_score = scores.get(legacy)
+        if legacy_score is not None and (
+            main_score == legacy or f"{legacy}_at_" in main_score
+        ):
+            return legacy_score
+    # Pair classification: `max_<metric>` is the max over the per-similarity
+    # `*_<metric>` scores (e.g. `cosine_ap`, `dot_ap`, ... for `max_ap`).
+    if main_score.startswith("max_"):
+        metric = main_score[len("max_") :]
+        candidates = [
+            v
+            for name, v in scores.items()
+            if name.endswith(f"_{metric}") and isinstance(v, (int, float))
+        ]
+        if candidates:
+            return max(candidates)
+    return None
+
+
 class TaskResult(BaseModel):  # noqa: PLR0904
     """A class to represent the MTEB result.
 
@@ -424,7 +461,50 @@ class TaskResult(BaseModel):  # noqa: PLR0904
         if pre_v_12_48:
             cls._fix_pair_classification_scores(obj)
 
+        cls._reconstruct_missing_main_scores(obj)
+
         return obj
+
+    @classmethod
+    def _reconstruct_missing_main_scores(cls, obj: TaskResult) -> None:
+        """Reconstruct ``main_score`` values that loaded as ``None``.
+
+        Historic result files predate the reranking and pair-classification metric
+        migrations, so their stored scores no longer include the task's current
+        ``main_score`` (see issue #4333). This runs after all other historic fixups
+        (so metric names are already normalized) and applies to every load path, not
+        just the pre-v1.11.0 one, since the reranking format also changed later.
+        """
+        if not any(
+            subset_scores.get("main_score") is None
+            for split_scores in obj.scores.values()
+            for subset_scores in split_scores
+        ):
+            return
+
+        from mteb import get_task
+
+        task_name = obj.task_name
+        if task_name in outdated_tasks:
+            task: AbsTask | type[AbsTask] = outdated_tasks[task_name]
+        else:
+            try:
+                task = get_task(task_name)
+            except Exception:
+                return
+        main_score = task.metadata.main_score
+
+        for split_scores in obj.scores.values():
+            for subset_scores in split_scores:
+                if subset_scores.get("main_score") is not None:
+                    continue
+                reconstructed = _reconstruct_legacy_main_score(
+                    main_score, subset_scores
+                )
+                if reconstructed is not None:
+                    subset_scores["main_score"] = reconstructed
+                else:
+                    log_once.warning(f"Main score {main_score} not found in scores")
 
     @classmethod
     def _fix_pair_classification_scores(cls, obj: TaskResult) -> None:
@@ -513,7 +593,8 @@ class TaskResult(BaseModel):  # noqa: PLR0904
                     if main_score in hf_subset_scores:
                         hf_subset_scores["main_score"] = hf_subset_scores[main_score]
                     else:
-                        log_once.warning(f"Main score {main_score} not found in scores")
+                        # Left as None here; reconstructed later (once metric names
+                        # are normalized) by `_reconstruct_missing_main_scores`.
                         hf_subset_scores["main_score"] = None
 
         # specific fixes:

--- a/tests/historic_results/MindSmallReranking.json
+++ b/tests/historic_results/MindSmallReranking.json
@@ -1,0 +1,19 @@
+{
+    "dataset_revision": "3bdac13927fdc888b903db93b2ffdbd90b295a69",
+    "task_name": "MindSmallReranking",
+    "evaluation_time": null,
+    "mteb_version": "1.14.17",
+    "scores": {
+        "test": [
+            {
+                "hf_subset": "default",
+                "languages": [
+                    "eng-Latn"
+                ],
+                "map": 0.339769104898534,
+                "mrr": 0.3532831430710564,
+                "main_score": null
+            }
+        ]
+    }
+}

--- a/tests/historic_results/SciDocsRR.json
+++ b/tests/historic_results/SciDocsRR.json
@@ -1,0 +1,10 @@
+{
+    "dataset_revision": "d3c5e1fc0b855ab6097bf1cda04dd73947d7caab",
+    "mteb_dataset_name": "SciDocsRR",
+    "mteb_version": "1.0.3.dev0",
+    "test": {
+        "evaluation_time": 2242.46,
+        "map": 0.8458048271261831,
+        "mrr": 0.9600679730581692
+    }
+}

--- a/tests/historic_results/SprintDuplicateQuestions.json
+++ b/tests/historic_results/SprintDuplicateQuestions.json
@@ -1,0 +1,1 @@
+{"test": {"cos_sim": {"ap": 0.9457614298}}, "mteb_dataset_name": "SprintDuplicateQuestions"}

--- a/tests/test_results/test_task_results.py
+++ b/tests/test_results/test_task_results.py
@@ -281,6 +281,37 @@ def test_merge_without_per_subset_version():
 def test_mteb_results_from_historic(path: Path):
     mteb_result = TaskResult.from_disk(path, load_historic_data=True)
     assert isinstance(mteb_result, TaskResult)
+    # Legacy result files stored reranking/pair-classification scores under names that
+    # no longer match the task's `main_score`; these should be reconstructed rather
+    # than left as None (https://github.com/embeddings-benchmark/mteb/issues/4333).
+    for split_scores in mteb_result.scores.values():
+        for subset_scores in split_scores:
+            assert subset_scores["main_score"] is not None
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected_main_score"),
+    [
+        # Reranking, pre-v1.11.0 layout: legacy `map` -> `map_at_1000`.
+        ("SciDocsRR.json", 0.8458048271261831),
+        # Pair classification, pre-v1.11.0 layout: `cos_sim.ap` -> `max_ap`.
+        ("SprintDuplicateQuestions.json", 0.9457614298),
+        # Reranking, modern layout with a null `main_score` (the format still stored
+        # `map`/`mrr` between ~v1.12 and v2). `max_over_subqueries_map_at_1000` is
+        # reconstructed from the legacy `map`. Regression guard for the v1.12-v2 gap.
+        ("MindSmallReranking.json", 0.339769104898534),
+    ],
+)
+def test_historic_main_score_reconstruction(filename: str, expected_main_score: float):
+    """Legacy metric names should be reconstructed to the correct `main_score` value.
+
+    Regression test for https://github.com/embeddings-benchmark/mteb/issues/4333.
+    """
+    path = tests_folder / "historic_results" / filename
+    mteb_result = TaskResult.from_disk(path, load_historic_data=True)
+    assert mteb_result.scores["test"][0]["main_score"] == pytest.approx(
+        expected_main_score
+    )
 
 
 def test_from_disk_with_multiversion_range(tmp_path: Path):


### PR DESCRIPTION
## Summary

Several historic result files load with `main_score = None` (see #4333, e.g. `SciDocsRR`, `MindSmallReranking`, `SprintDuplicateQuestions` for `openai/text-embedding-3-*`, `google/text-embedding-004`, `Alibaba-NLP/gme-Qwen2-VL-*`). These files predate the reranking and pair-classification metric migrations, so their stored scores no longer contain the task's current `main_score`.

This reconstructs `main_score` from the legacy metric names when it is otherwise absent:

- **Reranking** stored `map`/`mrr`; today's main score is a `*map_at_k` / `*mrr_at_k` variant (`map_at_1000`, `max_over_subqueries_map_at_1000`, …) computed the same way, so the legacy value is reused.
- **Pair classification** stored per-similarity metrics (e.g. `cosine_ap`, `dot_ap`) but not the `max_*` aggregate, which is reconstructed as the max over those metrics.

## Notes / addressing review

This continues the work in #4874 and addresses @Samoed's review there:

- Reconstruction now runs as a single post-load step in `from_disk` (`_reconstruct_missing_main_scores`), so it applies to **every** load path rather than only `_convert_from_before_v1_11_0`. This covers the reranking format change that also affected the ~v1.12–v2 range, and the pair-classification fixup path (post #1061).
- The reranking check is ordered before the pair-classification `max_*` branch so a reranking `max_over_subqueries_map_at_1000` main score isn't mistaken for a pair-classification aggregate.

Verified against a sample of real result files from `embeddings-benchmark/results`: previously-`None` reranking/pair-classification scores are reconstructed with correct values, and unrelated tasks (e.g. STS, which also stores `cos_sim`) are left unchanged.

## Tests

- `test_mteb_results_from_historic` now asserts no historic fixture loads a `None` main score.
- New `test_historic_main_score_reconstruction` checks reconstructed values for both task types and both file layouts, including a modern-layout reranking fixture (`MindSmallReranking.json`) as a regression guard for the v1.12–v2 gap.

Closes #4333