### PR TITLE
fix: bm25s fall back to language-agnostic tokenization for unknown langs

### DIFF
--- a/mteb/models/model_implementations/bm25.py
+++ b/mteb/models/model_implementations/bm25.py
@@ -57,6 +57,7 @@ _ISO3_TO_LANG: dict[str, tuple[str | None, str | None, str | None]] = {
     "lao": (None, None, "char"),  # Lao
     # PyStemmer only (no bm25s stopword list — pass None to skip stopword removal)
     "ara": (None, "arabic", None),
+    "arb": (None, "arabic", None),
     "hye": (None, "armenian", None),
     "eus": (None, "basque", None),
     "cat": (None, "catalan", None),
@@ -142,10 +143,13 @@ class BM25Tokenizer:
     ):
         # Resolve language defaults, then apply explicit overrides.
         # language=None means "no language assumptions" — no stopwords, stemmer, or tokenizer.
-        if language is None:
-            detected_sw, detected_stemmer, detected_tok = None, None, None
-        else:
-            detected_sw, detected_stemmer, detected_tok = _ISO3_TO_LANG[language]
+        # A language with no entry in _ISO3_TO_LANG gets the same treatment: many
+        # languages have no stopword list or Snowball stemmer available at all.
+
+        detected_sw, detected_stemmer, detected_tok = _ISO3_TO_LANG.get(
+            language, (None, None, None)
+        )
+
         self.stopwords_key = stopwords_key if stopwords_key is not None else detected_sw
         stemmer_lang = (
             stemmer_language if stemmer_language is not None else detected_stemmer


### PR DESCRIPTION
Issue:
BM25 crashes on any language that isn't in _ISO3_TO_LANG. The lookup in BM25Tokenizer.__init__ is a plain dict index (_ISO3_TO_LANG[language]), so a KeyError kills the whole run, which is not ideal. On AfriMTEB this is a big issue (as you might imagine, the bulk of langs in many AfriMTEB retrieval tasks are not supported here). For example, for BelebeleRetrieval around 80 or so langs are not in the table, and this leads to immediate failure. 

Fix:
I noticed that the class already has a way to manage cases where it is not clear which stemmer, stopword list, etc should be used, but this is only currently used for multilingual subsets (it's only reachable when _get_language returns None). In these situations, plain tokenization is done using whitespaces, and this is actually also desirable for many of the languages that AfriMTEB tasks include. Additionally, for many of these langs no stemmers or stopword lists even exist in the first place.

I thought it would be reasonable to also do this same exact thing for languages not in the dictionary. So my suggested fix is to just try to get the tokenizer, stopword list, and stemmer from the dict, but if we do not find any matches we just default to None which is already supported, as I already explained. This lets BM25 run as a baseline on AfriMTEB instead of crashing on the first unsupported language.

Also, the only recognized label for arabic is "ara", but there are tasks which reasonably refer to arabic as "arb" (and this is the case for some AfriMTEB tasks), so I added it as a mapping in the dict. 