### PR TITLE
leaderboard: add MTEB(por, v1) to Language-specific section

### DIFF
--- a/mteb/benchmarks/_leaderboard_menu.py
+++ b/mteb/benchmarks/_leaderboard_menu.py
@@ -100,7 +100,7 @@ GP_BENCHMARK_ENTRIES = [
                         "MTEB(fas, v2)",
                         "VN-MTEB (vie, v1)",
                         "MTEB(spa, v1)",
-                        "MTEB(por, v1)"
+                        "MTEB(por, v1)",
                     ]
                 )
                 + [

--- a/mteb/benchmarks/_leaderboard_menu.py
+++ b/mteb/benchmarks/_leaderboard_menu.py
@@ -100,6 +100,7 @@ GP_BENCHMARK_ENTRIES = [
                         "MTEB(fas, v2)",
                         "VN-MTEB (vie, v1)",
                         "MTEB(spa, v1)",
+                        "MTEB(por, v1)"
                     ]
                 )
                 + [


### PR DESCRIPTION
Add MTEB(por, v1) to leaderboard Language-specific section.

Benchmark Definition: [#4894](https://github.com/embeddings-benchmark/mteb/pull/4894)
Results: [embeddings-benchmark/results#616](https://github.com/embeddings-benchmark/results/pull/616)
