### PR TITLE
mock zeroshot tasks must declare the text modality

### DIFF
--- a/mteb/mocks/mock_tasks/zeroshot_classification.py
+++ b/mteb/mocks/mock_tasks/zeroshot_classification.py
@@ -206,7 +206,7 @@ class MockAudioZeroshotClassificationTask(AbsTaskZeroShotClassification):
         main_score="accuracy",
         **general_args,
     )
-    metadata.modalities = ["audio"]
+    metadata.modalities = ["audio", "text"]
 
     def load_data(self, **kwargs):
         mock_audio = create_mock_audio(self.np_rng)
@@ -283,7 +283,7 @@ class MockVideoZeroshotClassificationTask(AbsTaskZeroShotClassification):
         main_score="accuracy",
         **general_args,
     )
-    metadata.modalities = ["video"]
+    metadata.modalities = ["video", "text"]
     metadata.category = "v2c"
 
     def load_data(self, **kwargs):
@@ -370,7 +370,7 @@ class MockVideoAudioZeroshotClassificationTask(AbsTaskZeroShotClassification):
         main_score="accuracy",
         **general_args,
     )
-    metadata.modalities = ["video", "audio"]
+    metadata.modalities = ["video", "audio", "text"]
     metadata.category = "va2c"
 
     def load_data(self, **kwargs):


### PR DESCRIPTION
Zeroshot classification compares inputs against candidate text prompts, so any zeroshot task requires a model with a text tower. Three mock tasks don't declare that: `MockAudioZeroshotClassification`, `MockVideoZeroshotClassification` and `MockVideoAudioZeroshotClassification` omit `"text"` from `metadata.modalities`.

Because `get_compatible_mock_tasks` selects a task when its modalities are a subset of the model's, these get handed to audio-only and video-only models, which then raise `KeyError` on the input column when the task passes them label strings. This affects the eight `facebook/vjepa2-*` checkpoints already in the repo and every audio-only model.

Adding `"text"` makes them consistent with the image mock (`["image", "text"]`) and with the real zeroshot tasks (`Kinetics400ZeroShot`, `HMDB51ZeroShot`).

No effect on `expected_stats` — descriptive statistics build `col_map` from `metadata.modalities[0]`, which doesn't change.

Verified on six video-only checkpoints: `mteb mock-run` goes from `✗ (4/5)` to `✓ (4/4)`. `tests/test_mock_run.py` and `tests/test_cli.py` pass, 15 passed.