### PR TITLE
fix: avoid stacking variable-length tensors in JinaV4Wrapper.encode

### DIFF
--- a/mteb/models/model_implementations/jina_models.py
+++ b/mteb/models/model_implementations/jina_models.py
@@ -508,9 +508,9 @@ class JinaV4Wrapper(AbsEncoder):
             and embeddings
             and isinstance(embeddings[0], torch.Tensor)
         ):
-            embeddings = np.stack(
-                [e.cpu().detach().float().numpy() for e in embeddings]
-            )
+            # Multi-vector embeddings have one vector per token or image patch.
+            # Their sequence lengths vary by input, so they must remain ragged.
+            embeddings = [e.cpu().detach().float() for e in embeddings]
         return embeddings
 
     def get_text_embeddings(


### PR DESCRIPTION
Fixes #5049

## Summary

- Preserve variable-length multi-vector embeddings returned by Jina Embeddings
v4 instead of converting them into a dense NumPy array.

- Single-vector scoring remains unchanged, while DocumentUnderstanding retrieval
can pass ragged embeddings to the existing MaxSim scorer.

- `JinaV4Wrapper.encode()` used `np.stack()` for lists of tensors. In
multi-vector mode, each query or image can produce a different number of token
or patch vectors, so the tensors do not have matching shapes and cannot be
stacked.

## Verification

Tested `VidoreDocVQARetrieval` with the following code using Python 3.12.12,
PyTorch 2.11.0+cu128, Transformers 4.52.4, and flash-attn 2.8.3.post1:

```python
import mteb

model = mteb.get_model("jinaai/jina-embeddings-v4", device="cuda")
task = mteb.get_task("VidoreDocVQARetrieval")

mteb.evaluate(
    model,
    [task],
    encode_kwargs={"batch_size": 1},
)
```

### Before

```text
Traceback (most recent call last):
  File "/home/yongbinchoi/mteb/eval_jina.py", line 12, in <module>
    mteb.evaluate(
  File "/home/yongbinchoi/mteb/mteb/evaluate.py", line 571, in evaluate
    _res = evaluate(
           ^^^^^^^^^
  File "/home/yongbinchoi/mteb/mteb/evaluate.py", line 643, in evaluate
    result = _evaluate_task(
             ^^^^^^^^^^^^^^^
  File "/home/yongbinchoi/mteb/mteb/evaluate.py", line 215, in _evaluate_task
    res = task.evaluate(
          ^^^^^^^^^^^^^^
  File "/home/yongbinchoi/mteb/mteb/abstasks/retrieval.py", line 313, in evaluate
    return super().evaluate(
           ^^^^^^^^^^^^^^^^^
  File "/home/yongbinchoi/mteb/mteb/abstasks/abstask.py", line 223, in evaluate
    scores[hf_subset] = self._evaluate_subset(
                        ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yongbinchoi/mteb/mteb/abstasks/retrieval.py", line 384, in _evaluate_subset
    results = retriever(
              ^^^^^^^^^^
  File "/home/yongbinchoi/mteb/mteb/_evaluators/retrieval_evaluator.py", line 105, in __call__
    return search_model.search(
           ^^^^^^^^^^^^^^^^^^^^
  File "/home/yongbinchoi/mteb/mteb/models/search_wrappers.py", line 132, in search
    query_embeddings = self.model.encode(
                       ^^^^^^^^^^^^^^^^^^
  File "/home/yongbinchoi/mteb/mteb/models/model_implementations/jina_models.py", line 511, in encode
    embeddings = np.stack(
                 ^^^^^^^^^
  File "/home/yongbinchoi/mteb/.venv/lib/python3.12/site-packages/numpy/_core/shape_base.py", line 460, in stack
    raise ValueError('all input arrays must have the same shape')
ValueError: all input arrays must have the same shape
```

### After

The evaluation proceeds through multi-vector query encoding without the
`np.stack()` shape error.

```
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████████████████████████| 2/2 [00:01<00:00,  1.81it/s]
Fetching 2 files: 100%|█████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 1697.76it/s]
Encoding texts...: 100%|██████████████████████████████████████████████████████████████████████████████| 451/451 [00:13<00:00, 34.28it/s]
Encoding texts...:  99%|█████████████████████████████████████████████████████████████████████████████▍| 448/451 [00:13<00:00, 37.08it/s]
Encoding images...:  23%|█████████████████▊                                                           | 116/500 [01:31<06:03,  1.06it/s]
```
