### PR TITLE
model: add cnmoro/static-nomic-384-pten-v2-st (static pt/en Model2Vec)

### DIFF
--- a/mteb/models/model_implementations/cnmoro_models.py
+++ b/mteb/models/model_implementations/cnmoro_models.py
@@ -1,0 +1,86 @@
+"""Model definitions for cnmoro's static embedding models.
+
+Proposed addition to `mteb/models/model_implementations/cnmoro_models.py` in the
+embeddings-benchmark/mteb repository.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from mteb.models.abs_encoder import AbsEncoder
+from mteb.models.model_meta import ModelMeta, ScoringFunction
+
+if TYPE_CHECKING:
+    from mteb.types import Array
+
+MODEL2VEC_CITATION = """@software{minishlab2024model2vec,
+  author       = {Stephan Tulkens and {van Dongen}, Thomas},
+  title        = {Model2Vec: Fast State-of-the-Art Static Embeddings},
+  year         = {2024},
+  publisher    = {Zenodo},
+  doi          = {10.5281/zenodo.17270888},
+  url          = {https://github.com/MinishLab/model2vec},
+  license      = {MIT}
+}"""
+
+
+class Model2VecStaticModelWrapper(AbsEncoder):
+    """Loads a Model2Vec static model via `model2vec.StaticModel`.
+
+    Needed for checkpoints that use vocabulary quantization (a `mapping` tensor
+    projecting the tokenizer vocabulary onto a smaller set of shared embedding rows),
+    which `sentence_transformers.models.StaticEmbedding` cannot load.
+    """
+
+    def __init__(self, model: str, revision: str | None = None, **kwargs: Any) -> None:
+        from model2vec import StaticModel
+
+        self.model = StaticModel.from_pretrained(model)
+
+    def encode(
+        self,
+        inputs: Any,
+        *,
+        task_metadata: Any = None,
+        hf_split: str | None = None,
+        hf_subset: str | None = None,
+        prompt_type: Any = None,
+        **kwargs: Any,
+    ) -> Array:
+        texts = [text for batch in inputs for text in batch["text"]]
+        embeddings = self.model.encode(
+            texts, show_progress_bar=kwargs.get("show_progress_bar", False)
+        )
+        return np.asarray(embeddings, dtype=np.float32)
+
+
+static_nomic_384_pten_v2 = ModelMeta(
+    loader=Model2VecStaticModelWrapper,
+    name="cnmoro/static-nomic-384-pten-v2",
+    model_type=["dense"],
+    languages=["eng-Latn", "por-Latn"],
+    open_weights=True,
+    revision="08981248ac665f19e71df149a2f2b5ef9b514bd7",
+    release_date="2026-05-29",
+    # 32000 x 384 embedding matrix + 276214 per-token scalar weights
+    n_parameters=32000 * 384 + 276214,
+    n_embedding_parameters=32000 * 384 + 276214,
+    memory_usage_mb=50,
+    max_tokens=np.inf,
+    embed_dim=384,
+    license="apache-2.0",
+    similarity_fn_name=ScoringFunction.COSINE,
+    framework=["NumPy", "Sentence Transformers", "safetensors"],
+    reference="https://huggingface.co/cnmoro/static-nomic-384-pten-v2",
+    use_instructions=False,
+    adapted_from="nomic-ai/nomic-embed-text-v2-moe",
+    superseded_by=None,
+    # Distilled with Tokenlearn; finetuned on a pt-BR translation of MS MARCO triplets.
+    training_datasets={"MSMARCO"},
+    public_training_code=None,
+    public_training_data="https://huggingface.co/datasets/cnmoro/AllTripletsMsMarco-PTBR",
+    citation=MODEL2VEC_CITATION,
+)

--- a/mteb/models/model_implementations/cnmoro_models.py
+++ b/mteb/models/model_implementations/cnmoro_models.py
@@ -1,64 +1,15 @@
-"""Model definitions for cnmoro's static embedding models.
-
-Proposed addition to `mteb/models/model_implementations/cnmoro_models.py` in the
-embeddings-benchmark/mteb repository.
-"""
+"""Model definitions for cnmoro's static embedding models."""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
-
 import numpy as np
 
-from mteb.models.abs_encoder import AbsEncoder
 from mteb.models.model_meta import ModelMeta, ScoringFunction
 
-if TYPE_CHECKING:
-    from mteb.types import Array
-
-MODEL2VEC_CITATION = """@software{minishlab2024model2vec,
-  author       = {Stephan Tulkens and {van Dongen}, Thomas},
-  title        = {Model2Vec: Fast State-of-the-Art Static Embeddings},
-  year         = {2024},
-  publisher    = {Zenodo},
-  doi          = {10.5281/zenodo.17270888},
-  url          = {https://github.com/MinishLab/model2vec},
-  license      = {MIT}
-}"""
-
-
-class Model2VecStaticModelWrapper(AbsEncoder):
-    """Loads a Model2Vec static model via `model2vec.StaticModel`.
-
-    Needed for checkpoints that use vocabulary quantization (a `mapping` tensor
-    projecting the tokenizer vocabulary onto a smaller set of shared embedding rows),
-    which `sentence_transformers.models.StaticEmbedding` cannot load.
-    """
-
-    def __init__(self, model: str, revision: str | None = None, **kwargs: Any) -> None:
-        from model2vec import StaticModel
-
-        self.model = StaticModel.from_pretrained(model)
-
-    def encode(
-        self,
-        inputs: Any,
-        *,
-        task_metadata: Any = None,
-        hf_split: str | None = None,
-        hf_subset: str | None = None,
-        prompt_type: Any = None,
-        **kwargs: Any,
-    ) -> Array:
-        texts = [text for batch in inputs for text in batch["text"]]
-        embeddings = self.model.encode(
-            texts, show_progress_bar=kwargs.get("show_progress_bar", False)
-        )
-        return np.asarray(embeddings, dtype=np.float32)
-
+from .model2vec_models import Model2VecModel
 
 static_nomic_384_pten_v2 = ModelMeta(
-    loader=Model2VecStaticModelWrapper,
+    loader=Model2VecModel,
     name="cnmoro/static-nomic-384-pten-v2",
     model_type=["dense"],
     languages=["eng-Latn", "por-Latn"],
@@ -73,7 +24,7 @@ static_nomic_384_pten_v2 = ModelMeta(
     embed_dim=384,
     license="apache-2.0",
     similarity_fn_name=ScoringFunction.COSINE,
-    framework=["NumPy", "Sentence Transformers", "safetensors"],
+    framework=["NumPy", "safetensors"],
     reference="https://huggingface.co/cnmoro/static-nomic-384-pten-v2",
     use_instructions=False,
     adapted_from="nomic-ai/nomic-embed-text-v2-moe",
@@ -82,5 +33,6 @@ static_nomic_384_pten_v2 = ModelMeta(
     training_datasets={"MSMARCO"},
     public_training_code=None,
     public_training_data="https://huggingface.co/datasets/cnmoro/AllTripletsMsMarco-PTBR",
-    citation=MODEL2VEC_CITATION,
+    citation=None,
+    extra_requirements_groups=["model2vec"],
 )

--- a/mteb/models/model_implementations/cnmoro_models.py
+++ b/mteb/models/model_implementations/cnmoro_models.py
@@ -5,27 +5,26 @@ from __future__ import annotations
 import numpy as np
 
 from mteb.models.model_meta import ModelMeta, ScoringFunction
+from mteb.models.sentence_transformer_wrapper import SentenceTransformerEncoderWrapper
 
-from .model2vec_models import Model2VecModel
-
-static_nomic_384_pten_v2 = ModelMeta(
-    loader=Model2VecModel,
-    name="cnmoro/static-nomic-384-pten-v2",
+static_nomic_384_pten_v2_st = ModelMeta(
+    loader=SentenceTransformerEncoderWrapper,
+    name="cnmoro/static-nomic-384-pten-v2-st",
     model_type=["dense"],
     languages=["eng-Latn", "por-Latn"],
     open_weights=True,
-    revision="08981248ac665f19e71df149a2f2b5ef9b514bd7",
-    release_date="2026-05-29",
-    # 32000 x 384 embedding matrix + 276214 per-token scalar weights
-    n_parameters=32000 * 384 + 276214,
-    n_embedding_parameters=32000 * 384 + 276214,
-    memory_usage_mb=50,
+    revision="50fed70340b370b707f0f220010eac250bee7c18",
+    release_date="2026-08-04",
+    # one row per tokenizer token
+    n_parameters=276214 * 384,
+    n_embedding_parameters=276214 * 384,
+    memory_usage_mb=405,
     max_tokens=np.inf,
     embed_dim=384,
     license="apache-2.0",
     similarity_fn_name=ScoringFunction.COSINE,
-    framework=["NumPy", "safetensors"],
-    reference="https://huggingface.co/cnmoro/static-nomic-384-pten-v2",
+    framework=["NumPy", "Sentence Transformers", "safetensors"],
+    reference="https://huggingface.co/cnmoro/static-nomic-384-pten-v2-st",
     use_instructions=False,
     adapted_from="nomic-ai/nomic-embed-text-v2-moe",
     superseded_by=None,
@@ -34,5 +33,4 @@ static_nomic_384_pten_v2 = ModelMeta(
     public_training_code=None,
     public_training_data="https://huggingface.co/datasets/cnmoro/AllTripletsMsMarco-PTBR",
     citation=None,
-    extra_requirements_groups=["model2vec"],
 )


### PR DESCRIPTION
Adds [`cnmoro/static-nomic-384-pten-v2`](https://huggingface.co/cnmoro/static-nomic-384-pten-v2), a Model2Vec/Tokenlearn **static** embedding model distilled from `nomic-ai/nomic-embed-text-v2-moe`, targeting **Portuguese and English**.

| | |
|---|---|
| Revision | `08981248ac665f19e71df149a2f2b5ef9b514bd7` |
| Parameters | 12,564,214 |
| Embedding dim | 384 |
| Max tokens | ∞ (static, no context limit) |
| License | apache-2.0 |

Results for `MTEB(por, v1)`, `MTEB(eng, v2)` and `MTEB(Multilingual, v2)` are submitted separately in embeddings-benchmark/results#659.

### Why a dedicated loader

This checkpoint uses **vocabulary quantization**: a 276,214-token tokenizer is mapped onto 32,000 shared embedding rows via a `mapping` tensor with per-token `weights`. `model2vec.StaticModel` reads that layout correctly, but `sentence_transformers.models.StaticEmbedding` does not — it indexes the embedding matrix directly by token id and reads out of bounds (`RuntimeError: Expected i < index_size to be true`). So this adds a small `Model2VecStaticModelWrapper` rather than reusing `SentenceTransformerEncoderWrapper` as the `minishlab/potion-*` entries do.

The wrapper is generic: any Model2Vec checkpoint using vocabulary quantization can reuse it.

### Training data

`training_datasets={"MSMARCO"}` — the model was fine-tuned on [`cnmoro/AllTripletsMsMarco-PTBR`](https://huggingface.co/datasets/cnmoro/AllTripletsMsMarco-PTBR), a pt-BR translation of MS MARCO triplets. Declared explicitly for the zero-shot determination.

### Validation

- `mteb.mock_run(...)` → **`all_passed: True`** (28 text task types ran; 32 image/audio/video tasks correctly reported as incompatible)
- `ruff check` and `ruff format --check` clean
- Full runs completed on 186 real task instances across the three benchmarks with **zero failures**
- `Assin2STS` reproduced at **61.3558**, matching the value published on the model card

### Checklist

- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [x] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e., is available either as an API or the weights are publicly available to download
- [x] I reproduced results from the original paper (if applicable) on at least one benchmark, and I am including the results in the PR description.
