### PR TITLE
[MOEB] Add SEA-VL: Multicultural VL Dataset for Southeast Asia

### DIFF
--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/SeaVLCrawlingI2TRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/SeaVLCrawlingI2TRetrieval.json
@@ -1,0 +1,38 @@
+{
+    "test": {
+        "num_samples": 4096,
+        "num_queries": 2048,
+        "num_documents": 2048,
+        "number_of_characters": 124745,
+        "documents_text_statistics": {
+            "total_text_length": 124745,
+            "min_text_length": 5,
+            "average_text_length": 60.91064453125,
+            "max_text_length": 1309,
+            "unique_texts": 2047
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": {
+            "min_image_width": 67,
+            "average_image_width": 656.19287109375,
+            "max_image_width": 5152,
+            "min_image_height": 72,
+            "average_image_height": 493.9140625,
+            "max_image_height": 4272,
+            "unique_images": 2048
+        },
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 1810,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 1810
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/SeaVLCrawlingT2IRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/SeaVLCrawlingT2IRetrieval.json
@@ -1,0 +1,38 @@
+{
+    "test": {
+        "num_samples": 4096,
+        "num_queries": 2048,
+        "num_documents": 2048,
+        "number_of_characters": 124745,
+        "documents_text_statistics": null,
+        "documents_image_statistics": {
+            "min_image_width": 67,
+            "average_image_width": 656.19287109375,
+            "max_image_width": 5152,
+            "min_image_height": 72,
+            "average_image_height": 493.9140625,
+            "max_image_height": 4272,
+            "unique_images": 2048
+        },
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 124745,
+            "min_text_length": 5,
+            "average_text_length": 60.91064453125,
+            "max_text_length": 1309,
+            "unique_texts": 2047
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 1810,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 1810
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -297,6 +297,10 @@ from .sci_fact_retrieval import SciFact
 from .sci_mmir_i2t_retrieval import SciMMIRI2TRetrieval
 from .sci_mmir_t2i_retrieval import SciMMIRT2IRetrieval
 from .scidocs_retrieval import SCIDOCS
+from .sea_vl_crawling_retrieval import (
+    SeaVLCrawlingI2TRetrieval,
+    SeaVLCrawlingT2IRetrieval,
+)
 from .shot2story_retrieval import (
     Shot2Story20KA2VRetrieval,
     Shot2Story20KAT2VRetrieval,
@@ -307,6 +311,7 @@ from .shot2story_retrieval import (
     Shot2Story20KVA2TRetrieval,
     Shot2Story20KVT2ARetrieval,
 )
+from .shs100k_retrieval import SHS100KA2ARetrieval
 from .siqa_retrieval import SIQA
 from .sketchy_i2i_retrieval import SketchyI2IRetrieval
 from .sop_i2i_retrieval import SOPI2IRetrieval
@@ -683,10 +688,13 @@ __all__ = [
     "RParisMediumI2IRetrieval",
     "ReMe",
     "ReMuQIT2TRetrieval",
+    "SHS100KA2ARetrieval",
     "SOPI2IRetrieval",
     "SciFact",
     "SciMMIRI2TRetrieval",
     "SciMMIRT2IRetrieval",
+    "SeaVLCrawlingI2TRetrieval",
+    "SeaVLCrawlingT2IRetrieval",
     "Shot2Story20KA2VRetrieval",
     "Shot2Story20KAT2VRetrieval",
     "Shot2Story20KT2VARetrieval",

--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -311,7 +311,6 @@ from .shot2story_retrieval import (
     Shot2Story20KVA2TRetrieval,
     Shot2Story20KVT2ARetrieval,
 )
-from .shs100k_retrieval import SHS100KA2ARetrieval
 from .siqa_retrieval import SIQA
 from .sketchy_i2i_retrieval import SketchyI2IRetrieval
 from .sop_i2i_retrieval import SOPI2IRetrieval
@@ -688,7 +687,6 @@ __all__ = [
     "RParisMediumI2IRetrieval",
     "ReMe",
     "ReMuQIT2TRetrieval",
-    "SHS100KA2ARetrieval",
     "SOPI2IRetrieval",
     "SciFact",
     "SciMMIRI2TRetrieval",

--- a/mteb/tasks/retrieval/eng/sea_vl_crawling_retrieval.py
+++ b/mteb/tasks/retrieval/eng/sea_vl_crawling_retrieval.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from datasets import Dataset, Image, load_dataset
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.retrieval_dataset_loaders import RetrievalSplitData
+from mteb.abstasks.task_metadata import TaskMetadata
+
+_SOURCE = "SEACrowd/sea-vl_crawling"
+_SOURCE_REVISION = "4723b4f00b68dc2fe649624628f3e8d50afa1e74"
+_N_SAMPLES = 2048
+_SHUFFLE_BUFFER = 10_000
+_SEED = 42
+
+_REFERENCE = "https://arxiv.org/abs/2503.07920"
+_BIBTEX = r"""
+@inproceedings{cahyawijaya2025seavl,
+  title={Crowdsource, Crawl, or Generate? Creating {SEA}-{VL}, a Multicultural Vision-Language Dataset for Southeast Asia},
+  author={Cahyawijaya, Samuel and Lovenia, Holy and Moniz, Joel Ruben Antony and Wong, Tack Hwa and Farhansyah, Mohammad Rifqi and Maung, Thant Thiri and Hudi, Frederikus and Anugraha, David and Habibi, Muhammad Ravi Shulthan and Qorib, Muhammad Reza and others},
+  booktitle={Proceedings of the 63rd Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)},
+  pages={18685--18717},
+  year={2025}
+}
+"""
+_DESCRIPTION = (
+    "SEA-VL crawling is a large-scale Southeast Asia–focused image–caption collection "
+    "(~1.27M web-crawled culturally relevant pairs). For MTEB evaluation we deterministically "
+    f"downsample to {_N_SAMPLES} image–caption pairs via a seeded streaming shuffle "
+    f"(buffer={_SHUFFLE_BUFFER}), using the first non-empty caption per image."
+)
+
+
+def _first_caption(captions: list[str] | None) -> str | None:
+    if not captions:
+        return None
+    for cap in captions:
+        if isinstance(cap, str) and cap.strip():
+            return cap.strip()
+    return None
+
+
+def _sample_pairs(*, n_samples: int = _N_SAMPLES) -> list[dict]:
+    """Stream-sample image–caption pairs without downloading the full 1.27M set."""
+    stream = load_dataset(
+        _SOURCE,
+        revision=_SOURCE_REVISION,
+        split="train",
+        streaming=True,
+    )
+    stream = stream.shuffle(seed=_SEED, buffer_size=_SHUFFLE_BUFFER)
+
+    pairs: list[dict] = []
+    for row in stream:
+        text = _first_caption(row.get("caption"))
+        image = row.get("image")
+        if text is None or image is None:
+            continue
+        pairs.append(
+            {
+                "id": str(row["id"]),
+                "image": image,
+                "text": text,
+                "category": row.get("category"),
+            }
+        )
+        if len(pairs) >= n_samples:
+            break
+    if len(pairs) < n_samples:
+        raise RuntimeError(
+            f"Only collected {len(pairs)} valid pairs from {_SOURCE}; "
+            f"expected {n_samples}."
+        )
+    return pairs
+
+
+def _build_t2i_split(pairs: list[dict]) -> RetrievalSplitData:
+    query_rows = [
+        {"id": f"q-{p['id']}", "text": p["text"], "modality": "text"} for p in pairs
+    ]
+    corpus_rows = [
+        {"id": f"d-{p['id']}", "image": p["image"], "modality": "image"} for p in pairs
+    ]
+    relevant_docs = {f"q-{p['id']}": {f"d-{p['id']}": 1} for p in pairs}
+    return RetrievalSplitData(
+        queries=Dataset.from_list(query_rows),
+        corpus=Dataset.from_list(corpus_rows).cast_column("image", Image()),
+        relevant_docs=relevant_docs,
+    )
+
+
+def _build_i2t_split(pairs: list[dict]) -> RetrievalSplitData:
+    query_rows = [
+        {"id": f"q-{p['id']}", "image": p["image"], "modality": "image"} for p in pairs
+    ]
+    corpus_rows = [
+        {"id": f"d-{p['id']}", "text": p["text"], "modality": "text"} for p in pairs
+    ]
+    relevant_docs = {f"q-{p['id']}": {f"d-{p['id']}": 1} for p in pairs}
+    return RetrievalSplitData(
+        queries=Dataset.from_list(query_rows).cast_column("image", Image()),
+        corpus=Dataset.from_list(corpus_rows),
+        relevant_docs=relevant_docs,
+    )
+
+
+class SeaVLCrawlingT2IRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="SeaVLCrawlingT2IRetrieval",
+        description=_DESCRIPTION
+        + " Queries are captions; the corpus contains images (text→image retrieval).",
+        reference=_REFERENCE,
+        dataset={
+            "path": _SOURCE,
+            "revision": _SOURCE_REVISION,
+        },
+        type="Any2AnyRetrieval",
+        category="t2i",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2024-01-01", "2025-03-10"),
+        domains=["Web", "Written"],
+        task_subtypes=["Image Text Retrieval"],
+        license="cc-by-sa-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        modalities=["text", "image"],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find an image that matches the given caption."},
+        is_beta=True,
+    )
+
+    def load_data(self, **kwargs) -> None:
+        if self.data_loaded:
+            return
+        pairs = _sample_pairs()
+        self.dataset = {"default": {"test": _build_t2i_split(pairs)}}
+        self.data_loaded = True
+
+
+class SeaVLCrawlingI2TRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="SeaVLCrawlingI2TRetrieval",
+        description=_DESCRIPTION
+        + " Queries are images; the corpus contains captions (image→text retrieval).",
+        reference=_REFERENCE,
+        dataset={
+            "path": _SOURCE,
+            "revision": _SOURCE_REVISION,
+        },
+        type="Any2AnyRetrieval",
+        category="i2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2024-01-01", "2025-03-10"),
+        domains=["Web", "Written"],
+        task_subtypes=["Image Text Retrieval"],
+        license="cc-by-sa-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        modalities=["text", "image"],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find a caption that matches the given image."},
+        is_beta=True,
+    )
+
+    def load_data(self, **kwargs) -> None:
+        if self.data_loaded:
+            return
+        pairs = _sample_pairs()
+        self.dataset = {"default": {"test": _build_i2t_split(pairs)}}
+        self.data_loaded = True

--- a/mteb/tasks/retrieval/eng/sea_vl_crawling_retrieval.py
+++ b/mteb/tasks/retrieval/eng/sea_vl_crawling_retrieval.py
@@ -1,16 +1,7 @@
 from __future__ import annotations
 
-from datasets import Dataset, Image, load_dataset
-
 from mteb.abstasks.retrieval import AbsTaskRetrieval
-from mteb.abstasks.retrieval_dataset_loaders import RetrievalSplitData
 from mteb.abstasks.task_metadata import TaskMetadata
-
-_SOURCE = "SEACrowd/sea-vl_crawling"
-_SOURCE_REVISION = "4723b4f00b68dc2fe649624628f3e8d50afa1e74"
-_N_SAMPLES = 2048
-_SHUFFLE_BUFFER = 10_000
-_SEED = 42
 
 _REFERENCE = "https://arxiv.org/abs/2503.07920"
 _BIBTEX = r"""
@@ -23,86 +14,11 @@ _BIBTEX = r"""
 }
 """
 _DESCRIPTION = (
-    "SEA-VL crawling is a large-scale Southeast Asia–focused image–caption collection "
-    "(~1.27M web-crawled culturally relevant pairs). For MTEB evaluation we deterministically "
-    f"downsample to {_N_SAMPLES} image–caption pairs via a seeded streaming shuffle "
-    f"(buffer={_SHUFFLE_BUFFER}), using the first non-empty caption per image."
+    "SEA-VL crawling is a large-scale, Southeast Asia–focused image–caption dataset, "
+    "containing culturally relevant image–text pairs from the web. The subset used in MTEB "
+    "features 2048 unique images and their corresponding captions, offering an evaluation "
+    "benchmark for image–text and text–image retrieval in Southeast Asian cultural contexts."
 )
-
-
-def _first_caption(captions: list[str] | None) -> str | None:
-    if not captions:
-        return None
-    for cap in captions:
-        if isinstance(cap, str) and cap.strip():
-            return cap.strip()
-    return None
-
-
-def _sample_pairs(*, n_samples: int = _N_SAMPLES) -> list[dict]:
-    """Stream-sample image–caption pairs without downloading the full 1.27M set."""
-    stream = load_dataset(
-        _SOURCE,
-        revision=_SOURCE_REVISION,
-        split="train",
-        streaming=True,
-    )
-    stream = stream.shuffle(seed=_SEED, buffer_size=_SHUFFLE_BUFFER)
-
-    pairs: list[dict] = []
-    for row in stream:
-        text = _first_caption(row.get("caption"))
-        image = row.get("image")
-        if text is None or image is None:
-            continue
-        pairs.append(
-            {
-                "id": str(row["id"]),
-                "image": image,
-                "text": text,
-                "category": row.get("category"),
-            }
-        )
-        if len(pairs) >= n_samples:
-            break
-    if len(pairs) < n_samples:
-        raise RuntimeError(
-            f"Only collected {len(pairs)} valid pairs from {_SOURCE}; "
-            f"expected {n_samples}."
-        )
-    return pairs
-
-
-def _build_t2i_split(pairs: list[dict]) -> RetrievalSplitData:
-    query_rows = [
-        {"id": f"q-{p['id']}", "text": p["text"], "modality": "text"} for p in pairs
-    ]
-    corpus_rows = [
-        {"id": f"d-{p['id']}", "image": p["image"], "modality": "image"} for p in pairs
-    ]
-    relevant_docs = {f"q-{p['id']}": {f"d-{p['id']}": 1} for p in pairs}
-    return RetrievalSplitData(
-        queries=Dataset.from_list(query_rows),
-        corpus=Dataset.from_list(corpus_rows).cast_column("image", Image()),
-        relevant_docs=relevant_docs,
-        top_ranked=None,
-    )
-
-
-def _build_i2t_split(pairs: list[dict]) -> RetrievalSplitData:
-    query_rows = [
-        {"id": f"q-{p['id']}", "image": p["image"], "modality": "image"} for p in pairs
-    ]
-    corpus_rows = [
-        {"id": f"d-{p['id']}", "text": p["text"], "modality": "text"} for p in pairs
-    ]
-    relevant_docs = {f"q-{p['id']}": {f"d-{p['id']}": 1} for p in pairs}
-    return RetrievalSplitData(
-        queries=Dataset.from_list(query_rows).cast_column("image", Image()),
-        corpus=Dataset.from_list(corpus_rows),
-        relevant_docs=relevant_docs,
-        top_ranked=None,
-    )
 
 
 class SeaVLCrawlingT2IRetrieval(AbsTaskRetrieval):
@@ -112,8 +28,8 @@ class SeaVLCrawlingT2IRetrieval(AbsTaskRetrieval):
         + " Queries are captions; the corpus contains images (text→image retrieval).",
         reference=_REFERENCE,
         dataset={
-            "path": _SOURCE,
-            "revision": _SOURCE_REVISION,
+            "path": "Wissam42/SEA-VL-Crawling-T2I",
+            "revision": "b0f22ad420a61d217efb654d1fa3cc88b77ba40b",
         },
         type="Any2AnyRetrieval",
         category="t2i",
@@ -133,13 +49,6 @@ class SeaVLCrawlingT2IRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, **kwargs) -> None:
-        if self.data_loaded:
-            return
-        pairs = _sample_pairs()
-        self.dataset = {"default": {"test": _build_t2i_split(pairs)}}
-        self.data_loaded = True
-
 
 class SeaVLCrawlingI2TRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
@@ -148,8 +57,8 @@ class SeaVLCrawlingI2TRetrieval(AbsTaskRetrieval):
         + " Queries are images; the corpus contains captions (image→text retrieval).",
         reference=_REFERENCE,
         dataset={
-            "path": _SOURCE,
-            "revision": _SOURCE_REVISION,
+            "path": "Wissam42/SEA-VL-Crawling-I2T",
+            "revision": "112d27a26b4fcc5516940360771766c5feb785e8",
         },
         type="Any2AnyRetrieval",
         category="i2t",
@@ -168,10 +77,3 @@ class SeaVLCrawlingI2TRetrieval(AbsTaskRetrieval):
         prompt={"query": "Find a caption that matches the given image."},
         is_beta=True,
     )
-
-    def load_data(self, **kwargs) -> None:
-        if self.data_loaded:
-            return
-        pairs = _sample_pairs()
-        self.dataset = {"default": {"test": _build_i2t_split(pairs)}}
-        self.data_loaded = True

--- a/mteb/tasks/retrieval/eng/sea_vl_crawling_retrieval.py
+++ b/mteb/tasks/retrieval/eng/sea_vl_crawling_retrieval.py
@@ -85,6 +85,7 @@ def _build_t2i_split(pairs: list[dict]) -> RetrievalSplitData:
         queries=Dataset.from_list(query_rows),
         corpus=Dataset.from_list(corpus_rows).cast_column("image", Image()),
         relevant_docs=relevant_docs,
+        top_ranked=None,
     )
 
 
@@ -100,6 +101,7 @@ def _build_i2t_split(pairs: list[dict]) -> RetrievalSplitData:
         queries=Dataset.from_list(query_rows).cast_column("image", Image()),
         corpus=Dataset.from_list(corpus_rows),
         relevant_docs=relevant_docs,
+        top_ranked=None,
     )
 
 

--- a/scripts/data/sea_vl_crawling/create_data.py
+++ b/scripts/data/sea_vl_crawling/create_data.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Sample SEACrowd/sea-vl_crawling into MTEB t2i / i2t retrieval Hub datasets.
+
+Source is ~1.27M image–caption pairs (~109GB). This script stream-shuffles with
+a fixed seed and keeps 2048 unique pairs (first non-empty caption each; duplicate
+source ``id`` values are skipped), then pushes separate T2I and I2T repos in the
+standard corpus / queries / qrels layout.
+
+Usage:
+  export HF_TOKEN=...
+  uv run python scripts/data/sea_vl_crawling/create_data.py \\
+      --t2i-repo-id {base_repo}/SEA-VL-Crawling-T2I \\
+      --i2t-repo-id {base_repo}/SEA-VL-Crawling-I2T \\
+      --push
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+from datasets import Dataset, DatasetDict, Image, load_dataset
+from huggingface_hub import create_repo
+from tqdm import tqdm
+
+_SOURCE = "SEACrowd/sea-vl_crawling"
+_SOURCE_REVISION = "4723b4f00b68dc2fe649624628f3e8d50afa1e74"
+_N_SAMPLES = 2048
+_SHUFFLE_BUFFER = 10_000
+_SEED = 42
+
+
+def _first_caption(captions: list[str] | None) -> str | None:
+    if not captions:
+        return None
+    for cap in captions:
+        if isinstance(cap, str) and cap.strip():
+            return cap.strip()
+    return None
+
+
+def _sample_pairs(n_samples: int) -> list[dict]:
+    stream = load_dataset(
+        _SOURCE,
+        revision=_SOURCE_REVISION,
+        split="train",
+        streaming=True,
+    )
+    stream = stream.shuffle(seed=_SEED, buffer_size=_SHUFFLE_BUFFER)
+
+    pairs: list[dict] = []
+    seen_ids: set[str] = set()
+    for row in tqdm(stream, total=n_samples, desc="sample"):
+        pair_id = str(row["id"])
+        if pair_id in seen_ids:
+            continue
+        text = _first_caption(row.get("caption"))
+        image = row.get("image")
+        if text is None or image is None:
+            continue
+        seen_ids.add(pair_id)
+        pairs.append(
+            {
+                "id": pair_id,
+                "image": image,
+                "text": text,
+                "category": row.get("category") or "",
+            }
+        )
+        if len(pairs) >= n_samples:
+            break
+    if len(pairs) < n_samples:
+        raise SystemExit(f"Only collected {len(pairs)} pairs; expected {n_samples}")
+    return pairs
+
+
+def _push_t2i(pairs: list[dict], repo_id: str, token: str) -> None:
+    corpus = Dataset.from_list(
+        [
+            {"id": f"d-{p['id']}", "image": p["image"], "modality": "image"}
+            for p in pairs
+        ]
+    ).cast_column("image", Image())
+    queries = Dataset.from_list(
+        [{"id": f"q-{p['id']}", "text": p["text"], "modality": "text"} for p in pairs]
+    )
+    qrels = Dataset.from_list(
+        [
+            {"query-id": f"q-{p['id']}", "corpus-id": f"d-{p['id']}", "score": 1}
+            for p in pairs
+        ]
+    )
+    create_repo(repo_id, repo_type="dataset", token=token, exist_ok=True)
+    DatasetDict({"test": corpus}).push_to_hub(repo_id, "corpus", token=token)
+    DatasetDict({"test": queries}).push_to_hub(repo_id, "queries", token=token)
+    DatasetDict({"test": qrels}).push_to_hub(repo_id, "qrels", token=token)
+
+
+def _push_i2t(pairs: list[dict], repo_id: str, token: str) -> None:
+    corpus = Dataset.from_list(
+        [{"id": f"d-{p['id']}", "text": p["text"], "modality": "text"} for p in pairs]
+    )
+    queries = Dataset.from_list(
+        [
+            {"id": f"q-{p['id']}", "image": p["image"], "modality": "image"}
+            for p in pairs
+        ]
+    ).cast_column("image", Image())
+    qrels = Dataset.from_list(
+        [
+            {"query-id": f"q-{p['id']}", "corpus-id": f"d-{p['id']}", "score": 1}
+            for p in pairs
+        ]
+    )
+    create_repo(repo_id, repo_type="dataset", token=token, exist_ok=True)
+    DatasetDict({"test": corpus}).push_to_hub(repo_id, "corpus", token=token)
+    DatasetDict({"test": queries}).push_to_hub(repo_id, "queries", token=token)
+    DatasetDict({"test": qrels}).push_to_hub(repo_id, "qrels", token=token)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--t2i-repo-id", default="Wissam42/SEA-VL-Crawling-T2I")
+    parser.add_argument("--i2t-repo-id", default="Wissam42/SEA-VL-Crawling-I2T")
+    parser.add_argument("--n-samples", type=int, default=_N_SAMPLES)
+    parser.add_argument("--push", action="store_true")
+    parser.add_argument(
+        "--directions",
+        default="both",
+        choices=("t2i", "i2t", "both"),
+        help="Which Hub datasets to build",
+    )
+    args = parser.parse_args()
+
+    pairs = _sample_pairs(args.n_samples)
+    print(
+        f"sampled={len(pairs)} source={_SOURCE}@{_SOURCE_REVISION} "
+        f"seed={_SEED} buffer={_SHUFFLE_BUFFER}"
+    )
+
+    if not args.push:
+        print("Dry run (pass --push to upload). Example caption:")
+        print(f"  id={pairs[0]['id']} cat={pairs[0]['category']!r}")
+        print(f"  text={pairs[0]['text'][:200]!r}")
+        return
+
+    token = os.environ.get("HF_TOKEN")
+    if not token:
+        raise SystemExit("Set HF_TOKEN to push")
+
+    if args.directions in ("t2i", "both"):
+        print(f"Pushing T2I → {args.t2i_repo_id}")
+        _push_t2i(pairs, args.t2i_repo_id, token)
+    if args.directions in ("i2t", "both"):
+        print(f"Pushing I2T → {args.i2t_repo_id}")
+        _push_i2t(pairs, args.i2t_repo_id, token)
+    print("done — update task metadata revisions if Hub SHAs changed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- [x] I have outlined why this dataset is filling an existing gap in the MOEB benchmark
- [x] I have tested that the dataset runs with the `mteb` package.
- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
  - [x] `Qwen/Qwen3-VL-Embedding-2B`
  - [x] `mteb/baseline-random-encoder`
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [x] I have considered the size of the dataset and reduced it if it is too big (2048 examples is typically large enough for most tasks)

Results on `SeaVLCrawlingI2TRetrieval`:
```
metric                 random Qwen/Qwen3-VL-Embedding-2B
ndcg_at_1             0.00056        0.20124
ndcg_at_5             0.00137        0.28985
ndcg_at_10            0.00247        0.31536
ndcg_at_20            0.00422        0.33925
ndcg_at_100           0.01102        0.38362
map_at_10             0.00154        0.27391
recall_at_1           0.00056        0.20124
recall_at_5           0.00225        0.36931
recall_at_10          0.00562        0.44857
recall_at_20          0.01237        0.54244
mrr_at_10             0.00154        0.27393
```


Results on `SeaVLCrawlingT2IRetrieval`:
```
metric                 random Qwen/Qwen3-VL-Embedding-2B
ndcg_at_1             0.00056        0.27094
ndcg_at_5             0.00056        0.36701
ndcg_at_10            0.00150        0.39636
ndcg_at_20            0.00278        0.42038
ndcg_at_100           0.01213        0.45687
map_at_10             0.00096        0.35048
recall_at_1           0.00056        0.27094
recall_at_5           0.00056        0.45363
recall_at_10          0.00337        0.54413
recall_at_20          0.00843        0.63856
mrr_at_10             0.00096        0.35048
```