### PR TITLE
Declare `training_datasets` for `minetta/nemotron-3-embed-8b-legal`

### DIFF
--- a/mteb/models/model_implementations/minetta_models.py
+++ b/mteb/models/model_implementations/minetta_models.py
@@ -21,7 +21,13 @@ nemotron_3_embed_8b_legal = ModelMeta(
     reference="https://huggingface.co/minetta/nemotron-3-embed-8b-legal",
     similarity_fn_name=ScoringFunction.COSINE,
     use_instructions=False,
-    training_datasets=None,
+    # Fine-tuning sources: ECtHR case law, GDPR enforcement decisions, CaseHOLD (US case
+    # holdings), SEC EDGAR agreements, public terms-of-service text, Australian tax
+    # guidance and UK legislation. None of these is an MTEB dataset, so this set is
+    # empty; the base model's declared training data is inherited via adapted_from.
+    # Per-document containment audit of every training input against the evaluated
+    # corpora: https://huggingface.co/minetta/nemotron-3-embed-8b-legal/blob/main/CONTAMINATION.md
+    training_datasets=set(),
     adapted_from="nvidia/Nemotron-3-Embed-8B-BF16",
     superseded_by=None,
     modalities=["text"],


### PR DESCRIPTION
The entry for `minetta/nemotron-3-embed-8b-legal` has `training_datasets=None`, so the leaderboard shows N/A in the zero-shot column: `get_training_datasets()` returns `None` and `_zero_shot_pct_cached` short-circuits before computing.

Fine-tuning sources are ECtHR case law, GDPR enforcement decisions, CaseHOLD, SEC EDGAR agreements, public terms-of-service text, Australian tax guidance and UK legislation. None of those is an MTEB dataset, so the declared set is empty and the base model's training data is inherited via `adapted_from="nvidia/Nemotron-3-Embed-8B-BF16"`.

With this change the entry resolves to the 59 datasets inherited from the base, with no overlap against MTEB(Law, v1), so the column computes rather than reading N/A.

A per-document containment audit of every training input against the evaluated corpora is linked from the comment and published in [CONTAMINATION.md](https://huggingface.co/minetta/nemotron-3-embed-8b-legal/blob/main/CONTAMINATION.md).