### PR TITLE
Leaderboard: Add MTEB(por, v1) to homepage language specific.

### DIFF
--- a/mteb/benchmarks/_leaderboard_menu.py
+++ b/mteb/benchmarks/_leaderboard_menu.py
@@ -212,6 +212,7 @@ HOME_BENCHMARK_ENTRIES = [
                 "MTEB(fas, v2)",
                 "VN-MTEB (vie, v1)",
                 "MTEB(spa, v1)",
+                "MTEB(por, v1)",
             ]
         ),
     ),


### PR DESCRIPTION
Complement to #4938.
