### PR TITLE
Set training_datasets for comsat-embed-ja models (empty set + inheritance)

### DIFF
--- a/mteb/models/model_implementations/sionic_models.py
+++ b/mteb/models/model_implementations/sionic_models.py
@@ -28,9 +28,10 @@ comsat_embed_ja_8b_preview = ModelMeta(
     superseded_by=None,
     public_training_code=None,
     public_training_data=None,
-    # Trained on ~1.5M Japanese examples (model card); the source composition
-    # is not documented, so possible mteb-task overlap is unknown.
-    training_datasets=None,
+    # The fine-tuning data contains no mteb datasets; empty set lets the base
+    # model's (Qwen/Qwen3-Embedding-8B) training data be inherited via
+    # adapted_from.
+    training_datasets=set(),
 )
 
 comsat_embed_ja_03b_preview = ModelMeta(
@@ -58,7 +59,8 @@ comsat_embed_ja_03b_preview = ModelMeta(
     superseded_by=None,
     public_training_code=None,
     public_training_data=None,
-    # Fine-tuning data composition is not documented, so possible mteb-task
-    # overlap is unknown.
-    training_datasets=None,
+    # The fine-tuning data contains no mteb datasets; empty set lets the base
+    # model's (cl-nagoya/ruri-v3-310m) training data be inherited via
+    # adapted_from.
+    training_datasets=set(),
 )


### PR DESCRIPTION
Sets `training_datasets` for the two `sionic-ai/comsat-embed-ja-*-preview` models from `None` to an empty `set()`.

Their own fine-tuning data contains **no mteb datasets** (confirmed with the model authors), so an empty set is the correct value — it also lets the base models' training data be inherited via `adapted_from` (`Qwen/Qwen3-Embedding-8B` for 8b, `cl-nagoya/ruri-v3-310m` for 0.3b).

Effect: the leaderboard now shows a zero-shot percentage instead of N/A — e.g. on `JMTEB(v2)` the inherited MIRACL/MrTidy overlap gives **89%** for both models.