### PR TITLE
fix: load gte-Qwen2-7B-instruct in bf16 with trust_remote_code

### DIFF
--- a/mteb/models/model_implementations/gte_models.py
+++ b/mteb/models/model_implementations/gte_models.py
@@ -33,18 +33,12 @@ gte_qwen2_7b_instruct = ModelMeta(
     loader_kwargs=dict(
         instruction_template=instruction_template,
         apply_instruction_to_passages=False,
-        # bf16 per the model card; fp16 produces numerically-unstable
-        # embeddings for this model (nDCG@10 collapses on retrieval tasks).
         model_kwargs={"dtype": torch.bfloat16},
         # The remote modeling_qwen.py calls DynamicCache.get_usable_length(),
         # removed in transformers>=4.56; encoding never needs the KV cache,
         # and use_cache=False skips that code path.
         config_kwargs={"use_cache": False},
         add_eos_token=True,
-        # The model repo ships `modeling_qwen.py` with the bidirectional
-        # attention implementation the embedding head depends on. Without
-        # trust_remote_code, sentence-transformers falls back to the stock
-        # causal Qwen2 and embeddings collapse to noise.
         trust_remote_code=True,
     ),
     name="Alibaba-NLP/gte-Qwen2-7B-instruct",

--- a/mteb/models/model_implementations/gte_models.py
+++ b/mteb/models/model_implementations/gte_models.py
@@ -33,8 +33,19 @@ gte_qwen2_7b_instruct = ModelMeta(
     loader_kwargs=dict(
         instruction_template=instruction_template,
         apply_instruction_to_passages=False,
-        model_kwargs={"dtype": torch.float16},
+        # bf16 per the model card; fp16 produces numerically-unstable
+        # embeddings for this model (nDCG@10 collapses on retrieval tasks).
+        model_kwargs={"dtype": torch.bfloat16},
+        # The remote modeling_qwen.py calls DynamicCache.get_usable_length(),
+        # removed in transformers>=4.56; encoding never needs the KV cache,
+        # and use_cache=False skips that code path.
+        config_kwargs={"use_cache": False},
         add_eos_token=True,
+        # The model repo ships `modeling_qwen.py` with the bidirectional
+        # attention implementation the embedding head depends on. Without
+        # trust_remote_code, sentence-transformers falls back to the stock
+        # causal Qwen2 and embeddings collapse to noise.
+        trust_remote_code=True,
     ),
     name="Alibaba-NLP/gte-Qwen2-7B-instruct",
     model_type=["dense"],


### PR DESCRIPTION
## Summary
Fixes the loader for `Alibaba-NLP/gte-Qwen2-7B-instruct` so it loads on current `transformers` and produces correct embeddings. As shipped, the model either crashes at load (on `transformers>=4.56`) or, on older versions, loads in a configuration that collapses retrieval quality (e.g. nDCG@10 ~0.07 vs ~0.51 on reasoning-retrieval tasks). Three independent issues:

1. **dtype** — the [model card](https://huggingface.co/Alibaba-NLP/gte-Qwen2-7B-instruct) recommends bf16. The current `model_kwargs={"dtype": torch.float16}` yields numerically-unstable embeddings for this model; nDCG@10 collapses on retrieval.
2. **`trust_remote_code`** — the repo ships `modeling_qwen.py` with the bidirectional-attention implementation the embedding head depends on. Without `trust_remote_code=True`, sentence-transformers silently falls back to stock causal Qwen2 and embeddings degrade to noise.
3. **`use_cache`** — once `trust_remote_code` is enabled, the remote `modeling_qwen.py` calls `DynamicCache.get_usable_length()`, which was removed in `transformers>=4.56`, so loading crashes on current transformers. Encoding never needs the KV cache; `config_kwargs={"use_cache": False}` skips that code path.

## Change
```python
loader_kwargs=dict(
    instruction_template=instruction_template,
    apply_instruction_to_passages=False,
    model_kwargs={"dtype": torch.bfloat16},        # was float16
    config_kwargs={"use_cache": False},            # new
    add_eos_token=True,
    trust_remote_code=True,                        # new
),
```
Scoped to `gte_qwen2_7b_instruct` only; the 1.5B / 1.5-7B siblings are untouched (they don't hit the same remote-code path).

## Validation
On BRIGHT-Pro (7 StackExchange retrieval domains), with this loader gte-Qwen2-7B-instruct matches its published harness scores within noise:

| domain | MTEB (this fix) | reference harness | Δ |
|---|---:|---:|---:|
| biology | 0.51111 | 0.50996 | +0.00115 |
| earth_science | 0.55730 | 0.55145 | +0.00585 |
| economics | 0.28560 | 0.28374 | +0.00186 |
| psychology | 0.30203 | 0.28687 | +0.01516 |
| robotics | 0.35937 | 0.35703 | +0.00234 |
| stackoverflow | 0.33228 | 0.33279 | −0.00051 |
| sustainable_living | 0.29411 | 0.29174 | +0.00237 |

Before the fix (fp16, no `trust_remote_code`) these runs either crashed at load or collapsed to ~0.07 nDCG@10. Context: this came up while integrating BRIGHT-Pro (#4929); @Samoed suggested submitting the gte-Qwen2 loader fixes separately.

## Test plan
- [x] `ruff check` + `ruff format --check` clean.
- [x] Loads on `transformers` 4.57 / sentence-transformers 5.4 with the exact `loader_kwargs` above: bf16 weights, `config.use_cache == False`, and the remote `modeling_qwen` module active (the pre-fix `get_usable_length` load crash is gone).
- [x] Full 7-domain evaluation via `mteb.evaluate` reproduces the reference harness scores (table above); per-cell outputs at https://github.com/yilunzhao/bright-pro-mteb-validation (`results_2p18/`).
