### PR TITLE
Add NanoArguAna duplicate and qrel audit pilot

### DIFF
--- a/experiments/moeb_dataset_audit/audit_exact_duplicates.py
+++ b/experiments/moeb_dataset_audit/audit_exact_duplicates.py
@@ -1,0 +1,67 @@
+from collections import defaultdict
+
+import mteb
+
+
+def normalize_text(text: str) -> str:
+    """Normalize text before checking exact duplicates."""
+    return " ".join(text.lower().split())
+
+
+def find_duplicates(items: dict[str, object]) -> dict[str, list[str]]:
+    """
+    Group IDs whose normalized texts are identical.
+    Returns only groups containing at least two IDs.
+    """
+    text_to_ids: defaultdict[str, list[str]] = defaultdict(list)
+
+    for item_id, value in items.items():
+        if isinstance(value, dict):
+            text = str(value.get("text", ""))
+        else:
+            text = str(value)
+
+        normalized = normalize_text(text)
+        text_to_ids[normalized].append(item_id)
+
+    return {
+        text: ids
+        for text, ids in text_to_ids.items()
+        if text and len(ids) > 1
+    }
+
+
+def main() -> None:
+    task = mteb.get_task("NanoArguAnaRetrieval")
+    task.load_data()
+
+    split = "train"
+    queries = task.queries[split]
+    corpus = task.corpus[split]
+
+    query_duplicates = find_duplicates(queries)
+    corpus_duplicates = find_duplicates(corpus)
+
+    print("=== Dataset size ===")
+    print("Queries:", len(queries))
+    print("Corpus documents:", len(corpus))
+
+    print("\n=== Exact duplicate summary ===")
+    print("Duplicate query groups:", len(query_duplicates))
+    print("Duplicate corpus groups:", len(corpus_duplicates))
+
+    print("\n=== Example duplicate queries ===")
+    for text, ids in list(query_duplicates.items())[:3]:
+        print("IDs:", ids)
+        print("Text:", text[:300])
+        print()
+
+    print("\n=== Example duplicate corpus documents ===")
+    for text, ids in list(corpus_duplicates.items())[:3]:
+        print("IDs:", ids)
+        print("Text:", text[:300])
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/moeb_dataset_audit/audit_qrel_id_membership.py
+++ b/experiments/moeb_dataset_audit/audit_qrel_id_membership.py
@@ -1,0 +1,222 @@
+"""One-off audit: do qrels ever reference query/corpus IDs that don't exist?
+
+Not part of any PR. Checks a real, structural invariant that
+`RetrievalDatasetLoader` (mteb/abstasks/retrieval_dataset_loaders.py) does NOT
+enforce: it filters `queries` down to only the ids that appear in `qrels`
+(load(), lines ~97-99), but never checks the reverse -- that every
+qrel query-id actually has a matching row in `queries`, or that every qrel
+corpus-id actually has a matching row in `corpus`. If a dataset's qrels
+config references an id missing from queries/corpus, that silently produces
+either a dropped qrel or a KeyError somewhere downstream in evaluation,
+depending on the code path.
+
+This is a different failure mode than the Clotho bug (PR #5062): Clotho's
+empty-string queries still had *valid* ids and *valid* qrels pointing at
+*existing* documents -- the defect was empty text content, not a dangling
+reference. This script is a separate, from-scratch audit of a different
+invariant, done before deciding whether it's worth turning into a permanent
+check (mirrors the audit-first approach used for Clotho).
+
+Deliberately avoids ever touching a media column (audio/image/video), so it
+needs no torchcodec/ffmpeg: pulls only the "id" column from corpus/queries,
+which HF `datasets` can do without decoding any Audio/Video feature in other
+columns of the same file.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from datasets import get_dataset_config_names, get_dataset_split_names, load_dataset
+
+import mteb
+
+OUTPUT_PATH = Path(__file__).parent / "qrel_id_membership_audit.json"
+
+# Full de-duplicated retrieval-family task list across the four curated
+# omni-modal benchmarks (MTEB(eng, v2), MIEB(lite), MAEB(beta), MVEB(beta)),
+# derived from experiments/moeb_dataset_audit/moeb_task_inventory.json.
+# "ClothoT2ARetrieval" replaced with "ClothoT2ARetrieval.v2" (the inventory
+# snapshot predates the .v2 fix); "ClothoA2TRetrieval.v2" added even though
+# not separately in the inventory, since it's the natural pair and already
+# known-clean from the earlier pilot. Some of these (FEVER/HotpotQA/Climate
+# FEVER-HardNegatives, standard BEIR tasks) have multi-million-row corpora --
+# expect this run to take much longer than the earlier 12-task pilot, purely
+# from download/IO time, not from any media decoding (we still only ever
+# touch the "id" column).
+TASK_NAMES = [
+    "AVMemeExamAT2VRetrieval",
+    "ActivityNetCaptionsT2VRetrieval",
+    "ArguAna",
+    "AskUbuntuDupQuestions",
+    "AudioCapsAVVA2TRetrieval",
+    "AudioCapsAVVT2ARetrieval",
+    "AudioCapsT2ARetrieval",
+    "AudioCapsA2TRetrieval",
+    "CIRRIT2IRetrieval",
+    "CQADupstackGamingRetrieval",
+    "CQADupstackUnixRetrieval",
+    "CUB200I2IRetrieval",
+    "ClimateFEVERHardNegatives",
+    "ClothoT2ARetrieval.v2",
+    "ClothoA2TRetrieval.v2",
+    "CommonVoiceMini21T2ARetrieval",
+    "FEVERHardNegatives",
+    "Fashion200kI2TRetrieval",
+    "FiQA2018",
+    "FleursT2ARetrieval",
+    "GigaSpeechT2ARetrieval",
+    "HatefulMemesI2TRetrieval",
+    "HotpotQAHardNegatives",
+    "InfoSeekIT2TRetrieval",
+    "JamAltArtistA2ARetrieval",
+    "JamAltLyricA2TRetrieval",
+    "MACST2ARetrieval",
+    "MSVDT2VRetrieval",
+    "MindSmallReranking",
+    "NIGHTSI2IRetrieval",
+    "OVENIT2TRetrieval",
+    "RP2kI2IRetrieval",
+    "SCIDOCS",
+    "SpokenSQuADT2ARetrieval",
+    "TRECCOVID",
+    "Touche2020Retrieval.v3",
+    "UrbanSound8KT2ARetrieval",
+    "VALOR32KT2VARetrieval",
+    "VATEXV2ARetrieval",
+    "VATEXVA2TRetrieval",
+    "VGGSoundAVA2VRetrieval",
+    "VQA2IT2TRetrieval",
+    "VisualNewsI2TRetrieval",
+    "WebQAT2ITRetrieval",
+    "YouCook2T2VARetrieval",
+]
+
+
+def _resolve_split(hf_repo: str, revision: str, config: str, wanted_split: str) -> str:
+    """Mirrors RetrievalDatasetLoader._get_split: exact match, else the lone split."""
+    splits = get_dataset_split_names(hf_repo, revision=revision, config_name=config)
+    if wanted_split in splits:
+        return wanted_split
+    if len(splits) == 1:
+        return str(splits[0])
+    raise ValueError(f"Split {wanted_split} not found in {splits} for config {config}")
+
+
+def _ids_for_config(
+    hf_repo: str, revision: str, config: str, wanted_split: str
+) -> set[str]:
+    split = _resolve_split(hf_repo, revision, config, wanted_split)
+    ds = load_dataset(hf_repo, config, revision=revision, split=split)
+    id_col = "_id" if "_id" in ds.column_names and "id" not in ds.column_names else "id"
+    return {str(x) for x in ds[id_col]}
+
+
+def _resolve_config(
+    available: list[str], prefix: str | None, name: str, fallback: str | None
+) -> str:
+    candidate = f"{prefix}-{name}" if prefix else name
+    if candidate in available:
+        return candidate
+    if fallback is not None:
+        fallback_candidate = f"{prefix}-{fallback}" if prefix else fallback
+        if fallback_candidate in available:
+            return fallback_candidate
+    raise ValueError(f"No config found for {name!r}/{fallback!r} among {available}")
+
+
+def audit_task(task_name: str) -> dict[str, Any]:
+    task = mteb.get_task(task_name)
+    dataset_path = task.metadata.dataset["path"]
+    revision = task.metadata.dataset["revision"]
+    split = task.metadata.eval_splits[0]
+    hf_subsets = list(task.hf_subsets) if task.metadata.is_multilingual else ["default"]
+
+    available = get_dataset_config_names(dataset_path, revision)
+
+    per_subset: dict[str, Any] = {}
+    for hf_subset in hf_subsets:
+        prefix = None if hf_subset == "default" else hf_subset
+
+        corpus_config = _resolve_config(available, prefix, "corpus", None)
+        queries_config = _resolve_config(available, prefix, "queries", "query")
+        qrels_config = _resolve_config(available, prefix, "default", "qrels")
+        # "default" only resolves directly (no prefix trick needed) when unprefixed
+        if qrels_config not in available and prefix is None:
+            qrels_config = "qrels" if "qrels" in available else "default"
+
+        corpus_ids = _ids_for_config(dataset_path, revision, corpus_config, split)
+        query_ids = _ids_for_config(dataset_path, revision, queries_config, split)
+
+        qrels_split = _resolve_split(dataset_path, revision, qrels_config, split)
+        qrels_ds = load_dataset(
+            dataset_path, qrels_config, revision=revision, split=qrels_split
+        )
+        qrels_ds = qrels_ds.select_columns(["query-id", "corpus-id"])
+        qrel_query_ids = {str(x) for x in qrels_ds["query-id"]}
+        qrel_corpus_ids = {str(x) for x in qrels_ds["corpus-id"]}
+
+        missing_query_ids = qrel_query_ids - query_ids
+        missing_corpus_ids = qrel_corpus_ids - corpus_ids
+
+        per_subset[hf_subset] = {
+            "num_corpus": len(corpus_ids),
+            "num_queries": len(query_ids),
+            "num_qrel_rows": len(qrels_ds),
+            "num_missing_query_ids": len(missing_query_ids),
+            "num_missing_corpus_ids": len(missing_corpus_ids),
+            "example_missing_query_ids": sorted(missing_query_ids)[:5],
+            "example_missing_corpus_ids": sorted(missing_corpus_ids)[:5],
+        }
+
+    return {"dataset": dataset_path, "revision": revision, "subsets": per_subset}
+
+
+def main() -> None:
+    results: dict[str, Any] = {}
+    for task_name in TASK_NAMES:
+        print(f"\n=== {task_name} ===")
+        try:
+            result = audit_task(task_name)
+        except Exception as exc:  # noqa: BLE001
+            print(f"  ERROR: {exc!r}")
+            results[task_name] = {"error": repr(exc)}
+            continue
+
+        results[task_name] = result
+        for hf_subset, stats in result["subsets"].items():
+            flag = (
+                "FOUND"
+                if stats["num_missing_query_ids"] or stats["num_missing_corpus_ids"]
+                else "clean"
+            )
+            print(
+                f"  [{hf_subset}] corpus={stats['num_corpus']} "
+                f"queries={stats['num_queries']} qrel_rows={stats['num_qrel_rows']} "
+                f"missing_query_ids={stats['num_missing_query_ids']} "
+                f"missing_corpus_ids={stats['num_missing_corpus_ids']} -> {flag}"
+            )
+            if stats["example_missing_query_ids"]:
+                print(f"    example missing query ids: {stats['example_missing_query_ids']}")
+            if stats["example_missing_corpus_ids"]:
+                print(f"    example missing corpus ids: {stats['example_missing_corpus_ids']}")
+
+    OUTPUT_PATH.write_text(json.dumps(results, indent=2, ensure_ascii=False))
+    print(f"\nWrote {OUTPUT_PATH}")
+
+    total_found = sum(
+        1
+        for r in results.values()
+        if "subsets" in r
+        and any(
+            s["num_missing_query_ids"] or s["num_missing_corpus_ids"]
+            for s in r["subsets"].values()
+        )
+    )
+    print(f"\nTasks with dangling qrel ids: {total_found} / {len(TASK_NAMES)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/moeb_dataset_audit/audit_qrel_inconsistencies.py
+++ b/experiments/moeb_dataset_audit/audit_qrel_inconsistencies.py
@@ -1,0 +1,109 @@
+from collections import defaultdict
+
+import mteb
+
+
+def normalize_text(text: str) -> str:
+    """Ignore capitalization and whitespace differences."""
+    return " ".join(text.lower().split())
+
+
+def extract_text(value: object) -> str:
+    """Extract text from either a document dictionary or a plain string."""
+    if isinstance(value, dict):
+        return str(value.get("text", ""))
+    return str(value)
+
+
+def get_relevant_doc_ids(labels: object) -> set[str]:
+    """Convert MTEB relevance labels into a set of relevant document IDs."""
+    if isinstance(labels, dict):
+        return set(labels.keys())
+
+    if isinstance(labels, (list, tuple, set)):
+        return set(labels)
+
+    raise TypeError(f"Unsupported relevance-label type: {type(labels)}")
+
+
+def main() -> None:
+    task = mteb.get_task("NanoArguAnaRetrieval")
+    task.load_data()
+
+    split = "train"
+    corpus = task.corpus[split]
+    queries = task.queries[split]
+    relevant_docs = task.relevant_docs[split]
+
+    # Step 1: Group document IDs that have identical normalized text.
+    text_to_doc_ids: defaultdict[str, list[str]] = defaultdict(list)
+
+    for doc_id, document in corpus.items():
+        normalized_text = normalize_text(extract_text(document))
+
+        if normalized_text:
+            text_to_doc_ids[normalized_text].append(doc_id)
+
+    duplicate_groups = {
+        text: doc_ids
+        for text, doc_ids in text_to_doc_ids.items()
+        if len(doc_ids) > 1
+    }
+
+    # Step 2: For each query, check whether only some IDs in an
+    # identical-document group are marked relevant.
+    inconsistencies: list[dict[str, object]] = []
+
+    for query_id, labels in relevant_docs.items():
+        relevant_ids = get_relevant_doc_ids(labels)
+
+        for text, duplicate_doc_ids in duplicate_groups.items():
+            duplicate_id_set = set(duplicate_doc_ids)
+            marked_relevant = duplicate_id_set & relevant_ids
+
+            if marked_relevant and marked_relevant != duplicate_id_set:
+                inconsistencies.append(
+                    {
+                        "query_id": query_id,
+                        "query_text": queries[query_id],
+                        "duplicate_doc_ids": duplicate_doc_ids,
+                        "marked_relevant": sorted(marked_relevant),
+                        "not_marked_relevant": sorted(
+                            duplicate_id_set - marked_relevant
+                        ),
+                        "document_text": text,
+                    }
+                )
+
+    total_documents_in_duplicate_groups = sum(
+        len(doc_ids) for doc_ids in duplicate_groups.values()
+    )
+
+    redundant_document_copies = sum(
+        len(doc_ids) - 1 for doc_ids in duplicate_groups.values()
+    )
+
+    print("=== Duplicate summary ===")
+    print("Corpus documents:", len(corpus))
+    print("Duplicate text groups:", len(duplicate_groups))
+    print(
+        "Documents in duplicate groups:",
+        total_documents_in_duplicate_groups,
+    )
+    print("Redundant document copies:", redundant_document_copies)
+
+    print("\n=== Potential qrel inconsistencies ===")
+    print("Affected query/group cases:", len(inconsistencies))
+
+    for case in inconsistencies[:10]:
+        print("\n--- Potential inconsistency ---")
+        print("Query ID:", case["query_id"])
+        print("Query:", str(case["query_text"])[:500])
+        print("All duplicate document IDs:", case["duplicate_doc_ids"])
+        print("Marked relevant:", case["marked_relevant"])
+        print("Not marked relevant:", case["not_marked_relevant"])
+        print("Duplicate document text:", str(case["document_text"])[:500])
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/moeb_dataset_audit/inspect_duplicate_pair.py
+++ b/experiments/moeb_dataset_audit/inspect_duplicate_pair.py
@@ -1,0 +1,45 @@
+import mteb
+
+
+def main() -> None:
+    task = mteb.get_task("NanoArguAnaRetrieval")
+    task.load_data()
+
+    corpus = task.corpus["train"]
+
+    doc_id_1 = "test-economy-epiasghbf-con01b"
+    doc_id_2 = "test-society-epiasghbf-con01b"
+
+    doc_1 = corpus[doc_id_1]
+    doc_2 = corpus[doc_id_2]
+
+    print("=== Document 1 ===")
+    print("ID:", doc_id_1)
+    print(doc_1)
+
+    print("\n=== Document 2 ===")
+    print("ID:", doc_id_2)
+    print(doc_2)
+
+    text_1 = doc_1["text"]
+    text_2 = doc_2["text"]
+
+    print("\n=== Comparison ===")
+    print("Raw text equal:", text_1 == text_2)
+    print(
+        "Normalized text equal:",
+        " ".join(text_1.lower().split())
+        == " ".join(text_2.lower().split()),
+    )
+
+    query_id = "test-economy-epiasghbf-con01a"
+    relevant = task.relevant_docs["train"][query_id]
+
+    print("\n=== Qrel check ===")
+    print("Relevant docs:", relevant)
+    print("Document 1 marked relevant:", doc_id_1 in relevant)
+    print("Document 2 marked relevant:", doc_id_2 in relevant)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/moeb_dataset_audit/load_one_task.py
+++ b/experiments/moeb_dataset_audit/load_one_task.py
@@ -1,0 +1,71 @@
+import mteb
+
+
+def describe(name: str, value: object) -> None:
+    print(f"\n{name}:")
+    print(f"  type = {type(value)}")
+
+    if value is None:
+        print("  value = None")
+        return
+
+    if isinstance(value, dict):
+        print(f"  keys = {list(value.keys())}")
+
+    try:
+        print(f"  length = {len(value)}")  # type: ignore[arg-type]
+    except TypeError:
+        pass
+
+
+def main() -> None:
+    task = mteb.get_task("NanoArguAnaRetrieval")
+    task.load_data()
+
+    print("task",task)
+    print("Task class:", type(task))
+    print("Data loaded:", task.data_loaded)
+    print("Instance attributes:", list(vars(task).keys()))
+
+    for attribute_name in [
+        "dataset",
+        "corpus",
+        "queries",
+        "relevant_docs",
+        "qrels",
+    ]:
+        describe(
+            attribute_name,
+            getattr(task, attribute_name, None),
+        )
+    
+    split = "train"
+
+    corpus = task.corpus[split]
+    queries = task.queries[split]
+    relevant_docs = task.relevant_docs[split]
+
+    print("\nCorpus count:", len(corpus))
+    print("Query count:", len(queries))
+    print("Relevant-doc count:", len(relevant_docs))
+
+    # 取第一个 query
+    query_id, query_text = next(iter(queries.items()))
+
+    print("\n=== Example query ===")
+    print("Query ID:", query_id)
+    print("Query:", query_text)
+
+    print("\n=== Relevant document IDs ===")
+    print(relevant_docs[query_id])
+
+    relevant_document_id = next(iter(relevant_docs[query_id]))
+    relevant_document = corpus[relevant_document_id]
+
+    print("\n=== Relevant document ===")
+    print("Document ID:", relevant_document_id)
+    print("Document:", relevant_document)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/moeb_dataset_audit/qrel_id_membership_audit.json
+++ b/experiments/moeb_dataset_audit/qrel_id_membership_audit.json
@@ -1,0 +1,515 @@
+{
+  "AVMemeExamAT2VRetrieval": {
+    "error": "ValueError(\"No config found for 'corpus'/None among ['default']\")"
+  },
+  "ActivityNetCaptionsT2VRetrieval": {
+    "error": "ValueError(\"No config found for 'corpus'/None among ['default']\")"
+  },
+  "ArguAna": {
+    "dataset": "mteb/arguana",
+    "revision": "c22ab2a51041ffd869aaddef7af8d8215647e41a",
+    "subsets": {
+      "default": {
+        "num_corpus": 8674,
+        "num_queries": 1406,
+        "num_qrel_rows": 1406,
+        "num_missing_query_ids": 0,
+        "num_missing_corpus_ids": 5,
+        "example_missing_query_ids": [],
+        "example_missing_corpus_ids": [
+          "test-education-ufsdfkhbwu-con03b",
+          "test-free-speech-debate-yfsdfkhbwu-con03b",
+          "test-politics-dhwem-pro06b",
+          "test-science-sghwbdgmo-con03b",
+          "test-society-asfhwapg-con04b"
+        ]
+      }
+    }
+  },
+  "AskUbuntuDupQuestions": {
+    "dataset": "mteb/AskUbuntuDupQuestions",
+    "revision": "c5691e3c48741d5f83b5cc8e630653d7a8cfc048",
+    "subsets": {
+      "default": {
+        "num_corpus": 7220,
+        "num_queries": 361,
+        "num_qrel_rows": 7220,
+        "num_missing_query_ids": 0,
+        "num_missing_corpus_ids": 0,
+        "example_missing_query_ids": [],
+        "example_missing_corpus_ids": []
+      }
+    }
+  },
+  "AudioCapsAVVA2TRetrieval": {
+    "error": "ValueError(\"No config found for 'corpus'/None among ['default']\")"
+  },
+  "AudioCapsAVVT2ARetrieval": {
+    "error": "ValueError(\"No config found for 'corpus'/None among ['default']\")"
+  },
+  "AudioCapsT2ARetrieval": {
+    "dataset": "mteb/audiocaps_t2a",
+    "revision": "cb63d82bd4b2868f5e6410bf771d1c91bfc50203",
+    "subsets": {
+      "default": {
+        "num_corpus": 883,
+        "num_queries": 4411,
+        "num_qrel_rows": 4411,
+        "num_missing_query_ids": 0,
+        "num_missing_corpus_ids": 0,
+        "example_missing_query_ids": [],
+        "example_missing_corpus_ids": []
+      }
+    }
+  },
+  "AudioCapsA2TRetrieval": {
+    "dataset": "mteb/audiocaps_a2t",
+    "revision": "acfbf827c27f81787800129443780c072dc8ae62",
+    "subsets": {
+      "default": {
+        "num_corpus": 4411,
+        "num_queries": 883,
+        "num_qrel_rows": 4411,
+        "num_missing_query_ids": 0,
+        "num_missing_corpus_ids": 0,
+        "example_missing_query_ids": [],
+        "example_missing_corpus_ids": []
+      }
+    }
+  },
+  "CIRRIT2IRetrieval": {
+    "dataset": "mteb/mbeir_cirr_task7",
+    "revision": "bb0713ed1ed136b2974fce68df7e26388040b650",
+    "subsets": {
+      "default": {
+        "num_corpus": 21551,
+        "num_queries": 4170,
+        "num_qrel_rows": 4216,
+        "num_missing_query_ids": 0,
+        "num_missing_corpus_ids": 0,
+        "example_missing_query_ids": [],
+        "example_missing_corpus_ids": []
+      }
+    }
+  },
+  "CQADupstackGamingRetrieval": {
+    "dataset": "mteb/cqadupstack-gaming",
+    "revision": "4885aa143210c98657558c04aaf3dc47cfb54340",
+    "subsets": {
+      "default": {
+        "num_corpus": 45301,
+        "num_queries": 1595,
+        "num_qrel_rows": 2263,
+        "num_missing_query_ids": 0,
+        "num_missing_corpus_ids": 0,
+        "example_missing_query_ids": [],
+        "example_missing_corpus_ids": []
+      }
+    }
+  },
+  "CQADupstackUnixRetrieval": {
+    "dataset": "mteb/cqadupstack-unix",
+    "revision": "6c6430d3a6d36f8d2a829195bc5dc94d7e063e53",
+    "subsets": {
+      "default": {
+        "num_corpus": 47382,
+        "num_queries": 1072,
+        "num_qrel_rows": 1693,
+        "num_missing_query_ids": 0,
+        "num_missing_corpus_ids": 0,
+        "example_missing_query_ids": [],
+        "example_missing_corpus_ids": []
+      }
+    }
+  },
+  "CUB200I2IRetrieval": {
+    "dataset": "mteb/cub200_retrieval",
+    "revision": "ad08c1307b15a226bf1b64e62656a17f1f85f7ec",
+    "subsets": {
+      "default": {
+        "num_corpus": 5794,
+        "num_queries": 5794,
+        "num_qrel_rows": 163756,
+        "num_missing_query_ids": 0,
+        "num_missing_corpus_ids": 0,
+        "example_missing_query_ids": [],
+        "example_missing_corpus_ids": []
+      }
+    }
+  },
+  "ClimateFEVERHardNegatives": {
+    "dataset": "mteb/ClimateFEVER_test_top_250_only_w_correct-v2",
+    "revision": "3a309e201f3c2c4b13bd4a367a8f37eee2ec1d21",
+    "subsets": {
+      "default": {
+        "num_corpus": 47416,
+        "num_queries": 1000,
+        "num_qrel_rows": 3048,
+        "num_missing_query_ids": 0,
+        "num_missing_corpus_ids": 0,
+        "example_missing_query_ids": [],
+        "example_missing_corpus_ids": []
+      }
+    }
+  },
+  "ClothoT2ARetrieval.v2": {
+    "dataset": "lxercode/clotho_t2a_v2",
+    "revision": "13cf5105f96e1844ee3b0b84cfba9103a7ebe6a2",
+    "subsets": {
+      "default": {
+        "num_corpus": 1045,
+        "num_queries": 4680,
+        "num_qrel_rows": 4680,
+        "num_missing_query_ids": 0,
+        "num_missing_corpus_ids": 0,
+        "example_missing_query_ids": [],
+        "example_missing_corpus_ids": []
+      }
+    }
+  },
+  "ClothoA2TRetrieval.v2": {
+    "dataset": "lxercode/clotho_a2t_v2",
+    "revision": "fb4fbd5c1e612be4894a478bd45500eb0bcd689f",
+    "subsets": {
+      "default": {
+        "num_corpus": 4680,
+        "num_queries": 1045,
+        "num_qrel_rows": 4680,
+        "num_missing_query_ids": 0,
+        "num_missing_corpus_ids": 0,
+        "example_missing_query_ids": [],
+        "example_missing_corpus_ids": []
+      }
+    }
+  },
+  "CommonVoiceMini21T2ARetrieval": {
+    "error": "ValueError(\"No config found for 'corpus'/None among ['ab', 'af', 'am', 'ar', 'as', 'ast', 'az', 'ba', 'bas', 'be', 'bg', 'bn', 'br', 'ca', 'ckb', 'cnh', 'cs', 'cv', 'cy', 'da', 'dav', 'de', 'dv', 'dyu', 'el', 'en', 'eo', 'es', 'et', 'eu', 'fa', 'fi', 'fr', 'fy-NL', 'ga-IE', 'gl', 'gn', 'ha', 'he', 'hi', 'hsb', 'hu', 'hy-AM', 'ia', 'id', 'it', 'ja', 'ka', 'kab', 'kk', 'kln', 'kmr', 'ko', 'ky', 'lg', 'lij', 'lt', 'ltg', 'luo', 'lv', 'mdf', 'mhr', 'mk', 'ml', 'mn', 'mr', 'mrj', 'mt', 'myv', 'nan-tw', 'ne-NP', 'nl', 'nn-NO', 'oc', 'or', 'os', 'pa-IN', 'pl', 'ps', 'pt', 'rm-sursilv', 'rm-vallader', 'ro', 'ru', 'rw', 'sah', 'sat', 'sc', 'sk', 'skr', 'sl', 'sq', 'sr', 'sv-SE', 'sw', 'ta', 'te', 'th', 'tig', 'tk', 'tn', 'tok', 'tr', 'tt', 'ug', 'uk', 'ur', 'uz', 'vi', 'yi', 'yo', 'yue', 'zgh', 'zh-CN', 'zh-HK', 'zh-TW', 'zza']\")"
+  },
+  "FEVERHardNegatives": {
+    "dataset": "mteb/FEVER_test_top_250_only_w_correct-v2",
+    "revision": "080c9ed6267b65029207906e815d44a9240bafca",
+    "subsets": {
+      "default": {
+        "num_corpus": 163698,
+        "num_queries": 1000,
+        "num_qrel_rows": 1171,
+        "num_missing_query_ids": 0,
+        "num_missing_corpus_ids": 0,
+        "example_missing_query_ids": [],
+        "example_missing_corpus_ids": []
+      }
+    }
+  },
+  "Fashion200kI2TRetrieval": {
+    "dataset": "mteb/mbeir_fashion200k_task3",
+    "revision": "74e9e63bf8f802f8cfb4ba6e01f48efc4f49032c",
+    "subsets": {
+      "default": {
+        "num_corpus": 61707,
+        "num_queries": 4889,
+        "num_qrel_rows": 4889,
+        "num_missing_query_ids": 0,
+        "num_missing_corpus_ids": 0,
+        "example_missing_query_ids": [],
+        "example_missing_corpus_ids": []
+      }
+    }
+  },
+  "FiQA2018": {
+    "dataset": "mteb/fiqa",
+    "revision": "27a168819829fe9bcd655c2df245fb19452e8e06",
+    "subsets": {
+      "default": {
+        "num_corpus": 57638,
+        "num_queries": 6648,
+        "num_qrel_rows": 1706,
+        "num_missing_query_ids": 0,
+        "num_missing_corpus_ids": 0,
+        "example_missing_query_ids": [],
+        "example_missing_corpus_ids": []
+      }
+    }
+  },
+  "FleursT2ARetrieval": {
+    "error": "ValueError(\"No config found for 'corpus'/None among ['af_za', 'am_et', 'ar_eg', 'as_in', 'ast_es', 'az_az', 'be_by', 'bg_bg', 'bn_in', 'bs_ba', 'ca_es', 'ceb_ph', 'ckb_iq', 'cmn_hans_cn', 'cs_cz', 'cy_gb', 'da_dk', 'de_de', 'el_gr', 'en_us', 'es_419', 'et_ee', 'fa_ir', 'ff_sn', 'fi_fi', 'fil_ph', 'fr_fr', 'ga_ie', 'gl_es', 'gu_in', 'ha_ng', 'he_il', 'hi_in', 'hr_hr', 'hu_hu', 'hy_am', 'id_id', 'ig_ng', 'is_is', 'it_it', 'ja_jp', 'jv_id', 'ka_ge', 'kam_ke', 'kea_cv', 'kk_kz', 'km_kh', 'kn_in', 'ko_kr', 'ky_kg', 'lb_lu', 'lg_ug', 'ln_cd', 'lo_la', 'lt_lt', 'luo_ke', 'lv_lv', 'mi_nz', 'mk_mk', 'ml_in', 'mn_mn', 'mr_in', 'ms_my', 'mt_mt', 'my_mm', 'nb_no', 'ne_np', 'nl_nl', 'nso_za', 'ny_mw', 'oc_fr', 'om_et', 'or_in', 'pa_in', 'pl_pl', 'ps_af', 'pt_br', 'ro_ro', 'ru_ru', 'sd_in', 'sk_sk', 'sl_si', 'sn_zw', 'so_so', 'sr_rs', 'sv_se', 'sw_ke', 'ta_in', 'te_in', 'tg_tj', 'th_th', 'tr_tr', 'uk_ua', 'umb_ao', 'ur_pk', 'uz_uz', 'vi_vn', 'wo_sn', 'xh_za', 'yo_ng', 'yue_hant_hk', 'zu_za']\")"
+  },
+  "GigaSpeechT2ARetrieval": {
+    "dataset": "mteb/gigaspeech_t2a",
+    "revision": "38876698eba40ac88433e0ca0d9dff6f35e4d0ff",
+    "subsets": {
+      "default": {
+        "num_corpus": 6750,
+        "num_queries": 6750,
+        "num_qrel_rows": 6750,
+        "num_missing_query_ids": 0,
+        "num_missing_corpus_ids": 0,
+        "example_missing_query_ids": [],
+        "example_missing_corpus_ids": []
+      }
+    }
+  },
+  "HatefulMemesI2TRetrieval": {
+    "error": "ValueError(\"No config found for 'corpus'/None among ['default']\")"
+  },
+  "HotpotQAHardNegatives": {
+    "dataset": "mteb/HotpotQA_test_top_250_only_w_correct-v2",
+    "revision": "617612fa63afcb60e3b134bed8b7216a99707c37",
+    "subsets": {
+      "default": {
+        "num_corpus": 225621,
+        "num_queries": 1000,
+        "num_qrel_rows": 2000,
+        "num_missing_query_ids": 0,
+        "num_missing_corpus_ids": 0,
+        "example_missing_query_ids": [],
+        "example_missing_corpus_ids": []
+      }
+    }
+  },
+  "InfoSeekIT2TRetrieval": {
+    "dataset": "mteb/mbeir_infoseek_task6",
+    "revision": "4510aa3b456b23f39564694e053e70492cc1de9f",
+    "subsets": {
+      "default": {
+        "num_corpus": 611651,
+        "num_queries": 11323,
+        "num_qrel_rows": 73869,
+        "num_missing_query_ids": 0,
+        "num_missing_corpus_ids": 941,
+        "example_missing_query_ids": [],
+        "example_missing_corpus_ids": [
+          "5:10001",
+          "5:10003",
+          "5:10032",
+          "5:10044",
+          "5:10045"
+        ]
+      }
+    }
+  },
+  "JamAltArtistA2ARetrieval": {
+    "error": "ValueError(\"No config found for 'corpus'/None among ['merged', 'merged-de', 'merged-en', 'merged-es', 'merged-fr', 'pure', 'pure-de', 'pure-en', 'pure-es', 'pure-fr']\")"
+  },
+  "JamAltLyricA2TRetrieval": {
+    "error": "ValueError(\"No config found for 'corpus'/None among ['merged', 'merged-de', 'merged-en', 'merged-es', 'merged-fr', 'pure', 'pure-de', 'pure-en', 'pure-es', 'pure-fr']\")"
+  },
+  "MACST2ARetrieval": {
+    "dataset": "mteb/MACS_t2a",
+    "revision": "74ce553cb9b43aee5169f0bddd30bd5dee8d26d1",
+    "subsets": {
+      "default": {
+        "num_corpus": 393,
+        "num_queries": 393,
+        "num_qrel_rows": 393,
+        "num_missing_query_ids": 0,
+        "num_missing_corpus_ids": 0,
+        "example_missing_query_ids": [],
+        "example_missing_corpus_ids": []
+      }
+    }
+  },
+  "MSVDT2VRetrieval": {
+    "error": "ValueError(\"No config found for 'corpus'/None among ['default']\")"
+  },
+  "MindSmallReranking": {
+    "dataset": "mteb/MindSmallReranking",
+    "revision": "227478e3235572039f4f7661840e059f31ef6eb1",
+    "subsets": {
+      "default": {
+        "num_corpus": 5277,
+        "num_queries": 2362514,
+        "num_qrel_rows": 97006943,
+        "num_missing_query_ids": 0,
+        "num_missing_corpus_ids": 0,
+        "example_missing_query_ids": [],
+        "example_missing_corpus_ids": []
+      }
+    }
+  },
+  "NIGHTSI2IRetrieval": {
+    "dataset": "mteb/mbeir_nights_task4",
+    "revision": "c798fa2f5173dc9fe0c727fd0abfd2f94cbc2f23",
+    "subsets": {
+      "default": {
+        "num_corpus": 40038,
+        "num_queries": 2120,
+        "num_qrel_rows": 2120,
+        "num_missing_query_ids": 0,
+        "num_missing_corpus_ids": 0,
+        "example_missing_query_ids": [],
+        "example_missing_corpus_ids": []
+      }
+    }
+  },
+  "OVENIT2TRetrieval": {
+    "dataset": "mteb/mbeir_oven_task6",
+    "revision": "88994735625f4ebf646eaf42096f7ba204880ac2",
+    "subsets": {
+      "default": {
+        "num_corpus": 676667,
+        "num_queries": 50004,
+        "num_qrel_rows": 492654,
+        "num_missing_query_ids": 0,
+        "num_missing_corpus_ids": 21689,
+        "example_missing_query_ids": [],
+        "example_missing_corpus_ids": [
+          "6:1000",
+          "6:1001",
+          "6:1001068",
+          "6:1001427",
+          "6:1002"
+        ]
+      }
+    }
+  },
+  "RP2kI2IRetrieval": {
+    "dataset": "mteb/rp2k",
+    "revision": "03b56e190634e7138c906d67cb356900ee50c98f",
+    "subsets": {
+      "default": {
+        "num_corpus": 39457,
+        "num_queries": 39457,
+        "num_qrel_rows": 4409419,
+        "num_missing_query_ids": 0,
+        "num_missing_corpus_ids": 0,
+        "example_missing_query_ids": [],
+        "example_missing_corpus_ids": []
+      }
+    }
+  },
+  "SCIDOCS": {
+    "dataset": "mteb/scidocs",
+    "revision": "f8c2fcf00f625baaa80f62ec5bd9e1fff3b8ae88",
+    "subsets": {
+      "default": {
+        "num_corpus": 25657,
+        "num_queries": 1000,
+        "num_qrel_rows": 29928,
+        "num_missing_query_ids": 0,
+        "num_missing_corpus_ids": 0,
+        "example_missing_query_ids": [],
+        "example_missing_corpus_ids": []
+      }
+    }
+  },
+  "SpokenSQuADT2ARetrieval": {
+    "dataset": "mteb/spoken-squad-t2a",
+    "revision": "b311394fa5ab5e003012304799d0d724d64303b3",
+    "subsets": {
+      "default": {
+        "num_corpus": 300,
+        "num_queries": 300,
+        "num_qrel_rows": 307,
+        "num_missing_query_ids": 0,
+        "num_missing_corpus_ids": 0,
+        "example_missing_query_ids": [],
+        "example_missing_corpus_ids": []
+      }
+    }
+  },
+  "TRECCOVID": {
+    "dataset": "mteb/trec-covid",
+    "revision": "bb9466bac8153a0349341eb1b22e06409e78ef4e",
+    "subsets": {
+      "default": {
+        "num_corpus": 171332,
+        "num_queries": 50,
+        "num_qrel_rows": 66336,
+        "num_missing_query_ids": 0,
+        "num_missing_corpus_ids": 0,
+        "example_missing_query_ids": [],
+        "example_missing_corpus_ids": []
+      }
+    }
+  },
+  "Touche2020Retrieval.v3": {
+    "dataset": "mteb/webis-touche2020-v3",
+    "revision": "431886eaecc48f067a3975b70d0949ea2862463c",
+    "subsets": {
+      "default": {
+        "num_corpus": 303732,
+        "num_queries": 49,
+        "num_qrel_rows": 2849,
+        "num_missing_query_ids": 0,
+        "num_missing_corpus_ids": 0,
+        "example_missing_query_ids": [],
+        "example_missing_corpus_ids": []
+      }
+    }
+  },
+  "UrbanSound8KT2ARetrieval": {
+    "dataset": "mteb/Urbansound8K_t2a",
+    "revision": "d50fd1daded60cf136b82d845b9bda65b8b2376e",
+    "subsets": {
+      "default": {
+        "num_corpus": 5090,
+        "num_queries": 5090,
+        "num_qrel_rows": 5090,
+        "num_missing_query_ids": 0,
+        "num_missing_corpus_ids": 0,
+        "example_missing_query_ids": [],
+        "example_missing_corpus_ids": []
+      }
+    }
+  },
+  "VALOR32KT2VARetrieval": {
+    "error": "ValueError(\"No config found for 'corpus'/None among ['default']\")"
+  },
+  "VATEXV2ARetrieval": {
+    "error": "ValueError(\"No config found for 'corpus'/None among ['default']\")"
+  },
+  "VATEXVA2TRetrieval": {
+    "error": "ValueError(\"No config found for 'corpus'/None among ['default']\")"
+  },
+  "VGGSoundAVA2VRetrieval": {
+    "error": "ValueError(\"No config found for 'corpus'/None among ['default']\")"
+  },
+  "VQA2IT2TRetrieval": {
+    "dataset": "mteb/vqa-2",
+    "revision": "cee84d52b243da575fa9ba71501a8433464a79a1",
+    "subsets": {
+      "default": {
+        "num_corpus": 21597,
+        "num_queries": 214354,
+        "num_qrel_rows": 214354,
+        "num_missing_query_ids": 0,
+        "num_missing_corpus_ids": 0,
+        "example_missing_query_ids": [],
+        "example_missing_corpus_ids": []
+      }
+    }
+  },
+  "VisualNewsI2TRetrieval": {
+    "dataset": "mteb/mbeir_visualnews_task3",
+    "revision": "158d0c0ce9cdd4f292964393de7dd47dc3e87519",
+    "subsets": {
+      "default": {
+        "num_corpus": 537568,
+        "num_queries": 20000,
+        "num_qrel_rows": 20000,
+        "num_missing_query_ids": 0,
+        "num_missing_corpus_ids": 0,
+        "example_missing_query_ids": [],
+        "example_missing_corpus_ids": []
+      }
+    }
+  },
+  "WebQAT2ITRetrieval": {
+    "dataset": "mteb/mbeir_webqa_task2",
+    "revision": "8a9243d504a2039b3467abdef2208a127a5c0737",
+    "subsets": {
+      "default": {
+        "num_corpus": 403196,
+        "num_queries": 2511,
+        "num_qrel_rows": 3627,
+        "num_missing_query_ids": 0,
+        "num_missing_corpus_ids": 0,
+        "example_missing_query_ids": [],
+        "example_missing_corpus_ids": []
+      }
+    }
+  },
+  "YouCook2T2VARetrieval": {
+    "error": "ValueError(\"No config found for 'corpus'/None among ['default']\")"
+  }
+}

--- a/experiments/moeb_dataset_audit/qrel_id_membership_audit_report.md
+++ b/experiments/moeb_dataset_audit/qrel_id_membership_audit_report.md
@@ -1,0 +1,150 @@
+# Qrel ID membership audit (Issue #5021)
+
+Scope: whether retrieval-task qrels ever reference `query-id`/`corpus-id` values
+that don't actually exist in the task's loaded `queries`/`corpus` datasets — an
+invariant that is **not** enforced anywhere in MTEB's loading or evaluation
+code (see "Why this isn't already caught" below). Audited 45 retrieval-family
+tasks drawn from the de-duplicated task inventory across the four curated
+omni-modal benchmarks (`MTEB(eng, v2)`, `MIEB(lite)`, `MAEB(beta)`,
+`MVEB(beta)`; see [`moeb_task_inventory.json`](moeb_task_inventory.json)),
+plus `AudioCapsT2ARetrieval`/`AudioCapsA2TRetrieval`.
+
+Script: [`audit_qrel_id_membership.py`](audit_qrel_id_membership.py) (one-off,
+not part of any PR). For each task it re-derives the config-resolution and
+split-fallback logic from `RetrievalDatasetLoader`
+(`mteb/abstasks/retrieval_dataset_loaders.py`), but pulls **only the `id`
+column** from corpus/queries — never a media column — so it needs no
+torchcodec/ffmpeg and works identically across text/image/audio/video tasks.
+Computes `qrel_query_ids - query_ids` and `qrel_corpus_ids - corpus_ids` per
+task. Full raw results: [`qrel_id_membership_audit.json`](qrel_id_membership_audit.json).
+
+## Results
+
+35/45 tasks loaded successfully; 10 failed with a script-level (not data-level)
+limitation — see "Coverage gaps" below.
+
+| Task | corpus | qrel rows | missing corpus IDs | result |
+|---|---:|---:|---:|---|
+| **OVENIT2TRetrieval** | 676,667 | 492,654 | **442,650 rows (89.9%)** | **FOUND** |
+| **InfoSeekIT2TRetrieval** | 611,651 | 73,869 | **7,547 rows (10.2%)** | **FOUND** |
+| **ArguAna** | 8,674 | 1,406 | **5 IDs** | **FOUND** |
+| AskUbuntuDupQuestions, CIRRIT2IRetrieval, CQADupstackGamingRetrieval, CQADupstackUnixRetrieval, CUB200I2IRetrieval, ClimateFEVERHardNegatives, ClothoT2ARetrieval.v2, ClothoA2TRetrieval.v2, CommonVoice/AudioCaps (both directions), FEVERHardNegatives, Fashion200kI2TRetrieval, FiQA2018, GigaSpeechT2ARetrieval, HotpotQAHardNegatives, MACST2ARetrieval, MindSmallReranking, NIGHTSI2IRetrieval, RP2kI2IRetrieval, SCIDOCS, SpokenSQuADT2ARetrieval, TRECCOVID, Touche2020Retrieval.v3, UrbanSound8KT2ARetrieval, VQA2IT2TRetrieval, VisualNewsI2TRetrieval, WebQAT2ITRetrieval | — | — | 0 | clean |
+
+**Coverage gaps (script limitation, not evidence of correctness):** 10 tasks
+use HF repo config-naming schemes the script doesn't parse yet —
+per-language configs (`CommonVoiceMini21T2ARetrieval`, `FleursT2ARetrieval`:
+raw language codes as config names), `merged`/`pure` prefixes
+(`JamAltArtistA2ARetrieval`, `JamAltLyricA2TRetrieval`), and single-`"default"`-config
+repos (`AVMemeExamAT2VRetrieval`, `ActivityNetCaptionsT2VRetrieval`,
+`AudioCapsAVVA2TRetrieval`, `AudioCapsAVVT2ARetrieval`, `HatefulMemesI2TRetrieval`,
+`MSVDT2VRetrieval`, `VALOR32KT2VARetrieval`, `VATEXV2ARetrieval`,
+`VATEXVA2TRetrieval`, `VGGSoundAVA2VRetrieval`, `YouCook2T2VARetrieval`).
+These are **unaudited**, not confirmed clean.
+
+## Finding 1: OVEN / InfoSeek — systematic cross-source ID collision (M-BEIR family)
+
+Both are `task6` exports from the M-BEIR merged benchmark
+(`mteb/mbeir_oven_task6` @ `8899473562`, `mteb/mbeir_infoseek_task6` @ `4510aa3b45`).
+Verified directly against the HF repos (not just via the audit script):
+
+```python
+# OVEN
+corpus id prefix counts: Counter({'5': 676667})
+qrel corpus-id prefix counts: Counter({'6': 442650, '5': 50004})
+
+# InfoSeek
+corpus id prefix counts: Counter({'6': 611651})
+qrel corpus-id prefix counts: Counter({'6': 66322, '5': 7547})
+```
+
+Each task's `corpus` config contains only **one** M-BEIR source prefix, but
+the qrels (inherited wholesale from the original merged M-BEIR relevance
+judgments) reference **both**. Concrete example (OVEN):
+
+```
+qrel row: {query-id: '5:35085', corpus-id: '6:1000', score: 1}
+'6:1000' in corpus['id']  ->  False
+```
+
+**Per-query reachability** (does the query have *any* qrel-labeled positive
+that actually exists in corpus?):
+
+| | total queries | 0 reachable positives (metrics forced to 0 regardless of model) | some reachable + some dangling | fully clean |
+|---|---:|---:|---:|---:|
+| OVEN | 50,004 | 0 | 36,549 (73.1%) | 13,455 |
+| InfoSeek | 11,323 | 0 | 7,547 (66.7%) | 3,776 |
+
+No query has zero reachable positives, so MRR/Hit-Rate are largely unaffected
+(see evaluation-path analysis below) — but Recall@K/NDCG@K/MAP are
+structurally capped below their true achievable maximum for the majority of
+queries in both tasks.
+
+## Finding 2: ArguAna — small, likely a stale corpus-doc deletion
+
+`mteb/arguana` @ `c22ab2a510`, one of the most widely used BEIR datasets.
+5/8674 corpus docs referenced by qrels are missing. Concrete example:
+
+```
+query "test-education-ufsdfkhbwu-con03a" -> qrel corpus-id "test-education-ufsdfkhbwu-con03b"
+corpus actually contains for this topic: con01b, con02b, pro01b, pro02b, pro03b
+"con03b" is absent
+```
+
+Looks like a single document was dropped during corpus construction/dedup
+without removing or repointing the corresponding qrel. Small in scale (5
+IDs) but notable because ArguAna has been a standard benchmark for years.
+
+## Why this isn't already caught
+
+Traced the full evaluation path (`mteb/abstasks/retrieval.py::_evaluate_subset`,
+`mteb/_evaluators/retrieval_evaluator.py`, `mteb/models/search_wrappers.py`,
+`mteb/_evaluators/retrieval_metrics.py`):
+
+- `_filter_queries_without_positives` (`retrieval.py:67-80`) only drops
+  queries with an *empty* qrels dict — never checks whether qrel doc IDs
+  exist in corpus.
+- The search index (`SearchEncoderWrapper.index()`) is built strictly from
+  `corpus["id"]`; qrels never participate in indexing or search. A qrel
+  corpus-id absent from `corpus["id"]` is unretrievable by any model, by
+  construction.
+- `RetrievalDatasetLoader._load_qrels` (`retrieval_dataset_loaders.py:187-223`)
+  loads qrels independently with no join/validation against corpus IDs.
+- Scoring uses `pytrec_eval.RelevanceEvaluator` (`retrieval_metrics.py:588`),
+  standard TREC semantics: a qrel doc absent from the run is silently
+  counted as "not retrieved" (contributes to the denominator, never the
+  numerator). No exception, no warning.
+
+## Metric impact (toy example, k=2, one query)
+
+Qrels `{docA: 1, docB: 1}`, `docB` unreachable. Best possible model ranks
+`docA` at rank 1 (retrieval = `[docA, docC]`).
+
+| metric | A: qrels has dangling `docB` | B: dangling entry removed | affected? |
+|---|---:|---:|---|
+| Recall@2 | 0.50 | 1.00 | yes — denominator inflated |
+| MAP | 0.50 | 1.00 | yes — R inflated |
+| NDCG@2 | 0.613 | 1.00 | yes — IDCG assumes docB reachable |
+| MRR@2 | 1.00 | 1.00 | no — only cares about first reachable hit |
+| Precision@2 | 0.50 | 0.50 | no — denominator is k, not qrel count |
+
+A model already at the ceiling of what's achievable given the actual corpus
+is scored as if it failed to retrieve something that was never retrievable.
+
+## Conclusion / next steps
+
+This has moved from a theoretical invariant gap to a confirmed, real defect
+with quantified severity. Recommended next steps (not yet started):
+1. Expand the audit to the remaining M-BEIR-family tasks not yet covered
+   (other `mteb/mbeir_*_task*` exports) to check whether the prefix-mismatch
+   pattern generalizes across the whole family.
+2. Adapt the audit script's config-resolution to cover the 10 skipped tasks'
+   non-standard schemas (per-language configs, `merged`/`pure` prefixes,
+   single-`default`-config repos) for full coverage.
+3. Decide on a fix for OVEN/InfoSeek specifically: either regenerate their
+   `corpus` config to include both M-BEIR source prefixes, or drop
+   unreachable qrel rows at the source and document the resulting metric
+   discontinuity for any already-published scores.
+4. Consider whether a permanent CI check (mirroring this script's logic,
+   without media decoding) belongs in `tests/test_tasks/test_task_quality.py`
+   alongside the checks added in PR #5090 — deferred until the above
+   scoping/fix decisions are made.


### PR DESCRIPTION
## Summary

This PR adds a small, exploratory dataset-audit pilot for
`NanoArguAnaRetrieval`.

The scripts inspect the retrieval data structure, identify normalized
exact-duplicate corpus documents, and flag potential incomplete-qrels
cases where only one of multiple documents with identical text is
marked relevant for a query.

## Motivation

Duplicate corpus entries can create evaluation ambiguity. If two
document IDs contain identical text but only one ID is included in the
qrels, a model may retrieve equivalent content and still be scored as
incorrect.

The goal of this pilot is to quantify these cases and provide
reproducible examples before proposing a dataset fix.

## Changes

- `load_one_task.py`
  - Loads `NanoArguAnaRetrieval`
  - Inspects the `queries`, `corpus`, and `relevant_docs` structure
  - Prints an example query and labeled relevant document

- `audit_exact_duplicates.py`
  - Detects corpus and query duplicates after lowercasing and whitespace
    normalization

- `audit_qrel_inconsistencies.py`
  - Finds queries where only a subset of identical corpus document IDs
    are marked relevant

- `inspect_duplicate_pair.py`
  - Reproduces and manually inspects one concrete duplicate/qrel case

## Preliminary findings

For the current NanoArguAna dataset:

- 50 queries
- 3,635 corpus documents
- 25 normalized exact-duplicate corpus groups
- 50 document IDs involved in those groups
- 5 query/duplicate-group cases where only one of two identical
  document IDs is marked relevant

Example:

- Query: `test-economy-epiasghbf-con01a`
- Marked relevant:
  `test-economy-epiasghbf-con01b`
- Identical but unmarked:
  `test-society-epiasghbf-con01b`

The two corpus entries have exactly identical raw text.

## Scope and limitations

This is currently an audit pilot, not a dataset modification.

- It only checks exact duplicates after basic text normalization.
- It does not yet measure the actual metric impact.
- The five cases are flagged as potential incomplete-qrels cases and
  should be reviewed before applying a fix.
- No model or dataset is added by this PR.

## Possible next steps

Depending on the preferred remediation, I can follow up by:

1. measuring the metric impact of the affected cases;
2. deduplicating the corpus;
3. expanding qrels to include identical document IDs;
4. adding tests and preparing a focused dataset-fix PR.
