### PR TITLE
model: Add dragonkue/multilingual-e5-small-ko-v2 and sionic-ai/comsat-e…

### DIFF
--- a/mteb/models/model_implementations/korean_models.py
+++ b/mteb/models/model_implementations/korean_models.py
@@ -129,6 +129,7 @@ dragonkue_e5_small_ko = ModelMeta(
     framework=["Sentence Transformers", "PyTorch"],
     use_instructions=True,
     adapted_from="intfloat/multilingual-e5-small",
+    superseded_by="dragonkue/multilingual-e5-small-ko-v2",
     public_training_code=None,
     public_training_data=None,
     # Fine-tuned on the same data as dragonkue/snowflake-arctic-embed-l-v2.0-ko

--- a/mteb/models/model_implementations/korean_models.py
+++ b/mteb/models/model_implementations/korean_models.py
@@ -137,6 +137,34 @@ dragonkue_e5_small_ko = ModelMeta(
     training_datasets=set(),
 )
 
+dragonkue_e5_small_ko_v2 = ModelMeta(
+    loader=SentenceTransformerEncoderWrapper,
+    loader_kwargs=dict(model_prompts=E5_PROMPTS),
+    name="dragonkue/multilingual-e5-small-ko-v2",
+    model_type=["dense"],
+    languages=KOR_EN,
+    open_weights=True,
+    revision="fcfc26bf355882620c48df58be112275bd756f50",
+    release_date="2025-06-10",
+    n_parameters=117_653_760,
+    embed_dim=384,
+    license="apache-2.0",
+    max_tokens=512,
+    memory_usage_mb=449,
+    n_embedding_parameters=96_014_208,
+    reference="https://huggingface.co/dragonkue/multilingual-e5-small-ko-v2",
+    similarity_fn_name=ScoringFunction.COSINE,
+    framework=["Sentence Transformers", "PyTorch"],
+    use_instructions=True,
+    adapted_from="intfloat/multilingual-e5-small",
+    public_training_code=None,
+    public_training_data=None,
+    # Successor to dragonkue/multilingual-e5-small-ko; same architecture, fine-tuned
+    # on Korean MRC corpora (none are mteb datasets); empty set so the multilingual-e5
+    # base data is still inherited via adapted_from.
+    training_datasets=set(),
+)
+
 dragonkue_koen_e5_tiny = ModelMeta(
     loader=SentenceTransformerEncoderWrapper,
     loader_kwargs=dict(model_prompts=E5_PROMPTS),

--- a/mteb/models/model_implementations/sionic_models.py
+++ b/mteb/models/model_implementations/sionic_models.py
@@ -66,9 +66,6 @@ comsat_embed_ja_03b_preview = ModelMeta(
 )
 
 comsat_embed_ko_8b_preview = ModelMeta(
-    # Plain sentence-transformers load: the instruct query prompt
-    # ("Instruct: {task}\nQuery:") ships in the model's
-    # config_sentence_transformers.json and is picked up automatically.
     loader=SentenceTransformerEncoderWrapper,
     name="sionic-ai/comsat-embed-ko-8b-preview",
     model_type=["dense"],

--- a/mteb/models/model_implementations/sionic_models.py
+++ b/mteb/models/model_implementations/sionic_models.py
@@ -64,3 +64,34 @@ comsat_embed_ja_03b_preview = ModelMeta(
     # adapted_from.
     training_datasets=set(),
 )
+
+comsat_embed_ko_8b_preview = ModelMeta(
+    # Plain sentence-transformers load: the instruct query prompt
+    # ("Instruct: {task}\nQuery:") ships in the model's
+    # config_sentence_transformers.json and is picked up automatically.
+    loader=SentenceTransformerEncoderWrapper,
+    name="sionic-ai/comsat-embed-ko-8b-preview",
+    model_type=["dense"],
+    revision="a5cc22b651c1b2e51cdd8bf671774ae93584f0ab",
+    release_date="2026-07-02",
+    languages=["kor-Hang", "eng-Latn"],
+    open_weights=True,
+    framework=["Sentence Transformers", "PyTorch", "safetensors"],
+    n_parameters=7_567_295_488,
+    n_embedding_parameters=621_219_840,
+    memory_usage_mb=14433,
+    max_tokens=8192,
+    embed_dim=4096,
+    license="cc-by-nc-4.0",
+    reference="https://huggingface.co/sionic-ai/comsat-embed-ko-8b-preview",
+    similarity_fn_name=ScoringFunction.COSINE,
+    use_instructions=True,
+    adapted_from="Qwen/Qwen3-Embedding-8B",
+    superseded_by=None,
+    public_training_code=None,
+    public_training_data=None,
+    # The fine-tuning data contains no mteb datasets; empty set lets the base
+    # model's (Qwen/Qwen3-Embedding-8B) training data be inherited via
+    # adapted_from.
+    training_datasets=set(),
+)


### PR DESCRIPTION
Two Korean community embedding models evaluated on MTEB(kor, v2):
- dragonkue/multilingual-e5-small-ko-v2 (multilingual-e5-small finetune)
- sionic-ai/comsat-embed-ko-8b-preview (Qwen3-Embedding-8B finetune)

