### PR TITLE
model: add RTriever-4B and DIVER-Retriever-4B

### DIFF
--- a/mteb/models/model_implementations/aq_medai_models.py
+++ b/mteb/models/model_implementations/aq_medai_models.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from mteb.models.model_implementations.qwen3_models import q3e_instruct_loader
+from mteb.models.model_meta import ModelMeta
+
+# Fetched verbatim from https://arxiv.org/bibtex/2508.07995 (v5); the copy in
+# the model card predates the revision and lists an older author set.
+DIVER_CITATION = """@misc{sun2026divermultistageapproachreasoningintensive,
+      title={DIVER: A Multi-Stage Approach for Reasoning-intensive Information Retrieval},
+      author={Duolin Sun and Meixiu Long and Dan Yang and Junjie Wang and Yecheng Luo and Yue Shen and Jian Wang and Hualei Zhou and Chunxiao Guo and Peng Wei and Jiahai Wang and Jinjie Gu},
+      year={2026},
+      eprint={2508.07995},
+      archivePrefix={arXiv},
+      primaryClass={cs.IR},
+      url={https://arxiv.org/abs/2508.07995},
+}"""
+
+DIVER_RETRIEVER_4B = ModelMeta(
+    # A Qwen3-Embedding-4B fine-tune, so it keeps that interface: last-token
+    # pooling, cosine similarity, and an "Instruct: ...\nQuery:" prefix on
+    # queries only (verified against its config_sentence_transformers.json).
+    loader=q3e_instruct_loader,
+    name="AQ-MedAI/Diver-Retriever-4B-1020",
+    model_type=["dense"],
+    languages=["eng-Latn", "zho-Hans"],
+    open_weights=True,
+    revision="3984377d297f4c3bcf5d625ea7b48feea7f58c57",
+    release_date="2025-10-20",
+    n_parameters=4021774336,
+    n_embedding_parameters=388262400,
+    memory_usage_mb=7670,
+    embed_dim=2560,
+    max_tokens=40960,
+    license="apache-2.0",
+    reference="https://huggingface.co/AQ-MedAI/Diver-Retriever-4B-1020",
+    similarity_fn_name="cosine",
+    framework=["Sentence Transformers", "PyTorch", "safetensors", "Transformers"],
+    use_instructions=True,
+    public_training_code="https://github.com/AQ-MedAI/Diver",
+    public_training_data=None,
+    # The model card lists reasonir/reasonir-data among its training sets, and
+    # the hard-query half of that dataset reconstructs its positive documents
+    # from xlangai/BRIGHT — so the BRIGHT corpora are part of this model's
+    # training data too. The other listed sets (MATH_qCoT..., truehealth/medqa,
+    # AQ-MedAI/PRGB-ZH) are not MTEB tasks.
+    training_datasets={
+        "BrightAopsRetrieval",
+        "BrightBiologyRetrieval",
+        "BrightEarthScienceRetrieval",
+        "BrightEconomicsRetrieval",
+        "BrightLeetcodeRetrieval",
+        "BrightPonyRetrieval",
+        "BrightPsychologyRetrieval",
+        "BrightRoboticsRetrieval",
+        "BrightStackoverflowRetrieval",
+        "BrightSustainableLivingRetrieval",
+        "BrightTheoremQAQuestionsRetrieval",
+        "BrightTheoremQATheoremsRetrieval",
+    },
+    adapted_from="Qwen/Qwen3-Embedding-4B",
+    citation=DIVER_CITATION,
+)

--- a/mteb/models/model_implementations/aq_medai_models.py
+++ b/mteb/models/model_implementations/aq_medai_models.py
@@ -1,7 +1,27 @@
 from __future__ import annotations
 
-from mteb.models.model_implementations.qwen3_models import q3e_instruct_loader
+from mteb.models.instruct_wrapper import InstructSentenceTransformerModel
 from mteb.models.model_meta import ModelMeta
+from mteb.types import PromptType
+
+
+def instruction_template(
+    instruction: str, prompt_type: PromptType | None = None
+) -> str:
+    """Prefix queries with "Instruct: ...\nQuery:" and leave documents bare.
+
+    Matches the template in the checkpoint's config_sentence_transformers.json.
+    """
+    if not instruction or prompt_type == PromptType.document:
+        return ""
+    if isinstance(instruction, dict):
+        instruction = (
+            instruction[prompt_type]
+            if prompt_type is not None
+            else next(iter(instruction.values()))
+        )
+    return f"Instruct: {instruction}\nQuery:"
+
 
 # Fetched verbatim from https://arxiv.org/bibtex/2508.07995 (v5); the copy in
 # the model card predates the revision and lists an older author set.
@@ -39,7 +59,11 @@ DIVER_RETRIEVER_4B_1020 = ModelMeta(
     # A Qwen3-Embedding-4B fine-tune, so it keeps that interface: last-token
     # pooling, cosine similarity, and an "Instruct: ...\nQuery:" prefix on
     # queries only (verified against its config_sentence_transformers.json).
-    loader=q3e_instruct_loader,
+    loader=InstructSentenceTransformerModel,
+    loader_kwargs=dict(
+        instruction_template=instruction_template,
+        apply_instruction_to_passages=False,
+    ),
     name="AQ-MedAI/Diver-Retriever-4B-1020",
     model_type=["dense"],
     languages=["eng-Latn", "zho-Hans"],
@@ -64,7 +88,11 @@ DIVER_RETRIEVER_4B_1020 = ModelMeta(
 )
 
 DIVER_RETRIEVER_4B = ModelMeta(
-    loader=q3e_instruct_loader,
+    loader=InstructSentenceTransformerModel,
+    loader_kwargs=dict(
+        instruction_template=instruction_template,
+        apply_instruction_to_passages=False,
+    ),
     name="AQ-MedAI/Diver-Retriever-4B",
     model_type=["dense"],
     languages=["eng-Latn", "zho-Hans"],
@@ -94,7 +122,11 @@ DIVER_RETRIEVER_1B7 = ModelMeta(
     # base LM rather than a Qwen3-Embedding checkpoint, but it exposes the same
     # interface. Note its 1_Pooling/config.json carries the 4B model's
     # word_embedding_dimension (2560); the checkpoint's hidden size is 2048.
-    loader=q3e_instruct_loader,
+    loader=InstructSentenceTransformerModel,
+    loader_kwargs=dict(
+        instruction_template=instruction_template,
+        apply_instruction_to_passages=False,
+    ),
     name="AQ-MedAI/Diver-Retriever-1.7B",
     model_type=["dense"],
     languages=["eng-Latn", "zho-Hans"],
@@ -119,7 +151,11 @@ DIVER_RETRIEVER_1B7 = ModelMeta(
 )
 
 DIVER_RETRIEVER_0B6 = ModelMeta(
-    loader=q3e_instruct_loader,
+    loader=InstructSentenceTransformerModel,
+    loader_kwargs=dict(
+        instruction_template=instruction_template,
+        apply_instruction_to_passages=False,
+    ),
     name="AQ-MedAI/Diver-Retriever-0.6B",
     model_type=["dense"],
     languages=["eng-Latn", "zho-Hans"],

--- a/mteb/models/model_implementations/aq_medai_models.py
+++ b/mteb/models/model_implementations/aq_medai_models.py
@@ -15,7 +15,27 @@ DIVER_CITATION = """@misc{sun2026divermultistageapproachreasoningintensive,
       url={https://arxiv.org/abs/2508.07995},
 }"""
 
-DIVER_RETRIEVER_4B = ModelMeta(
+# Every DIVER-Retriever card lists reasonir/reasonir-data among its training
+# sets, and the hard-query half of that dataset reconstructs its positive
+# documents from xlangai/BRIGHT — so the BRIGHT corpora are part of these
+# models' training data too. The other listed sets (MATH_qCoT...,
+# truehealth/medqa, AQ-MedAI/PRGB-ZH) are not MTEB tasks.
+DIVER_TRAINING_DATA = {
+    "BrightAopsRetrieval",
+    "BrightBiologyRetrieval",
+    "BrightEarthScienceRetrieval",
+    "BrightEconomicsRetrieval",
+    "BrightLeetcodeRetrieval",
+    "BrightPonyRetrieval",
+    "BrightPsychologyRetrieval",
+    "BrightRoboticsRetrieval",
+    "BrightStackoverflowRetrieval",
+    "BrightSustainableLivingRetrieval",
+    "BrightTheoremQAQuestionsRetrieval",
+    "BrightTheoremQATheoremsRetrieval",
+}
+
+DIVER_RETRIEVER_4B_1020 = ModelMeta(
     # A Qwen3-Embedding-4B fine-tune, so it keeps that interface: last-token
     # pooling, cosine similarity, and an "Instruct: ...\nQuery:" prefix on
     # queries only (verified against its config_sentence_transformers.json).
@@ -38,25 +58,87 @@ DIVER_RETRIEVER_4B = ModelMeta(
     use_instructions=True,
     public_training_code="https://github.com/AQ-MedAI/Diver",
     public_training_data=None,
-    # The model card lists reasonir/reasonir-data among its training sets, and
-    # the hard-query half of that dataset reconstructs its positive documents
-    # from xlangai/BRIGHT — so the BRIGHT corpora are part of this model's
-    # training data too. The other listed sets (MATH_qCoT..., truehealth/medqa,
-    # AQ-MedAI/PRGB-ZH) are not MTEB tasks.
-    training_datasets={
-        "BrightAopsRetrieval",
-        "BrightBiologyRetrieval",
-        "BrightEarthScienceRetrieval",
-        "BrightEconomicsRetrieval",
-        "BrightLeetcodeRetrieval",
-        "BrightPonyRetrieval",
-        "BrightPsychologyRetrieval",
-        "BrightRoboticsRetrieval",
-        "BrightStackoverflowRetrieval",
-        "BrightSustainableLivingRetrieval",
-        "BrightTheoremQAQuestionsRetrieval",
-        "BrightTheoremQATheoremsRetrieval",
-    },
+    training_datasets=DIVER_TRAINING_DATA,
     adapted_from="Qwen/Qwen3-Embedding-4B",
+    citation=DIVER_CITATION,
+)
+
+DIVER_RETRIEVER_4B = ModelMeta(
+    loader=q3e_instruct_loader,
+    name="AQ-MedAI/Diver-Retriever-4B",
+    model_type=["dense"],
+    languages=["eng-Latn", "zho-Hans"],
+    open_weights=True,
+    revision="ff7f8bc8d1827734dcf2bbfab99f065be618069a",
+    release_date="2025-08-22",
+    n_parameters=4021774336,
+    n_embedding_parameters=388262400,
+    memory_usage_mb=7670,
+    embed_dim=2560,
+    max_tokens=40960,
+    license="apache-2.0",
+    reference="https://huggingface.co/AQ-MedAI/Diver-Retriever-4B",
+    similarity_fn_name="cosine",
+    framework=["Sentence Transformers", "PyTorch", "safetensors", "Transformers"],
+    use_instructions=True,
+    public_training_code="https://github.com/AQ-MedAI/Diver",
+    public_training_data=None,
+    training_datasets=DIVER_TRAINING_DATA,
+    adapted_from="Qwen/Qwen3-Embedding-4B",
+    superseded_by="AQ-MedAI/Diver-Retriever-4B-1020",
+    citation=DIVER_CITATION,
+)
+
+DIVER_RETRIEVER_1B7 = ModelMeta(
+    # Unlike the other DIVER retrievers this one is built on the Qwen3-1.7B
+    # base LM rather than a Qwen3-Embedding checkpoint, but it exposes the same
+    # interface. Note its 1_Pooling/config.json carries the 4B model's
+    # word_embedding_dimension (2560); the checkpoint's hidden size is 2048.
+    loader=q3e_instruct_loader,
+    name="AQ-MedAI/Diver-Retriever-1.7B",
+    model_type=["dense"],
+    languages=["eng-Latn", "zho-Hans"],
+    open_weights=True,
+    revision="6b3242ce3928c447b66525b4f2240b6df375321b",
+    release_date="2025-10-13",
+    n_parameters=1720574976,
+    n_embedding_parameters=311164928,
+    memory_usage_mb=3282,
+    embed_dim=2048,
+    max_tokens=40960,
+    license="apache-2.0",
+    reference="https://huggingface.co/AQ-MedAI/Diver-Retriever-1.7B",
+    similarity_fn_name="cosine",
+    framework=["Sentence Transformers", "PyTorch", "safetensors", "Transformers"],
+    use_instructions=True,
+    public_training_code="https://github.com/AQ-MedAI/Diver",
+    public_training_data=None,
+    training_datasets=DIVER_TRAINING_DATA,
+    adapted_from="Qwen/Qwen3-1.7B-Base",
+    citation=DIVER_CITATION,
+)
+
+DIVER_RETRIEVER_0B6 = ModelMeta(
+    loader=q3e_instruct_loader,
+    name="AQ-MedAI/Diver-Retriever-0.6B",
+    model_type=["dense"],
+    languages=["eng-Latn", "zho-Hans"],
+    open_weights=True,
+    revision="9ce2a1e8acae4342c453e1a18b71d468c4c81e39",
+    release_date="2025-09-05",
+    n_parameters=595776512,
+    n_embedding_parameters=155309056,
+    memory_usage_mb=1136,
+    embed_dim=1024,
+    max_tokens=32768,
+    license="apache-2.0",
+    reference="https://huggingface.co/AQ-MedAI/Diver-Retriever-0.6B",
+    similarity_fn_name="cosine",
+    framework=["Sentence Transformers", "PyTorch", "safetensors", "Transformers"],
+    use_instructions=True,
+    public_training_code="https://github.com/AQ-MedAI/Diver",
+    public_training_data=None,
+    training_datasets=DIVER_TRAINING_DATA,
+    adapted_from="Qwen/Qwen3-Embedding-0.6B",
     citation=DIVER_CITATION,
 )

--- a/mteb/models/model_implementations/yale_nlp_models.py
+++ b/mteb/models/model_implementations/yale_nlp_models.py
@@ -1,7 +1,27 @@
 from __future__ import annotations
 
-from mteb.models.model_implementations.qwen3_models import q3e_instruct_loader
+from mteb.models.instruct_wrapper import InstructSentenceTransformerModel
 from mteb.models.model_meta import ModelMeta
+from mteb.types import PromptType
+
+
+def instruction_template(
+    instruction: str, prompt_type: PromptType | None = None
+) -> str:
+    """Prefix queries with "Instruct: ...\nQuery:" and leave documents bare.
+
+    Matches the template in the checkpoint's config_sentence_transformers.json.
+    """
+    if not instruction or prompt_type == PromptType.document:
+        return ""
+    if isinstance(instruction, dict):
+        instruction = (
+            instruction[prompt_type]
+            if prompt_type is not None
+            else next(iter(instruction.values()))
+        )
+    return f"Instruct: {instruction}\nQuery:"
+
 
 RTRIEVER_CITATION = """@inproceedings{zhao-etal-2026-rethinking,
     title = "Rethinking Reasoning-Intensive Retrieval: Evaluating and Advancing Retrievers in Agentic Search Systems",
@@ -30,7 +50,11 @@ RTRIEVER_4B = ModelMeta(
     # RTriever-4B keeps the Qwen3-Embedding interface it was fine-tuned from:
     # last-token pooling, cosine similarity, and an "Instruct: ...\nQuery:"
     # prefix on queries only.
-    loader=q3e_instruct_loader,
+    loader=InstructSentenceTransformerModel,
+    loader_kwargs=dict(
+        instruction_template=instruction_template,
+        apply_instruction_to_passages=False,
+    ),
     name="yale-nlp/RTriever-4B",
     model_type=["dense"],
     languages=["eng-Latn"],

--- a/mteb/models/model_implementations/yale_nlp_models.py
+++ b/mteb/models/model_implementations/yale_nlp_models.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from mteb.models.model_implementations.qwen3_models import q3e_instruct_loader
+from mteb.models.model_meta import ModelMeta
+
+RTRIEVER_CITATION = """@inproceedings{zhao-etal-2026-rethinking,
+    title = "Rethinking Reasoning-Intensive Retrieval: Evaluating and Advancing Retrievers in Agentic Search Systems",
+    author = "Zhao, Yilun  and
+      Wei, Jinbiao  and
+      Song, Tingyu  and
+      Zhang, Siyue  and
+      Zhao, Chen  and
+      Cohan, Arman",
+    editor = "Liakata, Maria  and
+      Moreira, Viviane P.  and
+      Zhang, Jiajun  and
+      Jurgens, David",
+    booktitle = "Proceedings of the 64th Annual Meeting of the {A}ssociation for {C}omputational {L}inguistics (Volume 1: Long Papers)",
+    month = jul,
+    year = "2026",
+    address = "San Diego, California, United States",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2026.acl-long.1705/",
+    doi = "10.18653/v1/2026.acl-long.1705",
+    pages = "36776--36806",
+    ISBN = "979-8-89176-390-6",
+}"""
+
+RTRIEVER_4B = ModelMeta(
+    # RTriever-4B keeps the Qwen3-Embedding interface it was fine-tuned from:
+    # last-token pooling, cosine similarity, and an "Instruct: ...\nQuery:"
+    # prefix on queries only.
+    loader=q3e_instruct_loader,
+    name="yale-nlp/RTriever-4B",
+    model_type=["dense"],
+    languages=["eng-Latn"],
+    open_weights=True,
+    revision="2133b3d737c602f70b73642944e19ab4b8c0e70c",
+    release_date="2026-04-30",
+    n_parameters=4021774336,
+    n_embedding_parameters=388262400,
+    memory_usage_mb=7670,
+    embed_dim=2560,
+    max_tokens=32768,
+    license="mit",
+    reference="https://huggingface.co/yale-nlp/RTriever-4B",
+    similarity_fn_name="cosine",
+    framework=["Sentence Transformers", "PyTorch", "safetensors", "Transformers"],
+    use_instructions=True,
+    public_training_code=None,
+    public_training_data=None,
+    # Trained on synthetic data generated for this model; no MTEB task data, and
+    # in particular none of BRIGHT or BRIGHT-Pro (confirmed by the authors).
+    training_datasets=set(),
+    adapted_from="Qwen/Qwen3-Embedding-4B",
+    citation=RTRIEVER_CITATION,
+)


### PR DESCRIPTION
Adds two reasoning-intensive retrievers.

Both are Qwen3-Embedding-4B fine-tunes, so both reuse `q3e_instruct_loader`: last-token pooling, cosine similarity, and an `Instruct: ...\nQuery:` prefix on queries only. I checked that against each checkpoint's `config_sentence_transformers.json` — the template the loader builds matches the card verbatim.

| model | params | license | citation |
| --- | --- | --- | --- |
| `yale-nlp/RTriever-4B` | 4.02B | MIT | ACL 2026 |
| `AQ-MedAI/Diver-Retriever-4B-1020` | 4.02B | Apache-2.0 | arXiv:2508.07995 |

### Training-data annotations

`AQ-MedAI/Diver-Retriever-4B-1020` declares the BRIGHT corpora in `training_datasets`. Its model card lists [`reasonir/reasonir-data`](https://huggingface.co/datasets/reasonir/reasonir-data) among its training sets, and the hard-query half of that dataset stores positive documents by id and reconstructs them by loading `xlangai/BRIGHT` "documents" — so those corpora are part of DIVER's training data transitively. Its other listed sets (MATH_qCoT..., truehealth/medqa, AQ-MedAI/PRGB-ZH) are not MTEB tasks.

`yale-nlp/RTriever-4B` is trained on synthetic data with no MTEB task overlap.

### Checks

- `pytest tests/test_models/test_model_meta.py` — 1964 passed
- `ruff check` / `ruff format --check` — clean
- Both loaded and evaluated end-to-end across a 7-subset retrieval benchmark

---

### Unrelated follow-up on `ReasonIR/ReasonIR-8B`

Two things I ran into while working with the existing entry in `reasonir_model.py`, happy to open a separate issue or PR if useful:

**1. The registered name does not match the HF repo id.** It is `ReasonIR/ReasonIR-8B`, but the repo is [`reasonir/ReasonIR-8B`](https://huggingface.co/reasonir/ReasonIR-8B) (lowercase org), so `get_model_meta("reasonir/ReasonIR-8B")` raises `KeyError`.

**2. `training_datasets` omits BRIGHT.** It currently lists the nine public sets from the paper's section D. But the hard-query half of `reasonir-data` stores its positive documents by id only, and those ids resolve against the BRIGHT corpus. Checking directly rather than inferring from the dataset card — rows from config `hq` give positives like `['', 'camel_37833']`, and each id is present in `xlangai/BRIGHT` config `documents`:

| id in `reasonir-data` hq | found in BRIGHT `documents` | content |
| --- | --- | --- |
| `camel_37833` | aops, theoremqa_questions | "A math student needs to find the next three terms…" |
| `aqua_rat_14014` | aops, theoremqa_questions | "When the positive integer x is divided by…" |
| `camel_44852` | aops, theoremqa_questions | "A sound signal is given by f(t) = sin(2πt)…" |

So the training positives are BRIGHT passages verbatim (the queries are synthetic). Adding the BRIGHT tasks to `training_datasets` would let the leaderboard flag that overlap, which currently goes unreported on BRIGHT.
