### PR TITLE
Fix JinaV4Wrapper crashes and missing PairClassification prompt mapping

### DIFF
--- a/mteb/models/model_implementations/jina_models.py
+++ b/mteb/models/model_implementations/jina_models.py
@@ -484,13 +484,25 @@ class JinaV4Wrapper(AbsEncoder):
                 raise ValueError(
                     "The number of texts and images must have the same length"
                 )
-            fused_embeddings = text_embeddings + image_embeddings
-            return fused_embeddings
+            embeddings = text_embeddings + image_embeddings
         elif text_embeddings is not None:
-            return text_embeddings
+            embeddings = text_embeddings
         elif image_embeddings is not None:
-            return image_embeddings
-        raise ValueError
+            embeddings = image_embeddings
+        else:
+            raise ValueError
+
+        if isinstance(embeddings, torch.Tensor):
+            embeddings = embeddings.cpu().detach().float().numpy()
+        elif (
+            isinstance(embeddings, (list, tuple))
+            and embeddings
+            and isinstance(embeddings[0], torch.Tensor)
+        ):
+            embeddings = np.stack(
+                [e.cpu().detach().float().numpy() for e in embeddings]
+            )
+        return embeddings
 
     def get_text_embeddings(
         self,
@@ -519,7 +531,7 @@ class JinaV4Wrapper(AbsEncoder):
             task_metadata, prompt_type
         )
 
-        if task_type.startswith("DocumentUnderstanding"):
+        if task_type and task_type.startswith("DocumentUnderstanding"):
             self.vector_type = "multi_vector"
         else:
             self.vector_type = "single_vector"
@@ -549,7 +561,7 @@ class JinaV4Wrapper(AbsEncoder):
             task_metadata, prompt_type
         )
 
-        if task_type.startswith("DocumentUnderstanding"):
+        if task_type and task_type.startswith("DocumentUnderstanding"):
             self.vector_type = "multi_vector"
         else:
             self.vector_type = "single_vector"
@@ -1161,6 +1173,7 @@ jina_embeddings_v4 = ModelMeta(
             "Retrieval-query": "retrieval.query",
             "Retrieval-document": "retrieval.passage",
             "STS": "text-matching",
+            "PairClassification": "text-matching",
             "DocumentUnderstanding": "retrieval.query",
         },
     ),


### PR DESCRIPTION
This pull request resolves the following issues with JinaV4Wrapper in PairClassification tasks:

- Added `None` guard to `get_text_embeddings/get_image_embeddings` to handle scenarios where `get_prompt_name` returns `None`.
- Updated `jina_embeddings_v4`'s `model_prompts` to include a `PairClassification` entry, correctly mapping it to the text-matching adapter.
- Modified `JinaV4Wrapper.encode()` to return numpy arrays instead of raw GPU tensors, ensuring compatibility with downstream evaluators.