### PR TITLE
task: add uCO3D object-instance retrieval (i2v, v2v, t2v)

### DIFF
--- a/mteb/abstasks/task_metadata.py
+++ b/mteb/abstasks/task_metadata.py
@@ -278,6 +278,7 @@ TaskCategory = Literal[
     "va2va",
     "v2a",
     "a2v",
+    "i2v",
     "vt2a",
     "at2v",
     "a2i",

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/UCO3DI2VRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/UCO3DI2VRetrieval.json
@@ -1,0 +1,83 @@
+{
+    "test": {
+        "num_samples": 1000,
+        "num_queries": 500,
+        "num_documents": 500,
+        "number_of_characters": 0,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": {
+            "total_duration_seconds": 6913.861789698899,
+            "total_frames": 222109,
+            "min_width": 162,
+            "average_width": 403.072,
+            "max_width": 800,
+            "min_height": 360,
+            "average_height": 360.0,
+            "max_height": 360,
+            "min_duration_seconds": 4.220887554220887,
+            "average_duration_seconds": 13.827723579397798,
+            "max_duration_seconds": 26.633333333333333,
+            "unique_videos": 500,
+            "average_fps": 32.682,
+            "fps": {
+                "30": 421,
+                "29": 4,
+                "60": 28,
+                "25": 23,
+                "120": 8,
+                "27": 2,
+                "24": 9,
+                "22": 1,
+                "20": 3,
+                "28": 1
+            },
+            "min_resolution": [
+                162,
+                360
+            ],
+            "average_resolution": [
+                403.072,
+                360.0
+            ],
+            "max_resolution": [
+                800,
+                360
+            ],
+            "resolutions": {
+                "202x360": 263,
+                "640x360": 216,
+                "758x360": 7,
+                "360x360": 5,
+                "208x360": 1,
+                "800x360": 2,
+                "162x360": 1,
+                "270x360": 2,
+                "204x360": 1,
+                "176x360": 1,
+                "174x360": 1
+            }
+        },
+        "queries_text_statistics": null,
+        "queries_image_statistics": {
+            "min_image_width": 162,
+            "average_image_width": 403.072,
+            "max_image_width": 800,
+            "min_image_height": 360,
+            "average_image_height": 360.0,
+            "max_image_height": 360,
+            "unique_images": 500
+        },
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 500,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 500
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/UCO3DT2VRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/UCO3DT2VRetrieval.json
@@ -1,0 +1,81 @@
+{
+    "test": {
+        "num_samples": 1000,
+        "num_queries": 500,
+        "num_documents": 500,
+        "number_of_characters": 21497,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": {
+            "total_duration_seconds": 6913.861789698899,
+            "total_frames": 222109,
+            "min_width": 162,
+            "average_width": 403.072,
+            "max_width": 800,
+            "min_height": 360,
+            "average_height": 360.0,
+            "max_height": 360,
+            "min_duration_seconds": 4.220887554220887,
+            "average_duration_seconds": 13.827723579397798,
+            "max_duration_seconds": 26.633333333333333,
+            "unique_videos": 500,
+            "average_fps": 32.682,
+            "fps": {
+                "30": 421,
+                "29": 4,
+                "60": 28,
+                "25": 23,
+                "120": 8,
+                "27": 2,
+                "24": 9,
+                "22": 1,
+                "20": 3,
+                "28": 1
+            },
+            "min_resolution": [
+                162,
+                360
+            ],
+            "average_resolution": [
+                403.072,
+                360.0
+            ],
+            "max_resolution": [
+                800,
+                360
+            ],
+            "resolutions": {
+                "202x360": 263,
+                "640x360": 216,
+                "758x360": 7,
+                "360x360": 5,
+                "208x360": 1,
+                "800x360": 2,
+                "162x360": 1,
+                "270x360": 2,
+                "204x360": 1,
+                "176x360": 1,
+                "174x360": 1
+            }
+        },
+        "queries_text_statistics": {
+            "total_text_length": 21497,
+            "min_text_length": 0,
+            "average_text_length": 42.994,
+            "max_text_length": 79,
+            "unique_texts": 439
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 500,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 500
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/UCO3DV2VRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/UCO3DV2VRetrieval.json
@@ -1,0 +1,126 @@
+{
+    "test": {
+        "num_samples": 1000,
+        "num_queries": 500,
+        "num_documents": 500,
+        "number_of_characters": 0,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": {
+            "total_duration_seconds": 6913.861789698899,
+            "total_frames": 222109,
+            "min_width": 162,
+            "average_width": 403.072,
+            "max_width": 800,
+            "min_height": 360,
+            "average_height": 360.0,
+            "max_height": 360,
+            "min_duration_seconds": 4.220887554220887,
+            "average_duration_seconds": 13.827723579397798,
+            "max_duration_seconds": 26.633333333333333,
+            "unique_videos": 500,
+            "average_fps": 32.682,
+            "fps": {
+                "30": 421,
+                "29": 4,
+                "60": 28,
+                "25": 23,
+                "120": 8,
+                "27": 2,
+                "24": 9,
+                "22": 1,
+                "20": 3,
+                "28": 1
+            },
+            "min_resolution": [
+                162,
+                360
+            ],
+            "average_resolution": [
+                403.072,
+                360.0
+            ],
+            "max_resolution": [
+                800,
+                360
+            ],
+            "resolutions": {
+                "202x360": 263,
+                "640x360": 216,
+                "758x360": 7,
+                "360x360": 5,
+                "208x360": 1,
+                "800x360": 2,
+                "162x360": 1,
+                "270x360": 2,
+                "204x360": 1,
+                "176x360": 1,
+                "174x360": 1
+            }
+        },
+        "queries_text_statistics": null,
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": {
+            "total_duration_seconds": 6926.921656478665,
+            "total_frames": 222510,
+            "min_width": 162,
+            "average_width": 403.072,
+            "max_width": 800,
+            "min_height": 360,
+            "average_height": 360.0,
+            "max_height": 360,
+            "min_duration_seconds": 4.237570904237571,
+            "average_duration_seconds": 13.853843312957329,
+            "max_duration_seconds": 26.65,
+            "unique_videos": 500,
+            "average_fps": 32.682,
+            "fps": {
+                "30": 421,
+                "29": 4,
+                "60": 28,
+                "25": 23,
+                "120": 8,
+                "27": 2,
+                "24": 9,
+                "22": 1,
+                "20": 3,
+                "28": 1
+            },
+            "min_resolution": [
+                162,
+                360
+            ],
+            "average_resolution": [
+                403.072,
+                360.0
+            ],
+            "max_resolution": [
+                800,
+                360
+            ],
+            "resolutions": {
+                "202x360": 263,
+                "640x360": 216,
+                "758x360": 7,
+                "360x360": 5,
+                "208x360": 1,
+                "800x360": 2,
+                "162x360": 1,
+                "270x360": 2,
+                "204x360": 1,
+                "176x360": 1,
+                "174x360": 1
+            }
+        },
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 500,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 500
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -327,6 +327,7 @@ from .trecdl_retrieval import TRECDL2019, TRECDL2020
 from .tu_berlin_t2i_retrieval import TUBerlinT2IRetrieval
 from .tuna_bench_t2v_retrieval import TUNABenchT2VRetrieval
 from .tuna_bench_v2t_retrieval import TUNABenchV2TRetrieval
+from .uco3d_retrieval import UCO3DI2VRetrieval, UCO3DT2VRetrieval, UCO3DV2VRetrieval
 from .valor_32k_retrieval import (
     VALOR32KA2VRetrieval,
     VALOR32KAT2VRetrieval,
@@ -714,6 +715,9 @@ __all__ = [
     "TopiOCQARetrievalHardNegatives",
     "Touche2020",
     "Touche2020v3Retrieval",
+    "UCO3DI2VRetrieval",
+    "UCO3DT2VRetrieval",
+    "UCO3DV2VRetrieval",
     "VALOR32KA2VRetrieval",
     "VALOR32KAT2VRetrieval",
     "VALOR32KT2VARetrieval",

--- a/mteb/tasks/retrieval/eng/uco3d_retrieval.py
+++ b/mteb/tasks/retrieval/eng/uco3d_retrieval.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.task_metadata import TaskMetadata
+
+_REFERENCE = "https://arxiv.org/abs/2501.07574"
+_BIBTEX = r"""
+@inproceedings{liu2025uncommon,
+  author = {Liu, Xingchen and Tayal, Piyush and Wang, Jianyuan and Zarzar, Jesus and Monnier, Tom and Tertikas, Konstantinos and Duan, Jiali and Kleiman, Yanir and Neverova, Natalia and Vedaldi, Andrea and Novotny, David and Shapovalov, Roman},
+  booktitle = {IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR)},
+  title = {UnCommon Objects in 3D},
+  url = {https://arxiv.org/abs/2501.07574},
+  year = {2025},
+}
+"""
+_DESC = (
+    "Object-instance retrieval on uCO3D (UnCommon Objects in 3D), a large collection "
+    "of 360-degree turntable videos of individual objects. Each 360-degree orbit is "
+    "split into a viewpoint-disjoint first half and second half; the corpus is the "
+    "second-half clip and the query comes from the first half, so matching requires "
+    "viewpoint-invariant instance recognition rather than exact-view matching. 500 "
+    "object instances sampled with a fixed seed; same-category instances are hard "
+    "negatives. Videos re-encoded to 360p. "
+)
+
+
+class UCO3DI2VRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="UCO3DI2VRetrieval",
+        description=_DESC
+        + "The query is a single frame; retrieve the video clip of the same object instance.",
+        reference=_REFERENCE,
+        dataset={
+            "path": "dukesun99/uCO3D-I2V",
+            "revision": "875932253634b5d2973a3741b4d0c47c227b27d4",
+        },
+        type="Any2AnyRetrieval",
+        category="i2v",
+        modalities=["image", "video"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2024-01-01", "2025-01-01"),
+        domains=["Scene"],
+        task_subtypes=["Object recognition"],
+        license="cc-by-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Retrieve the video of the object shown in this image."},
+    )
+
+
+class UCO3DV2VRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="UCO3DV2VRetrieval",
+        description=_DESC
+        + "The query is the first-half orbit clip; retrieve the second-half clip of the same object instance.",
+        reference=_REFERENCE,
+        dataset={
+            "path": "dukesun99/uCO3D-V2V",
+            "revision": "b91417820f8d064a8e4dc10ffa2ebcfcd2090042",
+        },
+        type="Any2AnyRetrieval",
+        category="v2v",
+        modalities=["video"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2024-01-01", "2025-01-01"),
+        domains=["Scene"],
+        task_subtypes=["Object recognition"],
+        license="cc-by-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Retrieve the video of the same object shown in this video."},
+    )
+
+
+class UCO3DT2VRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="UCO3DT2VRetrieval",
+        description=_DESC
+        + "The query is a short natural-language caption; retrieve the video clip of the described object instance.",
+        reference=_REFERENCE,
+        dataset={
+            "path": "dukesun99/uCO3D-T2V",
+            "revision": "2dcb2a8dec36ff7e020fc279114d3278c32b2f1a",
+        },
+        type="Any2AnyRetrieval",
+        category="t2v",
+        modalities=["text", "video"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2024-01-01", "2025-01-01"),
+        domains=["Scene"],
+        task_subtypes=["Object recognition"],
+        license="cc-by-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Retrieve the video of the object described by this caption."},
+    )


### PR DESCRIPTION
Part of the MOEB effort (#4842), filling the image ↔ video direction. Self-contained: adds the `i2v` TaskCategory code.

Adds three object-instance retrieval tasks built from uCO3D ([UnCommon Objects in 3D](https://arxiv.org/abs/2501.07574), CVPR 2025, CC-BY-4.0), a large collection of 360° turntable videos of individual objects. Each orbit is split into a viewpoint-disjoint first half and second half; the corpus is the second-half clip and the query comes from the first half, so matching requires viewpoint-invariant instance recognition rather than exact-view matching. 500 object instances sampled with a fixed seed (same-category instances are hard negatives); videos re-encoded to 360p. Data at [dukesun99/uCO3D-{I2V,V2V,T2V}](https://huggingface.co/datasets/dukesun99/uCO3D-I2V).

- `UCO3DI2VRetrieval` (**i2v**): query = a single frame → retrieve the same instance's video clip
- `UCO3DV2VRetrieval` (**v2v**): query = first-half clip → second-half clip
- `UCO3DT2VRetrieval` (**t2v**): query = short caption → the described instance's clip

Dataset checklist:
- [x] Fills a gap: first image↔video (i2v) instance-retrieval task; adds `i2v` category code
- [x] Tested that the dataset runs with the mteb package
- [x] `mteb/baseline-random-encoder`: i2v 1.03 / v2v 0.96 / t2v 1.03 nDCG@10
- [x] Real model — Qwen/Qwen3-VL-Embedding-2B: **i2v 72.6 / v2v 89.8 / t2v 44.5** nDCG@10. 
- [x] Downsampled to evaluation scale (500 instances)
- [x] Paper-score reproduction: N/A — uCO3D is a 3D-reconstruction dataset with no retrieval benchmark; the instance-retrieval formulation is an adaptation