### PR TITLE
fix: Correctly use `.n_active_parameters` so that active parameters correct when using the API

### DIFF
--- a/mteb/api/schemas.py
+++ b/mteb/api/schemas.py
@@ -219,11 +219,7 @@ class ModelMetaSchema(_CamelModel):
         """Build the API schema view of a `ModelMeta`."""
         framework = list(meta.framework or [])
         model_type = (meta.model_type or ["dense"])[0]
-        n_active = (
-            meta.n_active_parameters_override
-            if meta.n_active_parameters_override is not None
-            else meta.n_parameters
-        )
+        n_active = meta.n_active_parameters
 
         lang_labels = sorted(
             {language_label(code) for code in (meta.languages or []) if code}


### PR DESCRIPTION
Fixes #5064

@Samoed anything I am missing here?
