### PR TITLE
[MOEB] Add MMVU dataset

### DIFF
--- a/mteb/descriptive_stats/VideoCentricQA/MMVUVideoCentricQA.json
+++ b/mteb/descriptive_stats/VideoCentricQA/MMVUVideoCentricQA.json
@@ -1,0 +1,103 @@
+{
+    "test": {
+        "num_samples": 3750,
+        "num_queries": 625,
+        "num_documents": 3125,
+        "number_of_characters": 223931,
+        "documents_text_statistics": {
+            "total_text_length": 160329,
+            "min_text_length": 1,
+            "average_text_length": 51.30528,
+            "max_text_length": 248,
+            "unique_texts": 2860
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 63602,
+            "min_text_length": 26,
+            "average_text_length": 101.7632,
+            "max_text_length": 432,
+            "unique_texts": 618
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": {
+            "total_duration_seconds": 32429.824763369106,
+            "total_frames": 900135,
+            "min_width": 202,
+            "average_width": 605.968,
+            "max_width": 640,
+            "min_height": 240,
+            "average_height": 359.0592,
+            "max_height": 640,
+            "min_duration_seconds": 9,
+            "average_duration_seconds": 51.88771962139057,
+            "max_duration_seconds": 195,
+            "unique_videos": 338,
+            "average_fps": 27.68,
+            "fps": {
+                "30": 406,
+                "25": 124,
+                "24": 72,
+                "10": 8,
+                "15": 10,
+                "22": 2,
+                "6": 3
+            },
+            "min_resolution": [
+                202,
+                360
+            ],
+            "average_resolution": [
+                605.968,
+                359.0592
+            ],
+            "max_resolution": [
+                640,
+                360
+            ],
+            "resolutions": {
+                "480x360": 61,
+                "640x360": 450,
+                "640x352": 44,
+                "480x328": 3,
+                "320x240": 6,
+                "352x288": 2,
+                "558x360": 5,
+                "360x360": 2,
+                "364x360": 3,
+                "620x360": 1,
+                "600x360": 2,
+                "202x360": 3,
+                "640x354": 2,
+                "490x360": 12,
+                "640x358": 4,
+                "492x360": 4,
+                "540x360": 2,
+                "528x360": 1,
+                "454x360": 3,
+                "482x360": 4,
+                "640x332": 2,
+                "320x320": 1,
+                "602x360": 2,
+                "576x360": 3,
+                "360x640": 3
+            }
+        },
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 625,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 625
+        },
+        "top_ranked_statistics": {
+            "num_top_ranked": 3125,
+            "min_top_ranked_per_query": 5,
+            "average_top_ranked_per_query": 5.0,
+            "max_top_ranked_per_query": 5
+        }
+    }
+}

--- a/mteb/tasks/multichoice/eng/__init__.py
+++ b/mteb/tasks/multichoice/eng/__init__.py
@@ -9,6 +9,7 @@ from .blink_it2t_multi_choice import BLINKIT2TMultiChoice
 from .cv_bench import CVBenchCount, CVBenchDepth, CVBenchDistance, CVBenchRelation
 from .daily_omni import DailyOmniVideoAudioCentricQA, DailyOmniVideoCentricQA
 from .egoschema import EgoSchemaVideoCentricQA
+from .mmvu import MMVUVideoCentricQA
 from .nextqa import NExTQAVideoCentricQA
 from .omni_video_bench import (
     OmniVideoBenchVideoAudioCentricQA,
@@ -38,6 +39,7 @@ __all__ = [
     "DailyOmniVideoAudioCentricQA",
     "DailyOmniVideoCentricQA",
     "EgoSchemaVideoCentricQA",
+    "MMVUVideoCentricQA",
     "NExTQAVideoCentricQA",
     "OmniVideoBenchVideoAudioCentricQA",
     "OmniVideoBenchVideoCentricQA",

--- a/mteb/tasks/multichoice/eng/mmvu.py
+++ b/mteb/tasks/multichoice/eng/mmvu.py
@@ -1,24 +1,20 @@
 from __future__ import annotations
 
-from pathlib import Path
-from urllib.parse import unquote, urlparse
-
-from datasets import Dataset, load_dataset
-from huggingface_hub import snapshot_download
-
 from mteb.abstasks.retrieval import AbsTaskRetrieval
-from mteb.abstasks.retrieval_dataset_loaders import RetrievalSplitData
 from mteb.abstasks.task_metadata import TaskMetadata
 
 
 class MMVUVideoCentricQA(AbsTaskRetrieval):
+    k_values = (1, 3, 5)  # 5 possible answers only
+    _top_k = 5
+
     metadata = TaskMetadata(
         name="MMVUVideoCentricQA",
         description="MMVU is an expert-level, multi-discipline video understanding benchmark with questions spanning 27 subjects across Science, Healthcare, Humanities & Social Sciences, and Engineering. Each multiple-choice example pairs a specialized-domain video with a question and 5 candidate answers. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate. Used the public validation multiple-choice subset (~625 examples).",
         reference="https://arxiv.org/abs/2501.12380",
         dataset={
-            "path": "yale-nlp/MMVU",
-            "revision": "b937f414a87e9012acba49d95669020b24fa9ee9",
+            "path": "Wissam42/MMVU-VQA",
+            "revision": "7a2990975222d1f09948299999221463ce1961bf",
         },
         type="VideoCentricQA",
         category="vt2t",
@@ -44,80 +40,3 @@ class MMVUVideoCentricQA(AbsTaskRetrieval):
 }
 """,
     )
-
-    def load_data(self, **kwargs) -> None:
-        from datasets import Video
-
-        def _video_relpath(url: str) -> str:
-            path = unquote(urlparse(url).path)
-            marker = "/videos/"
-            idx = path.lower().rfind(marker)
-            if idx < 0:
-                raise ValueError(f"Unexpected MMVU video URL: {url}")
-            return path[idx + len(marker) :]
-
-        if self.data_loaded:
-            return
-
-        ds = load_dataset(
-            self.metadata.dataset["path"],
-            revision=self.metadata.dataset["revision"],
-            split="validation",
-        )
-        ds = ds.filter(lambda row: row["question_type"] == "multiple-choice")
-        video_rels = sorted({_video_relpath(url) for url in ds["video"]})
-        repo_dir = Path(
-            snapshot_download(
-                repo_id=self.metadata.dataset["path"],
-                repo_type="dataset",
-                revision=self.metadata.dataset["revision"],
-                allow_patterns=[
-                    "validation.json",
-                    *[f"videos/{rel}" for rel in video_rels],
-                ],
-            )
-        )
-
-        query_rows: list[dict] = []
-        corpus_rows: list[dict] = []
-        relevant_docs: dict[str, dict[str, int]] = {}
-        top_ranked: dict[str, list[str]] = {}
-
-        for i, row in enumerate(ds):
-            qid = f"q{i}"
-            video_path = repo_dir / "videos" / _video_relpath(row["video"])
-            if not video_path.is_file():
-                raise FileNotFoundError(f"Missing MMVU video: {video_path}")
-
-            query_rows.append(
-                {
-                    "id": qid,
-                    "text": row["question"],
-                    "video": str(video_path),
-                }
-            )
-
-            answer_text = row["choices"][row["answer"]]
-            top_ranked[qid] = []
-            choice_keys = ("A", "B", "C", "D", "E")
-            for j, key in enumerate(choice_keys):
-                doc_id = f"{qid}_c{j}"
-                candidate = row["choices"][key]
-                corpus_rows.append({"id": doc_id, "text": candidate})
-                top_ranked[qid].append(doc_id)
-                if candidate == answer_text:
-                    relevant_docs[qid] = {doc_id: 1}
-
-        queries = Dataset.from_list(query_rows).cast_column("video", Video())
-        corpus = Dataset.from_list(corpus_rows)
-        self.dataset = {
-            "default": {
-                "test": RetrievalSplitData(
-                    queries=queries,
-                    corpus=corpus,
-                    relevant_docs=relevant_docs,
-                    top_ranked=top_ranked,
-                )
-            }
-        }
-        self.data_loaded = True

--- a/mteb/tasks/multichoice/eng/mmvu.py
+++ b/mteb/tasks/multichoice/eng/mmvu.py
@@ -6,7 +6,6 @@ from mteb.abstasks.task_metadata import TaskMetadata
 
 class MMVUVideoCentricQA(AbsTaskRetrieval):
     k_values = (1, 3, 5)  # 5 possible answers only
-    _top_k = 5
 
     metadata = TaskMetadata(
         name="MMVUVideoCentricQA",

--- a/mteb/tasks/multichoice/eng/mmvu.py
+++ b/mteb/tasks/multichoice/eng/mmvu.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from urllib.parse import unquote, urlparse
 
-from datasets import Dataset, Video, load_dataset
+from datasets import Dataset, load_dataset
 from huggingface_hub import snapshot_download
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -35,18 +35,19 @@ class MMVUVideoCentricQA(AbsTaskRetrieval):
         sample_creation="found",
         is_beta=True,
         bibtex_citation=r"""
-@misc{zhao2025mmvu,
-  author = {Zhao, Yilun and Xie, Lujing and Zhang, Haowei and Gan, Guo and Long, Yitao and Hu, Zhiyuan and Hu, Tongyan and Chen, Weiyuan and Li, Chuhan and Song, Junyang and Xu, Zhijian and Wang, Chengye and Pan, Weifeng and Shangguan, Ziyao and Tang, Xiangru and Liang, Zhenwen and Liu, Yixin and Zhao, Chen and Cohan, Arman},
-  eprint = {2501.12380},
-  primaryClass = {cs.CV},
-  title = {MMVU: Measuring Expert-Level Multi-Discipline Video Understanding},
-  url = {https://arxiv.org/abs/2501.12380},
-  year = {2025},
+@inproceedings{zhao2025mmvu,
+  title={MMVU: Measuring expert-level multi-discipline video understanding},
+  author={Zhao, Yilun and Zhang, Haowei and Xie, Lujing and Hu, Tongyan and Gan, Guo and Long, Yitao and Hu, Zhiyuan and Chen, Weiyuan and Li, Chuhan and Xu, Zhijian and others},
+  booktitle={Proceedings of the Computer Vision and Pattern Recognition Conference},
+  pages={8475--8489},
+  year={2025}
 }
 """,
     )
 
     def load_data(self, **kwargs) -> None:
+        from datasets import Video
+
         def _video_relpath(url: str) -> str:
             path = unquote(urlparse(url).path)
             marker = "/videos/"

--- a/mteb/tasks/multichoice/eng/mmvu.py
+++ b/mteb/tasks/multichoice/eng/mmvu.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+from datasets import Dataset, Video, load_dataset
+from huggingface_hub import snapshot_download
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.retrieval_dataset_loaders import RetrievalSplitData
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class MMVUVideoCentricQA(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="MMVUVideoCentricQA",
+        description="MMVU is an expert-level, multi-discipline video understanding benchmark with questions spanning 27 subjects across Science, Healthcare, Humanities & Social Sciences, and Engineering. Each multiple-choice example pairs a specialized-domain video with a question and 5 candidate answers. The task is formulated as multiple-choice retrieval: given the (video, question) pair, retrieve the correct candidate. Used the public validation multiple-choice subset (~625 examples).",
+        reference="https://arxiv.org/abs/2501.12380",
+        dataset={
+            "path": "yale-nlp/MMVU",
+            "revision": "b937f414a87e9012acba49d95669020b24fa9ee9",
+        },
+        type="VideoCentricQA",
+        category="vt2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        date=("2025-01-21", "2025-01-21"),
+        domains=["Academic", "Medical", "Engineering", "Web"],
+        task_subtypes=["Question answering"],
+        license="cc-by-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["video", "text"],
+        sample_creation="found",
+        is_beta=True,
+        bibtex_citation=r"""
+@misc{zhao2025mmvu,
+  author = {Zhao, Yilun and Xie, Lujing and Zhang, Haowei and Gan, Guo and Long, Yitao and Hu, Zhiyuan and Hu, Tongyan and Chen, Weiyuan and Li, Chuhan and Song, Junyang and Xu, Zhijian and Wang, Chengye and Pan, Weifeng and Shangguan, Ziyao and Tang, Xiangru and Liang, Zhenwen and Liu, Yixin and Zhao, Chen and Cohan, Arman},
+  eprint = {2501.12380},
+  primaryClass = {cs.CV},
+  title = {MMVU: Measuring Expert-Level Multi-Discipline Video Understanding},
+  url = {https://arxiv.org/abs/2501.12380},
+  year = {2025},
+}
+""",
+    )
+
+    def load_data(self, **kwargs) -> None:
+        def _video_relpath(url: str) -> str:
+            path = unquote(urlparse(url).path)
+            marker = "/videos/"
+            idx = path.lower().rfind(marker)
+            if idx < 0:
+                raise ValueError(f"Unexpected MMVU video URL: {url}")
+            return path[idx + len(marker) :]
+
+        if self.data_loaded:
+            return
+
+        ds = load_dataset(
+            self.metadata.dataset["path"],
+            revision=self.metadata.dataset["revision"],
+            split="validation",
+        )
+        ds = ds.filter(lambda row: row["question_type"] == "multiple-choice")
+        video_rels = sorted({_video_relpath(url) for url in ds["video"]})
+        repo_dir = Path(
+            snapshot_download(
+                repo_id=self.metadata.dataset["path"],
+                repo_type="dataset",
+                revision=self.metadata.dataset["revision"],
+                allow_patterns=[
+                    "validation.json",
+                    *[f"videos/{rel}" for rel in video_rels],
+                ],
+            )
+        )
+
+        query_rows: list[dict] = []
+        corpus_rows: list[dict] = []
+        relevant_docs: dict[str, dict[str, int]] = {}
+        top_ranked: dict[str, list[str]] = {}
+
+        for i, row in enumerate(ds):
+            qid = f"q{i}"
+            video_path = repo_dir / "videos" / _video_relpath(row["video"])
+            if not video_path.is_file():
+                raise FileNotFoundError(f"Missing MMVU video: {video_path}")
+
+            query_rows.append(
+                {
+                    "id": qid,
+                    "text": row["question"],
+                    "video": str(video_path),
+                }
+            )
+
+            answer_text = row["choices"][row["answer"]]
+            top_ranked[qid] = []
+            choice_keys = ("A", "B", "C", "D", "E")
+            for j, key in enumerate(choice_keys):
+                doc_id = f"{qid}_c{j}"
+                candidate = row["choices"][key]
+                corpus_rows.append({"id": doc_id, "text": candidate})
+                top_ranked[qid].append(doc_id)
+                if candidate == answer_text:
+                    relevant_docs[qid] = {doc_id: 1}
+
+        queries = Dataset.from_list(query_rows).cast_column("video", Video())
+        corpus = Dataset.from_list(corpus_rows)
+        self.dataset = {
+            "default": {
+                "test": RetrievalSplitData(
+                    queries=queries,
+                    corpus=corpus,
+                    relevant_docs=relevant_docs,
+                    top_ranked=top_ranked,
+                )
+            }
+        }
+        self.data_loaded = True

--- a/scripts/data/mmvu/create_data.py
+++ b/scripts/data/mmvu/create_data.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Package yale-nlp/MMVU multiple-choice examples for MTEB VideoCentricQA.
+
+Keeps the public validation multiple-choice subset (625 examples, 379 videos),
+resolves video URLs to local Hub files, and exports columns:
+  question, video, candidates, answer.
+
+Usage:
+  export HF_TOKEN=...
+  uv run python scripts/data/mmvu/create_data.py \\
+      --repo-id {base_repo}/MMVU-VQA \\
+      --work-dir /tmp/mmvu_mteb \\
+      --push
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+from datasets import Dataset, DatasetDict, Video, load_dataset
+from huggingface_hub import create_repo, snapshot_download
+from tqdm import tqdm
+
+_SOURCE = "yale-nlp/MMVU"
+_SOURCE_REVISION = "b937f414a87e9012acba49d95669020b24fa9ee9"
+_VIDEO_URL_RE = re.compile(r"/videos/(.+\.mp4)$", re.IGNORECASE)
+_CHOICE_KEYS = ("A", "B", "C", "D", "E")
+
+
+def _video_relpath(url: str) -> str:
+    path = unquote(urlparse(url).path)
+    m = _VIDEO_URL_RE.search(path)
+    if not m:
+        raise ValueError(f"Unexpected MMVU video URL: {url}")
+    return m.group(1)
+
+
+def _build_rows(repo_dir: Path) -> list[dict]:
+    ds = load_dataset(
+        _SOURCE,
+        revision=_SOURCE_REVISION,
+        split="validation",
+    )
+    ds = ds.filter(lambda row: row["question_type"] == "multiple-choice")
+
+    rows: list[dict] = []
+    missing = 0
+    for row in tqdm(ds, desc="rows"):
+        rel = _video_relpath(row["video"])
+        video_path = repo_dir / "videos" / rel
+        if not video_path.is_file():
+            missing += 1
+            continue
+        choices = row["choices"]
+        candidates = [choices[k] for k in _CHOICE_KEYS]
+        answer_letter = row["answer"]
+        if answer_letter not in choices:
+            raise SystemExit(f"Answer {answer_letter!r} not in choices for {row['id']}")
+        rows.append(
+            {
+                "question_id": row["id"],
+                "question": row["question"],
+                "video": str(video_path),
+                "candidates": candidates,
+                "answer": choices[answer_letter],
+                "subject": row["metadata"]["subject"],
+            }
+        )
+    if missing:
+        raise SystemExit(f"Missing {missing} video files under {repo_dir / 'videos'}")
+    return rows
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-id",
+        default="Wissam42/MMVU-VQA",
+        help="Hub dataset id to push (or local export label)",
+    )
+    parser.add_argument(
+        "--work-dir",
+        type=Path,
+        default=Path("/tmp/mmvu_mteb"),
+        help="Cache / local export directory",
+    )
+    parser.add_argument(
+        "--push",
+        action="store_true",
+        help="Push DatasetDict test split to Hub",
+    )
+    args = parser.parse_args()
+
+    args.work_dir.mkdir(parents=True, exist_ok=True)
+    print(f"Downloading {_SOURCE}@{_SOURCE_REVISION} …")
+    repo_dir = Path(
+        snapshot_download(
+            repo_id=_SOURCE,
+            repo_type="dataset",
+            revision=_SOURCE_REVISION,
+            local_dir=args.work_dir / "source",
+        )
+    )
+
+    rows = _build_rows(repo_dir)
+    print(f"Built {len(rows)} multiple-choice examples")
+    ds = Dataset.from_list(rows).cast_column("video", Video())
+    export = DatasetDict({"test": ds})
+
+    if args.push:
+        token = os.environ.get("HF_TOKEN")
+        if not token:
+            raise SystemExit("Set HF_TOKEN to push")
+        create_repo(args.repo_id, repo_type="dataset", token=token, exist_ok=True)
+        export.push_to_hub(args.repo_id, token=token)
+        print(f"Pushed {args.repo_id}. Pin the Hub commit SHA in TaskMetadata.")
+    else:
+        out = args.work_dir / "mteb_export"
+        export.save_to_disk(out)
+        print(f"Wrote local dataset to {out} (pass --push to upload)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- [x] I have outlined why this dataset is filling an existing gap in the MOEB benchmark
- [x] I have tested that the dataset runs with the `mteb` package.
- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
  - [x] `Qwen/Qwen3-VL-Embedding-2B`
  - [x] `mteb/baseline-random-encoder`
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [x] I have considered the size of the dataset and reduced it if it is too big (2048 examples is typically large enough for most tasks)

Eval results below. Random is not that low because retrieval is done over 5 answer choices where only 1 is true - but main metric (accuracy = recall at 1 = precision at 1) is still relevant and differs between random and a stronger model.
```
metric                 random Qwen/Qwen3-VL-Embedding-2B
ndcg_at_1             0.16800        0.37600
ndcg_at_3             0.40003        0.58702
recall_at_1           0.16800        0.37600
recall_at_3           0.57760        0.74400
```