### PR TITLE
task: add CASTELLA audio moment retrieval (t2a)

### DIFF
--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/CASTELLAAMRRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/CASTELLAAMRRetrieval.json
@@ -1,20 +1,20 @@
 {
     "test": {
-        "num_samples": 13393,
+        "num_samples": 1913,
         "num_queries": 1347,
-        "num_documents": 12046,
+        "num_documents": 566,
         "number_of_characters": 45808,
         "documents_text_statistics": null,
         "documents_image_statistics": null,
         "documents_audio_statistics": {
-            "total_duration_seconds": 119395.77224489796,
-            "min_duration_seconds": 2.0051020408163267,
-            "average_duration_seconds": 9.911653017175658,
-            "max_duration_seconds": 10.0,
-            "unique_audios": 11963,
-            "average_sampling_rate": 44100.0,
+            "total_duration_seconds": 119459.88737499999,
+            "min_duration_seconds": 59.9539375,
+            "average_duration_seconds": 211.05987168727913,
+            "max_duration_seconds": 300.00184375,
+            "unique_audios": 566,
+            "average_sampling_rate": 32000.0,
             "sampling_rates": {
-                "44100": 12046
+                "32000": 566
             }
         },
         "documents_video_statistics": null,
@@ -29,11 +29,11 @@
         "queries_audio_statistics": null,
         "queries_video_statistics": null,
         "relevant_docs_statistics": {
-            "num_relevant_docs": 6530,
+            "num_relevant_docs": 1347,
             "min_relevant_docs_per_query": 1,
-            "average_relevant_docs_per_query": 4.8478099480326655,
-            "max_relevant_docs_per_query": 30,
-            "unique_relevant_docs": 5742
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 566
         },
         "top_ranked_statistics": null
     }

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/CASTELLAAMRRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/CASTELLAAMRRetrieval.json
@@ -1,0 +1,40 @@
+{
+    "test": {
+        "num_samples": 13393,
+        "num_queries": 1347,
+        "num_documents": 12046,
+        "number_of_characters": 45808,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": {
+            "total_duration_seconds": 119395.77224489796,
+            "min_duration_seconds": 2.0051020408163267,
+            "average_duration_seconds": 9.911653017175658,
+            "max_duration_seconds": 10.0,
+            "unique_audios": 11963,
+            "average_sampling_rate": 44100.0,
+            "sampling_rates": {
+                "44100": 12046
+            }
+        },
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 45808,
+            "min_text_length": 8,
+            "average_text_length": 34.00742390497402,
+            "max_text_length": 102,
+            "unique_texts": 1154
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 6530,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 4.8478099480326655,
+            "max_relevant_docs_per_query": 30,
+            "unique_relevant_docs": 5742
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -63,6 +63,7 @@ from .bright_v1_1_retrieval import (
 )
 from .browse_comp_plus_retrieval import BrowseCompPlusRetrieval
 from .built_bench_retrieval import BuiltBenchRetrieval
+from .castella_amr import CASTELLAAMRRetrieval
 from .chat_doctor_retrieval import ChatDoctorRetrieval
 from .chem_hotpot_qa_retrieval import ChemHotpotQARetrieval
 from .chem_nq_retrieval import ChemNQRetrieval
@@ -472,6 +473,7 @@ __all__ = [
     "BrightTheoremQATheoremsRetrieval",
     "BrowseCompPlusRetrieval",
     "BuiltBenchRetrieval",
+    "CASTELLAAMRRetrieval",
     "CIRRIT2IRetrieval",
     "CMUArcticA2TRetrieval",
     "CMUArcticT2ARetrieval",

--- a/mteb/tasks/retrieval/eng/castella_amr.py
+++ b/mteb/tasks/retrieval/eng/castella_amr.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class CASTELLAAMRRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="CASTELLAAMRRetrieval",
+        description=(
+            "Audio moment retrieval on CASTELLA, the human-annotated long-audio "
+            "benchmark used as the DCASE 2026 Task 6 evaluation set: given a "
+            "caption, retrieve the 10-second window of a long recording (1 to 5 "
+            "minutes) that contains the described moment. The corpus holds 12,046 "
+            "windows from 566 recordings; 1,347 caption queries with relevance "
+            "from at least 50 percent overlap between window and annotated "
+            "moment. First temporal-localization retrieval task in the audio "
+            "benchmark."
+        ),
+        reference="https://arxiv.org/abs/2511.15131",
+        dataset={
+            "path": "dukesun99/CASTELLA-AMR",
+            "revision": "6b2a9905a1d0e787e84f635f4f9408941a384883",
+        },
+        type="Any2AnyRetrieval",
+        category="t2a",
+        modalities=["text", "audio"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2025-01-01", "2025-11-01"),
+        domains=["AudioScene"],
+        task_subtypes=["Environment Sound Retrieval"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=r"""
+@misc{munakata2025castella,
+  archiveprefix = {arXiv},
+  author = {Hokuto Munakata and Takehiro Imamura and Taichi Nishimura and Tatsuya Komatsu},
+  eprint = {2511.15131},
+  primaryclass = {eess.AS},
+  title = {CASTELLA: Long Audio Dataset with Captions and Temporal Boundaries},
+  url = {https://arxiv.org/abs/2511.15131},
+  year = {2025},
+}
+""",
+        prompt={
+            "query": "Retrieve the audio segment during which the described moment occurs."
+        },
+    )

--- a/mteb/tasks/retrieval/eng/castella_amr.py
+++ b/mteb/tasks/retrieval/eng/castella_amr.py
@@ -8,19 +8,19 @@ class CASTELLAAMRRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="CASTELLAAMRRetrieval",
         description=(
-            "Audio moment retrieval on CASTELLA, the human-annotated long-audio "
-            "benchmark used as the DCASE 2026 Task 6 evaluation set: given a "
-            "caption, retrieve the 10-second window of a long recording (1 to 5 "
-            "minutes) that contains the described moment. The corpus holds 12,046 "
-            "windows from 566 recordings; 1,347 caption queries with relevance "
-            "from at least 50 percent overlap between window and annotated "
-            "moment. First temporal-localization retrieval task in the audio "
-            "benchmark."
+            "Retrieval on CASTELLA, the human-annotated long-audio benchmark used "
+            "as the DCASE 2026 Task 6 evaluation set: given a caption describing a "
+            "moment, retrieve the full recording (1 to 5 minutes) that contains it. "
+            "The corpus is the 566 complete recordings and there are 1,347 caption "
+            "queries, each with its source recording as the single relevant "
+            "document. Adapted from CASTELLA's audio moment localization task, "
+            "which regresses a continuous time interval, to whole-recording "
+            "retrieval for the mteb ranking format."
         ),
         reference="https://arxiv.org/abs/2511.15131",
         dataset={
             "path": "dukesun99/CASTELLA-AMR",
-            "revision": "6b2a9905a1d0e787e84f635f4f9408941a384883",
+            "revision": "083b2816174890f60f36fa9f145cfe79c2f94d0a",
         },
         type="Any2AnyRetrieval",
         category="t2a",
@@ -47,6 +47,6 @@ class CASTELLAAMRRetrieval(AbsTaskRetrieval):
 }
 """,
         prompt={
-            "query": "Retrieve the audio segment during which the described moment occurs."
+            "query": "Retrieve the recording that contains the described moment."
         },
     )

--- a/mteb/tasks/retrieval/eng/castella_amr.py
+++ b/mteb/tasks/retrieval/eng/castella_amr.py
@@ -46,7 +46,5 @@ class CASTELLAAMRRetrieval(AbsTaskRetrieval):
   year = {2025},
 }
 """,
-        prompt={
-            "query": "Retrieve the recording that contains the described moment."
-        },
+        prompt={"query": "Retrieve the recording that contains the described moment."},
     )


### PR DESCRIPTION
Part of the MOEB effort (#4842): first temporal-localization retrieval task family for the audio benchmark. 

Adds `CASTELLAAMRRetrieval` from CASTELLA ([arXiv 2511.15131](https://arxiv.org/abs/2511.15131)), the human-annotated long-audio benchmark used as the DCASE 2026 Task 6 evaluation set: given a caption describing a moment, retrieve the full 1–5 minute recording that contains it. Corpus is the 566 complete recordings (60–300s), 1,347 caption queries, each with its source recording as the single relevant document. Data at [dukesun99/CASTELLA-AMR](https://huggingface.co/datasets/dukesun99/CASTELLA-AMR).

Dataset checklist:
- [x] Fills an existing gap: CASTELLA is not in mteb
- [x] Tested that the dataset runs with the mteb package
- [x] `mteb/baseline-random-encoder`: 0.77 nDCG@10
- [x] Real model — laion/clap-htsat-fused: 9.67 nDCG@10 (R@10 18.1). 
- [x] Corpus at evaluation scale
- [x] Paper-score reproduction: not applicable by construction — see Reproduction below

**Reproduction.** Not applicable — different task type, not just a different setting. The paper measures Audio Moment Retrieval: a DETR-style model regresses a continuous `[start, end]` interval within a recording, scored by Recall@1 at IoU (R1@0.7). This task adapts it to whole-recording retrieval (which recording contains the described moment), which the paper does not measure — R1@IoU is a localization metric with no ranking analogue, so no mteb model+metric matches it. The data (recordings + captions) ports unchanged; only the framing (moment localization → recording retrieval) is the adaptation.