### PR TITLE
model: Add ModelMeta for mixedbread-ai/deepset-mxbai-embed-de-large-v1

### DIFF
--- a/mteb/models/model_implementations/mixedbread_ai_models.py
+++ b/mteb/models/model_implementations/mixedbread_ai_models.py
@@ -66,6 +66,34 @@ mxbai_embed_large_v1 = ModelMeta(
     training_datasets=mixedbread_training_data,
 )
 
+deepset_mxbai_embed_de_large_v1 = ModelMeta(
+    loader=SentenceTransformerEncoderWrapper,
+    name="mixedbread-ai/deepset-mxbai-embed-de-large-v1",
+    model_type=["dense"],
+    languages=["deu-Latn", "eng-Latn"],
+    open_weights=True,
+    revision="cbbec43ebdf8b2d8304d3093781eee56a8cdfb69",
+    release_date="2024-07-12",  # initial commit of hf model.
+    n_parameters=487066624,
+    n_embedding_parameters=183178240,
+    memory_usage_mb=929,
+    max_tokens=514,
+    embed_dim=1024,
+    license="apache-2.0",
+    reference="https://huggingface.co/mixedbread-ai/deepset-mxbai-embed-de-large-v1",
+    similarity_fn_name=ScoringFunction.COSINE,
+    framework=[
+        "Sentence Transformers",
+        "Transformers",
+        "ONNX",
+        "safetensors",
+    ],
+    use_instructions=None,
+    public_training_code=None,
+    public_training_data=None,
+    training_datasets=None,
+)
+
 mxbai_embed_2d_large_v1 = ModelMeta(
     loader=SentenceTransformerEncoderWrapper,
     name="mixedbread-ai/mxbai-embed-2d-large-v1",


### PR DESCRIPTION
## Adding a Model

Registers `mixedbread-ai/deepset-mxbai-embed-de-large-v1` (487M params, XLM-RoBERTa backbone, 1024-dim, German + English) as a `ModelMeta` using the generic `SentenceTransformerEncoderWrapper` reference implementation, matching the existing sibling entries in `mixedbread_ai_models.py`.

This model has 3.3M downloads on the Hub but was previously unregistered in MTEB, which is currently blocking a companion results PR: [embeddings-benchmark/results#647](https://github.com/embeddings-benchmark/results/pull/647) (full `MTEB(deu, v1)` — 19 tasks — evaluated against a fork used purely to attach eval-results metadata, `Sieddi/deepset-mxbai-embed-de-large-v1`).

`ModelMeta.from_hub("mixedbread-ai/deepset-mxbai-embed-de-large-v1")` was used to generate the metadata and confirms the revision (`cbbec43ebdf8b2d8304d3093781eee56a8cdfb69`) matches what was used for the pending results PR.

### Checklist
- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [x] I have tested the implementation works on a representative set of tasks (see linked results PR — evaluated on all 19 tasks of `MTEB(deu, v1)`).
- [x] The model is public, i.e., is available either as an API or the weights are publicly available to download
- [ ] I reproduced results from the original paper (if applicable) on at least one benchmark, and I am including the results in the PR description.
  - N/A — no associated paper for this specific fine-tune found; results are original benchmark runs, not a reproduction.
