### PR TITLE
Add Hanno-Labs/dinghy-law-4b-v1 (legal embedding model)

### DIFF
--- a/mteb/models/model_implementations/hanno_labs_models.py
+++ b/mteb/models/model_implementations/hanno_labs_models.py
@@ -65,3 +65,60 @@ dinghy_law_0_6b = ModelMeta(
     citation=DINGHY_LAW_CITATION,
     adapted_from="Qwen/Qwen3-Embedding-0.6B",
 )
+
+# dinghy-law-4b-v1: the 4B sibling of dinghy-law-0.6b, a legal-domain contrastive fine-tune of
+# Qwen/Qwen3-Embedding-4B, keeping the same interface (last-token pooling, cosine, query-side
+# "Instruct: {instruction}\nQuery:" prefix, unprefixed documents). Adds German case-law and Chinese
+# case-to-case coverage over the 0.6b mix. Training data, licensing, and leakage accounting are on the model
+# card. training_data (GerDaLIR / GerDaLIRSmall / BillSumUS) is the shared MTEB-overlap declaration.
+
+DINGHY_LAW_4B_CITATION = """@misc{dinghy-law-4b,
+  title  = {dinghy-law-4b: a 4B legal text-embedding model},
+  author = {Solka, Stephen},
+  year   = {2026},
+  note   = {Hanno Labs / Clause Logic Inc.},
+  howpublished = {\\url{https://huggingface.co/Hanno-Labs/dinghy-law-4b-v1}}
+}"""
+
+# Per-task query instruction (the dominant eval lever); query-side only (apply_instruction_to_passages=False).
+_instructions_4b = {
+    "AILACasedocs": "Represent this legal case by its core governing legal issue, so cases on the same issue match: ",
+    "AILAStatutes": "Represent these facts by the legal provisions and issue that govern them: ",
+    "LegalSummarization": "Represent this contract clause by its legal function and the questions it answers: ",
+    "LegalBenchConsumerContractsQA": "Represent this contract clause by its legal function and the questions it answers: ",
+    "LegalBenchCorporateLobbying": "Represent this bill by its legislative purpose and legal effect: ",
+    "GerDaLIRSmall": "Represent this legal case by its core governing legal issue, so cases on the same issue match: ",
+    "LegalQuAD": "Represent this legal case by its core governing legal issue, so cases on the same issue match: ",
+    "LeCaRDv2": "Represent this legal case by its core governing legal issue, so cases on the same issue match: ",
+}
+
+dinghy_law_4b = ModelMeta(
+    loader=InstructSentenceTransformerModel,
+    loader_kwargs=dict(
+        instruction_template="Instruct: {instruction}\nQuery:",
+        apply_instruction_to_passages=False,
+        prompts_dict=_instructions_4b,
+        model_kwargs={"torch_dtype": "bfloat16"},
+    ),
+    name="Hanno-Labs/dinghy-law-4b-v1",
+    model_type=["dense"],
+    languages=["eng-Latn", "deu-Latn", "zho-Hans"],
+    open_weights=True,
+    revision="5a7a18f95c494cd9488428b2c38a492761f1fe6b",
+    release_date="2026-07-22",
+    n_parameters=4_028_327_936,
+    n_embedding_parameters=388_262_400,
+    memory_usage_mb=7683,
+    embed_dim=2560,
+    max_tokens=32768,
+    license="apache-2.0",
+    reference="https://huggingface.co/Hanno-Labs/dinghy-law-4b-v1",
+    similarity_fn_name="cosine",
+    framework=["Sentence Transformers", "PyTorch", "Transformers"],
+    use_instructions=True,
+    public_training_code=None,
+    public_training_data="https://huggingface.co/datasets/Hanno-Labs/legal-retrieval-pairs-v2",
+    training_datasets=training_data,
+    citation=DINGHY_LAW_4B_CITATION,
+    adapted_from="Qwen/Qwen3-Embedding-4B",
+)

--- a/mteb/models/model_implementations/hanno_labs_models.py
+++ b/mteb/models/model_implementations/hanno_labs_models.py
@@ -66,12 +66,6 @@ dinghy_law_0_6b = ModelMeta(
     adapted_from="Qwen/Qwen3-Embedding-0.6B",
 )
 
-# dinghy-law-4b-v1: the 4B sibling of dinghy-law-0.6b, a legal-domain contrastive fine-tune of
-# Qwen/Qwen3-Embedding-4B, keeping the same interface (last-token pooling, cosine, query-side
-# "Instruct: {instruction}\nQuery:" prefix, unprefixed documents). Adds German case-law and Chinese
-# case-to-case coverage over the 0.6b mix. Training data, licensing, and leakage accounting are on the model
-# card. training_data (GerDaLIR / GerDaLIRSmall / BillSumUS) is the shared MTEB-overlap declaration.
-
 DINGHY_LAW_4B_CITATION = """@misc{dinghy-law-4b,
   title  = {dinghy-law-4b: a 4B legal text-embedding model},
   author = {Solka, Stephen},


### PR DESCRIPTION
Adds the `ModelMeta` for `Hanno-Labs/dinghy-law-4b-v1`, a 4B legal text-embedding model — a contrastive fine-tune of `Qwen/Qwen3-Embedding-4B`, and the larger sibling of the previously-added `dinghy-law-0.6b-v1` (#4926). It keeps the base architecture/interface exactly (last-token pooling, cosine, query-side `Instruct: {instruction}\nQuery:` prefix with unprefixed documents), so it reuses the shared Qwen3 instruct loader. Public weights (apache-2.0), permissively/publicly-licensed training data.

### Results — MTEB(Law, v1), reproduced with `mteb.evaluate` 2.18.1 (this PR's ModelMeta config)

| Task | nDCG@10 |
|---|---|
| AILACasedocs | 46.19 |
| AILAStatutes | 78.56 |
| LegalSummarization | 67.11 |
| GerDaLIRSmall | 46.91 |
| LeCaRDv2 | 76.20 |
| LegalBenchConsumerContractsQA | 85.47 |
| LegalBenchCorporateLobbying | 95.39 |
| LegalQuAD | 73.96 |
| **Mean(Task)** | **71.22** |

For reference on the same benchmark: `Mira190/Euler-Legal-Embedding-V1` (7.6B) = 70.37 and `voyageai/voyage-law-2` = 65.39 — this 4B model edges the highest-scoring model in our reproduction, at roughly half the parameter count.

Note: declared non-zero-shot on MTEB(Law) — the model trained on GerDaLIR, which overlaps the GerDaLIRSmall task (declared in `training_datasets`).

Results PR: embeddings-benchmark/results#631

### Checklist

- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [x] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e., is available either as an API or the weights are publicly available to download
- [x] I reproduced results (included above).
