### PR TITLE
task: add SoundingEarth audio-image retrieval (a2i, i2a)

### DIFF
--- a/mteb/abstasks/task_metadata.py
+++ b/mteb/abstasks/task_metadata.py
@@ -280,6 +280,8 @@ TaskCategory = Literal[
     "a2v",
     "vt2a",
     "at2v",
+    "a2i",
+    "i2a",
 ]
 """The category of the task.
 
@@ -319,6 +321,8 @@ TaskCategory = Literal[
 34. va2va: video+audio to video+audio
 35. v2a: video to audio
 36. a2v: audio to video
+37. a2i: audio to image
+38. i2a: image to audio
 """
 
 _MODALITY_CODES: dict[str, str] = {

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/SoundingEarthA2IRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/SoundingEarthA2IRetrieval.json
@@ -1,0 +1,42 @@
+{
+    "test": {
+        "num_samples": 3048,
+        "num_queries": 1000,
+        "num_documents": 2048,
+        "number_of_characters": 0,
+        "documents_text_statistics": null,
+        "documents_image_statistics": {
+            "min_image_width": 1024,
+            "average_image_width": 1024.0,
+            "max_image_width": 1024,
+            "min_image_height": 1024,
+            "average_image_height": 1024.0,
+            "max_image_height": 1024,
+            "unique_images": 1969
+        },
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": null,
+        "queries_audio_statistics": {
+            "total_duration_seconds": 109140.38961451247,
+            "min_duration_seconds": 11.80734693877551,
+            "average_duration_seconds": 109.14038961451247,
+            "max_duration_seconds": 120.0,
+            "unique_audios": 1000,
+            "average_sampling_rate": 44100.0,
+            "sampling_rates": {
+                "44100": 1000
+            }
+        },
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 1000,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 1000
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/SoundingEarthI2ARetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/SoundingEarthI2ARetrieval.json
@@ -1,0 +1,42 @@
+{
+    "test": {
+        "num_samples": 3048,
+        "num_queries": 1000,
+        "num_documents": 2048,
+        "number_of_characters": 0,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": {
+            "total_duration_seconds": 222801.20587301586,
+            "min_duration_seconds": 11.80734693877551,
+            "average_duration_seconds": 108.78965130518353,
+            "max_duration_seconds": 120.0,
+            "unique_audios": 2048,
+            "average_sampling_rate": 44100.0,
+            "sampling_rates": {
+                "44100": 2048
+            }
+        },
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": {
+            "min_image_width": 1024,
+            "average_image_width": 1024.0,
+            "max_image_width": 1024,
+            "min_image_height": 1024,
+            "average_image_height": 1024.0,
+            "max_image_height": 1024,
+            "unique_images": 976
+        },
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 1000,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 1000
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -306,6 +306,7 @@ from .shot2story_retrieval import (
 from .siqa_retrieval import SIQA
 from .sketchy_i2i_retrieval import SketchyI2IRetrieval
 from .sop_i2i_retrieval import SOPI2IRetrieval
+from .sounding_earth import SoundingEarthA2IRetrieval, SoundingEarthI2ARetrieval
 from .spart_qa_retrieval import SpartQA
 from .spoken_s_qu_ad import SpokenSQuADT2ARetrieval
 from .stanford_cars_i2i_retrieval import StanfordCarsI2I
@@ -684,6 +685,8 @@ __all__ = [
     "Shot2Story20KVA2TRetrieval",
     "Shot2Story20KVT2ARetrieval",
     "SketchyI2IRetrieval",
+    "SoundingEarthA2IRetrieval",
+    "SoundingEarthI2ARetrieval",
     "SpartQA",
     "SpokenSQuADT2ARetrieval",
     "StanfordCarsI2I",

--- a/mteb/tasks/retrieval/eng/sounding_earth.py
+++ b/mteb/tasks/retrieval/eng/sounding_earth.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.task_metadata import TaskMetadata
+
+_REFERENCE = "https://arxiv.org/abs/2108.00688"
+_BIBTEX = r"""
+@article{heidler2023soundingearth,
+  author = {Heidler, Konrad and Mou, Lichao and Hu, Di and Jin, Pu and Li, Guangyao and Gan, Chuang and Wen, Ji-Rong and Zhu, Xiao Xiang},
+  journal = {International Journal of Applied Earth Observation and Geoinformation},
+  title = {Self-supervised audiovisual representation learning for remote sensing data},
+  url = {https://arxiv.org/abs/2108.00688},
+  volume = {116},
+  year = {2023},
+}
+"""
+_DESCRIPTION = (
+    "SoundingEarth pairs geotagged field recordings from the Radio Aporee sound "
+    "map with co-located aerial imagery; every location contributes exactly one "
+    "image and one recording, giving instance-level cross-modal ground truth. "
+    "This task uses 2,048 locations sampled with a fixed seed and 1,000 queries; recordings are "
+    "repair-transcoded to mono FLAC capped at 120 seconds. "
+)
+
+
+class SoundingEarthA2IRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="SoundingEarthA2IRetrieval",
+        description=_DESCRIPTION
+        + "Queries are field recordings and the corpus contains the aerial images; "
+        "the goal is to retrieve the image of the location where the recording was "
+        "made.",
+        reference=_REFERENCE,
+        dataset={
+            "path": "dukesun99/SoundingEarth-A2I",
+            "revision": "e97546c9ce77b71da1c8a97b6bb6c034f4378bee",
+        },
+        type="Any2AnyRetrieval",
+        category="a2i",
+        modalities=["audio", "image"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2006-01-01", "2021-10-01"),
+        domains=["AudioScene", "Scene"],
+        task_subtypes=["Cross-Modal Retrieval"],
+        license="cc-by-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={
+            "query": "Retrieve the aerial image of the location where this field recording was made."
+        },
+    )
+
+
+class SoundingEarthI2ARetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="SoundingEarthI2ARetrieval",
+        description=_DESCRIPTION
+        + "Queries are aerial images and the corpus contains the field recordings; "
+        "the goal is to retrieve the recording made at the depicted location.",
+        reference=_REFERENCE,
+        dataset={
+            "path": "dukesun99/SoundingEarth-I2A",
+            "revision": "137f91ccf6a3ce892697bd6022560b22ac3342f8",
+        },
+        type="Any2AnyRetrieval",
+        category="i2a",
+        modalities=["image", "audio"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2006-01-01", "2021-10-01"),
+        domains=["AudioScene", "Scene"],
+        task_subtypes=["Cross-Modal Retrieval"],
+        license="cc-by-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={
+            "query": "Retrieve the field recording made at the location shown in this aerial image."
+        },
+    )


### PR DESCRIPTION
Part of the MOEB effort (#4842), missing modality combination "audio ↔ image". Closes #4942. Adds the `a2i`/`i2a` TaskCategory codes.

Adds `SoundingEarthA2IRetrieval` and `SoundingEarthI2ARetrieval`: co-located aerial images and field recordings, 2,048 locations sampled with a fixed seed, 1,000 queries per direction, instance-level ground truth ([arXiv 2108.00688](https://arxiv.org/abs/2108.00688), CC-BY-4.0 on Zenodo). Audio is fetched per recording from Internet Archive and repair-transcoded to mono FLAC capped at 120 seconds; every clip validates through torchcodec, the decoder mteb uses at runtime. Data at [dukesun99/SoundingEarth-A2I](https://huggingface.co/datasets/dukesun99/SoundingEarth-A2I) and [-I2A](https://huggingface.co/datasets/dukesun99/SoundingEarth-I2A).

Dataset checklist:
- [x] Fills an existing gap: ambient-sound audio↔image, complementing SPEECH-COCO's spoken-caption flavor
- [x] Tested that the dataset runs with the mteb package
- [x] `mteb/baseline-random-encoder`: a2i 0.0025, i2a 0.0027 nDCG@10
- [x] Real model — LCO-Embedding-Omni-3B: a2i 0.0294, i2a 0.0233. Roughly 10x random. Please let me know if this is still too random.
- [x] Downsampled to evaluation scale
- [x] Paper-score reproduction: N/A directly — the paper trains self-supervised models on the full 50k pairs and reports recall on held-out splits; our fixed 2,048-pair zero-shot protocol differs by design
