### PR TITLE
task: add LoVR clip-to-video retrieval (v2v)

### DIFF
--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/LoVRC2VRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/LoVRC2VRetrieval.json
@@ -1,0 +1,92 @@
+{
+    "test": {
+        "num_samples": 240,
+        "num_queries": 120,
+        "num_documents": 120,
+        "number_of_characters": 0,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": {
+            "total_duration_seconds": 188517.49058709544,
+            "total_frames": 5193848,
+            "min_width": 640,
+            "average_width": 640.0,
+            "max_width": 640,
+            "min_height": 360,
+            "average_height": 360.0,
+            "max_height": 360,
+            "min_duration_seconds": 998.6977,
+            "average_duration_seconds": 1570.9790882257953,
+            "max_duration_seconds": 3298.0666666666666,
+            "unique_videos": 120,
+            "average_fps": 27.341666666666665,
+            "fps": {
+                "30": 64,
+                "25": 17,
+                "24": 39
+            },
+            "min_resolution": [
+                640,
+                360
+            ],
+            "average_resolution": [
+                640.0,
+                360.0
+            ],
+            "max_resolution": [
+                640,
+                360
+            ],
+            "resolutions": {
+                "640x360": 120
+            }
+        },
+        "queries_text_statistics": null,
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": {
+            "total_duration_seconds": 2174.687624582916,
+            "total_frames": 60434,
+            "min_width": 640,
+            "average_width": 640.0,
+            "max_width": 640,
+            "min_height": 360,
+            "average_height": 360.0,
+            "max_height": 360,
+            "min_duration_seconds": 3.04,
+            "average_duration_seconds": 18.122396871524302,
+            "max_duration_seconds": 190.5904,
+            "unique_videos": 120,
+            "average_fps": 27.341666666666665,
+            "fps": {
+                "30": 64,
+                "24": 39,
+                "25": 17
+            },
+            "min_resolution": [
+                640,
+                360
+            ],
+            "average_resolution": [
+                640.0,
+                360.0
+            ],
+            "max_resolution": [
+                640,
+                360
+            ],
+            "resolutions": {
+                "640x360": 120
+            }
+        },
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 120,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 120
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -201,6 +201,7 @@ from .lmeb_retrieval import (
     ToolBench,
 )
 from .lotte_retrieval import LoTTERetrieval
+from .lovr_c2v import LoVRC2VRetrieval
 from .macs import MACSA2TRetrieval, MACST2ARetrieval
 from .medical_qa_retrieval import MedicalQARetrieval
 from .memotion_i2t_retrieval import MemotionI2TRetrieval
@@ -597,6 +598,7 @@ __all__ = [
     "LitSearchRetrieval",
     "LoCoMo",
     "LoTTERetrieval",
+    "LoVRC2VRetrieval",
     "LongMemEval",
     "LooGLE",
     "MACSA2TRetrieval",

--- a/mteb/tasks/retrieval/eng/lovr_c2v.py
+++ b/mteb/tasks/retrieval/eng/lovr_c2v.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class LoVRC2VRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="LoVRC2VRetrieval",
+        description=(
+            "Clip-to-video retrieval from the LoVR long-video benchmark as "
+            "packaged in UVRB: the query is a short clip and the corpus contains "
+            "long videos; the goal is to retrieve the video the clip was taken "
+            "from. This evaluation set samples 120 corpus videos with a fixed "
+            "seed, re-encoded to 360p, together with all clip queries whose "
+            "target is in the sample."
+        ),
+        reference="https://arxiv.org/abs/2510.27571",
+        dataset={
+            "path": "dukesun99/LoVR-C2V",
+            "revision": "13a17a84ad1cf9b6a26f2a25367dd81899fda630",
+        },
+        type="Any2AnyRetrieval",
+        category="v2v",
+        modalities=["video"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2025-01-01", "2025-11-01"),
+        domains=["Scene", "Entertainment"],
+        task_subtypes=[],
+        license="not specified",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=r"""
+@misc{guo2025uvrb,
+  archiveprefix = {arXiv},
+  author = {Zhuoning Guo and Mingxin Li and Yanzhao Zhang and Dingkun Long and Pengjun Xie and Xiaowen Chu},
+  eprint = {2510.27571},
+  primaryclass = {cs.CV},
+  title = {Towards Universal Video Retrieval: Generalizing Video Embedding via Synthesized Multimodal Pyramid Curriculum},
+  url = {https://arxiv.org/abs/2510.27571},
+  year = {2025},
+}
+""",
+        prompt={"query": "Retrieve the long video that this clip was taken from."},
+        is_beta=True,
+    )


### PR DESCRIPTION
Part of the MOEB effort (#4842), thin direction "video → video". Closes #4945.

Adds `LoVRC2VRetrieval` from the LoVR benchmark as packaged in UVRB ([arXiv 2510.27571](https://arxiv.org/abs/2510.27571)): the query is a short clip, the corpus contains long videos re-encoded to 360p; 120 corpus videos sampled with a fixed seed from 467, with all clip queries whose target is in the sample. Data at [dukesun99/LoVR-C2V](https://huggingface.co/datasets/dukesun99/LoVR-C2V).

Dataset checklist:
- [x] Fills an existing gap: purely visual video-to-video retrieval
- [x] Tested that the dataset runs with the mteb package
- [x] `mteb/baseline-random-encoder`: 0.0351 nDCG@10
- [x] Real model — Qwen/Qwen3-VL-Embedding-2B: 0.8137 nDCG@10
- [x] Downsampled from the 97 GB release to evaluation scale
- [x] Paper-score reproduction: N/A — UVRB reports LoVR-C2V on the full 467-video corpus; ours is a seeded 120-video subsample