### PR TITLE
model: add webAI ColVec1.1 4B and 8B models

### DIFF
--- a/mteb/models/model_implementations/webai_models.py
+++ b/mteb/models/model_implementations/webai_models.py
@@ -376,8 +376,7 @@ colvec1_1_4b = ModelMeta(
     max_tokens=262144,
     embed_dim=640,
     license=(
-        "https://huggingface.co/webAI-Official/"
-        "webAI-ColVec1.1-4b/blob/main/LICENSE.md"
+        "https://huggingface.co/webAI-Official/webAI-ColVec1.1-4b/blob/main/LICENSE.md"
     ),
     open_weights=True,
     public_training_code=None,
@@ -392,7 +391,7 @@ colvec1_1_4b = ModelMeta(
     citation=COLVEC1_1_CITATION,
     contacts=["zhanlunchang-webai"],
     output_dtypes=None,
-    extra_requirements_groups=["flash_attention"],
+    extra_requirements_groups=["flash_attention", "colvec1_1"],
 )
 
 
@@ -425,8 +424,7 @@ colvec1_1_8b = ModelMeta(
     max_tokens=262144,
     embed_dim=640,
     license=(
-        "https://huggingface.co/webAI-Official/"
-        "webAI-ColVec1.1-8b/blob/main/LICENSE.md"
+        "https://huggingface.co/webAI-Official/webAI-ColVec1.1-8b/blob/main/LICENSE.md"
     ),
     open_weights=True,
     public_training_code=None,
@@ -441,5 +439,5 @@ colvec1_1_8b = ModelMeta(
     citation=COLVEC1_1_CITATION,
     contacts=["zhanlunchang-webai"],
     output_dtypes=None,
-    extra_requirements_groups=["flash_attention"],
+    extra_requirements_groups=["flash_attention", "colvec1_1"],
 )

--- a/mteb/models/model_implementations/webai_models.py
+++ b/mteb/models/model_implementations/webai_models.py
@@ -139,6 +139,97 @@ class ColVec1Wrapper(AbsEncoder):
         return self.processor.score_multi_vector(a, b, device=self.device)
 
 
+class ColVec11Wrapper(ColVec1Wrapper):
+    """
+    MTEB wrapper for ColVec1.1 (ColQwen3.5-based) retrieval models.
+
+    ColVec1.1 uses the retrieval-only processor API and allows model and
+    processor keyword arguments to be configured independently.
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        revision: str | None = None,
+        device: str | None = None,
+        trust_remote_code: bool = True,
+        torch_dtype: torch.dtype | None = torch.bfloat16,
+        processor_kwargs: dict[str, Any] | None = None,
+        **model_kwargs,
+    ):
+        requires_image_dependencies()
+        self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+        processor_kwargs = dict(processor_kwargs or {})
+
+        self.model = AutoModel.from_pretrained(
+            model_name,
+            revision=revision,
+            dtype=torch_dtype,
+            trust_remote_code=trust_remote_code,
+            **model_kwargs,
+        ).to(self.device)
+        self.model.eval()
+
+        self.processor = AutoProcessor.from_pretrained(
+            model_name,
+            revision=revision,
+            trust_remote_code=trust_remote_code,
+            **processor_kwargs,
+        )
+
+    def get_image_embeddings(
+        self, images, batch_size=32, show_progress_bar=True, **kwargs
+    ):
+        import torchvision.transforms.functional as F
+        from PIL import Image
+
+        all_embeds = []
+        with torch.no_grad():
+            for batch in tqdm(
+                images, disable=not show_progress_bar, desc="Encoding images"
+            ):
+                imgs = [
+                    F.to_pil_image(b) if not isinstance(b, Image.Image) else b
+                    for b in batch["image"]
+                ]
+                imgs = [img.convert("RGB") for img in imgs]
+                inputs = self.processor.process_images(imgs)
+                inputs = {k: v.to(self.device) for k, v in inputs.items()}
+                outs = self._encode_inputs(inputs)
+                all_embeds.extend(outs.cpu().to(torch.float32))
+        return torch.nn.utils.rnn.pad_sequence(
+            all_embeds, batch_first=True, padding_value=0
+        )
+
+    def encode(
+        self,
+        inputs: DataLoader[BatchedInput],
+        *,
+        task_metadata: TaskMetadata,
+        hf_split: str,
+        hf_subset: str,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
+    ) -> Array:
+        # ViDoRe v3.1 corpora expose both the page image and OCR markdown.
+        # ColVec1.1 encodes documents from images, so images must take
+        # precedence and corpus OCR text must not be encoded as a query.
+        if "image" in inputs.dataset.features:
+            return self.get_image_embeddings(inputs, **kwargs)
+        if "text" in inputs.dataset.features:
+            return self.get_text_embeddings(inputs, **kwargs)
+        raise ValueError("No text or image features found in inputs.")
+
+    def similarity(self, a, b):
+        a = [torch.as_tensor(x) for x in a]
+        b = [torch.as_tensor(x) for x in b]
+        return self.processor.score_retrieval(
+            a,
+            b,
+            output_dtype=torch.float32,
+        )
+
+
 COLWEBAI_TRAINING_DATA = {
     "VidoreDocVQARetrieval",
     "VidoreInfoVQARetrieval",
@@ -160,6 +251,34 @@ COLWEBAI_CITATION = """
   author={webAI},
   year={2026},
   url={https://huggingface.co/webAI-Official/webAI-ColVec1-4b}
+}
+"""
+
+
+COLVEC1_1_TRAINING_DATA = {
+    # from https://huggingface.co/datasets/vidore/colpali_train_set
+    "VidoreDocVQARetrieval",
+    "VidoreInfoVQARetrieval",
+    "VidoreTatdqaRetrieval",
+    "VidoreArxivQARetrieval",
+    # from https://huggingface.co/datasets/Tevatron/docmatix-ir
+    "docmatix-ir",
+    # from https://huggingface.co/datasets/openbmb/VisRAG-Ret-Train-In-domain-data
+    "VisRAG-Ret-Train-In-domain-data",
+    # from https://huggingface.co/datasets/openbmb/VisRAG-Ret-Train-Synthetic-data
+    "VisRAG-Ret-Train-Synthetic-data",
+    # from https://huggingface.co/datasets/llamaindex/vdr-multilingual-train
+    "VDRMultilingualRetrieval",
+    # from https://huggingface.co/datasets/Tevatron/wiki-ss-nq
+    "wiki-ss-nq",
+}
+
+COLVEC1_1_CITATION = """
+@misc{webai_colvec1_1,
+  title={webAI-ColVec1.1: Bidirectional Multi-Vector Models for Visual Document Retrieval},
+  author={webAI},
+  year={2026},
+  url={https://huggingface.co/webAI-Official}
 }
 """
 
@@ -225,4 +344,102 @@ colvec1_9b = ModelMeta(
     citation=COLWEBAI_CITATION,
     contacts=["psam-ai"],
     output_dtypes=OutputDType.FLOAT16,
+)
+
+
+colvec1_1_4b = ModelMeta(
+    loader=ColVec11Wrapper,
+    loader_kwargs={
+        "torch_dtype": torch.bfloat16,
+        "attn_implementation": "flash_attention_2",
+        "processor_kwargs": {
+            "max_num_visual_tokens": 1792,
+        },
+    },
+    name="webAI-Official/webAI-ColVec1.1-4b",
+    revision="b4f97a769bb1ac1de3a35308783ddd0d006d0394",
+    release_date="2026-07-22",
+    model_type=["late-interaction"],
+    languages=[
+        "eng-Latn",
+        "fra-Latn",
+        "deu-Latn",
+        "spa-Latn",
+        "ita-Latn",
+        "por-Latn",
+    ],
+    modalities=["image", "text"],
+    n_parameters=4540904576,
+    n_embedding_parameters=1639040,
+    n_active_parameters_override=None,
+    memory_usage_mb=8661,
+    max_tokens=262144,
+    embed_dim=640,
+    license=(
+        "https://huggingface.co/webAI-Official/"
+        "webAI-ColVec1.1-4b/blob/main/LICENSE.md"
+    ),
+    open_weights=True,
+    public_training_code=None,
+    public_training_data=None,
+    framework=["PyTorch", "Transformers", "safetensors"],
+    reference="https://huggingface.co/webAI-Official/webAI-ColVec1.1-4b",
+    similarity_fn_name=ScoringFunction.MAX_SIM,
+    use_instructions=True,
+    training_datasets=COLVEC1_1_TRAINING_DATA,
+    adapted_from="Qwen/Qwen3.5-4B",
+    superseded_by=None,
+    citation=COLVEC1_1_CITATION,
+    contacts=["zhanlunchang-webai"],
+    output_dtypes=None,
+    extra_requirements_groups=["flash_attention"],
+)
+
+
+colvec1_1_8b = ModelMeta(
+    loader=ColVec11Wrapper,
+    loader_kwargs={
+        "torch_dtype": torch.bfloat16,
+        "attn_implementation": "flash_attention_2",
+        "processor_kwargs": {
+            "max_num_visual_tokens": 1792,
+        },
+    },
+    name="webAI-Official/webAI-ColVec1.1-8b",
+    revision="5a6eef07351b1c1653aa82e2e4c2f84f45a0d13d",
+    release_date="2026-07-22",
+    model_type=["late-interaction"],
+    languages=[
+        "eng-Latn",
+        "fra-Latn",
+        "deu-Latn",
+        "spa-Latn",
+        "ita-Latn",
+        "por-Latn",
+    ],
+    modalities=["image", "text"],
+    n_parameters=8395317104,
+    n_embedding_parameters=2622080,
+    n_active_parameters_override=None,
+    memory_usage_mb=16013,
+    max_tokens=262144,
+    embed_dim=640,
+    license=(
+        "https://huggingface.co/webAI-Official/"
+        "webAI-ColVec1.1-8b/blob/main/LICENSE.md"
+    ),
+    open_weights=True,
+    public_training_code=None,
+    public_training_data=None,
+    framework=["PyTorch", "Transformers", "safetensors"],
+    reference="https://huggingface.co/webAI-Official/webAI-ColVec1.1-8b",
+    similarity_fn_name=ScoringFunction.MAX_SIM,
+    use_instructions=True,
+    training_datasets=COLVEC1_1_TRAINING_DATA,
+    adapted_from="Qwen/Qwen3.5-9B",
+    superseded_by=None,
+    citation=COLVEC1_1_CITATION,
+    contacts=["zhanlunchang-webai"],
+    output_dtypes=None,
+    extra_requirements_groups=["flash_attention"],
 )

--- a/mteb/models/model_implementations/webai_models.py
+++ b/mteb/models/model_implementations/webai_models.py
@@ -211,9 +211,10 @@ class ColVec11Wrapper(ColVec1Wrapper):
         prompt_type: PromptType | None = None,
         **kwargs: Any,
     ) -> Array:
-        # ViDoRe v3.1 corpora expose both the page image and OCR markdown.
-        # ColVec1.1 encodes documents from images, so images must take
-        # precedence and corpus OCR text must not be encoded as a query.
+        # ViDoRe v3.1 corpus rows include page images and auxiliary OCR
+        # Markdown. ColVec1.1 was trained with text queries and page-image
+        # documents; it has no trained OCR/document-text fusion path.
+        # Therefore, prefer the image whenever both features are present.
         if "image" in inputs.dataset.features:
             return self.get_image_embeddings(inputs, **kwargs)
         if "text" in inputs.dataset.features:
@@ -371,7 +372,6 @@ colvec1_1_4b = ModelMeta(
     modalities=["image", "text"],
     n_parameters=4540904576,
     n_embedding_parameters=1639040,
-    n_active_parameters_override=None,
     memory_usage_mb=8661,
     max_tokens=262144,
     embed_dim=640,
@@ -419,7 +419,6 @@ colvec1_1_8b = ModelMeta(
     modalities=["image", "text"],
     n_parameters=8395317104,
     n_embedding_parameters=2622080,
-    n_active_parameters_override=None,
     memory_usage_mb=16013,
     max_tokens=262144,
     embed_dim=640,

--- a/mteb/models/model_implementations/webai_models.py
+++ b/mteb/models/model_implementations/webai_models.py
@@ -352,7 +352,7 @@ colvec1_1_4b = ModelMeta(
     loader=ColVec11Wrapper,
     loader_kwargs={
         "torch_dtype": torch.bfloat16,
-        "attn_implementation": "flash_attention_2",
+        "attn_implementation": "sdpa",
         "processor_kwargs": {
             "max_num_visual_tokens": 1792,
         },
@@ -391,7 +391,7 @@ colvec1_1_4b = ModelMeta(
     citation=COLVEC1_1_CITATION,
     contacts=["zhanlunchang-webai"],
     output_dtypes=None,
-    extra_requirements_groups=["flash_attention", "colvec1_1"],
+    extra_requirements_groups=["colvec1_1"],
 )
 
 
@@ -399,7 +399,7 @@ colvec1_1_8b = ModelMeta(
     loader=ColVec11Wrapper,
     loader_kwargs={
         "torch_dtype": torch.bfloat16,
-        "attn_implementation": "flash_attention_2",
+        "attn_implementation": "sdpa",
         "processor_kwargs": {
             "max_num_visual_tokens": 1792,
         },
@@ -438,5 +438,5 @@ colvec1_1_8b = ModelMeta(
     citation=COLVEC1_1_CITATION,
     contacts=["zhanlunchang-webai"],
     output_dtypes=None,
-    extra_requirements_groups=["flash_attention", "colvec1_1"],
+    extra_requirements_groups=["colvec1_1"],
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ jina = ["einops>=0.8.0"]
 jina-clip = ["peft>=0.15.2", "einops>=0.8.0", "transformers>=4.52.0,<5.0.0", "torchvision>=0.22.1", "timm>=1.0.15,<1.1.0"]
 jina-v4 = ["peft>=0.15.2", "transformers>=4.52.0,<5.0.0", "torchvision>=0.22.1"]
 flash_attention = ["flash-attn>=2.6.3"]
+colvec1_1 = ["transformers>=5.14.1,<6.0.0"]
 openai = ["openai>=1.41.0", "tiktoken>=0.8.0"]
 model2vec = ["model2vec>=0.3.0"]
 pylate = ["pylate>=1.3.1"]
@@ -459,6 +460,7 @@ conflicts = [
         { extra = "multimodal-sbert" }, # conflicting version of sentence-transformers
         { extra = "colpali_engine" },
         { extra = "colqwen3" },
+        { extra = "colvec1-1" },
         { extra = "jina-v4" },
         { extra = "sauerkrautlm-colpali" },
         { extra = "vllm" },


### PR DESCRIPTION
## Summary

- Add `ColVec11Wrapper` for the retrieval-only ColVec1.1 processor API.
- Register `webAI-Official/webAI-ColVec1.1-4b`.
- Register `webAI-Official/webAI-ColVec1.1-8b`.
- Use SDPA as the default attention implementation.
- Require Transformers 5.14.1 or newer through the `colvec1_1` dependency group.
- Use FP32 MaxSim scoring through `processor.score_retrieval()`.
- Prefer page images over auxiliary OCR Markdown for mixed corpus rows.

## Model revisions

- 4B: `b4f97a769bb1ac1de3a35308783ddd0d006d0394`
- 8B: `5a6eef07351b1c1653aa82e2e4c2f84f45a0d13d`

## Validation

- Tested `mteb.get_model_meta()` for both models.
- Tested `mteb.get_model()` for both models.
- Tested query and image encoding.
- Tested `ColVec11Wrapper.similarity()`.
- Tested image precedence for mixed image-plus-OCR corpus rows.
- Confirmed that the models run with SDPA without requiring `flash_attn`.

Benchmark results generated through the finalized SDPA registry configuration will be submitted separately after this model registration is merged.

## Model checklist

- [x] I have filled out the ModelMeta object to the extent possible.
- [x] I have ensured that my model can be loaded using:
  - [x] `mteb.get_model(model_name, revision)`
  - [x] `mteb.get_model_meta(model_name, revision)`
- [x] I have tested the implementation on a representative set of tasks.
- [x] The model weights are publicly available.
- [x] I reproduced the reported results on at least one benchmark. The result files will be submitted separately after this model registration is merged.