### PR TITLE
fix: add av to the video extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ api = [
 og = [
     "playwright>=1.49.0",
 ]
-video = ["torchcodec"]
+video = ["torchcodec", "av>=17.0.0"]
 github = ["PyGithub>=1.60"]
 
 # model specific optional dependencies:


### PR DESCRIPTION
mteb[video] installs torchcodec but not av, so video decoding fails and mteb mock-run errors on all seven mock video tasks. av>=17.0.0 is already declared in the test extra, which is why CI passes — the dependency is real, just declared in the wrong group. Found while adding InternVideo2 (#5078).