### PR TITLE
model: Add mDenseOn/mLateOn definitions

### DIFF
--- a/mteb/models/model_implementations/denseon_models.py
+++ b/mteb/models/model_implementations/denseon_models.py
@@ -1,35 +1,16 @@
+from mteb.models.model_implementations.pylate_models import (
+    denseon_lateon_citation,
+    denseon_lateon_supervised_data,
+    denseon_lateon_unsupervised_data,
+    mdenseon_mlateon_citation,
+    mdenseon_mlateon_code_data,
+    mdenseon_mlateon_organic_data,
+)
 from mteb.models.model_meta import (
     ModelMeta,
     ScoringFunction,
 )
 from mteb.models.sentence_transformer_wrapper import SentenceTransformerEncoderWrapper
-
-denseon_lateon_unsupervised_data = {
-    "CQADupstackRetrieval",
-    "DBPedia",
-    "QuoraRetrieval",
-    "SCIDOCS",
-    "SciFact",
-}
-
-denseon_lateon_supervised_data = {
-    "FiQA2018",
-    "NQ",
-    "HotpotQA",
-    "MSMARCO",
-    "TRECDL2019",
-    "TRECDL2020",
-    "FEVER",
-    "ClimateFEVER",
-}
-
-denseon_lateon_citation = r"""@misc{sourty2026denseonlateon,
-  title={DenseOn with LateOn: Open State-of-the-Art Single and Multi-Vector Models},
-  author={Sourty, Raphael and Chaffin, Antoine and Weller, Orion and Moura Junior, Paulo Roberto and Chatelain, Amelie},
-  year={2026},
-  howpublished={\url{https://huggingface.co/blog/lightonai/denseon-lateon}},
-}"""
-
 
 lightonai__denseon_unsupervised = ModelMeta(
     loader=SentenceTransformerEncoderWrapper,
@@ -56,7 +37,7 @@ lightonai__denseon_unsupervised = ModelMeta(
     use_instructions=False,
     adapted_from="answerdotai/ModernBERT-base",
     superseded_by=None,
-    public_training_code="",  # We need to add the boilerplates
+    public_training_code="https://github.com/lightonai/mdenseon-mlateon/blob/main/scripts/pretrain/english_dense.py",
     public_training_data="https://huggingface.co/datasets/lightonai/embeddings-pre-training-curated",  # As detailed in the BP, the actual training data is proprietary Apache 2 compatible reproduction of this
     training_datasets=denseon_lateon_unsupervised_data,
     citation=denseon_lateon_citation,
@@ -88,8 +69,98 @@ lightonai__denseon = ModelMeta(
     use_instructions=False,
     adapted_from="lightonai/DenseOn-unsupervised",
     superseded_by=None,
-    public_training_code="",  # We need to add the boilerplates
+    public_training_code="https://github.com/lightonai/mdenseon-mlateon/blob/main/scripts/finetune/english_dense.py",
     public_training_data="https://huggingface.co/datasets/lightonai/embeddings-fine-tuning",  # As detailed in the BP, the actual training data is proprietary Apache 2 compatible reproduction of this
     training_datasets=denseon_lateon_unsupervised_data | denseon_lateon_supervised_data,
     citation=denseon_lateon_citation,
+)
+
+
+# English plus the eight translate-train target languages
+mdenseon_mlateon_languages = [
+    "ara-Arab",
+    "deu-Latn",
+    "eng-Latn",
+    "fra-Latn",
+    "ita-Latn",
+    "nob-Latn",
+    "por-Latn",
+    "spa-Latn",
+    "swe-Latn",
+]
+
+# Code languages covered by the LateOn-Code fine-tuning data
+mdenseon_mlateon_code_languages = [
+    "python-Code",
+    "go-Code",
+    "java-Code",
+    "javascript-Code",
+    "ruby-Code",
+    "php-Code",
+]
+
+lightonai__mdenseon_unsupervised = ModelMeta(
+    loader=SentenceTransformerEncoderWrapper,
+    name="lightonai/mDenseOn-unsupervised",
+    model_type=["dense"],
+    languages=mdenseon_mlateon_languages,
+    open_weights=True,
+    revision="5fc35cd49da5c561a8c1db20d7f349c036455919",
+    release_date="2026-07-30",
+    n_parameters=306939648,
+    n_embedding_parameters=196608000,
+    memory_usage_mb=1171,
+    max_tokens=8192,
+    embed_dim=768,
+    license="apache-2.0",
+    reference="https://huggingface.co/lightonai/mDenseOn-unsupervised",
+    similarity_fn_name=ScoringFunction.COSINE,
+    framework=[
+        "Sentence Transformers",
+        "PyTorch",
+        "Transformers",
+        "safetensors",
+    ],
+    use_instructions=False,
+    adapted_from="jhu-clsp/mmBERT-base",
+    superseded_by=None,
+    public_training_code="https://github.com/lightonai/mdenseon-mlateon/blob/main/scripts/pretrain/multilingual_dense.py",
+    public_training_data="https://huggingface.co/datasets/lightonai/multilingual-embeddings-pre-training-curated",  # As detailed in the BP, the actual training data is a proprietary Apache 2 compatible reproduction of this
+    training_datasets=denseon_lateon_unsupervised_data,
+    citation=mdenseon_mlateon_citation,
+)
+
+
+lightonai__mdenseon = ModelMeta(
+    loader=SentenceTransformerEncoderWrapper,
+    name="lightonai/mDenseOn",
+    model_type=["dense"],
+    languages=mdenseon_mlateon_languages + mdenseon_mlateon_code_languages,
+    open_weights=True,
+    revision="d61878b089bba2156fe029d3bb8ccaad368a6249",
+    release_date="2026-07-30",
+    n_parameters=306939648,
+    n_embedding_parameters=196608000,
+    memory_usage_mb=1171,
+    max_tokens=8192,
+    embed_dim=768,
+    license="apache-2.0",
+    reference="https://huggingface.co/lightonai/mDenseOn",
+    similarity_fn_name=ScoringFunction.COSINE,
+    framework=[
+        "Sentence Transformers",
+        "PyTorch",
+        "Transformers",
+        "safetensors",
+    ],
+    use_instructions=False,
+    adapted_from="lightonai/mDenseOn-unsupervised",
+    superseded_by=None,
+    public_training_code="https://github.com/lightonai/mdenseon-mlateon/blob/main/scripts/finetune/multilingual_dense.py",
+    public_training_data="https://huggingface.co/datasets/lightonai/embeddings-fine-tuning-multilingual-unfiltered",  # Filtered per-language versions are linked in the collection: https://huggingface.co/collections/lightonai/mdenseon-and-mlateon
+    training_datasets=denseon_lateon_unsupervised_data
+    | denseon_lateon_supervised_data
+    | mdenseon_mlateon_organic_data
+    | mdenseon_mlateon_code_data,
+    citation=mdenseon_mlateon_citation,
 )

--- a/mteb/models/model_implementations/pylate_models.py
+++ b/mteb/models/model_implementations/pylate_models.py
@@ -548,6 +548,21 @@ topk_io__iso_moderncolbert = ModelMeta(
     extra_requirements_groups=["pylate"],
 )
 
+# Code fine-tuning data from LateOn-Code (training splits)
+late_on_code_fine_tuning_data = {
+    "AppsRetrieval",
+    "SyntheticText2SQL",
+    "CosQA",
+    "CodeFeedbackMT",
+    "CodeFeedbackST",
+    "StackOverflowQA",
+    "CodeTransOceanContest",
+    "CodeTransOceanDL",
+    "CodeSearchNetRetrieval",
+    "CodeSearchNetCCRetrieval",
+    "COIRCodeSearchNetRetrieval",
+}
+
 late_on_code_citation = """@misc{LateOn-Code,
   title  = {LateOn-Code: a Family of State-Of-The-Art Late Interaction Code Retrieval Models},
   author = {Chaffin, Antoine},
@@ -641,29 +656,8 @@ lightonai__late_on_code = ModelMeta(
         "MSMARCO",
         "mMARCO-NL",
         "CornStack",
-        "AppsRetrieval",
-        "SyntheticText2SQL",
-        "CosQA",
-        "CodeFeedbackMT",
-        "CodeFeedbackST",
-        "StackOverflowQA",
-        "CodeTransOceanContest",
-        "CodeTransOceanDL",
-        "CodeSearchNetRetrieval",
-        "CodeSearchNetCCRetrieval",
-        "COIRCodeSearchNetRetrieval",
-        "AppsRetrieval",
-        "SyntheticText2SQL",
-        "CosQA",
-        "CodeFeedbackMT",
-        "CodeFeedbackST",
-        "StackOverflowQA",
-        "CodeTransOceanContest",
-        "CodeTransOceanDL",
-        "CodeSearchNetRetrieval",
-        "CodeSearchNetCCRetrieval",
-        "COIRCodeSearchNetRetrieval",
-    },
+    }
+    | late_on_code_fine_tuning_data,
     citation=late_on_code_citation,
     extra_requirements_groups=["pylate"],
 )
@@ -750,18 +744,8 @@ lightonai__late_on_code_edge = ModelMeta(
         "LoTTE",
         "MultiLongDocRetrieval",
         "CornStack",
-        "AppsRetrieval",
-        "SyntheticText2SQL",
-        "CosQA",
-        "CodeFeedbackMT",
-        "CodeFeedbackST",
-        "StackOverflowQA",
-        "CodeTransOceanContest",
-        "CodeTransOceanDL",
-        "CodeSearchNetRetrieval",
-        "CodeSearchNetCCRetrieval",
-        "COIRCodeSearchNetRetrieval",
-    },
+    }
+    | late_on_code_fine_tuning_data,
     citation=late_on_code_citation,
     extra_requirements_groups=["pylate"],
 )
@@ -955,11 +939,14 @@ denseon_lateon_supervised_data = {
     "ClimateFEVER",
 }
 
-denseon_lateon_citation = r"""@misc{sourty2026denseonlateon,
-  title={DenseOn with LateOn: Open State-of-the-Art Single and Multi-Vector Models},
-  author={Sourty, Raphael and Chaffin, Antoine and Weller, Orion and Moura Junior, Paulo Roberto and Chatelain, Amelie},
-  year={2026},
-  howpublished={\url{https://huggingface.co/blog/lightonai/denseon-lateon}},
+denseon_lateon_citation = r"""@misc{sourty2026denseonlateonfullyopen,
+  title         = {DenseOn with the LateOn: Fully Open Dense and Late-Interaction Models for Multilingual, Long-Context, and Code Search},
+  author        = {Raphaël Sourty and Antoine Chaffin and Paulo Roberto Moura Junior and Amélie Chatelain},
+  year          = {2026},
+  eprint        = {2607.27178},
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.CL},
+  url           = {https://arxiv.org/abs/2607.27178},
 }"""
 
 lightonai__lateon_unsupervised = ModelMeta(
@@ -971,7 +958,7 @@ lightonai__lateon_unsupervised = ModelMeta(
     ],
     open_weights=True,
     revision="db4d2f0b4295e2169fee5c9b1415b6cc334b0585",
-    public_training_code="",  # We need to add the boilerplates
+    public_training_code="https://github.com/lightonai/mdenseon-mlateon/blob/main/scripts/pretrain/english_late_interaction.py",
     public_training_data="https://huggingface.co/datasets/lightonai/embeddings-pre-training-curated",  # As detailed in the BP, the actual training data is proprietary Apache 2 compatible reproduction of this
     release_date="2026-04-21",
     n_parameters=149015808,
@@ -1001,7 +988,7 @@ lightonai__lateon = ModelMeta(
     ],
     open_weights=True,
     revision="6bb4488a7a1f1769f7a69fa1ff0c74c6a7b98cbd",
-    public_training_code="",  # We need to add the boilerplates
+    public_training_code="https://github.com/lightonai/mdenseon-mlateon/blob/main/scripts/finetune/english_late_interaction.py",
     public_training_data="https://huggingface.co/datasets/lightonai/embeddings-fine-tuning",  # As detailed in the BP, the actual training data is proprietary Apache 2 compatible reproduction of this
     release_date="2026-04-21",
     n_parameters=149015808,
@@ -1018,5 +1005,106 @@ lightonai__lateon = ModelMeta(
     superseded_by=None,
     training_datasets=denseon_lateon_unsupervised_data | denseon_lateon_supervised_data,
     citation=denseon_lateon_citation,
+    extra_requirements_groups=["pylate"],
+)
+
+# The multilingual pre-training and fine-tuning corpora are translate-train
+# extensions of the English DenseOn/LateOn data, so the same overlaps apply and
+# the denseon_lateon_* sets are reused below
+mdenseon_mlateon_organic_data = {
+    # Organic multilingual and long-context data (training splits)
+    "MIRACLRetrieval",
+    "MIRACLRetrievalHardNegatives",
+    "MIRACLReranking",
+    "MultiLongDocRetrieval",
+}
+
+mdenseon_mlateon_code_data = late_on_code_fine_tuning_data | {
+    # Built from CommitPackFT and decontaminated against the evaluation set
+    "CodeEditSearchRetrieval",
+}
+
+# English plus the eight translate-train target languages
+mdenseon_mlateon_languages = [
+    "ara-Arab",
+    "deu-Latn",
+    "eng-Latn",
+    "fra-Latn",
+    "ita-Latn",
+    "nob-Latn",
+    "por-Latn",
+    "spa-Latn",
+    "swe-Latn",
+]
+
+# Code languages covered by the LateOn-Code fine-tuning data
+mdenseon_mlateon_code_languages = [
+    "python-Code",
+    "go-Code",
+    "java-Code",
+    "javascript-Code",
+    "ruby-Code",
+    "php-Code",
+]
+
+# The English and multilingual releases share the same paper
+mdenseon_mlateon_citation = denseon_lateon_citation
+
+
+lightonai__mlateon_unsupervised = ModelMeta(
+    loader=MultiVectorModel,
+    name="lightonai/mLateOn-unsupervised",
+    model_type=["late-interaction"],
+    languages=mdenseon_mlateon_languages,
+    open_weights=True,
+    revision="5fcf9b20cdff594f0849a3ef928f3d79dcb0990c",
+    public_training_code="https://github.com/lightonai/mdenseon-mlateon/blob/main/scripts/pretrain/multilingual_late_interaction.py",
+    public_training_data="https://huggingface.co/datasets/lightonai/multilingual-embeddings-pre-training-curated",  # As detailed in the BP, the actual training data is a proprietary Apache 2 compatible reproduction of this
+    release_date="2026-07-30",
+    n_parameters=306941184,
+    n_embedding_parameters=196609536,
+    memory_usage_mb=585,
+    max_tokens=8192,
+    embed_dim=128,
+    license="apache-2.0",
+    similarity_fn_name="MaxSim",
+    framework=["PyLate", "ColBERT", "safetensors", "Sentence Transformers"],
+    reference="https://huggingface.co/lightonai/mLateOn-unsupervised",
+    use_instructions=False,
+    adapted_from="jhu-clsp/mmBERT-base",
+    superseded_by=None,
+    training_datasets=denseon_lateon_unsupervised_data,
+    citation=mdenseon_mlateon_citation,
+    extra_requirements_groups=["pylate"],
+)
+
+
+lightonai__mlateon = ModelMeta(
+    loader=MultiVectorModel,
+    name="lightonai/mLateOn",
+    model_type=["late-interaction"],
+    languages=mdenseon_mlateon_languages + mdenseon_mlateon_code_languages,
+    open_weights=True,
+    revision="1a3f1d70415f80515ee4611ce3ba96ea7f5816ca",
+    public_training_code="https://github.com/lightonai/mdenseon-mlateon/blob/main/scripts/finetune/multilingual_late_interaction.py",
+    public_training_data="https://huggingface.co/datasets/lightonai/embeddings-fine-tuning-multilingual-unfiltered",  # Filtered per-language versions are linked in the collection: https://huggingface.co/collections/lightonai/mdenseon-and-mlateon
+    release_date="2026-07-30",
+    n_parameters=306941184,
+    n_embedding_parameters=196609536,
+    memory_usage_mb=1171,
+    max_tokens=8192,
+    embed_dim=128,
+    license="apache-2.0",
+    similarity_fn_name="MaxSim",
+    framework=["PyLate", "ColBERT", "safetensors", "Sentence Transformers"],
+    reference="https://huggingface.co/lightonai/mLateOn",
+    use_instructions=False,
+    adapted_from="lightonai/mLateOn-unsupervised",
+    superseded_by=None,
+    training_datasets=denseon_lateon_unsupervised_data
+    | denseon_lateon_supervised_data
+    | mdenseon_mlateon_organic_data
+    | mdenseon_mlateon_code_data,
+    citation=mdenseon_mlateon_citation,
     extra_requirements_groups=["pylate"],
 )


### PR DESCRIPTION
<!-- Title: model: Add mDenseOn/mLateOn definitions -->

This is a PR to add the definition of the mLateOn/mDenseOn models, the multilingual extension of LateOn/DenseOn (#4545) trained with translate-train on eight target languages plus English.

Collection: https://huggingface.co/collections/lightonai/mdenseon-and-mlateon
Blogpost: https://huggingface.co/blog/lightonai/mDenseOn-mLateOn
Paper: https://arxiv.org/abs/2607.27178
Corresponding results PR: https://github.com/embeddings-benchmark/results/pull/653

A few notes:
- As with LateOn/DenseOn, the training data is a reproduction of the data we publicly release that is Apache 2.0 compatible. For the zero-shot computation, I listed as overlap what I find overlapping with the public data for fairness (same list as #4545 for the English seed, since the multilingual pre-training corpus is a translate-train extension of it).
- On top of the translated fine-tuning data, the models are fine-tuned on the training splits of MIRACL, MLDR, and the LateOn-Code data (which covers the MTEB code tasks), so those are listed in `training_datasets`. For CodeEditSearch, we built a training set from CommitPackFT and decontaminated it against the evaluation set (shared commit SHAs, exact normalized-text matches, and ≥50% 13-gram containment), but I still list it as overlap to be conservative.
- `languages` lists English plus the eight translate-train target languages (French, German, Italian, Spanish, Portuguese, Swedish, Norwegian, Arabic). The models transfer well beyond these (see the blog post), but I only listed the languages actually present in retrieval training.
- The backbone is [mmBERT-base](https://huggingface.co/jhu-clsp/mmBERT-base) (307M parameters, 8192 context).

cc @Samoed
