### PR TITLE
Add ModelMeta: minetta/nemotron-3-embed-8b-medical

### DIFF
--- a/mteb/models/model_implementations/minetta_models.py
+++ b/mteb/models/model_implementations/minetta_models.py
@@ -1,4 +1,12 @@
-from mteb.models import ModelMeta, sentence_transformers_loader
+from __future__ import annotations
+
+import numpy as np
+
+from mteb.models import (
+    ModelMeta,
+    SentenceTransformerEncoderWrapper,
+    sentence_transformers_loader,
+)
 from mteb.models.model_meta import ScoringFunction
 
 nemotron_3_embed_8b_legal = ModelMeta(
@@ -22,6 +30,82 @@ nemotron_3_embed_8b_legal = ModelMeta(
     similarity_fn_name=ScoringFunction.COSINE,
     use_instructions=False,
     training_datasets=None,
+    adapted_from="nvidia/Nemotron-3-Embed-8B-BF16",
+    superseded_by=None,
+    modalities=["text"],
+    model_type=["dense"],
+    citation=None,
+    contacts=None,
+)
+
+_HEADS = {
+    "MedrxivClusteringS2S.v2": "clustering_head/head_s2s.npz",
+    "MedrxivClusteringP2P.v2": "clustering_head/head_p2p.npz",
+}
+
+
+def _medical_loader(model_name: str, revision: str, **kwargs):
+    """Apply the clustering projection stored in the model repo, pass other tasks through.
+
+    Both projections are loaded once here, when the model is built, so nothing is fetched
+    during evaluation. Keying on task name is what model_prompts does
+    (abs_encoder.py:208), and jasper_models.py and harrier_models.py key on these same two
+    names. The map covers only the tasks the projection was measured on. Output stays
+    4096-dimensional, so embed_dim holds for every task.
+    """
+    from huggingface_hub import hf_hub_download
+
+    encoder = SentenceTransformerEncoderWrapper(
+        model=model_name, revision=revision, **kwargs
+    )
+    heads: dict[str, tuple[np.ndarray, np.ndarray]] = {}
+    for task, path in _HEADS.items():
+        z = np.load(hf_hub_download(model_name, path, revision=revision))
+        heads[task] = (z["mu"].astype(np.float32), z["P"].astype(np.float32))
+    inner_encode = encoder.encode
+
+    def encode(inputs, *args, **kw):
+        x = np.asarray(inner_encode(inputs, *args, **kw), dtype=np.float32)
+        head = heads.get(getattr(kw.get("task_metadata"), "name", None))
+        if head is None:
+            return x
+        mu, proj = head
+        z = ((x - mu) @ proj.T) @ proj
+        return z / np.maximum(np.linalg.norm(z, axis=1, keepdims=True), 1e-12)
+
+    encoder.encode = encode
+    return encoder
+
+
+nemotron_3_embed_8b_medical = ModelMeta(
+    loader=_medical_loader,
+    # model_max_length matches the base entry in nvidia_models.py. The checkpoint advertises a
+    # 32k window, but TRECCOVID and TRECCOVID-PL contain 122k-character documents, and running
+    # those uncapped needs more memory than an 80GB card has.
+    loader_kwargs={
+        "model_kwargs": {"torch_dtype": "bfloat16"},
+        "processor_kwargs": {"model_max_length": 4096},
+    },
+    name="minetta/nemotron-3-embed-8b-medical",
+    revision="388e7e642e6d486762f4e49d97d756af8fb63723",
+    release_date="2026-07-29",
+    languages=["eng-Latn", "cmn-Hans", "pol-Latn"],
+    n_parameters=7_952_683_008,
+    n_embedding_parameters=536_870_912,
+    memory_usage_mb=15168,
+    max_tokens=32768,
+    embed_dim=4096,
+    license="https://huggingface.co/minetta/nemotron-3-embed-8b-medical/blob/main/LICENSE",
+    open_weights=True,
+    public_training_code=None,
+    public_training_data=None,
+    framework=["Sentence Transformers", "PyTorch"],
+    reference="https://huggingface.co/minetta/nemotron-3-embed-8b-medical",
+    similarity_fn_name=ScoringFunction.COSINE,
+    use_instructions=False,
+    # Empty set rather than None: nothing was trained on. The weights come from adapted_from
+    # unchanged, and the projection is fitted on PubMed abstracts.
+    training_datasets=set(),
     adapted_from="nvidia/Nemotron-3-Embed-8B-BF16",
     superseded_by=None,
     modalities=["text"],


### PR DESCRIPTION
Adds a ModelMeta entry for [minetta/nemotron-3-embed-8b-medical](https://huggingface.co/minetta/nemotron-3-embed-8b-medical), a medical adaptation of nvidia/Nemotron-3-Embed-8B-BF16.

Weights are unchanged from the base. The loader applies a fixed orthonormal projection when
clustering and passes every other task through, keyed on task name the same way
`model_prompts` is. Output stays 4096-dimensional, so `embed_dim` holds for every task.

`processor_kwargs` sets `model_max_length` to 4096, the same as the base entry in
`nvidia_models.py`. The checkpoint advertises a 32k window and `max_tokens` reflects that, but
TRECCOVID and TRECCOVID-PL hold 122k-character documents and running those uncapped does not
fit in 80GB.

`training_datasets` is an empty set rather than None. No MTEB dataset or training split was
used at any stage. The projection is fitted on PubMed abstracts that were checked against all
twelve MTEB(Medical, v1) corpora first; the gate, the counts and what it removed are written up
in [CONTAMINATION.md](https://huggingface.co/minetta/nemotron-3-embed-8b-medical/blob/main/CONTAMINATION.md).

All twelve tasks, run through the loader and `loader_kwargs` in this diff, single H100,
batch 16. `mteb.get_model` and `mteb.get_model_meta` were checked separately against this
branch, along with the projection firing on the two clustering tasks and output staying
4096-dimensional:

| task | score |
|---|---|
| PublicHealthQA | 90.88 |
| MedicalQARetrieval | 87.16 |
| TRECCOVID | 86.78 |
| TRECCOVID-PL | 85.17 |
| SciFact | 83.33 |
| SciFact-PL | 80.71 |
| CMedQAv2-reranking | 79.91 |
| CUREv1 | 66.92 |
| MedrxivClusteringP2P.v2 | 42.77 |
| NFCorpus | 42.32 |
| MedrxivClusteringS2S.v2 | 41.96 |
| CmedqaRetrieval | 37.64 |
| **Mean(Task)** | **68.80** |

Results go to the results repo once this merges. That repo installs `mteb` from main, and its
`test_all_models_are_implemented_in_mteb` check needs this entry to exist first.

- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [x] I have tested the implementation works on a representative set of tasks. All twelve
  MTEB(Medical, v1) tasks were run through it, table above.
- [x] The model is public, i.e., is available either as an API or the weights are publicly available to download
- [ ] I reproduced results from the original paper (if applicable) on at least one benchmark, and I am including the results in the PR description. No paper.
