### PR TITLE
[MOEB] Add AESDD dataset

### DIFF
--- a/mteb/descriptive_stats/AudioClassification/AESDD.json
+++ b/mteb/descriptive_stats/AudioClassification/AESDD.json
@@ -1,0 +1,43 @@
+{
+    "train": {
+        "num_samples": 604,
+        "samples_in_train": null,
+        "text_statistics": null,
+        "image_statistics": null,
+        "audio_statistics": {
+            "total_duration_seconds": 2478.9245578231294,
+            "min_duration_seconds": 0.9811791383219954,
+            "average_duration_seconds": 4.104179731495248,
+            "max_duration_seconds": 12.734852607709751,
+            "unique_audios": 604,
+            "average_sampling_rate": 44100.0,
+            "sampling_rates": {
+                "44100": 604
+            }
+        },
+        "video_statistics": null,
+        "label_statistics": {
+            "min_labels_per_text": 1,
+            "average_label_per_text": 1.0,
+            "max_labels_per_text": 1,
+            "unique_labels": 5,
+            "labels": {
+                "0": {
+                    "count": 121
+                },
+                "1": {
+                    "count": 122
+                },
+                "2": {
+                    "count": 120
+                },
+                "3": {
+                    "count": 119
+                },
+                "4": {
+                    "count": 122
+                }
+            }
+        }
+    }
+}

--- a/mteb/tasks/classification/ell/__init__.py
+++ b/mteb/tasks/classification/ell/__init__.py
@@ -1,3 +1,4 @@
+from .aesdd import AESDD
 from .greek_legal_code_classification import GreekLegalCodeClassification
 
-__all__ = ["GreekLegalCodeClassification"]
+__all__ = ["AESDD", "GreekLegalCodeClassification"]

--- a/mteb/tasks/classification/ell/aesdd.py
+++ b/mteb/tasks/classification/ell/aesdd.py
@@ -1,10 +1,5 @@
-from typing import Any
-
 from mteb.abstasks.classification import AbsTaskClassification
 from mteb.abstasks.task_metadata import TaskMetadata
-
-# Corrupt/truncated WAV in the HF snapshot (no RIFF data chunk).
-_CORRUPTED_AUDIO_FILENAME = "s05 (3).wav"
 
 
 class AESDD(AbsTaskClassification):
@@ -13,8 +8,8 @@ class AESDD(AbsTaskClassification):
         description="Acted Emotional Speech Dynamic Database (AESDD): emotion classification of acted Greek speech into one of 5 classes: anger, disgust, fear, happiness, and sadness.",
         reference="https://m3c.web.auth.gr/research/aesdd-speech-emotion-recognition/",
         dataset={
-            "path": "mteb/AESDD",
-            "revision": "2ab5cc0f7126088d11d1752747cdd1d7f74625c6",
+            "path": "mteb/AESDD-fixed",
+            "revision": "2bfe310368859dadb0dbbcc8874135f817f469df",
         },
         type="AudioClassification",
         category="a2c",
@@ -47,21 +42,3 @@ class AESDD(AbsTaskClassification):
     label_column_name: str = "label"
 
     is_cross_validation: bool = True
-
-    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
-        """Drop the one corrupt WAV that cannot be decoded."""
-        from datasets import Audio
-
-        for split in self.dataset:
-            split_ds = self.dataset[split].cast_column(
-                self.input_column_name, Audio(decode=False)
-            )
-            split_ds = split_ds.filter(
-                lambda example, bad=_CORRUPTED_AUDIO_FILENAME: not example[
-                    self.input_column_name
-                ]["path"].endswith(bad),
-                num_proc=num_proc,
-            )
-            self.dataset[split] = split_ds.cast_column(
-                self.input_column_name, Audio(decode=True)
-            )

--- a/mteb/tasks/classification/ell/aesdd.py
+++ b/mteb/tasks/classification/ell/aesdd.py
@@ -1,5 +1,10 @@
+from typing import Any
+
 from mteb.abstasks.classification import AbsTaskClassification
 from mteb.abstasks.task_metadata import TaskMetadata
+
+# Corrupt/truncated WAV in the HF snapshot (no RIFF data chunk).
+_CORRUPTED_AUDIO_FILENAME = "s05 (3).wav"
 
 
 class AESDD(AbsTaskClassification):
@@ -42,3 +47,21 @@ class AESDD(AbsTaskClassification):
     label_column_name: str = "label"
 
     is_cross_validation: bool = True
+
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
+        """Drop the one corrupt WAV that cannot be decoded."""
+        from datasets import Audio
+
+        for split in self.dataset:
+            split_ds = self.dataset[split].cast_column(
+                self.input_column_name, Audio(decode=False)
+            )
+            split_ds = split_ds.filter(
+                lambda example, bad=_CORRUPTED_AUDIO_FILENAME: not example[
+                    self.input_column_name
+                ]["path"].endswith(bad),
+                num_proc=num_proc,
+            )
+            self.dataset[split] = split_ds.cast_column(
+                self.input_column_name, Audio(decode=True)
+            )

--- a/mteb/tasks/classification/ell/aesdd.py
+++ b/mteb/tasks/classification/ell/aesdd.py
@@ -1,0 +1,44 @@
+from mteb.abstasks.classification import AbsTaskClassification
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class AESDD(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="AESDD",
+        description="Acted Emotional Speech Dynamic Database (AESDD): emotion classification of acted Greek speech into one of 5 classes: anger, disgust, fear, happiness, and sadness.",
+        reference="https://m3c.web.auth.gr/research/aesdd-speech-emotion-recognition/",
+        dataset={
+            "path": "mteb/AESDD",
+            "revision": "2ab5cc0f7126088d11d1752747cdd1d7f74625c6",
+        },
+        type="AudioClassification",
+        category="a2c",
+        eval_splits=["train"],
+        eval_langs=["ell-Grek"],
+        main_score="accuracy",
+        date=("2017-10-01", "2017-10-31"),
+        domains=["Speech"],
+        task_subtypes=["Emotion classification"],
+        license="not specified",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        modalities=["audio"],
+        sample_creation="created",
+        bibtex_citation=r"""
+@article{vryzas2018speech,
+  author = {Vryzas, Nikolaos and Kotsakis, Rigas and Liatsou, Aikaterini and Dimoulas, Charalampos A and Kalliris, George},
+  journal = {Journal of the Audio Engineering Society},
+  number = {6},
+  pages = {457--467},
+  publisher = {Audio Engineering Society},
+  title = {Speech emotion recognition for performance interaction},
+  volume = {66},
+  year = {2018},
+}
+""",
+    )
+
+    input_column_name: str = "audio"
+    label_column_name: str = "label"
+
+    is_cross_validation: bool = True


### PR DESCRIPTION
- [x] I have outlined why this dataset is filling an existing gap in the MOEB benchmark
- [x] I have tested that the dataset runs with the `mteb` package.
- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
  - [x] `openai/whisper-tiny`
  - [x] `google/vggish`
  - [x] `mteb/baseline-random-encoder`
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [x] I have considered the size of the dataset and reduced it if it is too big (2048 examples is typically large enough for most tasks)

Results on tested models:
```
metric                 random   whisper-tiny         vggish
accuracy              0.21349        0.39076        0.44550
f1                    0.20830        0.38710        0.41320
f1_weighted           0.20949        0.39006        0.41933
precision             0.21016        0.40125        0.42021
precision_weighted      0.21346        0.40425        0.42729
recall                0.21415        0.38891        0.43898
recall_weighted       0.21349        0.39076        0.44550
```

Note: one corrupted file in the full dataset, filtering out in the transform method