### PR TITLE
Add Hanno-Labs/dinghy-law-0.6b-v1 (legal embedding model)

### DIFF
--- a/mteb/models/model_implementations/hanno_labs_models.py
+++ b/mteb/models/model_implementations/hanno_labs_models.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from mteb.models.model_implementations.qwen3_models import q3e_instruct_loader
+from mteb.models.model_meta import ModelMeta
+
+# dinghy-law-0.6b-v1 is a legal-domain contrastive fine-tune of Qwen/Qwen3-Embedding-0.6B. It keeps the
+# base architecture and interface exactly (last-token pooling, cosine similarity, query-side
+# "Instruct: {instruction}\nQuery:" prefix with unprefixed documents), so it reuses the shared Qwen3
+# instruct loader. Trained on public/permissively-licensed legal corpora; the GerDaLIR and BillSum splits
+# below overlap MTEB tasks and are declared for zero-shot accounting.
+
+DINGHY_LAW_CITATION = """@misc{dinghy-law-0.6b,
+  title  = {dinghy-law-0.6b: a compact legal text-embedding model},
+  author = {Solka, Stephen},
+  year   = {2026},
+  note   = {Hanno Labs / Clause Logic Inc.},
+  howpublished = {\\url{https://huggingface.co/Hanno-Labs/dinghy-law-0.6b-v1}}
+}"""
+
+# Sources used to train dinghy-law-0.6b-v1 that correspond to MTEB tasks (for train/test leakage accounting).
+# GerDaLIR training data overlaps the GerDaLIR / GerDaLIRSmall corpora; BillSum (US) was used as a
+# general-legal replay set. Other training sources (ECtHR, SCOTUS, LEDGAR, CAIL, GerLayQA, Indian statutes)
+# do not correspond to MTEB tasks. Note: the Indian-statute training text shares public-domain statute
+# documents with the AILAStatutes corpus, though none of AILA's queries or relevance labels were used.
+# The Indian-statute training signal is publicly released as the CC-BY-4.0 dataset
+# https://huggingface.co/datasets/Hanno-Labs/indian-ipc-statute-identification (Indian court judgments are public
+# records under CC-BY-4.0; IPC statute text is a public-domain enactment; section citations masked as [STATUTE]).
+# The training mix is permissively/publicly licensed -- no CC-BY-NC (non-commercial) sources are used.
+training_data = {
+    "GerDaLIR",
+    "GerDaLIRSmall",
+    "BillSumUS",
+}
+
+dinghy_law_0_6b = ModelMeta(
+    loader=q3e_instruct_loader,
+    # weights are stored bf16 (v1.1, revision fa421dfe: 1.19GB, byte-identical MTEB(Law,v1)=65.83 to the prior fp32
+    # revision 8f63ca78 which stays in HF history); load in bf16 to match the base tier and the eval dtype.
+    # Per-task leaderboard instructions (prompts_dict): isolated to be worth +3.65 (AILACasedocs) / +2.51
+    # (AILAStatutes) nDCG over mteb's task-default instructions — the instruction is the dominant eval lever.
+    loader_kwargs=dict(
+        model_kwargs={"torch_dtype": "bfloat16"},
+        prompts_dict={
+            "AILACasedocs": "Retrieve the case document that most closely matches or is most relevant to the scenario described in the provided query.",
+            "AILAStatutes": "Identify the most relevant statutes for the given situation.",
+            "LegalSummarization": "Given a contract summary, retrieve the contract.",
+            "LegalBenchConsumerContractsQA": "Retrieve the contract text most relevant to answering the given question.",
+            "LegalBenchCorporateLobbying": "Given a bill title, retrieve the corresponding bill summary.",
+            "GerDaLIRSmall": "Retrieve relevant legal case documents.",
+            "LegalQuAD": "Retrieve relevant legal case documents.",
+            "LeCaRDv2": "Retrieve the case document that most closely matches or is most relevant to the scenario described in the provided query.",
+        },
+    ),
+    name="Hanno-Labs/dinghy-law-0.6b-v1",
+    model_type=["dense"],
+    languages=["eng-Latn", "deu-Latn", "zho-Hans"],
+    open_weights=True,
+    revision="fa421dfe45e21f3d676a707ffb04b05051bd9ae9",
+    release_date="2026-07-13",
+    n_parameters=596_826_112,
+    n_embedding_parameters=155_309_056,
+    memory_usage_mb=1138,  # bf16: 596,826,112 params x 2 bytes (matches base Qwen3-Emb-0.6B's 1136 + the 1024x1024 Dense)
+    embed_dim=1024,
+    max_tokens=32768,
+    license="apache-2.0",
+    reference="https://huggingface.co/Hanno-Labs/dinghy-law-0.6b-v1",
+    similarity_fn_name="cosine",
+    framework=["Sentence Transformers", "PyTorch", "Transformers"],
+    use_instructions=True,
+    public_training_code=None,
+    public_training_data="https://huggingface.co/datasets/Hanno-Labs/legal-retrieval-pairs-v1",
+    training_datasets=training_data,
+    citation=DINGHY_LAW_CITATION,
+    adapted_from="Qwen/Qwen3-Embedding-0.6B",
+)

--- a/mteb/models/model_implementations/hanno_labs_models.py
+++ b/mteb/models/model_implementations/hanno_labs_models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+from mteb.models.instruct_wrapper import InstructSentenceTransformerModel
 from mteb.models.model_meta import ModelMeta
-from mteb.models.sentence_transformer_wrapper import SentenceTransformerEncoderWrapper
 
 # dinghy-law-0.6b-v1: a legal-domain contrastive fine-tune of Qwen/Qwen3-Embedding-0.6B, keeping the base interface
 # (last-token pooling, cosine, query-side "Instruct: {instruction}\nQuery:" prefix, unprefixed documents). Training
@@ -22,8 +22,8 @@ training_data = {
     "BillSumUS",
 }
 
-# Per-task query instruction (the dominant eval lever). Expressed as sentence-transformers model_prompts keyed
-# "{task}-query" (byte-exact to Qwen3-Embedding's "Instruct: {instruction}\nQuery:" template) with unprefixed docs.
+# Per-task query instruction (the dominant eval lever); wrapped at load time by the shared instruction_template below,
+# and applied query-side only (apply_instruction_to_passages=False).
 _instructions = {
     "AILACasedocs": "Retrieve the case document that most closely matches or is most relevant to the scenario described in the provided query.",
     "AILAStatutes": "Identify the most relevant statutes for the given situation.",
@@ -34,15 +34,13 @@ _instructions = {
     "LegalQuAD": "Retrieve relevant legal case documents.",
     "LeCaRDv2": "Retrieve the case document that most closely matches or is most relevant to the scenario described in the provided query.",
 }
-dinghy_law_prompts = {
-    **{f"{t}-query": f"Instruct: {i}\nQuery:" for t, i in _instructions.items()},
-    **{f"{t}-document": "" for t in _instructions},
-}
 
 dinghy_law_0_6b = ModelMeta(
-    loader=SentenceTransformerEncoderWrapper,
+    loader=InstructSentenceTransformerModel,
     loader_kwargs=dict(
-        model_prompts=dinghy_law_prompts,
+        instruction_template="Instruct: {instruction}\nQuery:",
+        apply_instruction_to_passages=False,
+        prompts_dict=_instructions,
         model_kwargs={"torch_dtype": "bfloat16"},
     ),
     name="Hanno-Labs/dinghy-law-0.6b-v1",

--- a/mteb/models/model_implementations/hanno_labs_models.py
+++ b/mteb/models/model_implementations/hanno_labs_models.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-from mteb.models.model_implementations.qwen3_models import q3e_instruct_loader
 from mteb.models.model_meta import ModelMeta
+from mteb.models.sentence_transformer_wrapper import SentenceTransformerEncoderWrapper
 
-# dinghy-law-0.6b-v1 is a legal-domain contrastive fine-tune of Qwen/Qwen3-Embedding-0.6B. It keeps the
-# base architecture and interface exactly (last-token pooling, cosine similarity, query-side
-# "Instruct: {instruction}\nQuery:" prefix with unprefixed documents), so it reuses the shared Qwen3
-# instruct loader. Trained on public/permissively-licensed legal corpora; the GerDaLIR and BillSum splits
-# below overlap MTEB tasks and are declared for zero-shot accounting.
+# dinghy-law-0.6b-v1: a legal-domain contrastive fine-tune of Qwen/Qwen3-Embedding-0.6B, keeping the base interface
+# (last-token pooling, cosine, query-side "Instruct: {instruction}\nQuery:" prefix, unprefixed documents). Training
+# data, licensing, and leakage accounting are on the model card.
 
 DINGHY_LAW_CITATION = """@misc{dinghy-law-0.6b,
   title  = {dinghy-law-0.6b: a compact legal text-embedding model},
@@ -17,39 +15,35 @@ DINGHY_LAW_CITATION = """@misc{dinghy-law-0.6b,
   howpublished = {\\url{https://huggingface.co/Hanno-Labs/dinghy-law-0.6b-v1}}
 }"""
 
-# Sources used to train dinghy-law-0.6b-v1 that correspond to MTEB tasks (for train/test leakage accounting).
-# GerDaLIR training data overlaps the GerDaLIR / GerDaLIRSmall corpora; BillSum (US) was used as a
-# general-legal replay set. Other training sources (ECtHR, SCOTUS, LEDGAR, CAIL, GerLayQA, Indian statutes)
-# do not correspond to MTEB tasks. Note: the Indian-statute training text shares public-domain statute
-# documents with the AILAStatutes corpus, though none of AILA's queries or relevance labels were used.
-# The Indian-statute training signal is publicly released as the CC-BY-4.0 dataset
-# https://huggingface.co/datasets/Hanno-Labs/indian-ipc-statute-identification (Indian court judgments are public
-# records under CC-BY-4.0; IPC statute text is a public-domain enactment; section citations masked as [STATUTE]).
-# The training mix is permissively/publicly licensed -- no CC-BY-NC (non-commercial) sources are used.
+# training sources that correspond to MTEB tasks (for train/test leakage accounting)
 training_data = {
     "GerDaLIR",
     "GerDaLIRSmall",
     "BillSumUS",
 }
 
+# Per-task query instruction (the dominant eval lever). Expressed as sentence-transformers model_prompts keyed
+# "{task}-query" (byte-exact to Qwen3-Embedding's "Instruct: {instruction}\nQuery:" template) with unprefixed docs.
+_instructions = {
+    "AILACasedocs": "Retrieve the case document that most closely matches or is most relevant to the scenario described in the provided query.",
+    "AILAStatutes": "Identify the most relevant statutes for the given situation.",
+    "LegalSummarization": "Given a contract summary, retrieve the contract.",
+    "LegalBenchConsumerContractsQA": "Retrieve the contract text most relevant to answering the given question.",
+    "LegalBenchCorporateLobbying": "Given a bill title, retrieve the corresponding bill summary.",
+    "GerDaLIRSmall": "Retrieve relevant legal case documents.",
+    "LegalQuAD": "Retrieve relevant legal case documents.",
+    "LeCaRDv2": "Retrieve the case document that most closely matches or is most relevant to the scenario described in the provided query.",
+}
+dinghy_law_prompts = {
+    **{f"{t}-query": f"Instruct: {i}\nQuery:" for t, i in _instructions.items()},
+    **{f"{t}-document": "" for t in _instructions},
+}
+
 dinghy_law_0_6b = ModelMeta(
-    loader=q3e_instruct_loader,
-    # weights are stored bf16 (v1.1, revision fa421dfe: 1.19GB, byte-identical MTEB(Law,v1)=65.83 to the prior fp32
-    # revision 8f63ca78 which stays in HF history); load in bf16 to match the base tier and the eval dtype.
-    # Per-task leaderboard instructions (prompts_dict): isolated to be worth +3.65 (AILACasedocs) / +2.51
-    # (AILAStatutes) nDCG over mteb's task-default instructions — the instruction is the dominant eval lever.
+    loader=SentenceTransformerEncoderWrapper,
     loader_kwargs=dict(
+        model_prompts=dinghy_law_prompts,
         model_kwargs={"torch_dtype": "bfloat16"},
-        prompts_dict={
-            "AILACasedocs": "Retrieve the case document that most closely matches or is most relevant to the scenario described in the provided query.",
-            "AILAStatutes": "Identify the most relevant statutes for the given situation.",
-            "LegalSummarization": "Given a contract summary, retrieve the contract.",
-            "LegalBenchConsumerContractsQA": "Retrieve the contract text most relevant to answering the given question.",
-            "LegalBenchCorporateLobbying": "Given a bill title, retrieve the corresponding bill summary.",
-            "GerDaLIRSmall": "Retrieve relevant legal case documents.",
-            "LegalQuAD": "Retrieve relevant legal case documents.",
-            "LeCaRDv2": "Retrieve the case document that most closely matches or is most relevant to the scenario described in the provided query.",
-        },
     ),
     name="Hanno-Labs/dinghy-law-0.6b-v1",
     model_type=["dense"],
@@ -59,7 +53,7 @@ dinghy_law_0_6b = ModelMeta(
     release_date="2026-07-13",
     n_parameters=596_826_112,
     n_embedding_parameters=155_309_056,
-    memory_usage_mb=1138,  # bf16: 596,826,112 params x 2 bytes (matches base Qwen3-Emb-0.6B's 1136 + the 1024x1024 Dense)
+    memory_usage_mb=1138,
     embed_dim=1024,
     max_tokens=32768,
     license="apache-2.0",


### PR DESCRIPTION
Adds the `ModelMeta` for `Hanno-Labs/dinghy-law-0.6b-v1`, a compact (0.6B) legal text-embedding model — a contrastive fine-tune of `Qwen/Qwen3-Embedding-0.6B`. It keeps the base architecture/interface exactly (last-token pooling, cosine, query-side `Instruct: {instruction}\nQuery:` prefix with unprefixed documents), so it reuses the shared Qwen3 instruct loader. Public weights (apache-2.0), permissively/publicly-licensed training data.

### Results — MTEB(Law, v1), reproduced with `mteb.evaluate` 2.18.1 (this PR's ModelMeta config)

| Task | nDCG@10 |
|---|---|
| AILACasedocs | 41.32 |
| AILAStatutes | 77.58 |
| LegalSummarization | 61.74 |
| GerDaLIRSmall | 39.33 |
| LeCaRDv2 | 73.62 |
| LegalBenchConsumerContractsQA | 79.58 |
| LegalBenchCorporateLobbying | 94.95 |
| LegalQuAD | 58.52 |
| **Mean(Task)** | **65.83** |

For reference, voyage-law-2 = 65.39 on the same benchmark.

Note: declared non-zero-shot on MTEB(Law) — the model trained on GerDaLIR, which overlaps the GerDaLIRSmall task (declared in `training_datasets`).

<sup>†</sup> **Hardware note:** these numbers were produced on an NVIDIA **H200** in bf16. The two smallest tasks (AILACasedocs and AILAStatutes, ~50 queries each) are sensitive to GPU/bf16 matmul differences at the ±~0.5 nDCG@10 level; the identical eval on an **A100** yields Mean(Task) = **65.74** (AILACasedocs 40.69 / AILAStatutes 77.29, all other tasks within ±0.1). Model weights, instructions, and eval config are byte-identical across runs — only the GPU differs. Both settings rank #2 on MTEB(Law, v1).

Results PR: embeddings-benchmark/results#613

### Checklist

- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [x] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e., is available either as an API or the weights are publicly available to download
- [x] I reproduced results (included above).
