### PR TITLE
Add UrbanSound8K Audio Clustering task (closes #5018)

### DIFF
--- a/mteb/descriptive_stats/AudioClustering/UrbanSound8kClustering.json
+++ b/mteb/descriptive_stats/AudioClustering/UrbanSound8kClustering.json
@@ -1,0 +1,46 @@
+{
+    "train": {
+        "num_samples": 8732,
+        "text_statistics": null,
+        "image_statistics": null,
+        "audio_statistics": {
+            "total_duration_seconds": 31500.880612979,
+            "min_duration_seconds": 0.05,
+            "average_duration_seconds": 3.6075218292463354,
+            "max_duration_seconds": 4.036647314949202,
+            "unique_audios": 8732,
+            "average_sampling_rate": 48456.97927164452,
+            "sampling_rates": {
+                "44100": 5370,
+                "48000": 2502,
+                "96000": 610,
+                "22050": 44,
+                "16000": 45,
+                "11025": 39,
+                "192000": 17,
+                "32000": 4,
+                "11024": 7,
+                "24000": 82,
+                "8000": 12
+            }
+        },
+        "labels_statistics": {
+            "min_labels_per_text": 1,
+            "average_label_per_text": 1.0,
+            "max_labels_per_text": 1,
+            "unique_labels": 10,
+            "labels": {
+                "0": {"count": 1000},
+                "1": {"count": 429},
+                "2": {"count": 1000},
+                "3": {"count": 1000},
+                "4": {"count": 1000},
+                "5": {"count": 1000},
+                "6": {"count": 374},
+                "7": {"count": 1000},
+                "8": {"count": 929},
+                "9": {"count": 1000}
+            }
+        }
+    }
+}

--- a/mteb/tasks/clustering/zxx/__init__.py
+++ b/mteb/tasks/clustering/zxx/__init__.py
@@ -1,6 +1,7 @@
 from .esc50_clustering import ESC50Clustering
 from .gtzan_genre_clustering import GTZANGenreClustering
 from .music_genre import MusicGenreClustering
+from .urban_sound8k_clustering import UrbanSound8kClustering
 from .vehicle_sound_clustering import VehicleSoundClustering
 from .vim_sketch_clustering import VimSketchImitationClustering
 
@@ -8,6 +9,7 @@ __all__ = [
     "ESC50Clustering",
     "GTZANGenreClustering",
     "MusicGenreClustering",
+    "UrbanSound8kClustering",
     "VehicleSoundClustering",
     "VimSketchImitationClustering",
 ]

--- a/mteb/tasks/clustering/zxx/urban_sound8k_clustering.py
+++ b/mteb/tasks/clustering/zxx/urban_sound8k_clustering.py
@@ -1,0 +1,45 @@
+from mteb.abstasks import AbsTaskClustering
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class UrbanSound8kClustering(AbsTaskClustering):
+    label_column_name: str = "classID"
+    input_column_name: str = "audio"
+    max_fraction_of_documents_to_embed = None
+    metadata = TaskMetadata(
+        name="UrbanSound8kClustering",
+        description=(
+            "Audio clustering of UrbanSound8K: 8,732 urban sound recordings across "
+            "10 environmental categories (air conditioner, car horn, children playing, "
+            "dog bark, drilling, engine idling, gun shot, jackhammer, siren, street "
+            "music). Evaluates unsupervised grouping of real-world urban soundscapes."
+        ),
+        reference="https://huggingface.co/datasets/danavery/urbansound8K",
+        dataset={
+            "path": "mteb/urbansound8K",
+            "revision": "5b3867ddd7583a24871acdf6eb5494696ddd4cbc",
+        },
+        type="AudioClustering",
+        category="a2a",
+        modalities=["audio"],
+        eval_splits=["train"],
+        eval_langs=["zxx-Zxxx"],
+        main_score="v_measure",
+        date=("2014-11-01", "2014-11-03"),
+        domains=["AudioScene"],
+        task_subtypes=["Environment Sound Clustering"],
+        license="cc-by-nc-sa-3.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=r"""
+@inproceedings{Salamon:UrbanSound:ACMMM:14,
+  author = {Salamon, Justin and Jacoby, Christopher and Bello, Juan Pablo},
+  booktitle = {Proceedings of the 22nd ACM international conference on Multimedia},
+  organization = {ACM},
+  pages = {1041--1044},
+  title = {A Dataset and Taxonomy for Urban Sound Research},
+  year = {2014},
+}
+""",
+    )


### PR DESCRIPTION
 ## Summary
  - Adds `UrbanSound8kClustering` — an AudioClustering (a2a) task based on UrbanSound8K
  - 8,732 recordings across 10 urban sound categories, evaluated with v_measure
  - Complements existing UrbanSound8K classification and retrieval tasks in MTEB

  Closes #5018
  Part of MOEB: Massive Omni Embedding Benchmark (tracking issue #4842)