### PR TITLE
task: add VimSketch query-by-vocal-imitation retrieval (a2a)

### DIFF
--- a/mteb/descriptive_stats/AudioClustering/VimSketchImitationClustering.json
+++ b/mteb/descriptive_stats/AudioClustering/VimSketchImitationClustering.json
@@ -1,0 +1,177 @@
+{
+    "test": {
+        "num_samples": 1230,
+        "text_statistics": null,
+        "image_statistics": null,
+        "audio_statistics": {
+            "total_duration_seconds": 5957.21380952381,
+            "min_duration_seconds": 0.046439909297052155,
+            "average_duration_seconds": 4.843263259775455,
+            "max_duration_seconds": 45.789750566893424,
+            "unique_audios": 1230,
+            "average_sampling_rate": 44100.0,
+            "sampling_rates": {
+                "44100": 1230
+            }
+        },
+        "video_statistics": null,
+        "labels_statistics": {
+            "min_labels_per_text": 1,
+            "average_label_per_text": 1.0,
+            "max_labels_per_text": 1,
+            "unique_labels": 50,
+            "labels": {
+                "2002-single_synthesizer.wav": {
+                    "count": 21
+                },
+                "2057-single_synthesizer.wav": {
+                    "count": 21
+                },
+                "2078-single_synthesizer.wav": {
+                    "count": 21
+                },
+                "2127-single_synthesizer.wav": {
+                    "count": 21
+                },
+                "2176-single_synthesizer.wav": {
+                    "count": 21
+                },
+                "2186-single_synthesizer.wav": {
+                    "count": 21
+                },
+                "2238-single_synthesizer.wav": {
+                    "count": 21
+                },
+                "2248-single_synthesizer.wav": {
+                    "count": 21
+                },
+                "2917-single_synthesizer.wav": {
+                    "count": 20
+                },
+                "4708-single_synthesizer.wav": {
+                    "count": 21
+                },
+                "9879-single_synthesizer.wav": {
+                    "count": 21
+                },
+                "Alarm_Air horn_truck horn.wav": {
+                    "count": 20
+                },
+                "Alarm_Fire alarm.wav": {
+                    "count": 21
+                },
+                "Alarm_Siren_Police car (siren).wav": {
+                    "count": 21
+                },
+                "Domestic animals_pets_Dog_Howl.wav": {
+                    "count": 20
+                },
+                "Domestic sounds_home sounds_Electric shaver_electric razor.wav": {
+                    "count": 20
+                },
+                "Domestic sounds_home sounds_Scissors.wav": {
+                    "count": 21
+                },
+                "Human group actions_Cheering.wav": {
+                    "count": 20
+                },
+                "Human voice_Laughter_Giggle.wav": {
+                    "count": 20
+                },
+                "Musical instrument_Bowed string instrument_Violin_fiddle_Pizzicato.wav": {
+                    "count": 20
+                },
+                "Musical instrument_Brass instrument_Bugle.wav": {
+                    "count": 21
+                },
+                "Musical instrument_Brass instrument_Cornet.wav": {
+                    "count": 20
+                },
+                "Musical instrument_Harmonica.wav": {
+                    "count": 20
+                },
+                "Musical instrument_Percussion_Cymbal_Hi_hat.wav": {
+                    "count": 21
+                },
+                "Musical instrument_Percussion_Drum kit_Drum machine.wav": {
+                    "count": 20
+                },
+                "Musical instrument_Percussion_Mallet percussion_Vibraphone.wav": {
+                    "count": 20
+                },
+                "Musical instrument_Wind instrument_woodwind instrument_Flute.wav": {
+                    "count": 20
+                },
+                "Respiratory sounds_Breathing_Gasp.wav": {
+                    "count": 21
+                },
+                "Respiratory sounds_Breathing_Pant.wav": {
+                    "count": 20
+                },
+                "Respiratory sounds_Cough_Throat clearing.wav": {
+                    "count": 20
+                },
+                "Tools_Hammer.wav": {
+                    "count": 21
+                },
+                "Tools_Sanding.wav": {
+                    "count": 20
+                },
+                "Vehicle_Motor vehicle (road)_Traffic noise_roadway noise.wav": {
+                    "count": 20
+                },
+                "attack_bass-commercial_synthesizers.wav": {
+                    "count": 30
+                },
+                "bass-commercial_synthesizers.wav": {
+                    "count": 31
+                },
+                "bells-acoustic_instruments.wav": {
+                    "count": 29
+                },
+                "calling-everyday.wav": {
+                    "count": 40
+                },
+                "cymbal_hit_with_a_stick-acoustic_instruments.wav": {
+                    "count": 40
+                },
+                "dropping-everyday.wav": {
+                    "count": 31
+                },
+                "firing-everyday.wav": {
+                    "count": 30
+                },
+                "flushing-everyday.wav": {
+                    "count": 29
+                },
+                "highs-commercial_synthesizers.wav": {
+                    "count": 30
+                },
+                "in_a_glass_bowl-commercial_synthesizers.wav": {
+                    "count": 31
+                },
+                "instruments.wav": {
+                    "count": 40
+                },
+                "mower_starting-everyday.wav": {
+                    "count": 31
+                },
+                "ringing-everyday.wav": {
+                    "count": 40
+                },
+                "shuffling-everyday.wav": {
+                    "count": 29
+                },
+                "stapling-everyday.wav": {
+                    "count": 30
+                },
+                "tearing-everyday.wav": {
+                    "count": 31
+                },
+                "trumpeting-everyday.wav": {
+                    "count": 31
+                }
+            }
+        }
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/VimSketchA2ARetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/VimSketchA2ARetrieval.json
@@ -1,0 +1,44 @@
+{
+    "test": {
+        "num_samples": 2710,
+        "num_queries": 2168,
+        "num_documents": 542,
+        "number_of_characters": 0,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": {
+            "total_duration_seconds": 2542.528888888889,
+            "min_duration_seconds": 0.07605442176870748,
+            "average_duration_seconds": 4.691012710127102,
+            "max_duration_seconds": 15.360657596371881,
+            "unique_audios": 542,
+            "average_sampling_rate": 44100.0,
+            "sampling_rates": {
+                "44100": 542
+            }
+        },
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": null,
+        "queries_audio_statistics": {
+            "total_duration_seconds": 11979.811746031746,
+            "min_duration_seconds": 0.046439909297052155,
+            "average_duration_seconds": 5.525743425291396,
+            "max_duration_seconds": 46.81142857142857,
+            "unique_audios": 2168,
+            "average_sampling_rate": 44100.0,
+            "sampling_rates": {
+                "44100": 2168
+            }
+        },
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 2168,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 542
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/tasks/clustering/zxx/__init__.py
+++ b/mteb/tasks/clustering/zxx/__init__.py
@@ -2,10 +2,12 @@ from .esc50_clustering import ESC50Clustering
 from .gtzan_genre_clustering import GTZANGenreClustering
 from .music_genre import MusicGenreClustering
 from .vehicle_sound_clustering import VehicleSoundClustering
+from .vim_sketch_clustering import VimSketchImitationClustering
 
 __all__ = [
     "ESC50Clustering",
     "GTZANGenreClustering",
     "MusicGenreClustering",
     "VehicleSoundClustering",
+    "VimSketchImitationClustering",
 ]

--- a/mteb/tasks/clustering/zxx/vim_sketch_clustering.py
+++ b/mteb/tasks/clustering/zxx/vim_sketch_clustering.py
@@ -1,35 +1,34 @@
-from __future__ import annotations
-
-from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks import AbsTaskClustering
 from mteb.abstasks.task_metadata import TaskMetadata
 
 
-class VimSketchA2ARetrieval(AbsTaskRetrieval):
+class VimSketchImitationClustering(AbsTaskClustering):
+    label_column_name: str = "label"
+    input_column_name: str = "audio"
+    max_fraction_of_documents_to_embed = None
     metadata = TaskMetadata(
-        name="VimSketchA2ARetrieval",
+        name="VimSketchImitationClustering",
         description=(
-            "Query-by-vocal-imitation retrieval on the VimSketch dataset. Queries are "
-            "human vocal imitations of a sound and the corpus contains the 542 "
-            "reference sounds (environmental sounds, instruments and sound effects) "
-            "they imitate; the goal is to retrieve the imitated reference sound. VimSketch merges the Vocal Imitation Set and "
-            "VocalSketch and provides one reference recording per sound class. "
-            "Queries are downsampled to at most 4 imitations per reference "
-            "(2,168 queries)."
+            "Clustering of vocal imitations from the VimSketch dataset by the "
+            "sound they imitate: 1,230 human vocal imitations covering 50 "
+            "reference-sound classes sampled with a fixed seed (at most 40 "
+            "imitations per class). Labels are the imitated reference classes."
         ),
         reference="https://zenodo.org/record/2596911",
         dataset={
             "path": "dukesun99/VimSketch",
+            "name": "clustering",
             "revision": "466e0ea0ed8f50bad9c240f3bfc8426c08430aa2",
         },
-        type="Any2AnyRetrieval",
+        type="AudioClustering",
         category="a2a",
         modalities=["audio"],
         eval_splits=["test"],
         eval_langs=["zxx-Zxxx"],
-        main_score="ndcg_at_10",
+        main_score="v_measure",
         date=("2015-01-01", "2019-03-18"),
         domains=["AudioScene", "Spoken"],
-        task_subtypes=["Environment Sound Retrieval"],
+        task_subtypes=["Environment Sound Clustering"],
         license="cc-by-4.0",
         annotations_creators="derived",
         dialect=[],
@@ -51,7 +50,4 @@ class VimSketchA2ARetrieval(AbsTaskRetrieval):
   year = {2018},
 }
 """,
-        prompt={
-            "query": "Retrieve the original sound that this vocal imitation mimics."
-        },
     )

--- a/mteb/tasks/retrieval/zxx/__init__.py
+++ b/mteb/tasks/retrieval/zxx/__init__.py
@@ -1,6 +1,7 @@
 from .music_caps import MusicCapsA2TRetrieval, MusicCapsT2ARetrieval
 from .sound_descs import SoundDescsA2TRetrieval, SoundDescsT2ARetrieval
 from .urban_sound8k_retrieval import UrbanSound8KA2TRetrieval, UrbanSound8KT2ARetrieval
+from .vim_sketch_retrieval import VimSketchA2ARetrieval
 
 __all__ = [
     "MusicCapsA2TRetrieval",
@@ -9,4 +10,5 @@ __all__ = [
     "SoundDescsT2ARetrieval",
     "UrbanSound8KA2TRetrieval",
     "UrbanSound8KT2ARetrieval",
+    "VimSketchA2ARetrieval",
 ]

--- a/mteb/tasks/retrieval/zxx/vim_sketch_retrieval.py
+++ b/mteb/tasks/retrieval/zxx/vim_sketch_retrieval.py
@@ -35,20 +35,18 @@ class VimSketchA2ARetrieval(AbsTaskRetrieval):
         dialect=[],
         sample_creation="created",
         bibtex_citation=r"""
-@inproceedings{cartwright2015vocalsketch,
-  author = {Cartwright, Mark and Pardo, Bryan},
-  booktitle = {Proceedings of the 33rd Annual ACM Conference on Human Factors in Computing Systems},
-  pages = {43--46},
-  title = {VocalSketch: Vocally Imitating Audio Concepts},
-  year = {2015},
-}
-
-@inproceedings{kim2018vocal,
-  author = {Kim, Bongjun and Ghei, Madhav and Pardo, Bryan and Duan, Zhiyao},
-  booktitle = {Proceedings of the Detection and Classification of Acoustic Scenes and Events 2018 Workshop (DCASE2018)},
-  pages = {148--152},
-  title = {Vocal Imitation Set: a dataset of vocally imitated sound events using the AudioSet ontology},
-  year = {2018},
+@dataset{bongjun_kim_2019_2596911,
+  author       = {Bongjun Kim and
+                  Mark Cartwright and
+                  Fatemeh Pishdadian and
+                  Bryan Pardo},
+  title        = {VimSketch Dataset},
+  month        = mar,
+  year         = 2019,
+  publisher    = {Zenodo},
+  version      = {1.0},
+  doi          = {10.5281/zenodo.2596911},
+  url          = {https://doi.org/10.5281/zenodo.2596911},
 }
 """,
         prompt={

--- a/mteb/tasks/retrieval/zxx/vim_sketch_retrieval.py
+++ b/mteb/tasks/retrieval/zxx/vim_sketch_retrieval.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class VimSketchA2ARetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="VimSketchA2ARetrieval",
+        description=(
+            "Query-by-vocal-imitation retrieval on the VimSketch dataset. Queries are "
+            "human vocal imitations of a sound and the corpus contains the 542 "
+            "reference sounds (environmental sounds, instruments and sound effects) "
+            "they imitate; the goal is to retrieve the imitated reference sound. VimSketch merges the Vocal Imitation Set and "
+            "VocalSketch and provides one reference recording per sound class. "
+            "Queries are downsampled to at most 4 imitations per reference "
+            "(2,168 queries)."
+        ),
+        reference="https://zenodo.org/record/2596911",
+        dataset={
+            "path": "dukesun99/VimSketch",
+            "revision": "7ce441ca24859315fb78c3a987d5c62d0b642cae",
+        },
+        type="Any2AnyRetrieval",
+        category="a2a",
+        modalities=["audio"],
+        eval_splits=["test"],
+        eval_langs=["zxx-Zxxx"],
+        main_score="ndcg_at_10",
+        date=("2015-01-01", "2019-03-18"),
+        domains=["AudioScene", "Spoken"],
+        task_subtypes=["Environment Sound Retrieval"],
+        license="cc-by-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="created",
+        bibtex_citation=r"""
+@inproceedings{cartwright2015vocalsketch,
+  author = {Cartwright, Mark and Pardo, Bryan},
+  booktitle = {Proceedings of the 33rd Annual ACM Conference on Human Factors in Computing Systems},
+  pages = {43--46},
+  title = {VocalSketch: Vocally Imitating Audio Concepts},
+  year = {2015},
+}
+
+@inproceedings{kim2018vocal,
+  author = {Kim, Bongjun and Ghei, Madhav and Pardo, Bryan and Duan, Zhiyao},
+  booktitle = {Proceedings of the Detection and Classification of Acoustic Scenes and Events 2018 Workshop (DCASE2018)},
+  pages = {148--152},
+  title = {Vocal Imitation Set: a dataset of vocally imitated sound events using the AudioSet ontology},
+  year = {2018},
+}
+""",
+        prompt={
+            "query": "Retrieve the original sound that this vocal imitation mimics."
+        },
+    )

--- a/mteb/tasks/retrieval/zxx/vim_sketch_retrieval.py
+++ b/mteb/tasks/retrieval/zxx/vim_sketch_retrieval.py
@@ -36,17 +36,17 @@ class VimSketchA2ARetrieval(AbsTaskRetrieval):
         sample_creation="created",
         bibtex_citation=r"""
 @dataset{bongjun_kim_2019_2596911,
-  author       = {Bongjun Kim and
-                  Mark Cartwright and
-                  Fatemeh Pishdadian and
-                  Bryan Pardo},
-  title        = {VimSketch Dataset},
-  month        = mar,
-  year         = 2019,
-  publisher    = {Zenodo},
-  version      = {1.0},
-  doi          = {10.5281/zenodo.2596911},
-  url          = {https://doi.org/10.5281/zenodo.2596911},
+  author = {Bongjun Kim and
+Mark Cartwright and
+Fatemeh Pishdadian and
+Bryan Pardo},
+  doi = {10.5281/zenodo.2596911},
+  month = mar,
+  publisher = {Zenodo},
+  title = {VimSketch Dataset},
+  url = {https://doi.org/10.5281/zenodo.2596911},
+  version = {1.0},
+  year = {2019},
 }
 """,
         prompt={


### PR DESCRIPTION
Part of the MOEB effort (#4842), thin direction "audio → audio retrieval". Closes #2242.

Adds `VimSketchA2ARetrieval`, the first audio-to-audio retrieval task in mteb: queries are human vocal imitations and the corpus contains the reference sounds they imitate ([VimSketch](https://zenodo.org/record/2596911), CC-BY-4.0, merging VocalSketch and the Vocal Imitation Set). Instance-level ground truth from the dataset's imitation-to-reference mapping.

Data was repackaged into the standard corpus/queries/qrels layout at [dukesun99/VimSketch](https://huggingface.co/datasets/dukesun99/VimSketch): 542 reference sounds, 2,168 imitation queries downsampled to at most 4 per reference class with a fixed seed. Happy to transfer the repo to the mteb org.

Dataset checklist:
- [x] Fills an existing gap: first a2a retrieval task (direction requested in #4842, dataset requested in #2242)
- [x] Tested that the dataset runs with the mteb package
- [x] `mteb/baseline-random-encoder`: 0.0100 nDCG@10
- [x] Small real model — laion/clap-htsat-fused: 0.0952 nDCG@10 (retrieval); clustering task: random v-measure 0.2479, CLAP 0.4777
- [x] Downsampled to evaluation scale
- [x] Paper-score reproduction: N/A — the original query-by-vocal-imitation works report MRR over different candidate pools; no published protocol matches this corpus construction
