### PR TITLE
fix: upcast reranker logits to float32 before softmax (HPS)

### DIFF
--- a/mteb/models/model_implementations/qwen3_reranker.py
+++ b/mteb/models/model_implementations/qwen3_reranker.py
@@ -101,7 +101,13 @@ class Qwen3RerankerWrapper:
         true_vector = batch_scores[:, self.token_true_id]
         false_vector = batch_scores[:, self.token_false_id]
         batch_scores = torch.stack([false_vector, true_vector], dim=1)
-        batch_scores = torch.nn.functional.log_softmax(batch_scores, dim=1)
+        # High-Precision Scoring (HPS): upcast the logits to float32 before the
+        # softmax. The model runs in bfloat16, whose 7-bit mantissa coarsely
+        # buckets the (0, 1) probability range and collapses distinct relevance
+        # scores into spurious ties. The upcast is value-preserving and adds
+        # negligible cost. See "Reliable Evaluation Protocol for Low-Precision
+        # Retrieval" (Yang et al., 2026), https://aclanthology.org/2026.acl-short.33.
+        batch_scores = torch.nn.functional.log_softmax(batch_scores.float(), dim=1)
         return batch_scores[:, 1].exp().tolist()
 
     @torch.inference_mode()

--- a/mteb/models/model_implementations/qwen3_reranker.py
+++ b/mteb/models/model_implementations/qwen3_reranker.py
@@ -101,12 +101,7 @@ class Qwen3RerankerWrapper:
         true_vector = batch_scores[:, self.token_true_id]
         false_vector = batch_scores[:, self.token_false_id]
         batch_scores = torch.stack([false_vector, true_vector], dim=1)
-        # High-Precision Scoring (HPS): upcast the logits to float32 before the
-        # softmax. The model runs in bfloat16, whose 7-bit mantissa coarsely
-        # buckets the (0, 1) probability range and collapses distinct relevance
-        # scores into spurious ties. The upcast is value-preserving and adds
-        # negligible cost. See "Reliable Evaluation Protocol for Low-Precision
-        # Retrieval" (Yang et al., 2026), https://aclanthology.org/2026.acl-short.33.
+        # upcast the logits to float32 before the softmax
         batch_scores = torch.nn.functional.log_softmax(batch_scores.float(), dim=1)
         return batch_scores[:, 1].exp().tolist()
 

--- a/mteb/models/model_implementations/rerankers_monot5_based.py
+++ b/mteb/models/model_implementations/rerankers_monot5_based.py
@@ -152,13 +152,7 @@ class MonoT5Reranker(RerankerWrapper):
         )
         batch_scores = output.scores[0]
         batch_scores = batch_scores[:, [self.token_false_id, self.token_true_id]]
-        # High-Precision Scoring (HPS): upcast the logits to float32 before the
-        # softmax. Rerankers are commonly run in float16/bfloat16, whose reduced
-        # mantissa coarsely buckets the (0, 1) probability range and collapses
-        # distinct relevance scores into spurious ties. The upcast is
-        # value-preserving and adds negligible cost. See "Reliable Evaluation
-        # Protocol for Low-Precision Retrieval" (Yang et al., 2026),
-        # https://aclanthology.org/2026.acl-short.33.
+        # upcast the logits to float32 before the softmax
         batch_scores = torch.nn.functional.log_softmax(batch_scores.float(), dim=1)
         return batch_scores[:, 1].exp().tolist()
 
@@ -272,13 +266,12 @@ Relevant: """
             true_vector = batch_scores[:, self.token_true_id]
             false_vector = batch_scores[:, self.token_false_id]
             batch_scores = torch.stack([false_vector, true_vector], dim=1)
-            # HPS: upcast to float32 before the softmax to avoid low-precision
-            # tie collisions (see the note in MonoT5Reranker.predict above).
+            # upcast the logits to float32 before the softmax
             batch_scores = torch.nn.functional.log_softmax(batch_scores.float(), dim=1)
             scores = batch_scores[:, 1].exp().tolist()
         else:
             batch_scores = self.model(**tokens).logits
-            # HPS: upcast to float32 before the softmax (see note above).
+            # upcast the logits to float32 before the softmax
             batch_scores = torch.nn.functional.log_softmax(batch_scores.float(), dim=1)
             scores = batch_scores[:, 1].exp().tolist()
 

--- a/mteb/models/model_implementations/rerankers_monot5_based.py
+++ b/mteb/models/model_implementations/rerankers_monot5_based.py
@@ -152,7 +152,14 @@ class MonoT5Reranker(RerankerWrapper):
         )
         batch_scores = output.scores[0]
         batch_scores = batch_scores[:, [self.token_false_id, self.token_true_id]]
-        batch_scores = torch.nn.functional.log_softmax(batch_scores, dim=1)
+        # High-Precision Scoring (HPS): upcast the logits to float32 before the
+        # softmax. Rerankers are commonly run in float16/bfloat16, whose reduced
+        # mantissa coarsely buckets the (0, 1) probability range and collapses
+        # distinct relevance scores into spurious ties. The upcast is
+        # value-preserving and adds negligible cost. See "Reliable Evaluation
+        # Protocol for Low-Precision Retrieval" (Yang et al., 2026),
+        # https://aclanthology.org/2026.acl-short.33.
+        batch_scores = torch.nn.functional.log_softmax(batch_scores.float(), dim=1)
         return batch_scores[:, 1].exp().tolist()
 
 
@@ -265,11 +272,14 @@ Relevant: """
             true_vector = batch_scores[:, self.token_true_id]
             false_vector = batch_scores[:, self.token_false_id]
             batch_scores = torch.stack([false_vector, true_vector], dim=1)
-            batch_scores = torch.nn.functional.log_softmax(batch_scores, dim=1)
+            # HPS: upcast to float32 before the softmax to avoid low-precision
+            # tie collisions (see the note in MonoT5Reranker.predict above).
+            batch_scores = torch.nn.functional.log_softmax(batch_scores.float(), dim=1)
             scores = batch_scores[:, 1].exp().tolist()
         else:
             batch_scores = self.model(**tokens).logits
-            batch_scores = torch.nn.functional.log_softmax(batch_scores, dim=1)
+            # HPS: upcast to float32 before the softmax (see note above).
+            batch_scores = torch.nn.functional.log_softmax(batch_scores.float(), dim=1)
             scores = batch_scores[:, 1].exp().tolist()
 
         return scores


### PR DESCRIPTION
## What
The Qwen3 and monoT5-family cross-encoder rerankers now upcast their logits to **float32** immediately before `log_softmax`.

## Why
These rerankers run the model in **bfloat16/float16** and applied the softmax directly to the low-precision logits. The reduced mantissa coarsely buckets the (0, 1) probability range, so distinct query–document relevance scores collapse into **spurious ties**. Reranking metrics then depend on arbitrary tie-breaking, which inflates their variance and bias — e.g. for Qwen3-Reranker-0.6B under bf16 the paper reports up to ~38%p MRR@10 range and +9.08%p bias, both largely removed by this one-line **High-Precision Scoring (HPS)** upcast (Yang et al., 2026, https://aclanthology.org/2026.acl-short.33).

The upcast is value-preserving and adds negligible cost (only a small logits tensor is converted). `kalm_reranker.py` already does this; this PR brings the other softmax rerankers in line.

## Changes
- `mteb/models/model_implementations/qwen3_reranker.py`: `.float()` before `log_softmax` in `compute_logits`.
- `mteb/models/model_implementations/rerankers_monot5_based.py`: `.float()` before each `log_softmax` (MonoT5Reranker and LlamaReranker paths).

## Checks
- `ruff check` / `ruff format --check`: pass on changed files
- Modules compile; scoring math verified: a bf16 two-logit softmax over 200 candidates yields ~145 unique scores, vs ~196 with HPS (fp32 reference: 200).

## Notes
Disclosure: I'm the first author of the referenced paper. Companion PR handles the bi-encoder similarity primitives. Related issue: #4932.
