### PR TITLE
fix: type mismatch between some whisper models and mel features

### DIFF
--- a/mteb/models/model_implementations/whisper_models.py
+++ b/mteb/models/model_implementations/whisper_models.py
@@ -64,6 +64,11 @@ class WhisperAudioWrapper(AbsEncoder):
                 max_length=int(self.max_audio_length_seconds * self.sampling_rate),
                 return_attention_mask=True,
             ).to(self.device)
+            # Some Whisper checkpoints load as fp16;
+            # the processor always returns float32 mel features.
+            feature_inputs["input_features"] = feature_inputs["input_features"].to(
+                dtype=self.model.dtype
+            )
 
             with torch.no_grad():
                 outputs = self.model.encoder(


### PR DESCRIPTION
Some whisper model (especially large) can have a type mismatch with mel features. Implementing a fix that casts mel features type to model param type.