### PR TITLE
dataset: add Greatest Hits audio-video material retrieval (a2v, v2a)

### DIFF
--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/GreatestHitsA2VRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/GreatestHitsA2VRetrieval.json
@@ -1,0 +1,66 @@
+{
+    "test": {
+        "num_samples": 1984,
+        "num_queries": 992,
+        "num_documents": 992,
+        "number_of_characters": 0,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": {
+            "total_duration_seconds": 2002.266933333333,
+            "total_frames": 60008,
+            "min_width": 638,
+            "average_width": 638.0,
+            "max_width": 638,
+            "min_height": 360,
+            "average_height": 360.0,
+            "max_height": 360,
+            "min_duration_seconds": 2.002,
+            "average_duration_seconds": 2.018414247311828,
+            "max_duration_seconds": 2.0353666666666665,
+            "unique_videos": 992,
+            "average_fps": 30.0,
+            "fps": {
+                "30": 992
+            },
+            "min_resolution": [
+                638,
+                360
+            ],
+            "average_resolution": [
+                638.0,
+                360.0
+            ],
+            "max_resolution": [
+                638,
+                360
+            ],
+            "resolutions": {
+                "638x360": 992
+            }
+        },
+        "queries_text_statistics": null,
+        "queries_image_statistics": null,
+        "queries_audio_statistics": {
+            "total_duration_seconds": 1982.6017083333334,
+            "min_duration_seconds": 0.6017083333333333,
+            "average_duration_seconds": 1.9985904317876344,
+            "max_duration_seconds": 2.0,
+            "unique_audios": 992,
+            "average_sampling_rate": 48000.0,
+            "sampling_rates": {
+                "48000": 992
+            }
+        },
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 105638,
+            "min_relevant_docs_per_query": 2,
+            "average_relevant_docs_per_query": 106.4899193548387,
+            "max_relevant_docs_per_query": 195,
+            "unique_relevant_docs": 992
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/GreatestHitsA2VRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/GreatestHitsA2VRetrieval.json
@@ -1,15 +1,15 @@
 {
     "test": {
-        "num_samples": 1984,
-        "num_queries": 992,
-        "num_documents": 992,
+        "num_samples": 2000,
+        "num_queries": 1000,
+        "num_documents": 1000,
         "number_of_characters": 0,
         "documents_text_statistics": null,
         "documents_image_statistics": null,
         "documents_audio_statistics": null,
         "documents_video_statistics": {
-            "total_duration_seconds": 2002.266933333333,
-            "total_frames": 60008,
+            "total_duration_seconds": 2017.8825333333332,
+            "total_frames": 60476,
             "min_width": 638,
             "average_width": 638.0,
             "max_width": 638,
@@ -17,12 +17,12 @@
             "average_height": 360.0,
             "max_height": 360,
             "min_duration_seconds": 2.002,
-            "average_duration_seconds": 2.018414247311828,
+            "average_duration_seconds": 2.0178825333333332,
             "max_duration_seconds": 2.0353666666666665,
-            "unique_videos": 992,
+            "unique_videos": 1000,
             "average_fps": 30.0,
             "fps": {
-                "30": 992
+                "30": 1000
             },
             "min_resolution": [
                 638,
@@ -37,29 +37,29 @@
                 360
             ],
             "resolutions": {
-                "638x360": 992
+                "638x360": 1000
             }
         },
         "queries_text_statistics": null,
         "queries_image_statistics": null,
         "queries_audio_statistics": {
-            "total_duration_seconds": 1982.6017083333334,
-            "min_duration_seconds": 0.6017083333333333,
-            "average_duration_seconds": 1.9985904317876344,
+            "total_duration_seconds": 2000.0,
+            "min_duration_seconds": 2.0,
+            "average_duration_seconds": 2.0,
             "max_duration_seconds": 2.0,
-            "unique_audios": 992,
+            "unique_audios": 1000,
             "average_sampling_rate": 48000.0,
             "sampling_rates": {
-                "48000": 992
+                "48000": 1000
             }
         },
         "queries_video_statistics": null,
         "relevant_docs_statistics": {
-            "num_relevant_docs": 105638,
-            "min_relevant_docs_per_query": 2,
-            "average_relevant_docs_per_query": 106.4899193548387,
-            "max_relevant_docs_per_query": 195,
-            "unique_relevant_docs": 992
+            "num_relevant_docs": 98292,
+            "min_relevant_docs_per_query": 7,
+            "average_relevant_docs_per_query": 98.292,
+            "max_relevant_docs_per_query": 163,
+            "unique_relevant_docs": 1000
         },
         "top_ranked_statistics": null
     }

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/GreatestHitsV2ARetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/GreatestHitsV2ARetrieval.json
@@ -1,0 +1,66 @@
+{
+    "test": {
+        "num_samples": 1984,
+        "num_queries": 992,
+        "num_documents": 992,
+        "number_of_characters": 0,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": {
+            "total_duration_seconds": 1982.6017083333334,
+            "min_duration_seconds": 0.6017083333333333,
+            "average_duration_seconds": 1.9985904317876344,
+            "max_duration_seconds": 2.0,
+            "unique_audios": 992,
+            "average_sampling_rate": 48000.0,
+            "sampling_rates": {
+                "48000": 992
+            }
+        },
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": {
+            "total_duration_seconds": 2002.266933333333,
+            "total_frames": 60008,
+            "min_width": 638,
+            "average_width": 638.0,
+            "max_width": 638,
+            "min_height": 360,
+            "average_height": 360.0,
+            "max_height": 360,
+            "min_duration_seconds": 2.002,
+            "average_duration_seconds": 2.018414247311828,
+            "max_duration_seconds": 2.0353666666666665,
+            "unique_videos": 992,
+            "average_fps": 30.0,
+            "fps": {
+                "30": 992
+            },
+            "min_resolution": [
+                638,
+                360
+            ],
+            "average_resolution": [
+                638.0,
+                360.0
+            ],
+            "max_resolution": [
+                638,
+                360
+            ],
+            "resolutions": {
+                "638x360": 992
+            }
+        },
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 105638,
+            "min_relevant_docs_per_query": 2,
+            "average_relevant_docs_per_query": 106.4899193548387,
+            "max_relevant_docs_per_query": 195,
+            "unique_relevant_docs": 992
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/GreatestHitsV2ARetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/GreatestHitsV2ARetrieval.json
@@ -1,20 +1,20 @@
 {
     "test": {
-        "num_samples": 1984,
-        "num_queries": 992,
-        "num_documents": 992,
+        "num_samples": 2000,
+        "num_queries": 1000,
+        "num_documents": 1000,
         "number_of_characters": 0,
         "documents_text_statistics": null,
         "documents_image_statistics": null,
         "documents_audio_statistics": {
-            "total_duration_seconds": 1982.6017083333334,
-            "min_duration_seconds": 0.6017083333333333,
-            "average_duration_seconds": 1.9985904317876344,
+            "total_duration_seconds": 2000.0,
+            "min_duration_seconds": 2.0,
+            "average_duration_seconds": 2.0,
             "max_duration_seconds": 2.0,
-            "unique_audios": 992,
+            "unique_audios": 1000,
             "average_sampling_rate": 48000.0,
             "sampling_rates": {
-                "48000": 992
+                "48000": 1000
             }
         },
         "documents_video_statistics": null,
@@ -22,8 +22,8 @@
         "queries_image_statistics": null,
         "queries_audio_statistics": null,
         "queries_video_statistics": {
-            "total_duration_seconds": 2002.266933333333,
-            "total_frames": 60008,
+            "total_duration_seconds": 2017.8825333333332,
+            "total_frames": 60476,
             "min_width": 638,
             "average_width": 638.0,
             "max_width": 638,
@@ -31,12 +31,12 @@
             "average_height": 360.0,
             "max_height": 360,
             "min_duration_seconds": 2.002,
-            "average_duration_seconds": 2.018414247311828,
+            "average_duration_seconds": 2.0178825333333332,
             "max_duration_seconds": 2.0353666666666665,
-            "unique_videos": 992,
+            "unique_videos": 1000,
             "average_fps": 30.0,
             "fps": {
-                "30": 992
+                "30": 1000
             },
             "min_resolution": [
                 638,
@@ -51,15 +51,15 @@
                 360
             ],
             "resolutions": {
-                "638x360": 992
+                "638x360": 1000
             }
         },
         "relevant_docs_statistics": {
-            "num_relevant_docs": 105638,
-            "min_relevant_docs_per_query": 2,
-            "average_relevant_docs_per_query": 106.4899193548387,
-            "max_relevant_docs_per_query": 195,
-            "unique_relevant_docs": 992
+            "num_relevant_docs": 98292,
+            "min_relevant_docs_per_query": 7,
+            "average_relevant_docs_per_query": 98.292,
+            "max_relevant_docs_per_query": 163,
+            "unique_relevant_docs": 1000
         },
         "top_ranked_statistics": null
     }

--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -146,6 +146,7 @@ from .giga_speech import GigaSpeechA2TRetrieval, GigaSpeechT2ARetrieval
 from .gl_dv2_i2i_retrieval import GLDv2I2IRetrieval
 from .gl_dv2_i2t_retrieval import GLDv2I2TRetrieval
 from .gov_report_retrieval import GovReportRetrieval
+from .greatest_hits_retrieval import GreatestHitsA2VRetrieval, GreatestHitsV2ARetrieval
 from .hagrid_retrieval import HagridRetrieval
 from .hateful_memes_i2t_retrieval import HatefulMemesI2TRetrieval
 from .hateful_memes_t2i_retrieval import HatefulMemesT2IRetrieval
@@ -565,6 +566,8 @@ __all__ = [
     "GigaSpeechT2ARetrieval",
     "Gorilla",
     "GovReportRetrieval",
+    "GreatestHitsA2VRetrieval",
+    "GreatestHitsV2ARetrieval",
     "HC3FinanceRetrieval",
     "HagridRetrieval",
     "HatefulMemesI2TRetrieval",

--- a/mteb/tasks/retrieval/eng/greatest_hits_retrieval.py
+++ b/mteb/tasks/retrieval/eng/greatest_hits_retrieval.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.task_metadata import TaskMetadata
+
+_REFERENCE = "https://andrewowens.com/vis/"
+_BIBTEX = r"""
+@inproceedings{owens2016visually,
+  author = {Owens, Andrew and Isola, Phillip and McDermott, Josh and Torralba, Antonio and Adelson, Edward H. and Freeman, William T.},
+  booktitle = {IEEE Conference on Computer Vision and Pattern Recognition (CVPR)},
+  title = {Visually Indicated Sounds},
+  year = {2016},
+}
+"""
+_DESC = (
+    "Audio-video retrieval on the Greatest Hits (Visually Indicated Sounds) dataset, "
+    "in which a person strikes and scratches objects with a drumstick. Each item is a "
+    "2-second clip centered on an annotated impact and labeled with the material struck "
+    "(wood, metal, water, glass, ...). The task matches impacts across modalities by "
+    "material. 992 impacts across 17 materials, sampled with a fixed seed. Videos "
+    "re-encoded to 360p. "
+)
+
+
+class GreatestHitsA2VRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="GreatestHitsA2VRetrieval",
+        description=_DESC
+        + "The query is an impact sound; retrieve the video clips of the same material.",
+        reference=_REFERENCE,
+        dataset={
+            "path": "dukesun99/GreatestHits-A2V",
+            "revision": "a9d0f5b7faf64c300d0c5e0a3f146ee48fae52da",
+        },
+        type="Any2AnyRetrieval",
+        category="a2v",
+        modalities=["audio", "video"],
+        eval_splits=["test"],
+        eval_langs=["zxx-Zxxx"],
+        main_score="ndcg_at_10",
+        date=("2015-01-01", "2016-06-01"),
+        domains=["Scene"],
+        task_subtypes=["Environment Sound Retrieval"],
+        license="cc-by-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Retrieve videos of the same material as this impact sound."},
+    )
+
+
+class GreatestHitsV2ARetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="GreatestHitsV2ARetrieval",
+        description=_DESC
+        + "The query is a video clip; retrieve the impact sounds of the same material.",
+        reference=_REFERENCE,
+        dataset={
+            "path": "dukesun99/GreatestHits-V2A",
+            "revision": "2c4fc4aab06afdd89d87747dc42b40884229e0b6",
+        },
+        type="Any2AnyRetrieval",
+        category="v2a",
+        modalities=["video", "audio"],
+        eval_splits=["test"],
+        eval_langs=["zxx-Zxxx"],
+        main_score="ndcg_at_10",
+        date=("2015-01-01", "2016-06-01"),
+        domains=["Scene"],
+        task_subtypes=["Environment Sound Retrieval"],
+        license="cc-by-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Retrieve impact sounds of the same material as this video."},
+    )

--- a/mteb/tasks/retrieval/eng/greatest_hits_retrieval.py
+++ b/mteb/tasks/retrieval/eng/greatest_hits_retrieval.py
@@ -30,7 +30,7 @@ class GreatestHitsA2VRetrieval(AbsTaskRetrieval):
         reference=_REFERENCE,
         dataset={
             "path": "dukesun99/GreatestHits-A2V",
-            "revision": "a9d0f5b7faf64c300d0c5e0a3f146ee48fae52da",
+            "revision": "bfb8cbecc345ea78cd92d669a09e8f410f56c8c9",
         },
         type="Any2AnyRetrieval",
         category="a2v",
@@ -58,7 +58,7 @@ class GreatestHitsV2ARetrieval(AbsTaskRetrieval):
         reference=_REFERENCE,
         dataset={
             "path": "dukesun99/GreatestHits-V2A",
-            "revision": "2c4fc4aab06afdd89d87747dc42b40884229e0b6",
+            "revision": "2b1cd359f987fc1db90c745269d10426c86205c7",
         },
         type="Any2AnyRetrieval",
         category="v2a",


### PR DESCRIPTION
Part of the MOEB effort (#4842), filling the audio ↔ video direction.

Adds two audio↔video retrieval tasks from Greatest Hits / [Visually Indicated Sounds](https://andrewowens.com/vis/) (CVPR 2016, CC-BY-4.0), in which a person strikes and scratches objects with a drumstick. Each item is a 2-second clip centered on an annotated impact, labeled with the material struck (wood, metal, water, glass, …). The task matches an impact **across modalities by material**: 1000 impacts over 17 materials, sampled with a fixed seed; videos re-encoded to 360p. Data at [dukesun99/GreatestHits-{A2V,V2A}](https://huggingface.co/datasets/dukesun99/GreatestHits-A2V).

- `GreatestHitsA2VRetrieval` (**a2v**): query = impact sound → retrieve video clips of the same material
- `GreatestHitsV2ARetrieval` (**v2a**): query = video clip → retrieve impact sounds of the same material

Dataset checklist:
- [x] Fills a gap: first audio↔video (a2v/v2a) retrieval tasks in mteb
- [x] Tested that the dataset runs with the mteb package
- [x] `mteb/baseline-random-encoder`: a2v 10.0 / v2a 9.8 nDCG@10 (high base rate — material relevance is dense, ~98 relevant/query)
- [x] Real model — LCO-Embedding-Omni-3B: **a2v 19.8 / v2a 16.2** nDCG@10; map@10 is ~4× random (a2v 1.58 vs 0.37, v2a 1.55 vs 0.35). 
- [x] Downsampled to evaluation scale (1000 impacts)
- [x] Paper-score reproduction: N/A — Greatest Hits was released for sound prediction, not retrieval; the material-retrieval formulation is an adaptation

@Samoed @AdnanElAssadi56  I am not sure if this kind of adaptation is natural enough as retrieval. Or pair classification? Please do let me know your thoughts.
