### PR TITLE
Cite the Fusion Embedding arXiv paper in both ModelMetas

### DIFF
--- a/mteb/models/model_implementations/fusion_embedding_models.py
+++ b/mteb/models/model_implementations/fusion_embedding_models.py
@@ -251,12 +251,11 @@ fusion_embedding_1_2b_preview = ModelMeta(
     },
     model_type=["dense"],
     citation="""
-@software{fusion_embedding_2026,
-  title  = {Fusion Embedding: A Unified Embedding Space for Text,
-            Image, Video, and Audio},
-  author = {Tonmoy, Abdul Basit},
-  year   = {2026},
-  url    = {https://github.com/Eximius-Labs/fusion-embedding}
+@article{tonmoy2026fusion,
+  title   = {Fusion Embedding: A Unified Embedding Space for Text, Image, Video, and Audio},
+  author  = {Tonmoy, Abdul Basit and Hoque, Kazi Fardinul and Arham, Md. Shahrier Islam and Luthra, Arman},
+  journal = {arXiv preprint arXiv:2607.18666},
+  year    = {2026}
 }
 """,
     extra_requirements_groups=["fusion-embedding"],
@@ -309,12 +308,11 @@ fusion_embedding_2_2b_preview = ModelMeta(
     },
     model_type=["dense"],
     citation="""
-@software{fusion_embedding_2026,
-  title  = {Fusion Embedding: A Unified Embedding Space for Text,
-            Image, Video, and Audio},
-  author = {Tonmoy, Abdul Basit},
-  year   = {2026},
-  url    = {https://github.com/Eximius-Labs/fusion-embedding}
+@article{tonmoy2026fusion,
+  title   = {Fusion Embedding: A Unified Embedding Space for Text, Image, Video, and Audio},
+  author  = {Tonmoy, Abdul Basit and Hoque, Kazi Fardinul and Arham, Md. Shahrier Islam and Luthra, Arman},
+  journal = {arXiv preprint arXiv:2607.18666},
+  year    = {2026}
 }
 """,
     extra_requirements_groups=["fusion-embedding"],


### PR DESCRIPTION
Updates the citation for both `fusion-embedding-1-2b-preview` and `fusion-embedding-2-2b-preview` ModelMetas now that the family's technical report is published on arXiv.

Both models point to the same paper (one report covers both generations), so both `citation` fields use the shared `@article{tonmoy2026fusion}` entry:

Fusion Embedding: A Unified Embedding Space for Text, Image, Video, and Audio — arXiv:2607.18666 (https://arxiv.org/abs/2607.18666).

Weights, revisions, and all other ModelMeta fields are unchanged. Local `tests/test_models/test_model_meta.py` (2280 passed) and the shared-key case of `tests/test_get_tasks.py::test_no_duplicate_citations_with_different_ids` pass — the two models sharing one citation key is correct here, since it is a single paper.
