### PR TITLE
task: add Song Describer text-music retrieval (t2a, a2t)

### DIFF
--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/SongDescriberA2TRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/SongDescriberA2TRetrieval.json
@@ -1,15 +1,15 @@
 {
     "test": {
-        "num_samples": 1293,
-        "num_queries": 547,
-        "num_documents": 746,
-        "number_of_characters": 74730,
+        "num_samples": 1812,
+        "num_queries": 706,
+        "num_documents": 1106,
+        "number_of_characters": 128815,
         "documents_text_statistics": {
-            "total_text_length": 74730,
+            "total_text_length": 128815,
             "min_text_length": 40,
-            "average_text_length": 100.17426273458445,
-            "max_text_length": 370,
-            "unique_texts": 746
+            "average_text_length": 116.46925858951175,
+            "max_text_length": 503,
+            "unique_texts": 1106
         },
         "documents_image_statistics": null,
         "documents_audio_statistics": null,
@@ -17,24 +17,24 @@
         "queries_text_statistics": null,
         "queries_image_statistics": null,
         "queries_audio_statistics": {
-            "total_duration_seconds": 64658.22884155328,
-            "min_duration_seconds": 33.89136054421769,
-            "average_duration_seconds": 118.20517155677017,
+            "total_duration_seconds": 83433.33318494898,
+            "min_duration_seconds": 31.077936507936506,
+            "average_duration_seconds": 118.1775257577181,
             "max_duration_seconds": 119.99453514739228,
-            "unique_audios": 547,
-            "average_sampling_rate": 44235.46617915905,
+            "unique_audios": 706,
+            "average_sampling_rate": 44232.57790368272,
             "sampling_rates": {
-                "48000": 19,
-                "44100": 528
+                "48000": 24,
+                "44100": 682
             }
         },
         "queries_video_statistics": null,
         "relevant_docs_statistics": {
-            "num_relevant_docs": 746,
+            "num_relevant_docs": 1106,
             "min_relevant_docs_per_query": 1,
-            "average_relevant_docs_per_query": 1.363802559414991,
+            "average_relevant_docs_per_query": 1.56657223796034,
             "max_relevant_docs_per_query": 5,
-            "unique_relevant_docs": 746
+            "unique_relevant_docs": 1106
         },
         "top_ranked_statistics": null
     }

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/SongDescriberA2TRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/SongDescriberA2TRetrieval.json
@@ -1,0 +1,41 @@
+{
+    "test": {
+        "num_samples": 1293,
+        "num_queries": 547,
+        "num_documents": 746,
+        "number_of_characters": 74730,
+        "documents_text_statistics": {
+            "total_text_length": 74730,
+            "min_text_length": 40,
+            "average_text_length": 100.17426273458445,
+            "max_text_length": 370,
+            "unique_texts": 746
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": null,
+        "queries_audio_statistics": {
+            "total_duration_seconds": 64658.22884155328,
+            "min_duration_seconds": 33.89136054421769,
+            "average_duration_seconds": 118.20517155677017,
+            "max_duration_seconds": 119.99453514739228,
+            "unique_audios": 547,
+            "average_sampling_rate": 44235.46617915905,
+            "sampling_rates": {
+                "48000": 19,
+                "44100": 528
+            }
+        },
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 746,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.363802559414991,
+            "max_relevant_docs_per_query": 5,
+            "unique_relevant_docs": 746
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/SongDescriberT2ARetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/SongDescriberT2ARetrieval.json
@@ -1,40 +1,40 @@
 {
     "test": {
-        "num_samples": 1293,
-        "num_queries": 746,
-        "num_documents": 547,
-        "number_of_characters": 74730,
+        "num_samples": 1812,
+        "num_queries": 1106,
+        "num_documents": 706,
+        "number_of_characters": 128815,
         "documents_text_statistics": null,
         "documents_image_statistics": null,
         "documents_audio_statistics": {
-            "total_duration_seconds": 64658.22884155328,
-            "min_duration_seconds": 33.89136054421769,
-            "average_duration_seconds": 118.20517155677017,
+            "total_duration_seconds": 83433.33318494898,
+            "min_duration_seconds": 31.077936507936506,
+            "average_duration_seconds": 118.1775257577181,
             "max_duration_seconds": 119.99453514739228,
-            "unique_audios": 547,
-            "average_sampling_rate": 44235.46617915905,
+            "unique_audios": 706,
+            "average_sampling_rate": 44232.57790368272,
             "sampling_rates": {
-                "48000": 19,
-                "44100": 528
+                "48000": 24,
+                "44100": 682
             }
         },
         "documents_video_statistics": null,
         "queries_text_statistics": {
-            "total_text_length": 74730,
+            "total_text_length": 128815,
             "min_text_length": 40,
-            "average_text_length": 100.17426273458445,
-            "max_text_length": 370,
-            "unique_texts": 746
+            "average_text_length": 116.46925858951175,
+            "max_text_length": 503,
+            "unique_texts": 1106
         },
         "queries_image_statistics": null,
         "queries_audio_statistics": null,
         "queries_video_statistics": null,
         "relevant_docs_statistics": {
-            "num_relevant_docs": 746,
+            "num_relevant_docs": 1106,
             "min_relevant_docs_per_query": 1,
             "average_relevant_docs_per_query": 1.0,
             "max_relevant_docs_per_query": 1,
-            "unique_relevant_docs": 547
+            "unique_relevant_docs": 706
         },
         "top_ranked_statistics": null
     }

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/SongDescriberT2ARetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/SongDescriberT2ARetrieval.json
@@ -1,0 +1,41 @@
+{
+    "test": {
+        "num_samples": 1293,
+        "num_queries": 746,
+        "num_documents": 547,
+        "number_of_characters": 74730,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": {
+            "total_duration_seconds": 64658.22884155328,
+            "min_duration_seconds": 33.89136054421769,
+            "average_duration_seconds": 118.20517155677017,
+            "max_duration_seconds": 119.99453514739228,
+            "unique_audios": 547,
+            "average_sampling_rate": 44235.46617915905,
+            "sampling_rates": {
+                "48000": 19,
+                "44100": 528
+            }
+        },
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 74730,
+            "min_text_length": 40,
+            "average_text_length": 100.17426273458445,
+            "max_text_length": 370,
+            "unique_texts": 746
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 746,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 547
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/tasks/retrieval/zxx/__init__.py
+++ b/mteb/tasks/retrieval/zxx/__init__.py
@@ -1,4 +1,5 @@
 from .music_caps import MusicCapsA2TRetrieval, MusicCapsT2ARetrieval
+from .song_describer import SongDescriberA2TRetrieval, SongDescriberT2ARetrieval
 from .sound_descs import SoundDescsA2TRetrieval, SoundDescsT2ARetrieval
 from .urban_sound8k_retrieval import UrbanSound8KA2TRetrieval, UrbanSound8KT2ARetrieval
 from .vim_sketch_retrieval import VimSketchA2ARetrieval
@@ -6,6 +7,8 @@ from .vim_sketch_retrieval import VimSketchA2ARetrieval
 __all__ = [
     "MusicCapsA2TRetrieval",
     "MusicCapsT2ARetrieval",
+    "SongDescriberA2TRetrieval",
+    "SongDescriberT2ARetrieval",
     "SoundDescsA2TRetrieval",
     "SoundDescsT2ARetrieval",
     "UrbanSound8KA2TRetrieval",

--- a/mteb/tasks/retrieval/zxx/song_describer.py
+++ b/mteb/tasks/retrieval/zxx/song_describer.py
@@ -37,7 +37,7 @@ class SongDescriberT2ARetrieval(AbsTaskRetrieval):
         modalities=["audio", "text"],
         eval_splits=["test"],
         eval_langs=["eng-Latn"],
-        main_score="hit_rate_at_5",
+        main_score="recall_at_5",
         date=("2023-01-01", "2023-11-01"),
         domains=["Music"],
         task_subtypes=["Music Caption Retrieval"],

--- a/mteb/tasks/retrieval/zxx/song_describer.py
+++ b/mteb/tasks/retrieval/zxx/song_describer.py
@@ -16,7 +16,7 @@ _BIBTEX = r"""
 _DESCRIPTION = (
     "The Song Describer Dataset (SDD) is a corpus of human-written natural-language "
     "captions of music tracks, released for music-and-language evaluation. It "
-    "provides 746 captions over 547 music recordings drawn from MTG-Jamendo "
+    "provides 1,106 captions over 706 music recordings drawn from MTG-Jamendo "
     "(Creative Commons). "
 )
 
@@ -26,11 +26,11 @@ class SongDescriberT2ARetrieval(AbsTaskRetrieval):
         name="SongDescriberT2ARetrieval",
         description=_DESCRIPTION
         + "Text-to-music retrieval: the query is a caption and the goal is to "
-        "retrieve the music track it describes from the corpus of 547 recordings.",
+        "retrieve the music track it describes from the corpus of 706 recordings.",
         reference=_REFERENCE,
         dataset={
             "path": "dukesun99/SongDescriber-T2A",
-            "revision": "f673048958",
+            "revision": "c58ad9b08343e56ce412d4da41accd15bffdbd6d",
         },
         type="Any2AnyRetrieval",
         category="t2a",
@@ -55,11 +55,11 @@ class SongDescriberA2TRetrieval(AbsTaskRetrieval):
         name="SongDescriberA2TRetrieval",
         description=_DESCRIPTION
         + "Music-to-text retrieval: the query is a music recording and the goal is "
-        "to retrieve its caption(s) from the corpus of 746 captions.",
+        "to retrieve its caption(s) from the corpus of 1,106 captions.",
         reference=_REFERENCE,
         dataset={
             "path": "dukesun99/SongDescriber-A2T",
-            "revision": "27e379ddf6",
+            "revision": "205f679a640b5fecf9ca9ee74bb715b339d228a5",
         },
         type="Any2AnyRetrieval",
         category="a2t",

--- a/mteb/tasks/retrieval/zxx/song_describer.py
+++ b/mteb/tasks/retrieval/zxx/song_describer.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.task_metadata import TaskMetadata
+
+_REFERENCE = "https://arxiv.org/abs/2311.10057"
+_BIBTEX = r"""
+@inproceedings{manco2023song,
+  author = {Manco, Ilaria and Weck, Benno and Doh, Seungheon and Won, Minz and Zhang, Yixiao and Bogdanov, Dmitry and Wu, Yusong and Chen, Ke and Tovstogan, Philip and Benetos, Emmanouil and Quinton, Elio and Fazekas, Gy{\"o}rgy and Nam, Juhan},
+  booktitle = {Machine Learning for Audio Workshop at NeurIPS 2023},
+  title = {The Song Describer Dataset: a Corpus of Audio Captions for Music-and-Language Evaluation},
+  url = {https://arxiv.org/abs/2311.10057},
+  year = {2023},
+}
+"""
+_DESCRIPTION = (
+    "The Song Describer Dataset (SDD) is a corpus of human-written natural-language "
+    "captions of music tracks, released for music-and-language evaluation. It "
+    "provides 746 captions over 547 music recordings drawn from MTG-Jamendo "
+    "(Creative Commons). "
+)
+
+
+class SongDescriberT2ARetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="SongDescriberT2ARetrieval",
+        description=_DESCRIPTION
+        + "Text-to-music retrieval: the query is a caption and the goal is to "
+        "retrieve the music track it describes from the corpus of 547 recordings.",
+        reference=_REFERENCE,
+        dataset={
+            "path": "dukesun99/SongDescriber-T2A",
+            "revision": "f673048958",
+        },
+        type="Any2AnyRetrieval",
+        category="t2a",
+        modalities=["audio", "text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="hit_rate_at_5",
+        date=("2023-01-01", "2023-11-01"),
+        domains=["Music"],
+        task_subtypes=["Music Caption Retrieval"],
+        license="cc-by-sa-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Retrieve the music recording described by this caption."},
+    )
+
+
+class SongDescriberA2TRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="SongDescriberA2TRetrieval",
+        description=_DESCRIPTION
+        + "Music-to-text retrieval: the query is a music recording and the goal is "
+        "to retrieve its caption(s) from the corpus of 746 captions.",
+        reference=_REFERENCE,
+        dataset={
+            "path": "dukesun99/SongDescriber-A2T",
+            "revision": "27e379ddf6",
+        },
+        type="Any2AnyRetrieval",
+        category="a2t",
+        modalities=["audio", "text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="hit_rate_at_5",
+        date=("2023-01-01", "2023-11-01"),
+        domains=["Music"],
+        task_subtypes=["Music Caption Retrieval"],
+        license="cc-by-sa-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Retrieve the caption that describes this music recording."},
+    )

--- a/mteb/tasks/retrieval/zxx/song_describer.py
+++ b/mteb/tasks/retrieval/zxx/song_describer.py
@@ -66,7 +66,7 @@ class SongDescriberA2TRetrieval(AbsTaskRetrieval):
         modalities=["audio", "text"],
         eval_splits=["test"],
         eval_langs=["eng-Latn"],
-        main_score="hit_rate_at_5",
+        main_score="recall_at_5",
         date=("2023-01-01", "2023-11-01"),
         domains=["Music"],
         task_subtypes=["Music Caption Retrieval"],


### PR DESCRIPTION
Part of the MOEB effort (#4842). Adds `SongDescriberT2ARetrieval` and `SongDescriberA2TRetrieval` from the Song Describer Dataset ([arXiv 2311.10057](https://arxiv.org/abs/2311.10057)), a corpus of human-written captions for music tracks drawn from MTG-Jamendo (Creative Commons). 1,106 captions over 706 recordings. Data at [dukesun99/SongDescriber-T2A](https://huggingface.co/datasets/dukesun99/SongDescriber-T2A) and [dukesun99/SongDescriber-A2T](https://huggingface.co/datasets/dukesun99/SongDescriber-A2T). Complements the existing MusicCaps music-caption task with human-written captions and a published retrieval benchmark.

Dataset checklist:
- [x] Human-annotated music captions, distinct from MusicCaps' machine-generated captions
- [x] Tested that the dataset runs with the mteb package
- [x] `mteb/baseline-random-encoder`: T2A 1.00 / A2T 1.13 hit_rate@5
- [x] Real model — laion/clap-htsat-fused: T2A 5.51 / A2T 4.39 hit_rate@5 (T2A R@1/5/10 = 1.45 / 5.51 / 8.77)
- [x] Corpus at evaluation scale
- [x] Paper-score reproduction — see below

**Reproduction.** The SDD paper reports a text→music retrieval benchmark (Table 5) where CLAP scores R@1/5/10 = 4.42 / 17.02 / 26.01. The data ports faithfully. The paper's "CLAP, trained on AudioSet and LAION-Audio-630k" is the *larger* LAION-CLAP general model, and running that exact model on this port reproduces the paper almost cell-for-cell: `laion/larger_clap_general` scores **R@1/5/10 = 4.79 / 17.72 / 29.48** (paper 4.42 / 17.02 / 26.01). The mteb-registered baseline uses the smaller `laion/clap-htsat-fused` checkpoint (8.77 R@10), which underperforms the paper's larger CLAP on music. 