### PR TITLE
Add new version for LCO-3B

### DIFF
--- a/mteb/models/model_implementations/lco_embedding_models.py
+++ b/mteb/models/model_implementations/lco_embedding_models.py
@@ -207,6 +207,41 @@ lco_3b = ModelMeta(
 }""",
 )
 
+lco_3b_2605 = ModelMeta(
+    loader=LCOEmbedding,
+    name="LCO-Embedding/LCO-Embedding-Omni-3B-2605",
+    languages=["eng-Latn"],
+    open_weights=True,
+    revision="93aadb155d07c16018cc241efe03e4c278e6001c",
+    release_date="2026-05-13",
+    max_tokens=32768,
+    n_parameters=4_703_464_448,
+    n_embedding_parameters=311164928,
+    memory_usage_mb=8978,
+    embed_dim=2048,
+    license="apache-2.0",
+    reference="https://huggingface.co/LCO-Embedding/LCO-Embedding-Omni-3B-2605",
+    similarity_fn_name="cosine",
+    framework=["PyTorch"],
+    use_instructions=True,
+    public_training_code=None,
+    public_training_data=None,
+    training_datasets=set(
+        # SeaDoc (not in MTEB)
+    ),
+    modalities=["audio", "image", "text", "video"],
+    citation="""
+@misc{xiao2025scalinglanguagecentricomnimodalrepresentation,
+  title={Scaling Language-Centric Omnimodal Representation Learning},
+  author={Chenghao Xiao and Hou Pong Chan and Hao Zhang and Weiwen Xu and Mahani Aljunied and Yu Rong},
+  year={2025},
+  eprint={2510.11693},
+  archivePrefix={arXiv},
+  primaryClass={cs.CL},
+  url={https://arxiv.org/abs/2510.11693},
+}""",
+)
+
 lco_7b = ModelMeta(
     loader=LCOEmbedding,
     name="LCO-Embedding/LCO-Embedding-Omni-7B",


### PR DESCRIPTION
Add new version for LCO-3B model. This version release on May 2025 and has shown better performance compared to it's predecessors.

- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [ ] **NA** I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e., is available either as an API or the weights are publicly available to download
- [] **NA** I reproduced results from the original paper (if applicable) on at least one benchmark, and I am including the results in the PR description.

Why not reproducing the results?
* Numbers are only reported at higher level: MTEB, MIEB, and MAEB and not per dataset.
* As mentioned in [the HF ](https://huggingface.co/LCO-Embedding/LCO-Embedding-Omni-3B-2605), everything is the same and changing the model name is sufficient.

Fixes: https://github.com/embeddings-benchmark/mteb/issues/4956