### PR TITLE
task: add SPEECH-COCO spoken-caption image retrieval (a2i, i2a)

### DIFF
--- a/mteb/abstasks/task_metadata.py
+++ b/mteb/abstasks/task_metadata.py
@@ -280,6 +280,8 @@ TaskCategory = Literal[
     "a2v",
     "vt2a",
     "at2v",
+    "a2i",
+    "i2a",
 ]
 """The category of the task.
 
@@ -319,6 +321,8 @@ TaskCategory = Literal[
 34. va2va: video+audio to video+audio
 35. v2a: video to audio
 36. a2v: audio to video
+37. a2i: audio to image
+38. i2a: image to audio
 """
 
 _MODALITY_CODES: dict[str, str] = {

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/SpeechCocoA2IRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/SpeechCocoA2IRetrieval.json
@@ -1,0 +1,42 @@
+{
+    "test": {
+        "num_samples": 3048,
+        "num_queries": 1000,
+        "num_documents": 2048,
+        "number_of_characters": 0,
+        "documents_text_statistics": null,
+        "documents_image_statistics": {
+            "min_image_width": 240,
+            "average_image_width": 576.15966796875,
+            "max_image_width": 640,
+            "min_image_height": 180,
+            "average_image_height": 485.4619140625,
+            "max_image_height": 640,
+            "unique_images": 2048
+        },
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": null,
+        "queries_audio_statistics": {
+            "total_duration_seconds": 3543.47825,
+            "min_duration_seconds": 1.8605625,
+            "average_duration_seconds": 3.54347825,
+            "max_duration_seconds": 9.9656875,
+            "unique_audios": 1000,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 1000
+            }
+        },
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 1000,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 1000
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/SpeechCocoI2ARetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/SpeechCocoI2ARetrieval.json
@@ -1,0 +1,42 @@
+{
+    "test": {
+        "num_samples": 3048,
+        "num_queries": 1000,
+        "num_documents": 2048,
+        "number_of_characters": 0,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": {
+            "total_duration_seconds": 7263.982875,
+            "min_duration_seconds": 1.8605625,
+            "average_duration_seconds": 3.5468666381835936,
+            "max_duration_seconds": 9.9656875,
+            "unique_audios": 2048,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 2048
+            }
+        },
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": {
+            "min_image_width": 304,
+            "average_image_width": 573.126,
+            "max_image_width": 640,
+            "min_image_height": 181,
+            "average_image_height": 484.43,
+            "max_image_height": 640,
+            "unique_images": 1000
+        },
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 1000,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 1000
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -307,6 +307,7 @@ from .siqa_retrieval import SIQA
 from .sketchy_i2i_retrieval import SketchyI2IRetrieval
 from .sop_i2i_retrieval import SOPI2IRetrieval
 from .spart_qa_retrieval import SpartQA
+from .speech_coco import SpeechCocoA2IRetrieval, SpeechCocoI2ARetrieval
 from .spoken_s_qu_ad import SpokenSQuADT2ARetrieval
 from .stanford_cars_i2i_retrieval import StanfordCarsI2I
 from .temp_reason_l1_retrieval import TempReasonL1
@@ -685,6 +686,8 @@ __all__ = [
     "Shot2Story20KVT2ARetrieval",
     "SketchyI2IRetrieval",
     "SpartQA",
+    "SpeechCocoA2IRetrieval",
+    "SpeechCocoI2ARetrieval",
     "SpokenSQuADT2ARetrieval",
     "StanfordCarsI2I",
     "TUBerlinT2IRetrieval",

--- a/mteb/tasks/retrieval/eng/speech_coco.py
+++ b/mteb/tasks/retrieval/eng/speech_coco.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.task_metadata import TaskMetadata
+
+_REFERENCE = "https://arxiv.org/abs/1707.08435"
+_BIBTEX = r"""
+@inproceedings{havard2017speechcoco,
+  author = {Havard, William and Besacier, Laurent and Rosec, Olivier},
+  booktitle = {Proceedings of the GLU 2017 International Workshop on Grounding Language Understanding},
+  title = {SPEECH-COCO: 600k Visually Grounded Spoken Captions Aligned to MSCOCO Data Set},
+  year = {2017},
+}
+"""
+_DESCRIPTION = (
+    "SPEECH-COCO pairs MS-COCO images with spoken captions synthesized using eight "
+    "high-quality commercial TTS voices with varied speaking rates and injected "
+    "disfluencies. This retrieval task uses a deterministic downsample of the "
+    "validation split: 2,048 images sampled from the first eight validation shards "
+    "with 1,000 queries. "
+)
+
+
+class SpeechCocoA2IRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="SpeechCocoA2IRetrieval",
+        description=_DESCRIPTION
+        + "Queries are spoken captions and the corpus contains the images; the goal "
+        "is to retrieve the image described by the spoken caption.",
+        reference=_REFERENCE,
+        dataset={
+            "path": "dukesun99/SpeechCoco-A2I",
+            "revision": "217c6660258de6e60002f748abdf11be623c8e0e",
+        },
+        type="Any2AnyRetrieval",
+        category="a2i",
+        modalities=["audio", "image"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2014-01-01", "2017-07-31"),
+        domains=["Scene", "Spoken"],
+        task_subtypes=["Cross-Modal Retrieval"],
+        license="cc-by-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="created",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find the image described by the spoken caption."},
+    )
+
+
+class SpeechCocoI2ARetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="SpeechCocoI2ARetrieval",
+        description=_DESCRIPTION
+        + "Queries are images and the corpus contains spoken captions; the goal is "
+        "to retrieve the spoken caption describing the image.",
+        reference=_REFERENCE,
+        dataset={
+            "path": "dukesun99/SpeechCoco-I2A",
+            "revision": "afb9e08254be4e9c2e5af432912291dde7528b68",
+        },
+        type="Any2AnyRetrieval",
+        category="i2a",
+        modalities=["image", "audio"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2014-01-01", "2017-07-31"),
+        domains=["Scene", "Spoken"],
+        task_subtypes=["Cross-Modal Retrieval"],
+        license="cc-by-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="created",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find the spoken caption that describes the image."},
+    )


### PR DESCRIPTION
Part of the MOEB effort (#4842), missing modality combination "audio ↔ image". Closes #2298, reviving the dataset upload from the stale PR #3070 (credit to its author for the original processing into `mteb/SpeechCoco`). Adds the `a2i` and `i2a` TaskCategory codes this task needs.

Adds `SpeechCocoA2IRetrieval` and `SpeechCocoI2ARetrieval`: spoken MS-COCO captions (eight commercial TTS voices, varied speed, injected disfluencies — [arXiv 1707.08435](https://arxiv.org/abs/1707.08435), CC-BY-4.0 on [Zenodo](https://zenodo.org/record/4282267)) against COCO images, in both directions. Synthetic-speech evaluation has in-repo precedent (SpokenSQuAD, LibriTTS).

Data is a deterministic downsample of the `mteb/SpeechCoco` validation split (2,048 images from the first eight shards, 1,000 queries per direction), repackaged in standard layout at [dukesun99/SpeechCoco-A2I](https://huggingface.co/datasets/dukesun99/SpeechCoco-A2I) and [dukesun99/SpeechCoco-I2A](https://huggingface.co/datasets/dukesun99/SpeechCoco-I2A). Happy to transfer to the mteb org.

Dataset checklist:
- [x] Fills an existing gap: first a2i/i2a tasks (direction requested in #4842, dataset requested in #2298)
- [x] Tested that the dataset runs with the mteb package
- [x] `mteb/baseline-random-encoder`: a2i 0.0034, i2a 0.0008 nDCG@10
- [x] Real model — LCO-Embedding/LCO-Embedding-Omni-3B: a2i 0.7432, i2a 0.7171 (nDCG@10). 
- [x] Downsampled to evaluation scale
- [x] Paper-score reproduction: N/A — SPEECH-COCO was released for grounded-language research without a retrieval benchmar