### PR TITLE
model: Declare Common Voice in fusion-embedding training_datasets (contamination disclosure)

### DIFF
--- a/mteb/models/model_implementations/fusion_embedding_models.py
+++ b/mteb/models/model_implementations/fusion_embedding_models.py
@@ -245,6 +245,13 @@ fusion_embedding_1_2b_preview = ModelMeta(
         # AudioSet-SL / WavCaps captions over strongly-labelled AudioSet clips
         "AudioSet",
         "AudioSetMini",
+        # Common Voice: corpus samples the `validated` pool the test split is drawn
+        # from; measured overlap 22% of eval clips / 47% of eval sentences (see the
+        # model card's evaluation-integrity section and mteb#5096)
+        "CommonVoiceMini21T2ARetrieval",
+        # CommonLanguage derives from Common Voice; overlap unaudited, declared
+        # conservatively
+        "CommonLanguageAgeDetection",
         # LAION-FreeSound (not in MTEB)
         # Clotho / ESC-50 / UrbanSound8K / VGGSound eval clips excluded from training
         # by id blacklist at ingestion (see the model card)
@@ -302,6 +309,13 @@ fusion_embedding_2_2b_preview = ModelMeta(
         # AudioSet-SL / WavCaps captions over strongly-labelled AudioSet clips
         "AudioSet",
         "AudioSetMini",
+        # Common Voice: corpus samples the `validated` pool the test split is drawn
+        # from; measured overlap 22% of eval clips / 47% of eval sentences (see the
+        # model card's evaluation-integrity section and mteb#5096)
+        "CommonVoiceMini21T2ARetrieval",
+        # CommonLanguage derives from Common Voice; overlap unaudited, declared
+        # conservatively
+        "CommonLanguageAgeDetection",
         # LAION-FreeSound (not in MTEB)
         # Clotho / ESC-50 / UrbanSound8K / VGGSound eval clips excluded from training
         # by id blacklist at ingestion (see the model card)


### PR DESCRIPTION
Follows @Samoed's guidance in #5096: declares `CommonVoiceMini21T2ARetrieval` in `training_datasets` for both fusion-embedding ModelMetas, so the leaderboard marks the models as trained on that task. Measured overlap is documented on the model card (22 percent of eval clips, 47 percent of eval sentences): https://huggingface.co/EximiusLabs/fusion-embedding-2-2b-preview#common-voice-overlap-why-one-cell-is-not-reported

Also declares `CommonLanguageAgeDetection` conservatively: CommonLanguage derives from Common Voice and we have not audited that overlap, so we would rather flag it than claim zero-shot.

Model checklist (existing models, metadata-only change):
- [x] Not a new model: updates `training_datasets` on the existing fusion-embedding entries only
- [x] No scores or implementations changed
- [x] `fusion_embedding_models.py` parses; sets remain valid task names

The corresponding results-side re-add of the Common Voice cell is in embeddings-benchmark/results#635.