### PR TITLE
task: add FineVideo video clustering (v2c)

### DIFF
--- a/mteb/descriptive_stats/VideoClustering/FineVideoClustering.json
+++ b/mteb/descriptive_stats/VideoClustering/FineVideoClustering.json
@@ -1,0 +1,443 @@
+{
+    "test": {
+        "num_samples": 846,
+        "text_statistics": null,
+        "image_statistics": null,
+        "audio_statistics": null,
+        "video_statistics": {
+            "total_duration_seconds": 250977.76669647376,
+            "total_frames": 7085360,
+            "min_width": 202,
+            "average_width": 595.4420803782506,
+            "max_width": 640,
+            "min_height": 226,
+            "average_height": 380.31205673758865,
+            "max_height": 640,
+            "min_duration_seconds": 19.185833333333335,
+            "average_duration_seconds": 296.66402682798315,
+            "max_duration_seconds": 656.0887666666666,
+            "unique_videos": 845,
+            "average_fps": 28.166666666666668,
+            "fps": {
+                "24": 129,
+                "30": 569,
+                "25": 134,
+                "26": 2,
+                "29": 5,
+                "15": 3,
+                "7": 1,
+                "10": 1,
+                "27": 2
+            },
+            "min_resolution": [
+                202,
+                360
+            ],
+            "average_resolution": [
+                595.4420803782506,
+                380.31205673758865
+            ],
+            "max_resolution": [
+                640,
+                360
+            ],
+            "resolutions": {
+                "640x360": 691,
+                "626x360": 1,
+                "270x480": 12,
+                "480x360": 22,
+                "480x272": 2,
+                "202x360": 13,
+                "360x640": 58,
+                "416x236": 1,
+                "526x360": 1,
+                "204x360": 2,
+                "296x640": 2,
+                "576x360": 4,
+                "474x360": 1,
+                "360x360": 4,
+                "490x360": 1,
+                "580x360": 1,
+                "320x240": 2,
+                "492x360": 1,
+                "640x272": 3,
+                "540x360": 3,
+                "360x480": 1,
+                "360x370": 1,
+                "400x226": 1,
+                "484x360": 1,
+                "476x360": 1,
+                "576x324": 1,
+                "514x360": 1,
+                "638x360": 1,
+                "640x338": 1,
+                "636x360": 2,
+                "508x360": 1,
+                "478x360": 1,
+                "600x360": 1,
+                "640x358": 1,
+                "480x270": 2,
+                "408x360": 1,
+                "640x352": 1,
+                "270x360": 1,
+                "486x360": 1
+            }
+        },
+        "labels_statistics": {
+            "min_labels_per_text": 1,
+            "average_label_per_text": 1.0,
+            "max_labels_per_text": 1,
+            "unique_labels": 116,
+            "labels": {
+                "Engineering Projects": {
+                    "count": 8
+                },
+                "Game Reviews": {
+                    "count": 7
+                },
+                "Career Highlights": {
+                    "count": 8
+                },
+                "Recipe Videos": {
+                    "count": 8
+                },
+                "Fashion Hauls": {
+                    "count": 7
+                },
+                "Remixes": {
+                    "count": 8
+                },
+                "Skincare Routines": {
+                    "count": 8
+                },
+                "Music Videos": {
+                    "count": 8
+                },
+                "Documentaries": {
+                    "count": 8
+                },
+                "Home Improvement": {
+                    "count": 8
+                },
+                "Cultural Explainers": {
+                    "count": 8
+                },
+                "Film Trailers": {
+                    "count": 8
+                },
+                "Space Missions": {
+                    "count": 8
+                },
+                "Toy Collections": {
+                    "count": 8
+                },
+                "Camping": {
+                    "count": 8
+                },
+                "Software Tutorials": {
+                    "count": 8
+                },
+                "Chemistry": {
+                    "count": 8
+                },
+                "Poetry Readings": {
+                    "count": 8
+                },
+                "Memorabilia": {
+                    "count": 8
+                },
+                "Short Films": {
+                    "count": 8
+                },
+                "Let's Plays": {
+                    "count": 8
+                },
+                "Political Commentary": {
+                    "count": 8
+                },
+                "Marketing Strategies": {
+                    "count": 8
+                },
+                "Astronomy": {
+                    "count": 8
+                },
+                "Car Modifications": {
+                    "count": 8
+                },
+                "Conservation Efforts": {
+                    "count": 8
+                },
+                "Entrepreneurship": {
+                    "count": 8
+                },
+                "World News": {
+                    "count": 8
+                },
+                "Climate Change": {
+                    "count": 8
+                },
+                "Unboxing Videos": {
+                    "count": 8
+                },
+                "Book Reviews": {
+                    "count": 8
+                },
+                "Stand-up": {
+                    "count": 8
+                },
+                "Pranks": {
+                    "count": 6
+                },
+                "Buyer\u2019s Guides": {
+                    "count": 8
+                },
+                "Motivational Talks": {
+                    "count": 8
+                },
+                "Sports Talk Shows": {
+                    "count": 8
+                },
+                "Parodies": {
+                    "count": 8
+                },
+                "ASMR": {
+                    "count": 8
+                },
+                "Sketches": {
+                    "count": 8
+                },
+                "Political Interviews": {
+                    "count": 8
+                },
+                "Editorials": {
+                    "count": 8
+                },
+                "Analysis Shows": {
+                    "count": 8
+                },
+                "Hiking": {
+                    "count": 8
+                },
+                "Writing Tips": {
+                    "count": 8
+                },
+                "Knitting": {
+                    "count": 8
+                },
+                "Storytime": {
+                    "count": 8
+                },
+                "Training Techniques": {
+                    "count": 8
+                },
+                "Mental Health Tips": {
+                    "count": 8
+                },
+                "AI Concepts": {
+                    "count": 8
+                },
+                "Nutrition Guides": {
+                    "count": 8
+                },
+                "Off-Roading": {
+                    "count": 5
+                },
+                "Investment Guides": {
+                    "count": 8
+                },
+                "Celebrity Interviews": {
+                    "count": 8
+                },
+                "Destination Guides": {
+                    "count": 8
+                },
+                "Documentary Profiles": {
+                    "count": 8
+                },
+                "Food Reviews": {
+                    "count": 8
+                },
+                "Biology": {
+                    "count": 8
+                },
+                "Social Commentary": {
+                    "count": 8
+                },
+                "Travel Vlogs": {
+                    "count": 8
+                },
+                "Top 10 Videos": {
+                    "count": 8
+                },
+                "Ranked Lists": {
+                    "count": 8
+                },
+                "Travel Tips": {
+                    "count": 8
+                },
+                "Makeup Tutorials": {
+                    "count": 8
+                },
+                "Movie Reviews": {
+                    "count": 8
+                },
+                "Parenting Tips": {
+                    "count": 8
+                },
+                "Gadget Reviews": {
+                    "count": 8
+                },
+                "Expert Interviews": {
+                    "count": 8
+                },
+                "Pronunciation Guides": {
+                    "count": 8
+                },
+                "Match Replays": {
+                    "count": 8
+                },
+                "Game Commentary": {
+                    "count": 8
+                },
+                "Drawing Tutorials": {
+                    "count": 8
+                },
+                "Athlete Workouts": {
+                    "count": 8
+                },
+                "Daily Vlogs": {
+                    "count": 6
+                },
+                "Political News": {
+                    "count": 8
+                },
+                "Gardening Tips": {
+                    "count": 8
+                },
+                "TED Talks": {
+                    "count": 8
+                },
+                "Tech Reviews": {
+                    "count": 8
+                },
+                "Family Vlogs": {
+                    "count": 8
+                },
+                "Car Reviews": {
+                    "count": 8
+                },
+                "Event Livestreams": {
+                    "count": 8
+                },
+                "Physics": {
+                    "count": 8
+                },
+                "Lyric Videos": {
+                    "count": 8
+                },
+                "Historical Analysis": {
+                    "count": 8
+                },
+                "Walkthroughs": {
+                    "count": 8
+                },
+                "Software Reviews": {
+                    "count": 8
+                },
+                "Gameplay Tutorials": {
+                    "count": 8
+                },
+                "Fishing": {
+                    "count": 7
+                },
+                "Motorsport Commentary": {
+                    "count": 5
+                },
+                "Mechanical Engineering": {
+                    "count": 8
+                },
+                "Academic Lectures": {
+                    "count": 8
+                },
+                "Cooking Tutorials": {
+                    "count": 6
+                },
+                "DIY & Crafts": {
+                    "count": 8
+                },
+                "Q&A Sessions": {
+                    "count": 8
+                },
+                "Art Exhibitions": {
+                    "count": 8
+                },
+                "Cinematography": {
+                    "count": 6
+                },
+                "Language Lessons": {
+                    "count": 8
+                },
+                "Reaction Videos": {
+                    "count": 8
+                },
+                "Breaking News": {
+                    "count": 8
+                },
+                "Racing Highlights": {
+                    "count": 6
+                },
+                "Painting Tutorials": {
+                    "count": 8
+                },
+                "Political Debates": {
+                    "count": 1
+                },
+                "Science Explainers": {
+                    "count": 6
+                },
+                "Gaming Livestreams": {
+                    "count": 8
+                },
+                "Machine Learning Tutorials": {
+                    "count": 6
+                },
+                "Photography Tips": {
+                    "count": 6
+                },
+                "Interior Design": {
+                    "count": 2
+                },
+                "Covers": {
+                    "count": 8
+                },
+                "Workout Routines": {
+                    "count": 8
+                },
+                "Driving Tutorials": {
+                    "count": 5
+                },
+                "Game Highlights": {
+                    "count": 8
+                },
+                "Best of [Category]": {
+                    "count": 1
+                },
+                "Social Issue Debates": {
+                    "count": 1
+                },
+                "Childcare Advice": {
+                    "count": 1
+                },
+                "Social Experiments": {
+                    "count": 2
+                },
+                "DIY Projects": {
+                    "count": 1
+                },
+                "Electrical Engineering": {
+                    "count": 1
+                }
+            }
+        }
+    }
+}

--- a/mteb/tasks/clustering/eng/__init__.py
+++ b/mteb/tasks/clustering/eng/__init__.py
@@ -17,6 +17,7 @@ from .built_bench_clustering_s2s import BuiltBenchClusteringS2S
 from .cifar import CIFAR10Clustering, CIFAR100Clustering
 from .clus_trec_covid import ClusTrecCovid
 from .crema_d_clustering import CREMADClustering
+from .finevideo_clustering import FineVideoClustering
 from .hmdb51_clustering import HMDB51Clustering
 from .human_concepts_clustering import HumanConceptsClustering
 from .hume_arxiv_clustering_p2p import HUMEArxivClusteringP2P
@@ -86,6 +87,7 @@ __all__ = [
     "CIFAR100Clustering",
     "CREMADClustering",
     "ClusTrecCovid",
+    "FineVideoClustering",
     "HMDB51Clustering",
     "HUMEArxivClusteringP2P",
     "HUMERedditClusteringP2P",

--- a/mteb/tasks/clustering/eng/finevideo_clustering.py
+++ b/mteb/tasks/clustering/eng/finevideo_clustering.py
@@ -6,7 +6,7 @@ import time
 from collections import defaultdict
 from pathlib import Path
 
-from datasets import Dataset, Features, Value, Video, load_dataset
+from datasets import Dataset, load_dataset
 
 from mteb.abstasks import AbsTaskClustering
 from mteb.abstasks.task_metadata import TaskMetadata
@@ -17,7 +17,6 @@ _VIDEOS_PER_CATEGORY = 8
 _CACHE_DIR = Path(tempfile.gettempdir()) / "mteb_finevideo_clustering_cache"
 _MAX_STREAM_ATTEMPTS = 5
 _MAX_LOAD_SECONDS = 900
-_FEATURES = Features({"video": Video(), "label": Value("string")})
 
 
 class FineVideoClustering(AbsTaskClustering):
@@ -73,6 +72,13 @@ class FineVideoClustering(AbsTaskClustering):
     def load_data(self, **kwargs) -> None:
         if self.data_loaded:
             return
+        # Imported lazily: datasets.Video is only available when the
+        # optional `torchcodec` codec backend is installed, and importing
+        # it at module level would break importing this task (and thus the
+        # whole `mteb.tasks` package) in environments without it.
+        from datasets import Features, Value, Video
+
+        features = Features({"video": Video(), "label": Value("string")})
         _CACHE_DIR.mkdir(exist_ok=True, parents=True)
 
         counts: dict[str, int] = defaultdict(int)
@@ -111,7 +117,7 @@ class FineVideoClustering(AbsTaskClustering):
                     # single flaky shard can otherwise stall for a long time.
                     if rows_scanned % 50 == 0 and _time_budget_exceeded():
                         self.dataset = {
-                            "test": Dataset.from_list(records, features=_FEATURES)
+                            "test": Dataset.from_list(records, features=features)
                         }
                         self.data_loaded = True
                         return
@@ -124,7 +130,7 @@ class FineVideoClustering(AbsTaskClustering):
                         # just to skip most of them.
                         if rows_since_last_add >= 1500 and rows_scanned >= 4000:
                             self.dataset = {
-                                "test": Dataset.from_list(records, features=_FEATURES)
+                                "test": Dataset.from_list(records, features=features)
                             }
                             self.data_loaded = True
                             return
@@ -156,5 +162,5 @@ class FineVideoClustering(AbsTaskClustering):
                     raise
                 time.sleep(5)
 
-        self.dataset = {"test": Dataset.from_list(records, features=_FEATURES)}
+        self.dataset = {"test": Dataset.from_list(records, features=features)}
         self.data_loaded = True

--- a/mteb/tasks/clustering/eng/finevideo_clustering.py
+++ b/mteb/tasks/clustering/eng/finevideo_clustering.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import logging
+import tempfile
+import time
+from collections import defaultdict
+from pathlib import Path
+
+from datasets import Dataset, Features, Value, Video, load_dataset
+
+from mteb.abstasks import AbsTaskClustering
+from mteb.abstasks.task_metadata import TaskMetadata
+
+logger = logging.getLogger(__name__)
+
+_VIDEOS_PER_CATEGORY = 8
+_CACHE_DIR = Path(tempfile.gettempdir()) / "mteb_finevideo_clustering_cache"
+_MAX_STREAM_ATTEMPTS = 5
+_MAX_LOAD_SECONDS = 900
+_FEATURES = Features({"video": Video(), "label": Value("string")})
+
+
+class FineVideoClustering(AbsTaskClustering):
+    metadata = TaskMetadata(
+        name="FineVideoClustering",
+        description=(
+            "Clustering of YouTube videos into fine-grained content categories "
+            "from FineVideo, a Creative Commons video dataset derived by "
+            "filtering 1.9M videos from YouTube-Commons down to ~44K fully "
+            "annotated videos. Sampled up to 8 videos per fine-grained "
+            "category (content_fine_category, ~122 categories) directly from "
+            "the source dataset at load time; no repackaged copy is "
+            "distributed. Any use of this data must abide by the terms of the "
+            "original Creative Commons licenses of the individual videos, per "
+            "the FineVideo Terms of Use. Because a handful of categories are "
+            "rare in the source stream and the upstream host can be slow, "
+            "load_data() is time-boxed to roughly 15 minutes: it ships "
+            "whichever subset of categories it managed to fill by then "
+            "rather than guaranteeing full coverage of every category."
+        ),
+        reference="https://huggingface.co/blog/fine-video",
+        dataset={
+            "path": "HuggingFaceFV/finevideo",
+            "revision": "84c74091e1c6ee7a5dffabfafb5c9033e4718883",
+        },
+        type="VideoClustering",
+        category="v2c",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="v_measure",
+        date=("2024-09-01", "2024-09-19"),
+        domains=["Web", "Scene"],
+        task_subtypes=["Activity recognition"],
+        license="multiple",
+        annotations_creators="derived",
+        dialect=[],
+        modalities=["video"],
+        sample_creation="found",
+        is_beta=True,
+        bibtex_citation=r"""
+@misc{farre2024finevideo,
+  author = {Farr\'{e}, Miquel and Marafioti, Andres and Tunstall, Lewis and Von Werra, Leandro and Cuenca, Pedro and Wolf, Thomas},
+  title = {FineVideo},
+  url = {https://huggingface.co/datasets/HuggingFaceFV/finevideo},
+  year = {2024},
+}
+""",
+    )
+    max_fraction_of_documents_to_embed = None
+    input_column_name: str = "video"
+    label_column_name: str = "label"
+
+    def load_data(self, **kwargs) -> None:
+        if self.data_loaded:
+            return
+        _CACHE_DIR.mkdir(exist_ok=True, parents=True)
+
+        counts: dict[str, int] = defaultdict(int)
+        records: list[dict] = []
+        rows_scanned = 0
+        rows_since_last_add = 0
+        rows_to_skip = 0
+        load_start = time.time()
+
+        def _time_budget_exceeded() -> bool:
+            return time.time() - load_start > _MAX_LOAD_SECONDS
+
+        for attempt in range(1, _MAX_STREAM_ATTEMPTS + 1):
+            if _time_budget_exceeded():
+                logger.warning(
+                    "FineVideoClustering: %ds time budget reached before "
+                    "attempt %d; shipping the %d-video subset collected so far.",
+                    _MAX_LOAD_SECONDS,
+                    attempt,
+                    len(records),
+                )
+                break
+            try:
+                ds = load_dataset(
+                    self.metadata.dataset["path"],
+                    revision=self.metadata.dataset["revision"],
+                    split="train",
+                    streaming=True,
+                )
+                for i, row in enumerate(ds):
+                    if i < rows_to_skip:
+                        continue
+                    rows_scanned += 1
+                    # Bail out mid-shard once the time budget is hit, rather
+                    # than only checking between streaming attempts, since a
+                    # single flaky shard can otherwise stall for a long time.
+                    if rows_scanned % 50 == 0 and _time_budget_exceeded():
+                        self.dataset = {
+                            "test": Dataset.from_list(records, features=_FEATURES)
+                        }
+                        self.data_loaded = True
+                        return
+                    label = row["json"]["content_fine_category"]
+                    if counts[label] >= _VIDEOS_PER_CATEGORY:
+                        rows_since_last_add += 1
+                        # Stop once quotas have clearly stopped filling and
+                        # we've scanned a reasonable fraction of the
+                        # dataset, so we don't stream through all ~44K rows
+                        # just to skip most of them.
+                        if rows_since_last_add >= 1500 and rows_scanned >= 4000:
+                            self.dataset = {
+                                "test": Dataset.from_list(records, features=_FEATURES)
+                            }
+                            self.data_loaded = True
+                            return
+                        continue
+                    rows_since_last_add = 0
+                    video_id = row["json"]["original_video_filename"]
+                    video_path = _CACHE_DIR / f"{video_id}.mp4"
+                    if not video_path.exists():
+                        video_path.write_bytes(row["mp4"])
+                    records.append(
+                        {
+                            "video": {"path": str(video_path), "bytes": None},
+                            "label": label,
+                        }
+                    )
+                    counts[label] += 1
+                # Stream exhausted naturally before quotas/early-exit hit.
+                break
+            except Exception:
+                rows_to_skip = rows_scanned
+                logger.warning(
+                    "FineVideoClustering: stream error on attempt %d/%d after "
+                    "%d rows scanned, retrying with a fresh stream.",
+                    attempt,
+                    _MAX_STREAM_ATTEMPTS,
+                    rows_scanned,
+                )
+                if attempt == _MAX_STREAM_ATTEMPTS:
+                    raise
+                time.sleep(5)
+
+        self.dataset = {"test": Dataset.from_list(records, features=_FEATURES)}
+        self.data_loaded = True


### PR DESCRIPTION
## Summary
- Adds `FineVideoClustering`, a `VideoClustering` (v2c) task built on [HuggingFaceFV/finevideo](https://huggingface.co/datasets/HuggingFaceFV/finevideo)
- Samples up to 8 videos per `content_fine_category` directly from the source dataset at `load_data()` time — no repackaged copy is pushed/distributed, avoiding any redistribution/licensing complexity (each video keeps its original uploader's CC license per FineVideo's Terms of Use)
- `load_data()` is time-boxed to a 15-minute wall-clock budget (checked every 50 scanned rows, not just between retry attempts) so it reliably terminates and ships whichever subset of categories it filled, rather than requiring full coverage of all ~122 categories — this was necessary because the upstream HF host has intermittently stalled for hours on individual parquet shards
- Descriptive stats generated and committed: 846 videos, 116/122 categories represented (most at the full quota of 8)
- Verified with `mteb.evaluate` using `mteb/baseline-random-encoder` (main_score/v_measure ≈ 0.566, as expected for a random baseline)

Closes #5005

## Test plan
- [x] `ruff check` / `ruff format --check` pass on new/changed files
- [x] `mteb.get_task("FineVideoClustering")` loads without error
- [x] `calculate_descriptive_statistics` succeeds, stats JSON committed at `mteb/descriptive_stats/VideoClustering/FineVideoClustering.json`
- [x] Baseline eval via `mteb.evaluate(mteb.get_model("mteb/baseline-random-encoder"), FineVideoClustering(), cache=None)` completes and produces a plausible score