### PR TITLE
dataset: Add SciRepEval classification tasks (DRSM, biomimicry, FoS, MeSH)

### DIFF
--- a/mteb/descriptive_stats/Classification/SciRepEvalBiomimicryClassification.json
+++ b/mteb/descriptive_stats/Classification/SciRepEvalBiomimicryClassification.json
@@ -1,0 +1,58 @@
+{
+    "test": {
+        "num_samples": 2048,
+        "samples_in_train": 0,
+        "text_statistics": {
+            "total_text_length": 2892662,
+            "min_text_length": 29,
+            "average_text_length": 1412.4326171875,
+            "max_text_length": 3979,
+            "unique_texts": 2048
+        },
+        "image_statistics": null,
+        "audio_statistics": null,
+        "video_statistics": null,
+        "label_statistics": {
+            "min_labels_per_text": 1,
+            "average_label_per_text": 1.0,
+            "max_labels_per_text": 1,
+            "unique_labels": 2,
+            "labels": {
+                "0": {
+                    "count": 1791
+                },
+                "1": {
+                    "count": 257
+                }
+            }
+        }
+    },
+    "train": {
+        "num_samples": 7693,
+        "samples_in_train": null,
+        "text_statistics": {
+            "total_text_length": 10960740,
+            "min_text_length": 30,
+            "average_text_length": 1424.7679708826206,
+            "max_text_length": 6999,
+            "unique_texts": 7693
+        },
+        "image_statistics": null,
+        "audio_statistics": null,
+        "video_statistics": null,
+        "label_statistics": {
+            "min_labels_per_text": 1,
+            "average_label_per_text": 1.0,
+            "max_labels_per_text": 1,
+            "unique_labels": 2,
+            "labels": {
+                "1": {
+                    "count": 967
+                },
+                "0": {
+                    "count": 6726
+                }
+            }
+        }
+    }
+}

--- a/mteb/descriptive_stats/Classification/SciRepEvalBiomimicryClassification.json
+++ b/mteb/descriptive_stats/Classification/SciRepEvalBiomimicryClassification.json
@@ -1,41 +1,13 @@
 {
-    "test": {
-        "num_samples": 2048,
-        "samples_in_train": 0,
-        "text_statistics": {
-            "total_text_length": 2892662,
-            "min_text_length": 29,
-            "average_text_length": 1412.4326171875,
-            "max_text_length": 3979,
-            "unique_texts": 2048
-        },
-        "image_statistics": null,
-        "audio_statistics": null,
-        "video_statistics": null,
-        "label_statistics": {
-            "min_labels_per_text": 1,
-            "average_label_per_text": 1.0,
-            "max_labels_per_text": 1,
-            "unique_labels": 2,
-            "labels": {
-                "0": {
-                    "count": 1791
-                },
-                "1": {
-                    "count": 257
-                }
-            }
-        }
-    },
     "train": {
-        "num_samples": 7693,
+        "num_samples": 10991,
         "samples_in_train": null,
         "text_statistics": {
-            "total_text_length": 10960740,
-            "min_text_length": 30,
-            "average_text_length": 1424.7679708826206,
+            "total_text_length": 15650184,
+            "min_text_length": 29,
+            "average_text_length": 1423.9090164680192,
             "max_text_length": 6999,
-            "unique_texts": 7693
+            "unique_texts": 10991
         },
         "image_statistics": null,
         "audio_statistics": null,
@@ -47,10 +19,10 @@
             "unique_labels": 2,
             "labels": {
                 "1": {
-                    "count": 967
+                    "count": 1381
                 },
                 "0": {
-                    "count": 6726
+                    "count": 9610
                 }
             }
         }

--- a/mteb/descriptive_stats/Classification/SciRepEvalBiomimicryClassification.json
+++ b/mteb/descriptive_stats/Classification/SciRepEvalBiomimicryClassification.json
@@ -1,5 +1,5 @@
 {
-    "train": {
+    "evaluation": {
         "num_samples": 10991,
         "samples_in_train": null,
         "text_statistics": {

--- a/mteb/descriptive_stats/Classification/SciRepEvalDRSMClassification.json
+++ b/mteb/descriptive_stats/Classification/SciRepEvalDRSMClassification.json
@@ -1,0 +1,76 @@
+{
+    "test": {
+        "num_samples": 2048,
+        "samples_in_train": 0,
+        "text_statistics": {
+            "total_text_length": 2798020,
+            "min_text_length": 33,
+            "average_text_length": 1366.220703125,
+            "max_text_length": 4099,
+            "unique_texts": 2048
+        },
+        "image_statistics": null,
+        "audio_statistics": null,
+        "video_statistics": null,
+        "label_statistics": {
+            "min_labels_per_text": 1,
+            "average_label_per_text": 1.0,
+            "max_labels_per_text": 1,
+            "unique_labels": 5,
+            "labels": {
+                "0": {
+                    "count": 968
+                },
+                "2": {
+                    "count": 651
+                },
+                "1": {
+                    "count": 79
+                },
+                "3": {
+                    "count": 271
+                },
+                "4": {
+                    "count": 79
+                }
+            }
+        }
+    },
+    "train": {
+        "num_samples": 6169,
+        "samples_in_train": null,
+        "text_statistics": {
+            "total_text_length": 8454623,
+            "min_text_length": 107,
+            "average_text_length": 1370.5013778570271,
+            "max_text_length": 7240,
+            "unique_texts": 6168
+        },
+        "image_statistics": null,
+        "audio_statistics": null,
+        "video_statistics": null,
+        "label_statistics": {
+            "min_labels_per_text": 1,
+            "average_label_per_text": 1.0,
+            "max_labels_per_text": 1,
+            "unique_labels": 5,
+            "labels": {
+                "2": {
+                    "count": 1961
+                },
+                "0": {
+                    "count": 2916
+                },
+                "3": {
+                    "count": 816
+                },
+                "4": {
+                    "count": 239
+                },
+                "1": {
+                    "count": 237
+                }
+            }
+        }
+    }
+}

--- a/mteb/descriptive_stats/Classification/SciRepEvalDRSMClassification.json
+++ b/mteb/descriptive_stats/Classification/SciRepEvalDRSMClassification.json
@@ -1,5 +1,5 @@
 {
-    "train": {
+    "evaluation": {
         "num_samples": 8812,
         "samples_in_train": null,
         "text_statistics": {

--- a/mteb/descriptive_stats/Classification/SciRepEvalDRSMClassification.json
+++ b/mteb/descriptive_stats/Classification/SciRepEvalDRSMClassification.json
@@ -1,50 +1,13 @@
 {
-    "test": {
-        "num_samples": 2048,
-        "samples_in_train": 0,
-        "text_statistics": {
-            "total_text_length": 2805677,
-            "min_text_length": 33,
-            "average_text_length": 1369.95947265625,
-            "max_text_length": 4099,
-            "unique_texts": 2048
-        },
-        "image_statistics": null,
-        "audio_statistics": null,
-        "video_statistics": null,
-        "label_statistics": {
-            "min_labels_per_text": 1,
-            "average_label_per_text": 1.0,
-            "max_labels_per_text": 1,
-            "unique_labels": 5,
-            "labels": {
-                "0": {
-                    "count": 968
-                },
-                "2": {
-                    "count": 651
-                },
-                "1": {
-                    "count": 79
-                },
-                "3": {
-                    "count": 271
-                },
-                "4": {
-                    "count": 79
-                }
-            }
-        }
-    },
     "train": {
-        "num_samples": 6168,
+        "num_samples": 8812,
         "samples_in_train": null,
         "text_statistics": {
-            "total_text_length": 8453021,
-            "min_text_length": 107,
-            "average_text_length": 1370.4638456549935,
+            "total_text_length": 12062862,
+            "min_text_length": 33,
+            "average_text_length": 1368.9130730821607,
             "max_text_length": 7240,
-            "unique_texts": 6168
+            "unique_texts": 8812
         },
         "image_statistics": null,
         "audio_statistics": null,
@@ -55,20 +18,20 @@
             "max_labels_per_text": 1,
             "unique_labels": 5,
             "labels": {
-                "2": {
-                    "count": 1961
-                },
                 "0": {
-                    "count": 2915
-                },
-                "3": {
-                    "count": 816
+                    "count": 4165
                 },
                 "1": {
-                    "count": 237
+                    "count": 339
+                },
+                "2": {
+                    "count": 2801
+                },
+                "3": {
+                    "count": 1166
                 },
                 "4": {
-                    "count": 239
+                    "count": 341
                 }
             }
         }

--- a/mteb/descriptive_stats/Classification/SciRepEvalDRSMClassification.json
+++ b/mteb/descriptive_stats/Classification/SciRepEvalDRSMClassification.json
@@ -3,9 +3,9 @@
         "num_samples": 2048,
         "samples_in_train": 0,
         "text_statistics": {
-            "total_text_length": 2798020,
+            "total_text_length": 2805677,
             "min_text_length": 33,
-            "average_text_length": 1366.220703125,
+            "average_text_length": 1369.95947265625,
             "max_text_length": 4099,
             "unique_texts": 2048
         },
@@ -37,12 +37,12 @@
         }
     },
     "train": {
-        "num_samples": 6169,
+        "num_samples": 6168,
         "samples_in_train": null,
         "text_statistics": {
-            "total_text_length": 8454623,
+            "total_text_length": 8453021,
             "min_text_length": 107,
-            "average_text_length": 1370.5013778570271,
+            "average_text_length": 1370.4638456549935,
             "max_text_length": 7240,
             "unique_texts": 6168
         },
@@ -59,16 +59,16 @@
                     "count": 1961
                 },
                 "0": {
-                    "count": 2916
+                    "count": 2915
                 },
                 "3": {
                     "count": 816
                 },
-                "4": {
-                    "count": 239
-                },
                 "1": {
                     "count": 237
+                },
+                "4": {
+                    "count": 239
                 }
             }
         }

--- a/mteb/descriptive_stats/Classification/SciRepEvalMeSHDescriptorsClassification.json
+++ b/mteb/descriptive_stats/Classification/SciRepEvalMeSHDescriptorsClassification.json
@@ -1,5 +1,5 @@
 {
-    "train": {
+    "evaluation": {
         "num_samples": 8192,
         "samples_in_train": null,
         "text_statistics": {

--- a/mteb/descriptive_stats/Classification/SciRepEvalMeSHDescriptorsClassification.json
+++ b/mteb/descriptive_stats/Classification/SciRepEvalMeSHDescriptorsClassification.json
@@ -1,125 +1,13 @@
 {
-    "test": {
-        "num_samples": 2048,
-        "samples_in_train": 0,
-        "text_statistics": {
-            "total_text_length": 2949420,
-            "min_text_length": 131,
-            "average_text_length": 1440.146484375,
-            "max_text_length": 8621,
-            "unique_texts": 2048
-        },
-        "image_statistics": null,
-        "audio_statistics": null,
-        "video_statistics": null,
-        "label_statistics": {
-            "min_labels_per_text": 1,
-            "average_label_per_text": 1.0,
-            "max_labels_per_text": 1,
-            "unique_labels": 30,
-            "labels": {
-                "24": {
-                    "count": 97
-                },
-                "3": {
-                    "count": 86
-                },
-                "6": {
-                    "count": 159
-                },
-                "25": {
-                    "count": 55
-                },
-                "26": {
-                    "count": 66
-                },
-                "0": {
-                    "count": 37
-                },
-                "10": {
-                    "count": 37
-                },
-                "13": {
-                    "count": 65
-                },
-                "8": {
-                    "count": 69
-                },
-                "2": {
-                    "count": 98
-                },
-                "23": {
-                    "count": 121
-                },
-                "12": {
-                    "count": 60
-                },
-                "5": {
-                    "count": 69
-                },
-                "7": {
-                    "count": 111
-                },
-                "28": {
-                    "count": 72
-                },
-                "14": {
-                    "count": 82
-                },
-                "18": {
-                    "count": 51
-                },
-                "27": {
-                    "count": 40
-                },
-                "29": {
-                    "count": 38
-                },
-                "19": {
-                    "count": 53
-                },
-                "17": {
-                    "count": 93
-                },
-                "15": {
-                    "count": 61
-                },
-                "20": {
-                    "count": 65
-                },
-                "16": {
-                    "count": 51
-                },
-                "21": {
-                    "count": 49
-                },
-                "4": {
-                    "count": 47
-                },
-                "11": {
-                    "count": 68
-                },
-                "9": {
-                    "count": 38
-                },
-                "1": {
-                    "count": 57
-                },
-                "22": {
-                    "count": 53
-                }
-            }
-        }
-    },
     "train": {
-        "num_samples": 5734,
+        "num_samples": 8192,
         "samples_in_train": null,
         "text_statistics": {
-            "total_text_length": 8283004,
+            "total_text_length": 11816485,
             "min_text_length": 80,
-            "average_text_length": 1444.542029996512,
+            "average_text_length": 1442.4420166015625,
             "max_text_length": 10064,
-            "unique_texts": 5734
+            "unique_texts": 8192
         },
         "image_statistics": null,
         "audio_statistics": null,
@@ -130,95 +18,95 @@
             "max_labels_per_text": 1,
             "unique_labels": 30,
             "labels": {
-                "24": {
-                    "count": 272
-                },
-                "7": {
-                    "count": 309
-                },
                 "0": {
-                    "count": 105
-                },
-                "2": {
-                    "count": 276
-                },
-                "23": {
-                    "count": 339
-                },
-                "16": {
-                    "count": 143
-                },
-                "12": {
-                    "count": 168
-                },
-                "9": {
-                    "count": 104
-                },
-                "27": {
-                    "count": 111
-                },
-                "17": {
-                    "count": 262
-                },
-                "5": {
-                    "count": 193
-                },
-                "25": {
-                    "count": 154
-                },
-                "20": {
-                    "count": 182
-                },
-                "3": {
-                    "count": 240
-                },
-                "8": {
-                    "count": 195
-                },
-                "11": {
-                    "count": 191
-                },
-                "14": {
-                    "count": 229
-                },
-                "6": {
-                    "count": 444
-                },
-                "28": {
-                    "count": 199
-                },
-                "22": {
                     "count": 150
                 },
-                "10": {
-                    "count": 104
+                "23": {
+                    "count": 484
                 },
-                "4": {
-                    "count": 133
+                "24": {
+                    "count": 388
                 },
-                "26": {
-                    "count": 186
+                "3": {
+                    "count": 343
                 },
                 "21": {
-                    "count": 138
-                },
-                "29": {
-                    "count": 107
-                },
-                "15": {
-                    "count": 169
-                },
-                "13": {
-                    "count": 182
+                    "count": 197
                 },
                 "18": {
-                    "count": 141
+                    "count": 202
                 },
-                "19": {
-                    "count": 148
+                "14": {
+                    "count": 327
+                },
+                "6": {
+                    "count": 635
+                },
+                "2": {
+                    "count": 394
+                },
+                "4": {
+                    "count": 190
+                },
+                "16": {
+                    "count": 204
+                },
+                "9": {
+                    "count": 149
+                },
+                "11": {
+                    "count": 273
+                },
+                "17": {
+                    "count": 374
                 },
                 "1": {
-                    "count": 160
+                    "count": 228
+                },
+                "28": {
+                    "count": 285
+                },
+                "13": {
+                    "count": 260
+                },
+                "12": {
+                    "count": 240
+                },
+                "19": {
+                    "count": 212
+                },
+                "29": {
+                    "count": 153
+                },
+                "7": {
+                    "count": 442
+                },
+                "25": {
+                    "count": 220
+                },
+                "15": {
+                    "count": 242
+                },
+                "22": {
+                    "count": 214
+                },
+                "20": {
+                    "count": 260
+                },
+                "8": {
+                    "count": 278
+                },
+                "26": {
+                    "count": 265
+                },
+                "5": {
+                    "count": 276
+                },
+                "10": {
+                    "count": 148
+                },
+                "27": {
+                    "count": 159
                 }
             }
         }

--- a/mteb/descriptive_stats/Classification/SciRepEvalMeSHDescriptorsClassification.json
+++ b/mteb/descriptive_stats/Classification/SciRepEvalMeSHDescriptorsClassification.json
@@ -1,0 +1,226 @@
+{
+    "test": {
+        "num_samples": 2048,
+        "samples_in_train": 0,
+        "text_statistics": {
+            "total_text_length": 2949420,
+            "min_text_length": 131,
+            "average_text_length": 1440.146484375,
+            "max_text_length": 8621,
+            "unique_texts": 2048
+        },
+        "image_statistics": null,
+        "audio_statistics": null,
+        "video_statistics": null,
+        "label_statistics": {
+            "min_labels_per_text": 1,
+            "average_label_per_text": 1.0,
+            "max_labels_per_text": 1,
+            "unique_labels": 30,
+            "labels": {
+                "24": {
+                    "count": 97
+                },
+                "3": {
+                    "count": 86
+                },
+                "6": {
+                    "count": 159
+                },
+                "25": {
+                    "count": 55
+                },
+                "26": {
+                    "count": 66
+                },
+                "0": {
+                    "count": 37
+                },
+                "10": {
+                    "count": 37
+                },
+                "13": {
+                    "count": 65
+                },
+                "8": {
+                    "count": 69
+                },
+                "2": {
+                    "count": 98
+                },
+                "23": {
+                    "count": 121
+                },
+                "12": {
+                    "count": 60
+                },
+                "5": {
+                    "count": 69
+                },
+                "7": {
+                    "count": 111
+                },
+                "28": {
+                    "count": 72
+                },
+                "14": {
+                    "count": 82
+                },
+                "18": {
+                    "count": 51
+                },
+                "27": {
+                    "count": 40
+                },
+                "29": {
+                    "count": 38
+                },
+                "19": {
+                    "count": 53
+                },
+                "17": {
+                    "count": 93
+                },
+                "15": {
+                    "count": 61
+                },
+                "20": {
+                    "count": 65
+                },
+                "16": {
+                    "count": 51
+                },
+                "21": {
+                    "count": 49
+                },
+                "4": {
+                    "count": 47
+                },
+                "11": {
+                    "count": 68
+                },
+                "9": {
+                    "count": 38
+                },
+                "1": {
+                    "count": 57
+                },
+                "22": {
+                    "count": 53
+                }
+            }
+        }
+    },
+    "train": {
+        "num_samples": 5734,
+        "samples_in_train": null,
+        "text_statistics": {
+            "total_text_length": 8283004,
+            "min_text_length": 80,
+            "average_text_length": 1444.542029996512,
+            "max_text_length": 10064,
+            "unique_texts": 5734
+        },
+        "image_statistics": null,
+        "audio_statistics": null,
+        "video_statistics": null,
+        "label_statistics": {
+            "min_labels_per_text": 1,
+            "average_label_per_text": 1.0,
+            "max_labels_per_text": 1,
+            "unique_labels": 30,
+            "labels": {
+                "24": {
+                    "count": 272
+                },
+                "7": {
+                    "count": 309
+                },
+                "0": {
+                    "count": 105
+                },
+                "2": {
+                    "count": 276
+                },
+                "23": {
+                    "count": 339
+                },
+                "16": {
+                    "count": 143
+                },
+                "12": {
+                    "count": 168
+                },
+                "9": {
+                    "count": 104
+                },
+                "27": {
+                    "count": 111
+                },
+                "17": {
+                    "count": 262
+                },
+                "5": {
+                    "count": 193
+                },
+                "25": {
+                    "count": 154
+                },
+                "20": {
+                    "count": 182
+                },
+                "3": {
+                    "count": 240
+                },
+                "8": {
+                    "count": 195
+                },
+                "11": {
+                    "count": 191
+                },
+                "14": {
+                    "count": 229
+                },
+                "6": {
+                    "count": 444
+                },
+                "28": {
+                    "count": 199
+                },
+                "22": {
+                    "count": 150
+                },
+                "10": {
+                    "count": 104
+                },
+                "4": {
+                    "count": 133
+                },
+                "26": {
+                    "count": 186
+                },
+                "21": {
+                    "count": 138
+                },
+                "29": {
+                    "count": 107
+                },
+                "15": {
+                    "count": 169
+                },
+                "13": {
+                    "count": 182
+                },
+                "18": {
+                    "count": 141
+                },
+                "19": {
+                    "count": 148
+                },
+                "1": {
+                    "count": 160
+                }
+            }
+        }
+    }
+}

--- a/mteb/descriptive_stats/MultilabelClassification/SciRepEvalFoSClassification.json
+++ b/mteb/descriptive_stats/MultilabelClassification/SciRepEvalFoSClassification.json
@@ -1,0 +1,184 @@
+{
+    "test": {
+        "num_samples": 2458,
+        "samples_in_train": 0,
+        "text_statistics": {
+            "total_text_length": 2150882,
+            "min_text_length": 15,
+            "average_text_length": 875.053702196908,
+            "max_text_length": 5881,
+            "unique_texts": 2458
+        },
+        "image_statistics": null,
+        "audio_statistics": null,
+        "video_statistics": null,
+        "label_statistics": {
+            "min_labels_per_text": 1,
+            "average_label_per_text": 1.1761594792514238,
+            "max_labels_per_text": 3,
+            "unique_labels": 23,
+            "labels": {
+                "Biology": {
+                    "count": 243
+                },
+                "Mathematics": {
+                    "count": 166
+                },
+                "Political science": {
+                    "count": 103
+                },
+                "Agricultural and Food sciences": {
+                    "count": 110
+                },
+                "Chemistry": {
+                    "count": 180
+                },
+                "Geology": {
+                    "count": 59
+                },
+                "Computer science": {
+                    "count": 162
+                },
+                "Environmental science": {
+                    "count": 240
+                },
+                "Education": {
+                    "count": 140
+                },
+                "Engineering": {
+                    "count": 150
+                },
+                "Physics": {
+                    "count": 321
+                },
+                "Medicine": {
+                    "count": 307
+                },
+                "Psychology": {
+                    "count": 126
+                },
+                "Materials science": {
+                    "count": 105
+                },
+                "History": {
+                    "count": 189
+                },
+                "Philosophy": {
+                    "count": 26
+                },
+                "Economics": {
+                    "count": 103
+                },
+                "Geography": {
+                    "count": 42
+                },
+                "Art": {
+                    "count": 17
+                },
+                "Law": {
+                    "count": 29
+                },
+                "Business": {
+                    "count": 36
+                },
+                "Linguistics": {
+                    "count": 8
+                },
+                "Sociology": {
+                    "count": 29
+                }
+            }
+        }
+    },
+    "train": {
+        "num_samples": 5734,
+        "samples_in_train": null,
+        "text_statistics": {
+            "total_text_length": 4991112,
+            "min_text_length": 13,
+            "average_text_length": 870.441576560865,
+            "max_text_length": 10098,
+            "unique_texts": 5734
+        },
+        "image_statistics": null,
+        "audio_statistics": null,
+        "video_statistics": null,
+        "label_statistics": {
+            "min_labels_per_text": 1,
+            "average_label_per_text": 1.1996860830136031,
+            "max_labels_per_text": 3,
+            "unique_labels": 23,
+            "labels": {
+                "Engineering": {
+                    "count": 358
+                },
+                "Physics": {
+                    "count": 765
+                },
+                "Environmental science": {
+                    "count": 561
+                },
+                "Chemistry": {
+                    "count": 437
+                },
+                "Economics": {
+                    "count": 223
+                },
+                "History": {
+                    "count": 434
+                },
+                "Geology": {
+                    "count": 140
+                },
+                "Medicine": {
+                    "count": 768
+                },
+                "Agricultural and Food sciences": {
+                    "count": 207
+                },
+                "Computer science": {
+                    "count": 422
+                },
+                "Business": {
+                    "count": 104
+                },
+                "Biology": {
+                    "count": 590
+                },
+                "Psychology": {
+                    "count": 285
+                },
+                "Mathematics": {
+                    "count": 364
+                },
+                "Education": {
+                    "count": 327
+                },
+                "Political science": {
+                    "count": 279
+                },
+                "Philosophy": {
+                    "count": 91
+                },
+                "Materials science": {
+                    "count": 228
+                },
+                "Geography": {
+                    "count": 107
+                },
+                "Sociology": {
+                    "count": 63
+                },
+                "Law": {
+                    "count": 62
+                },
+                "Art": {
+                    "count": 42
+                },
+                "Linguistics": {
+                    "count": 22
+                }
+            }
+        }
+    }
+}

--- a/mteb/tasks/classification/eng/__init__.py
+++ b/mteb/tasks/classification/eng/__init__.py
@@ -231,6 +231,7 @@ from .ravdess_av_classification import (
     RAVDESSVClassification,
 )
 from .resisc45_classification import RESISC45Classification
+from .scirepeval_drsm_classification import SciRepEvalDRSMClassification
 from .sds_eye_protection_classification import (
     SDSEyeProtectionClassification,
     SDSEyeProtectionClassificationV2,
@@ -526,6 +527,7 @@ __all__ = [
     "SDSGlovesClassificationV2",
     "STL10Classification",
     "SUN397Classification",
+    "SciRepEvalDRSMClassification",
     "SomethingSomethingV2Classification",
     "SpeechCommandsClassification",
     "SpokeNEnglishClassification",

--- a/mteb/tasks/classification/eng/__init__.py
+++ b/mteb/tasks/classification/eng/__init__.py
@@ -231,7 +231,11 @@ from .ravdess_av_classification import (
     RAVDESSVClassification,
 )
 from .resisc45_classification import RESISC45Classification
+from .scirepeval_biomimicry_classification import SciRepEvalBiomimicryClassification
 from .scirepeval_drsm_classification import SciRepEvalDRSMClassification
+from .scirepeval_mesh_descriptors_classification import (
+    SciRepEvalMeSHDescriptorsClassification,
+)
 from .sds_eye_protection_classification import (
     SDSEyeProtectionClassification,
     SDSEyeProtectionClassificationV2,
@@ -527,7 +531,9 @@ __all__ = [
     "SDSGlovesClassificationV2",
     "STL10Classification",
     "SUN397Classification",
+    "SciRepEvalBiomimicryClassification",
     "SciRepEvalDRSMClassification",
+    "SciRepEvalMeSHDescriptorsClassification",
     "SomethingSomethingV2Classification",
     "SpeechCommandsClassification",
     "SpokeNEnglishClassification",

--- a/mteb/tasks/classification/eng/scirepeval_biomimicry_classification.py
+++ b/mteb/tasks/classification/eng/scirepeval_biomimicry_classification.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from mteb.abstasks.classification import AbsTaskClassification
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class SciRepEvalBiomimicryClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="SciRepEvalBiomimicryClassification",
+        description=(
+            "Biomimicry relevance classification task from the SciRepEval "
+            "benchmark. Given the title and abstract of a scientific paper, "
+            "predict whether the paper is relevant to biomimicry research "
+            "(binary classification)."
+        ),
+        reference="https://aclanthology.org/2023.emnlp-main.338/",
+        dataset={
+            "path": "allenai/scirepeval",
+            "name": "biomimicry",
+            "revision": "781d35d1bf87253b3dcd0fadcb82bfbee9c244f1",
+        },
+        type="Classification",
+        category="t2c",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2022-01-01", "2023-12-06"),
+        domains=["Academic", "Engineering", "Written"],
+        task_subtypes=["Topic classification"],
+        license="not specified",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=r"""
+@inproceedings{singh-etal-2023-scirepeval,
+  address = {Singapore},
+  author = {Singh, Amanpreet  and
+D{'}Arcy, Mike  and
+Cohan, Arman  and
+Downey, Doug  and
+Feldman, Sergey},
+  booktitle = {Proceedings of the 2023 Conference on Empirical Methods in Natural Language Processing},
+  doi = {10.18653/v1/2023.emnlp-main.338},
+  month = dec,
+  pages = {5548--5566},
+  publisher = {Association for Computational Linguistics},
+  title = {{SciRepEval: A Multi-Format Benchmark for Scientific Document Representations}},
+  url = {https://aclanthology.org/2023.emnlp-main.338/},
+  year = {2023},
+}
+""",
+    )
+
+    def dataset_transform(self, num_proc: int | None = None) -> None:
+        # SciRepEval exposes only a single "evaluation" split for `biomimicry`,
+        # so we build a stratified train/test split for the classification probe.
+        ds = self.dataset["evaluation"]
+        ds = ds.map(
+            lambda x: {"text": f"{x['title'] or ''}\n\n{x['abstract'] or ''}".strip()},
+            num_proc=num_proc,
+        )
+        keep = {"text", "label"}
+        ds = ds.remove_columns([c for c in ds.column_names if c not in keep])
+        ds = ds.class_encode_column("label")
+        ds = ds.train_test_split(
+            test_size=0.3, seed=self.seed, stratify_by_column="label"
+        )
+        ds = self.stratified_subsampling(
+            dataset_dict=ds, seed=self.seed, splits=["test"]
+        )
+        self.dataset = ds

--- a/mteb/tasks/classification/eng/scirepeval_biomimicry_classification.py
+++ b/mteb/tasks/classification/eng/scirepeval_biomimicry_classification.py
@@ -8,10 +8,10 @@ class SciRepEvalBiomimicryClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="SciRepEvalBiomimicryClassification",
         description=(
-            "Biomimicry relevance classification task from the SciRepEval "
-            "benchmark. Given the title and abstract of a scientific paper, "
-            "predict whether the paper is relevant to biomimicry research "
-            "(binary classification)."
+            "Biomimicry relevance classification. Given the title and abstract "
+            "of a scientific paper, predict whether the paper is relevant to "
+            "biomimicry research (binary classification). Published as a part of "
+            "SciRepEval."
         ),
         reference="https://aclanthology.org/2023.emnlp-main.338/",
         dataset={
@@ -28,8 +28,8 @@ class SciRepEvalBiomimicryClassification(AbsTaskClassification):
         date=("2022-01-01", "2023-12-06"),
         domains=["Academic", "Engineering", "Written"],
         task_subtypes=["Topic classification"],
-        license="not specified",
-        annotations_creators="derived",
+        license="odc-by",
+        annotations_creators="human-annotated",
         dialect=[],
         sample_creation="found",
         bibtex_citation=r"""

--- a/mteb/tasks/classification/eng/scirepeval_biomimicry_classification.py
+++ b/mteb/tasks/classification/eng/scirepeval_biomimicry_classification.py
@@ -22,7 +22,7 @@ class SciRepEvalBiomimicryClassification(AbsTaskClassification):
         type="Classification",
         category="t2c",
         modalities=["text"],
-        eval_splits=["train"],
+        eval_splits=["evaluation"],
         eval_langs=["eng-Latn"],
         main_score="accuracy",
         date=("2022-01-01", "2023-12-06"),
@@ -53,10 +53,11 @@ Feldman, Sergey},
     )
 
     is_cross_validation: bool = True
+    train_split: str = "evaluation"
 
     def dataset_transform(self, num_proc: int | None = None) -> None:
         # SciRepEval exposes only a single "evaluation" split for `biomimicry`.
-        # We keep it as one split named "train" and let MTEB's cross-validation
+        # We keep it named "evaluation" and let MTEB's cross-validation
         # path (is_cross_validation) run KFold over the whole split.
         from datasets import DatasetDict
 
@@ -68,4 +69,4 @@ Feldman, Sergey},
         keep = {"text", "label"}
         ds = ds.remove_columns([c for c in ds.column_names if c not in keep])
         ds = ds.class_encode_column("label")
-        self.dataset = DatasetDict({"train": ds})
+        self.dataset = DatasetDict({"evaluation": ds})

--- a/mteb/tasks/classification/eng/scirepeval_biomimicry_classification.py
+++ b/mteb/tasks/classification/eng/scirepeval_biomimicry_classification.py
@@ -22,7 +22,7 @@ class SciRepEvalBiomimicryClassification(AbsTaskClassification):
         type="Classification",
         category="t2c",
         modalities=["text"],
-        eval_splits=["test"],
+        eval_splits=["train"],
         eval_langs=["eng-Latn"],
         main_score="accuracy",
         date=("2022-01-01", "2023-12-06"),
@@ -52,9 +52,14 @@ Feldman, Sergey},
 """,
     )
 
+    is_cross_validation: bool = True
+
     def dataset_transform(self, num_proc: int | None = None) -> None:
-        # SciRepEval exposes only a single "evaluation" split for `biomimicry`,
-        # so we build a stratified train/test split for the classification probe.
+        # SciRepEval exposes only a single "evaluation" split for `biomimicry`.
+        # We keep it as one split named "train" and let MTEB's cross-validation
+        # path (is_cross_validation) run KFold over the whole split.
+        from datasets import DatasetDict
+
         ds = self.dataset["evaluation"]
         ds = ds.map(
             lambda x: {"text": f"{x['title'] or ''}\n\n{x['abstract'] or ''}".strip()},
@@ -63,10 +68,4 @@ Feldman, Sergey},
         keep = {"text", "label"}
         ds = ds.remove_columns([c for c in ds.column_names if c not in keep])
         ds = ds.class_encode_column("label")
-        ds = ds.train_test_split(
-            test_size=0.3, seed=self.seed, stratify_by_column="label"
-        )
-        ds = self.stratified_subsampling(
-            dataset_dict=ds, seed=self.seed, splits=["test"]
-        )
-        self.dataset = ds
+        self.dataset = DatasetDict({"train": ds})

--- a/mteb/tasks/classification/eng/scirepeval_drsm_classification.py
+++ b/mteb/tasks/classification/eng/scirepeval_drsm_classification.py
@@ -24,7 +24,7 @@ class SciRepEvalDRSMClassification(AbsTaskClassification):
         type="Classification",
         category="t2c",
         modalities=["text"],
-        eval_splits=["test"],
+        eval_splits=["train"],
         eval_langs=["eng-Latn"],
         main_score="accuracy",
         date=("2022-01-01", "2023-12-06"),
@@ -54,9 +54,14 @@ Feldman, Sergey},
 """,
     )
 
+    is_cross_validation: bool = True
+
     def dataset_transform(self, num_proc: int | None = None) -> None:
-        # SciRepEval exposes only a single "evaluation" split for `drsm`, so we
-        # build a stratified train/test split for the classification evaluator.
+        # SciRepEval exposes only a single "evaluation" split for `drsm`. We keep
+        # it as one split named "train" and let MTEB's cross-validation path
+        # (is_cross_validation) run KFold over the whole split.
+        from datasets import DatasetDict
+
         ds = self.dataset["evaluation"]
         ds = ds.map(
             lambda x: {"text": f"{x['title'] or ''}\n\n{x['abstract'] or ''}".strip()},
@@ -66,7 +71,7 @@ Feldman, Sergey},
         ds = ds.remove_columns([c for c in ds.column_names if c not in keep])
         ds = ds.rename_column("class", "label")
         # A couple of papers share an identical title+abstract; drop duplicate
-        # texts so the same document cannot leak across the train/test split.
+        # texts so the same document cannot appear in multiple cross-validation folds.
         seen: set = set()
 
         def _first_per_text(example: dict) -> bool:
@@ -77,10 +82,4 @@ Feldman, Sergey},
 
         ds = ds.filter(_first_per_text)
         ds = ds.class_encode_column("label")
-        ds = ds.train_test_split(
-            test_size=0.3, seed=self.seed, stratify_by_column="label"
-        )
-        ds = self.stratified_subsampling(
-            dataset_dict=ds, seed=self.seed, splits=["test"]
-        )
-        self.dataset = ds
+        self.dataset = DatasetDict({"train": ds})

--- a/mteb/tasks/classification/eng/scirepeval_drsm_classification.py
+++ b/mteb/tasks/classification/eng/scirepeval_drsm_classification.py
@@ -8,11 +8,12 @@ class SciRepEvalDRSMClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="SciRepEvalDRSMClassification",
         description=(
-            "Disease Research State Model (DRSM) classification task from the "
-            "SciRepEval benchmark. Given the title and abstract of a biomedical "
-            "paper, classify it into one of five research-state categories: "
-            "'clinical characteristics or disease pathology', 'disease mechanism', "
-            "'therapeutics in the clinic', 'patient-based therapeutics', or 'other'."
+            "Disease Research State Model (DRSM) classification. Given the title "
+            "and abstract of a biomedical paper, classify it into one of five "
+            "research-state categories (clinical characteristics or disease "
+            "pathology, disease mechanism, therapeutics in the clinic, "
+            "patient-based therapeutics, or other). Published as a part of "
+            "SciRepEval."
         ),
         reference="https://aclanthology.org/2023.emnlp-main.338/",
         dataset={
@@ -29,7 +30,7 @@ class SciRepEvalDRSMClassification(AbsTaskClassification):
         date=("2022-01-01", "2023-12-06"),
         domains=["Academic", "Medical", "Written"],
         task_subtypes=["Topic classification"],
-        license="not specified",
+        license="odc-by",
         annotations_creators="expert-annotated",
         dialect=[],
         sample_creation="found",

--- a/mteb/tasks/classification/eng/scirepeval_drsm_classification.py
+++ b/mteb/tasks/classification/eng/scirepeval_drsm_classification.py
@@ -24,7 +24,7 @@ class SciRepEvalDRSMClassification(AbsTaskClassification):
         type="Classification",
         category="t2c",
         modalities=["text"],
-        eval_splits=["train"],
+        eval_splits=["evaluation"],
         eval_langs=["eng-Latn"],
         main_score="accuracy",
         date=("2022-01-01", "2023-12-06"),
@@ -55,10 +55,11 @@ Feldman, Sergey},
     )
 
     is_cross_validation: bool = True
+    train_split: str = "evaluation"
 
     def dataset_transform(self, num_proc: int | None = None) -> None:
         # SciRepEval exposes only a single "evaluation" split for `drsm`. We keep
-        # it as one split named "train" and let MTEB's cross-validation path
+        # it named "evaluation" and let MTEB's cross-validation path
         # (is_cross_validation) run KFold over the whole split.
         from datasets import DatasetDict
 
@@ -82,4 +83,4 @@ Feldman, Sergey},
 
         ds = ds.filter(_first_per_text)
         ds = ds.class_encode_column("label")
-        self.dataset = DatasetDict({"train": ds})
+        self.dataset = DatasetDict({"evaluation": ds})

--- a/mteb/tasks/classification/eng/scirepeval_drsm_classification.py
+++ b/mteb/tasks/classification/eng/scirepeval_drsm_classification.py
@@ -64,6 +64,17 @@ Feldman, Sergey},
         keep = {"text", "class"}
         ds = ds.remove_columns([c for c in ds.column_names if c not in keep])
         ds = ds.rename_column("class", "label")
+        # A couple of papers share an identical title+abstract; drop duplicate
+        # texts so the same document cannot leak across the train/test split.
+        seen: set = set()
+
+        def _first_per_text(example: dict) -> bool:
+            if example["text"] in seen:
+                return False
+            seen.add(example["text"])
+            return True
+
+        ds = ds.filter(_first_per_text)
         ds = ds.class_encode_column("label")
         ds = ds.train_test_split(
             test_size=0.3, seed=self.seed, stratify_by_column="label"

--- a/mteb/tasks/classification/eng/scirepeval_drsm_classification.py
+++ b/mteb/tasks/classification/eng/scirepeval_drsm_classification.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from mteb.abstasks.classification import AbsTaskClassification
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class SciRepEvalDRSMClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="SciRepEvalDRSMClassification",
+        description=(
+            "Disease Research State Model (DRSM) classification task from the "
+            "SciRepEval benchmark. Given the title and abstract of a biomedical "
+            "paper, classify it into one of five research-state categories: "
+            "'clinical characteristics or disease pathology', 'disease mechanism', "
+            "'therapeutics in the clinic', 'patient-based therapeutics', or 'other'."
+        ),
+        reference="https://aclanthology.org/2023.emnlp-main.338/",
+        dataset={
+            "path": "allenai/scirepeval",
+            "name": "drsm",
+            "revision": "781d35d1bf87253b3dcd0fadcb82bfbee9c244f1",
+        },
+        type="Classification",
+        category="t2c",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2022-01-01", "2023-12-06"),
+        domains=["Academic", "Medical", "Written"],
+        task_subtypes=["Topic classification"],
+        license="not specified",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=r"""
+@inproceedings{singh-etal-2023-scirepeval,
+  address = {Singapore},
+  author = {Singh, Amanpreet  and
+D{'}Arcy, Mike  and
+Cohan, Arman  and
+Downey, Doug  and
+Feldman, Sergey},
+  booktitle = {Proceedings of the 2023 Conference on Empirical Methods in Natural Language Processing},
+  doi = {10.18653/v1/2023.emnlp-main.338},
+  month = dec,
+  pages = {5548--5566},
+  publisher = {Association for Computational Linguistics},
+  title = {{SciRepEval: A Multi-Format Benchmark for Scientific Document Representations}},
+  url = {https://aclanthology.org/2023.emnlp-main.338/},
+  year = {2023},
+}
+""",
+    )
+
+    def dataset_transform(self, num_proc: int | None = None) -> None:
+        # SciRepEval exposes only a single "evaluation" split for `drsm`, so we
+        # build a stratified train/test split for the classification evaluator.
+        ds = self.dataset["evaluation"]
+        ds = ds.map(
+            lambda x: {"text": f"{x['title'] or ''}\n\n{x['abstract'] or ''}".strip()},
+            num_proc=num_proc,
+        )
+        keep = {"text", "class"}
+        ds = ds.remove_columns([c for c in ds.column_names if c not in keep])
+        ds = ds.rename_column("class", "label")
+        ds = ds.class_encode_column("label")
+        ds = ds.train_test_split(
+            test_size=0.3, seed=self.seed, stratify_by_column="label"
+        )
+        ds = self.stratified_subsampling(
+            dataset_dict=ds, seed=self.seed, splits=["test"]
+        )
+        self.dataset = ds

--- a/mteb/tasks/classification/eng/scirepeval_mesh_descriptors_classification.py
+++ b/mteb/tasks/classification/eng/scirepeval_mesh_descriptors_classification.py
@@ -23,7 +23,7 @@ class SciRepEvalMeSHDescriptorsClassification(AbsTaskClassification):
         type="Classification",
         category="t2c",
         modalities=["text"],
-        eval_splits=["train"],
+        eval_splits=["evaluation"],
         eval_langs=["eng-Latn"],
         main_score="accuracy",
         date=("2022-01-01", "2023-12-06"),
@@ -54,12 +54,13 @@ Feldman, Sergey},
     )
 
     is_cross_validation: bool = True
+    train_split: str = "evaluation"
 
     def dataset_transform(self, num_proc: int | None = None) -> None:
         # Only the "evaluation" split is loaded (see `split` in metadata.dataset).
         # Each row is a (paper, descriptor) pair; deduplicate by paper so a single
         # abstract cannot appear in multiple cross-validation folds with different
-        # labels. The deduplicated split is kept as one split named "train" and
+        # labels. The deduplicated split is kept named "evaluation" and
         # MTEB's cross-validation path (is_cross_validation) runs KFold over it.
         from datasets import DatasetDict
 
@@ -85,4 +86,4 @@ Feldman, Sergey},
         ds = ds.remove_columns([c for c in ds.column_names if c not in keep])
         ds = ds.class_encode_column("label")
         ds = ds.shuffle(seed=self.seed).select(range(min(len(ds), 8192)))
-        self.dataset = DatasetDict({"train": ds})
+        self.dataset = DatasetDict({"evaluation": ds})

--- a/mteb/tasks/classification/eng/scirepeval_mesh_descriptors_classification.py
+++ b/mteb/tasks/classification/eng/scirepeval_mesh_descriptors_classification.py
@@ -8,11 +8,10 @@ class SciRepEvalMeSHDescriptorsClassification(AbsTaskClassification):
     metadata = TaskMetadata(
         name="SciRepEvalMeSHDescriptorsClassification",
         description=(
-            "MeSH descriptor classification task from the SciRepEval benchmark. "
-            "Given the title and abstract of a biomedical paper, predict its "
-            "primary Medical Subject Headings (MeSH) descriptor from a set of 30 "
-            "common disease-related descriptors (e.g. 'Hypertension', "
-            "'Myocardial Infarction', 'Anti-Bacterial Agents')."
+            "MeSH descriptor classification. Given the title and abstract of a "
+            "biomedical paper, predict its Medical Subject Headings (MeSH) "
+            "descriptor from a set of 30 common disease-related descriptors "
+            "(multi-class classification). Published as a part of SciRepEval."
         ),
         reference="https://aclanthology.org/2023.emnlp-main.338/",
         dataset={
@@ -30,7 +29,7 @@ class SciRepEvalMeSHDescriptorsClassification(AbsTaskClassification):
         date=("2022-01-01", "2023-12-06"),
         domains=["Academic", "Medical", "Written"],
         task_subtypes=["Topic classification"],
-        license="not specified",
+        license="odc-by",
         annotations_creators="derived",
         dialect=[],
         sample_creation="found",

--- a/mteb/tasks/classification/eng/scirepeval_mesh_descriptors_classification.py
+++ b/mteb/tasks/classification/eng/scirepeval_mesh_descriptors_classification.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from mteb.abstasks.classification import AbsTaskClassification
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class SciRepEvalMeSHDescriptorsClassification(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="SciRepEvalMeSHDescriptorsClassification",
+        description=(
+            "MeSH descriptor classification task from the SciRepEval benchmark. "
+            "Given the title and abstract of a biomedical paper, predict its "
+            "primary Medical Subject Headings (MeSH) descriptor from a set of 30 "
+            "common disease-related descriptors (e.g. 'Hypertension', "
+            "'Myocardial Infarction', 'Anti-Bacterial Agents')."
+        ),
+        reference="https://aclanthology.org/2023.emnlp-main.338/",
+        dataset={
+            "path": "allenai/scirepeval",
+            "name": "mesh_descriptors",
+            "revision": "781d35d1bf87253b3dcd0fadcb82bfbee9c244f1",
+            "split": "evaluation",
+        },
+        type="Classification",
+        category="t2c",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2022-01-01", "2023-12-06"),
+        domains=["Academic", "Medical", "Written"],
+        task_subtypes=["Topic classification"],
+        license="not specified",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=r"""
+@inproceedings{singh-etal-2023-scirepeval,
+  address = {Singapore},
+  author = {Singh, Amanpreet  and
+D{'}Arcy, Mike  and
+Cohan, Arman  and
+Downey, Doug  and
+Feldman, Sergey},
+  booktitle = {Proceedings of the 2023 Conference on Empirical Methods in Natural Language Processing},
+  doi = {10.18653/v1/2023.emnlp-main.338},
+  month = dec,
+  pages = {5548--5566},
+  publisher = {Association for Computational Linguistics},
+  title = {{SciRepEval: A Multi-Format Benchmark for Scientific Document Representations}},
+  url = {https://aclanthology.org/2023.emnlp-main.338/},
+  year = {2023},
+}
+""",
+    )
+
+    def dataset_transform(self, num_proc: int | None = None) -> None:
+        # Only the "evaluation" split is loaded (see `split` in metadata.dataset).
+        # Each row is a (paper, descriptor) pair; deduplicate by paper so a single
+        # abstract cannot leak across the train/test split with different labels.
+        ds = self.dataset
+        seen: set = set()
+
+        def _first_per_paper(example: dict) -> bool:
+            cid = example["corpus_id"]
+            if cid in seen:
+                return False
+            seen.add(cid)
+            return True
+
+        ds = ds.filter(_first_per_paper)
+        ds = ds.map(
+            lambda x: {
+                "text": f"{x['title'] or ''}\n\n{x['abstract'] or ''}".strip(),
+                "label": x["descriptor"],
+            },
+            num_proc=num_proc,
+        )
+        keep = {"text", "label"}
+        ds = ds.remove_columns([c for c in ds.column_names if c not in keep])
+        ds = ds.class_encode_column("label")
+        ds = ds.shuffle(seed=self.seed).select(range(min(len(ds), 8192)))
+        ds = ds.train_test_split(
+            test_size=0.3, seed=self.seed, stratify_by_column="label"
+        )
+        ds = self.stratified_subsampling(
+            dataset_dict=ds, seed=self.seed, splits=["test"]
+        )
+        self.dataset = ds

--- a/mteb/tasks/classification/eng/scirepeval_mesh_descriptors_classification.py
+++ b/mteb/tasks/classification/eng/scirepeval_mesh_descriptors_classification.py
@@ -23,7 +23,7 @@ class SciRepEvalMeSHDescriptorsClassification(AbsTaskClassification):
         type="Classification",
         category="t2c",
         modalities=["text"],
-        eval_splits=["test"],
+        eval_splits=["train"],
         eval_langs=["eng-Latn"],
         main_score="accuracy",
         date=("2022-01-01", "2023-12-06"),
@@ -53,10 +53,16 @@ Feldman, Sergey},
 """,
     )
 
+    is_cross_validation: bool = True
+
     def dataset_transform(self, num_proc: int | None = None) -> None:
         # Only the "evaluation" split is loaded (see `split` in metadata.dataset).
         # Each row is a (paper, descriptor) pair; deduplicate by paper so a single
-        # abstract cannot leak across the train/test split with different labels.
+        # abstract cannot appear in multiple cross-validation folds with different
+        # labels. The deduplicated split is kept as one split named "train" and
+        # MTEB's cross-validation path (is_cross_validation) runs KFold over it.
+        from datasets import DatasetDict
+
         ds = self.dataset
         seen: set = set()
 
@@ -79,10 +85,4 @@ Feldman, Sergey},
         ds = ds.remove_columns([c for c in ds.column_names if c not in keep])
         ds = ds.class_encode_column("label")
         ds = ds.shuffle(seed=self.seed).select(range(min(len(ds), 8192)))
-        ds = ds.train_test_split(
-            test_size=0.3, seed=self.seed, stratify_by_column="label"
-        )
-        ds = self.stratified_subsampling(
-            dataset_dict=ds, seed=self.seed, splits=["test"]
-        )
-        self.dataset = ds
+        self.dataset = DatasetDict({"train": ds})

--- a/mteb/tasks/multilabel_classification/eng/__init__.py
+++ b/mteb/tasks/multilabel_classification/eng/__init__.py
@@ -5,11 +5,13 @@ from .audio_set import (
 from .fsd50_hf import FSD50HFMultilingualClassification
 from .fsd2019_kaggle import FSD2019KaggleMultilingualClassification
 from .pascal_voc2007 import VOC2007Classification
+from .scirepeval_fos_classification import SciRepEvalFoSClassification
 
 __all__ = [
     "AudioSetMiniMultilingualClassification",
     "AudioSetMultilingualClassification",
     "FSD50HFMultilingualClassification",
     "FSD2019KaggleMultilingualClassification",
+    "SciRepEvalFoSClassification",
     "VOC2007Classification",
 ]

--- a/mteb/tasks/multilabel_classification/eng/scirepeval_fos_classification.py
+++ b/mteb/tasks/multilabel_classification/eng/scirepeval_fos_classification.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from mteb.abstasks.multilabel_classification import AbsTaskMultilabelClassification
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class SciRepEvalFoSClassification(AbsTaskMultilabelClassification):
+    metadata = TaskMetadata(
+        name="SciRepEvalFoSClassification",
+        description=(
+            "Fields of Study (FoS) multi-label classification task from the "
+            "SciRepEval benchmark. Given the title and abstract of a scientific "
+            "paper, predict its Microsoft Academic Graph fields of study (e.g. "
+            "'Chemistry', 'Materials science', 'Environmental science'). A paper "
+            "may belong to multiple fields."
+        ),
+        reference="https://aclanthology.org/2023.emnlp-main.338/",
+        dataset={
+            "path": "allenai/scirepeval",
+            "name": "fos",
+            "revision": "781d35d1bf87253b3dcd0fadcb82bfbee9c244f1",
+            "split": "evaluation",
+        },
+        type="MultilabelClassification",
+        category="t2c",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2022-01-01", "2023-12-06"),
+        domains=["Academic", "Written"],
+        task_subtypes=["Topic classification"],
+        license="not specified",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=r"""
+@inproceedings{singh-etal-2023-scirepeval,
+  address = {Singapore},
+  author = {Singh, Amanpreet  and
+D{'}Arcy, Mike  and
+Cohan, Arman  and
+Downey, Doug  and
+Feldman, Sergey},
+  booktitle = {Proceedings of the 2023 Conference on Empirical Methods in Natural Language Processing},
+  doi = {10.18653/v1/2023.emnlp-main.338},
+  month = dec,
+  pages = {5548--5566},
+  publisher = {Association for Computational Linguistics},
+  title = {{SciRepEval: A Multi-Format Benchmark for Scientific Document Representations}},
+  url = {https://aclanthology.org/2023.emnlp-main.338/},
+  year = {2023},
+}
+""",
+    )
+
+    def dataset_transform(self, num_proc: int | None = None) -> None:
+        # Only the "evaluation" split is loaded (see `split` in metadata.dataset);
+        # build text/label columns and a random train/test split for the probe.
+        ds = self.dataset
+        ds = ds.map(
+            lambda x: {
+                "text": f"{x['title'] or ''}\n\n{x['abstract'] or ''}".strip(),
+                "label": x["labels_text"],
+            },
+            num_proc=num_proc,
+        )
+        ds = ds.filter(lambda x: len(x["label"]) > 0, num_proc=num_proc)
+        keep = {"text", "label"}
+        ds = ds.remove_columns([c for c in ds.column_names if c not in keep])
+        ds = ds.shuffle(seed=self.seed).select(range(min(len(ds), 8192)))
+        self.dataset = ds.train_test_split(test_size=0.3, seed=self.seed)

--- a/mteb/tasks/multilabel_classification/eng/scirepeval_fos_classification.py
+++ b/mteb/tasks/multilabel_classification/eng/scirepeval_fos_classification.py
@@ -8,11 +8,9 @@ class SciRepEvalFoSClassification(AbsTaskMultilabelClassification):
     metadata = TaskMetadata(
         name="SciRepEvalFoSClassification",
         description=(
-            "Fields of Study (FoS) multi-label classification task from the "
-            "SciRepEval benchmark. Given the title and abstract of a scientific "
-            "paper, predict its Microsoft Academic Graph fields of study (e.g. "
-            "'Chemistry', 'Materials science', 'Environmental science'). A paper "
-            "may belong to multiple fields."
+            "Fields of Study (FoS) classification. Given the title and abstract "
+            "of a scientific paper, predict one or more of its fields of study "
+            "(multi-label classification). Published as a part of SciRepEval."
         ),
         reference="https://aclanthology.org/2023.emnlp-main.338/",
         dataset={
@@ -30,7 +28,7 @@ class SciRepEvalFoSClassification(AbsTaskMultilabelClassification):
         date=("2022-01-01", "2023-12-06"),
         domains=["Academic", "Written"],
         task_subtypes=["Topic classification"],
-        license="not specified",
+        license="odc-by",
         annotations_creators="derived",
         dialect=[],
         sample_creation="found",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -590,6 +590,8 @@ extend-ignore-re = [
 
 [tool.typos.type.py.extend-identifiers]
 BulgarianStoreReviewSentimentClassfication = "BulgarianStoreReviewSentimentClassfication"
+SciRepEvalFoSClassification = "SciRepEvalFoSClassification"
+FoS = "FoS"
 LaBSE = "LaBSE"
 
 [tool.typos.type.py.extend-words]


### PR DESCRIPTION
## Why

[SciRepEval](https://aclanthology.org/2023.emnlp-main.338/) (Singh et al., EMNLP 2023) is the Semantic Scholar team's recommended successor to SciDocs for scientific-document embedding evaluation, and adding it was requested in #591. It is a multi-format benchmark; this PR adds all of its **classification-type** subtasks. Retrieval- and proximity-style subtasks will follow in a separate `tasks/retrieval/` PR (see below).

## What

Adds four SciRepEval classification tasks (all `category="t2c"`, `eng-Latn`, source `allenai/scirepeval` pinned to `781d35d1bf87253b3dcd0fadcb82bfbee9c244f1`):

| Task | Class | Labels |
|---|---|---|
| `SciRepEvalDRSMClassification` | `AbsTaskClassification` | 5-way Disease Research State Model |
| `SciRepEvalBiomimicryClassification` | `AbsTaskClassification` | binary biomimicry relevance |
| `SciRepEvalFoSClassification` | `AbsTaskMultilabelClassification` | multi-label MAG Fields of Study |
| `SciRepEvalMeSHDescriptorsClassification` | `AbsTaskClassification` | 30-way MeSH descriptor |

Implementation notes:
- Input text is `title` + `abstract`.
- `drsm` and `biomimicry` expose only a single `evaluation` split, so `dataset_transform()` builds a stratified train/test split (test subsampled to 2048).
- `fos` and `mesh_descriptors` have huge upstream `train` splits (0.5M / 2M rows), so only the `evaluation` split is loaded (via `split` in `metadata.dataset`) and split locally.
- `mesh_descriptors` rows are `(paper, descriptor)` pairs, so papers are **deduplicated** before splitting to prevent one abstract leaking across train/test with different labels.
- Each task registers in the relevant `eng/__init__.py` and ships precomputed descriptive statistics.

## Reference runs (accuracy, CPU)

`mteb run -m {model} -t {task}`:

| Task | `baseline-random-encoder` | `multilingual-e5-small` |
|---|---|---|
| DRSM | 0.199 | 0.598 |
| Biomimicry | 0.510 | 0.728 |
| FoS (multi-label) | 0.001 | 0.178 |
| MeSH | 0.033 | 0.582 |

Every task is well above its random baseline and none is trivial.

## Out of scope (separate follow-up PR)

These SciRepEval configs are retrieval/proximity/regression tasks and belong under `tasks/retrieval/` (or pair-classification / regression), not `tasks/classification/`, so they are intentionally excluded here: `scidocs_mag_mesh`, `scidocs_view_cite_read`, `cite_prediction*`, `high_influence_cite`, `same_author`, `paper_reviewer_matching`, `nfcorpus`, `search`, `trec_covid`, `relish`, `tweet_mentions`, `cite_count`, `pub_year`, `peer_review_score_hIndex`.

## Checklist

- [x] Metadata filled for every task
- [x] Descriptive statistics computed
- [x] Tasks picked up by `tests/test_tasks/test_metadata.py` (4 passed) and `test_dataset_on_hf.py` (revision check passes)
- [x] `ruff check` and `ruff format --check` clean
- [x] Reference runs beat the random baseline

Part of #591.
