### PR TITLE
[MOEB] Add VELOCITI video pair classification task (#4980)

### DIFF
--- a/mteb/descriptive_stats/VideoPairClassification/VELOCITIPairClassification.json
+++ b/mteb/descriptive_stats/VideoPairClassification/VELOCITIPairClassification.json
@@ -1,0 +1,68 @@
+{
+    "test": {
+        "num_samples": 17584,
+        "unique_pairs": 11670,
+        "number_of_characters": null,
+        "text1_statistics": null,
+        "image1_statistics": null,
+        "audio1_statistics": null,
+        "video1_statistics": {
+            "total_duration_seconds": 176015.808,
+            "total_frames": 4220160,
+            "min_width": 1070,
+            "average_width": 1278.7340764331211,
+            "max_width": 1280,
+            "min_height": 720,
+            "average_height": 720.0,
+            "max_height": 720,
+            "min_duration_seconds": 10,
+            "average_duration_seconds": 10.009998180163784,
+            "max_duration_seconds": 10.010666666666667,
+            "unique_videos": 864,
+            "average_fps": 24.0,
+            "fps": {
+                "24": 17584
+            },
+            "min_resolution": [
+                1070,
+                720
+            ],
+            "average_resolution": [
+                1278.7340764331211,
+                720.0
+            ],
+            "max_resolution": [
+                1280,
+                720
+            ],
+            "resolutions": {
+                "1280x720": 17478,
+                "1070x720": 106
+            }
+        },
+        "text2_statistics": {
+            "total_text_length": 1620508,
+            "min_text_length": 29,
+            "average_text_length": 92.1580982711556,
+            "max_text_length": 345,
+            "unique_texts": 10118
+        },
+        "image2_statistics": null,
+        "audio2_statistics": null,
+        "video2_statistics": null,
+        "labels_statistics": {
+            "min_labels_per_text": 1,
+            "average_label_per_text": 1.0,
+            "max_labels_per_text": 1,
+            "unique_labels": 2,
+            "labels": {
+                "1": {
+                    "count": 8792
+                },
+                "0": {
+                    "count": 8792
+                }
+            }
+        }
+    }
+}

--- a/mteb/descriptive_stats/VideoPairClassification/VELOCITIPairClassification.json
+++ b/mteb/descriptive_stats/VideoPairClassification/VELOCITIPairClassification.json
@@ -1,34 +1,34 @@
 {
     "test": {
-        "num_samples": 17584,
-        "unique_pairs": 11670,
+        "num_samples": 11669,
+        "unique_pairs": 11669,
         "number_of_characters": null,
         "text1_statistics": null,
         "image1_statistics": null,
         "audio1_statistics": null,
         "video1_statistics": {
-            "total_duration_seconds": 176015.808,
-            "total_frames": 4220160,
+            "total_duration_seconds": 116806.67599999999,
+            "total_frames": 2800560,
             "min_width": 1070,
-            "average_width": 1278.7340764331211,
+            "average_width": 1278.650269946011,
             "max_width": 1280,
             "min_height": 720,
             "average_height": 720.0,
             "max_height": 720,
             "min_duration_seconds": 10,
-            "average_duration_seconds": 10.009998180163784,
+            "average_duration_seconds": 10.009998800239952,
             "max_duration_seconds": 10.010666666666667,
             "unique_videos": 864,
             "average_fps": 24.0,
             "fps": {
-                "24": 17584
+                "24": 11669
             },
             "min_resolution": [
                 1070,
                 720
             ],
             "average_resolution": [
-                1278.7340764331211,
+                1278.650269946011,
                 720.0
             ],
             "max_resolution": [
@@ -36,14 +36,14 @@
                 720
             ],
             "resolutions": {
-                "1280x720": 17478,
-                "1070x720": 106
+                "1280x720": 11594,
+                "1070x720": 75
             }
         },
         "text2_statistics": {
-            "total_text_length": 1620508,
+            "total_text_length": 1154947,
             "min_text_length": 29,
-            "average_text_length": 92.1580982711556,
+            "average_text_length": 98.97566201045505,
             "max_text_length": 345,
             "unique_texts": 10118
         },
@@ -57,10 +57,10 @@
             "unique_labels": 2,
             "labels": {
                 "1": {
-                    "count": 8792
+                    "count": 4206
                 },
                 "0": {
-                    "count": 8792
+                    "count": 7463
                 }
             }
         }

--- a/mteb/tasks/pair_classification/eng/__init__.py
+++ b/mteb/tasks/pair_classification/eng/__init__.py
@@ -29,6 +29,7 @@ from .ravdess_av_pc import (
 from .sprint_duplicate_questions_pc import SprintDuplicateQuestionsPC
 from .twitter_sem_eval2015_pc import TwitterSemEval2015PC
 from .twitter_url_corpus_pc import TwitterURLCorpus
+from .velociti import VELOCITIPairClassification
 from .videocon_pc import VideoConPairClassification
 from .vinoground_pc import VinogroundPairClassification
 from .vocal_sound import VocalSoundPairClassification
@@ -56,6 +57,7 @@ __all__ = [
     "SprintDuplicateQuestionsPC",
     "TwitterSemEval2015PC",
     "TwitterURLCorpus",
+    "VELOCITIPairClassification",
     "VideoConPairClassification",
     "VinogroundPairClassification",
     "VocalSoundPairClassification",

--- a/mteb/tasks/pair_classification/eng/velociti.py
+++ b/mteb/tasks/pair_classification/eng/velociti.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from mteb.abstasks import AbsTaskPairClassification
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class VELOCITIPairClassification(AbsTaskPairClassification):
+    metadata = TaskMetadata(
+        name="VELOCITIPairClassification",
+        description=(
+            "Pair classification on VELOCITI: determining whether a text caption "
+            "correctly entails the events in a video or is a compositional negative "
+            "constructed via in-video negation (swapping agents/actions occurring in "
+            "the same video) or text-inspired negation (LLM-generated contradictions). "
+            "Tests fine-grained video-language compositional binding of agents to actions "
+            "across events."
+        ),
+        reference="https://arxiv.org/abs/2406.10889",
+        dataset={
+            "path": "yaswanth169/VELOCITI-PC",
+            "revision": "509144fa4727a3f9b92602d491725154c32a958f",
+        },
+        type="VideoPairClassification",
+        category="v2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="max_ap",
+        date=("2024-06-16", "2024-06-16"),
+        domains=["Activity", "Web"],
+        task_subtypes=["Caption Pairing"],
+        license="cc-by-nc-sa-4.0",
+        annotations_creators="LM-generated and reviewed",
+        dialect=[],
+        modalities=["video", "text"],
+        sample_creation="LM-generated and verified",
+        is_beta=True,
+        bibtex_citation=r"""
+@inproceedings{saravanan2025velociti,
+  author = {Saravanan, Darshana and Gupta, Varun and Singh, Darshan and Khan, Zeeshan and Gandhi, Vineet and Tapaswi, Makarand},
+  booktitle = {Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition},
+  title = {VELOCITI: Benchmarking Video-Language Compositional Reasoning with Strict Entailment},
+  year = {2025},
+}
+""",
+    )
+
+    input1_column_name = {"video": "video"}
+    input2_column_name = {"text": "text"}
+    label_column_name: str = "label"

--- a/mteb/tasks/pair_classification/eng/velociti.py
+++ b/mteb/tasks/pair_classification/eng/velociti.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, ClassVar
+
 from mteb.abstasks import AbsTaskPairClassification
 from mteb.abstasks.task_metadata import TaskMetadata
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 
 class VELOCITIPairClassification(AbsTaskPairClassification):
@@ -44,6 +49,6 @@ class VELOCITIPairClassification(AbsTaskPairClassification):
 """,
     )
 
-    input1_column_name = {"video": "video"}
-    input2_column_name = {"text": "text"}
+    input1_column_name: ClassVar[Mapping[str, str]] = {"video": "video"}
+    input2_column_name: ClassVar[Mapping[str, str]] = {"text": "text"}
     label_column_name: str = "label"

--- a/mteb/tasks/pair_classification/eng/velociti.py
+++ b/mteb/tasks/pair_classification/eng/velociti.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
+import tempfile
+import zipfile
+from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
+
+from datasets import Dataset, load_dataset
+from huggingface_hub import hf_hub_download
 
 from mteb.abstasks import AbsTaskPairClassification
 from mteb.abstasks.task_metadata import TaskMetadata
@@ -8,22 +14,25 @@ from mteb.abstasks.task_metadata import TaskMetadata
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
+_CACHE_DIR = Path(tempfile.gettempdir()) / "mteb_velociti_pairclassification_cache"
+
 
 class VELOCITIPairClassification(AbsTaskPairClassification):
     metadata = TaskMetadata(
         name="VELOCITIPairClassification",
         description=(
-            "Pair classification on VELOCITI: determining whether a text caption "
-            "correctly entails the events in a video or is a compositional negative "
-            "constructed via in-video negation (swapping agents/actions occurring in "
-            "the same video) or text-inspired negation (LLM-generated contradictions). "
-            "Tests fine-grained video-language compositional binding of agents to actions "
-            "across events."
+            "Tests whether a model correctly binds actions to the agents performing "
+            "them across a video, by pairing each video with a correct caption and a "
+            "subtly wrong one and measuring how well embedding similarity separates "
+            "the two. Negatives are constructed via in-video negation (swapping "
+            "agents/actions that both occur in the same video) or text-inspired "
+            "negation (LLM-generated contradictions), forming a strict entailment "
+            "test rather than a coarse mismatch. From the VELOCITI benchmark."
         ),
         reference="https://arxiv.org/abs/2406.10889",
         dataset={
             "path": "yaswanth169/VELOCITI-PC",
-            "revision": "509144fa4727a3f9b92602d491725154c32a958f",
+            "revision": "cab7ae8f379937ee687375fb23aac3ffe1039802",
         },
         type="VideoPairClassification",
         category="v2t",
@@ -52,3 +61,42 @@ class VELOCITIPairClassification(AbsTaskPairClassification):
     input1_column_name: ClassVar[Mapping[str, str]] = {"video": "video"}
     input2_column_name: ClassVar[Mapping[str, str]] = {"text": "text"}
     label_column_name: str = "label"
+
+    def load_data(self, **kwargs) -> None:
+        if self.data_loaded:
+            return
+        # Imported lazily: datasets.Video requires the optional torchcodec
+        # backend, and importing it at module level would break importing
+        # this task (and thus the whole mteb.tasks package) without it.
+        from datasets import Features, Value, Video
+
+        raw = load_dataset(
+            self.metadata.dataset["path"],
+            revision=self.metadata.dataset["revision"],
+            split="test",
+        )
+
+        zip_path = hf_hub_download(
+            repo_id=self.metadata.dataset["path"],
+            filename="videos.zip",
+            repo_type="dataset",
+            revision=self.metadata.dataset["revision"],
+        )
+        if not _CACHE_DIR.exists():
+            _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+            with zipfile.ZipFile(zip_path) as zf:
+                zf.extractall(_CACHE_DIR)
+
+        features = Features(
+            {"video": Video(), "text": Value("string"), "label": Value("int64")}
+        )
+        records = [
+            {
+                "video": {"path": str(_CACHE_DIR / row["video_id"]), "bytes": None},
+                "text": row["text"],
+                "label": row["label"],
+            }
+            for row in raw
+        ]
+        self.dataset = {"test": Dataset.from_list(records, features=features)}
+        self.data_loaded = True

--- a/mteb/tasks/pair_classification/eng/velociti.py
+++ b/mteb/tasks/pair_classification/eng/velociti.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar
 
-from datasets import concatenate_datasets, load_dataset
+import pandas as pd
+from datasets import Dataset, concatenate_datasets, load_dataset
+from huggingface_hub import hf_hub_download
 
 from mteb.abstasks import AbsTaskPairClassification
 from mteb.abstasks.task_metadata import TaskMetadata
@@ -63,12 +65,20 @@ class VELOCITIPairClassification(AbsTaskPairClassification):
         revision = self.metadata.dataset["revision"]
 
         # (video_id, text, label), 17,584 rows -- one per pos/neg caption.
-        # force_redownload: this small table is occasionally re-pushed under the
-        # same file path with different content (e.g. dedup fixes), and datasets'
-        # local cache can otherwise silently keep serving an older snapshot.
-        raw = load_dataset(
-            path, revision=revision, split="test", download_mode="force_redownload"
+        # Downloaded directly rather than via load_dataset: this small table
+        # is occasionally re-pushed under the same file path with different
+        # content (e.g. dedup fixes), and datasets' Arrow-cache build for it
+        # isn't safe under CI's parallel test workers (pytest-xdist) sharing
+        # one HF cache dir -- a concurrent load from another worker can race
+        # the rebuild. hf_hub_download is a single atomic, revision-pinned
+        # file fetch with no cache-build step to race.
+        parquet_path = hf_hub_download(
+            repo_id=path,
+            filename="data/test-00000-of-00001.parquet",
+            repo_type="dataset",
+            revision=revision,
         )
+        raw = Dataset.from_pandas(pd.read_parquet(parquet_path), preserve_index=False)
         # (video_id, video), 864 unique rows -- no per-row video duplication.
         videos_ds = load_dataset(path, "videos", revision=revision, split="test")
 

--- a/mteb/tasks/pair_classification/eng/velociti.py
+++ b/mteb/tasks/pair_classification/eng/velociti.py
@@ -26,7 +26,7 @@ class VELOCITIPairClassification(AbsTaskPairClassification):
         reference="https://arxiv.org/abs/2406.10889",
         dataset={
             "path": "yaswanth169/VELOCITI-PC",
-            "revision": "820ccb697f5312dbeb4057e3c6626d77577011c2",
+            "revision": "dfbe014eacf4507cb0fad6a66497f43d30ce8044",
         },
         type="VideoPairClassification",
         category="v2t",

--- a/mteb/tasks/pair_classification/eng/velociti.py
+++ b/mteb/tasks/pair_classification/eng/velociti.py
@@ -63,7 +63,12 @@ class VELOCITIPairClassification(AbsTaskPairClassification):
         revision = self.metadata.dataset["revision"]
 
         # (video_id, text, label), 17,584 rows -- one per pos/neg caption.
-        raw = load_dataset(path, revision=revision, split="test")
+        # force_redownload: this small table is occasionally re-pushed under the
+        # same file path with different content (e.g. dedup fixes), and datasets'
+        # local cache can otherwise silently keep serving an older snapshot.
+        raw = load_dataset(
+            path, revision=revision, split="test", download_mode="force_redownload"
+        )
         # (video_id, video), 864 unique rows -- no per-row video duplication.
         videos_ds = load_dataset(path, "videos", revision=revision, split="test")
 

--- a/mteb/tasks/pair_classification/eng/velociti.py
+++ b/mteb/tasks/pair_classification/eng/velociti.py
@@ -1,20 +1,14 @@
 from __future__ import annotations
 
-import tempfile
-import zipfile
-from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 
-from datasets import Dataset, load_dataset
-from huggingface_hub import hf_hub_download
+from datasets import concatenate_datasets, load_dataset
 
 from mteb.abstasks import AbsTaskPairClassification
 from mteb.abstasks.task_metadata import TaskMetadata
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
-
-_CACHE_DIR = Path(tempfile.gettempdir()) / "mteb_velociti_pairclassification_cache"
 
 
 class VELOCITIPairClassification(AbsTaskPairClassification):
@@ -32,7 +26,7 @@ class VELOCITIPairClassification(AbsTaskPairClassification):
         reference="https://arxiv.org/abs/2406.10889",
         dataset={
             "path": "yaswanth169/VELOCITI-PC",
-            "revision": "cab7ae8f379937ee687375fb23aac3ffe1039802",
+            "revision": "820ccb697f5312dbeb4057e3c6626d77577011c2",
         },
         type="VideoPairClassification",
         category="v2t",
@@ -65,38 +59,17 @@ class VELOCITIPairClassification(AbsTaskPairClassification):
     def load_data(self, **kwargs) -> None:
         if self.data_loaded:
             return
-        # Imported lazily: datasets.Video requires the optional torchcodec
-        # backend, and importing it at module level would break importing
-        # this task (and thus the whole mteb.tasks package) without it.
-        from datasets import Features, Value, Video
+        path = self.metadata.dataset["path"]
+        revision = self.metadata.dataset["revision"]
 
-        raw = load_dataset(
-            self.metadata.dataset["path"],
-            revision=self.metadata.dataset["revision"],
-            split="test",
-        )
+        # (video_id, text, label), 17,584 rows -- one per pos/neg caption.
+        raw = load_dataset(path, revision=revision, split="test")
+        # (video_id, video), 864 unique rows -- no per-row video duplication.
+        videos_ds = load_dataset(path, "videos", revision=revision, split="test")
 
-        zip_path = hf_hub_download(
-            repo_id=self.metadata.dataset["path"],
-            filename="videos.zip",
-            repo_type="dataset",
-            revision=self.metadata.dataset["revision"],
-        )
-        if not _CACHE_DIR.exists():
-            _CACHE_DIR.mkdir(parents=True, exist_ok=True)
-            with zipfile.ZipFile(zip_path) as zf:
-                zf.extractall(_CACHE_DIR)
+        video_id_to_idx = {vid: i for i, vid in enumerate(videos_ds["video_id"])}
+        aligned_indices = [video_id_to_idx[vid] for vid in raw["video_id"]]
+        aligned_videos = videos_ds.select(aligned_indices).select_columns(["video"])
 
-        features = Features(
-            {"video": Video(), "text": Value("string"), "label": Value("int64")}
-        )
-        records = [
-            {
-                "video": {"path": str(_CACHE_DIR / row["video_id"]), "bytes": None},
-                "text": row["text"],
-                "label": row["label"],
-            }
-            for row in raw
-        ]
-        self.dataset = {"test": Dataset.from_list(records, features=features)}
+        self.dataset = {"test": concatenate_datasets([raw, aligned_videos], axis=1)}
         self.data_loaded = True

--- a/mteb/tasks/pair_classification/eng/velociti.py
+++ b/mteb/tasks/pair_classification/eng/velociti.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar
 
-import pandas as pd
-from datasets import Dataset, concatenate_datasets, load_dataset
-from huggingface_hub import hf_hub_download
+from datasets import concatenate_datasets, load_dataset
 
 from mteb.abstasks import AbsTaskPairClassification
 from mteb.abstasks.task_metadata import TaskMetadata
@@ -64,21 +62,8 @@ class VELOCITIPairClassification(AbsTaskPairClassification):
         path = self.metadata.dataset["path"]
         revision = self.metadata.dataset["revision"]
 
-        # (video_id, text, label), 17,584 rows -- one per pos/neg caption.
-        # Downloaded directly rather than via load_dataset: this small table
-        # is occasionally re-pushed under the same file path with different
-        # content (e.g. dedup fixes), and datasets' Arrow-cache build for it
-        # isn't safe under CI's parallel test workers (pytest-xdist) sharing
-        # one HF cache dir -- a concurrent load from another worker can race
-        # the rebuild. hf_hub_download is a single atomic, revision-pinned
-        # file fetch with no cache-build step to race.
-        parquet_path = hf_hub_download(
-            repo_id=path,
-            filename="data/test-00000-of-00001.parquet",
-            repo_type="dataset",
-            revision=revision,
-        )
-        raw = Dataset.from_pandas(pd.read_parquet(parquet_path), preserve_index=False)
+        # (video_id, text, label), 11,669 rows -- one per pos/neg caption.
+        raw = load_dataset(path, revision=revision, split="test")
         # (video_id, video), 864 unique rows -- no per-row video duplication.
         videos_ds = load_dataset(path, "videos", revision=revision, split="test")
 


### PR DESCRIPTION
Add VELOCITIPairClassification (v2t) for the VELOCITI benchmark (CVPR 2025) — filling the "video pair classification" gap under MOEB Track 1 (#4842).

VELOCITI tests fine-grained compositional binding of agents to actions across events in a video, via two negative-caption strategies: in-video negation (swap agents/actions occurring in the same video) and text-inspired negation (LLM-generated contradictions).

The raw dataset (katha-ai-iiith/VELOCITI, gated) is not in a directly usable shape for AbsTaskPairClassification — it stores (video_id, pos, neg) per row rather than (video, text, label). I reshaped it into 17,584 rows (video, text, label), one row per pos/neg caption per original example, and repackaged it to yaswanth169/VELOCITI-PC.

Baseline (mteb/baseline-random-encoder) results attached — max_ap 0.504, max_accuracy 0.512, both at chance level as expected for a random encoder on a balanced binary task.

Closes #4980