### PR TITLE
fix: combine subsets in run_settings.jsonl

### DIFF
--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -101,7 +101,7 @@ For more details, see the [Results API documentation](./api/results.md#timing-an
 To improve reproducibility and auditing of evaluations, MTEB now automatically tracks the settings used for each run by generating and maintaining a `run_settings.jsonl` file under each model revision's directory.
 
 For every evaluation run, this file tracks:
-- **Task metadata**: The specific task, split, and Hugging Face subsets that were evaluated. Subsets evaluated with the same settings are combined into a single row.
+- **Task metadata**: The specific task, splits, and Hugging Face subsets that were evaluated. Splits and subsets evaluated with the same settings are combined into a single row.
 - **Library versions**: The exact versions of the packages in your python environment (including `mteb`, `torch`, `sentence-transformers`, `transformers`, and `flash-attn`).
 - **Encode settings**: The keyword arguments passed to the model's `encode` method (`encode_kwargs`).
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -101,7 +101,7 @@ For more details, see the [Results API documentation](./api/results.md#timing-an
 To improve reproducibility and auditing of evaluations, MTEB now automatically tracks the settings used for each run by generating and maintaining a `run_settings.jsonl` file under each model revision's directory.
 
 For every evaluation run, this file tracks:
-- **Task metadata**: The specific task, split, and Hugging Face subset that was evaluated.
+- **Task metadata**: The specific task, split, and Hugging Face subsets that were evaluated. Subsets evaluated with the same settings are combined into a single row.
 - **Library versions**: The exact versions of the packages in your python environment (including `mteb`, `torch`, `sentence-transformers`, `transformers`, and `flash-attn`).
 - **Encode settings**: The keyword arguments passed to the model's `encode` method (`encode_kwargs`).
 

--- a/mteb/cache/result_cache.py
+++ b/mteb/cache/result_cache.py
@@ -414,7 +414,7 @@ class ResultCache:
         for split, split_scores in task_result.scores.items():
             run_settings = {
                 "task": task_result.task_name,
-                "split": split,
+                "splits": [split],
                 "version": version_dict,
                 "encode_kwargs": json.loads(json.dumps(encode_kwargs, default=str))
                 if encode_kwargs is not None

--- a/mteb/cache/result_cache.py
+++ b/mteb/cache/result_cache.py
@@ -412,18 +412,21 @@ class ResultCache:
 
         run_settings_list: list[dict[str, Any]] = []
         for split, split_scores in task_result.scores.items():
-            for score_entry in split_scores:
-                hf_subset = score_entry.get("hf_subset", "default")
-                run_settings = {
-                    "task": task_result.task_name,
-                    "split": split,
-                    "subset": hf_subset,
-                    "version": version_dict,
-                    "encode_kwargs": json.loads(json.dumps(encode_kwargs, default=str))
-                    if encode_kwargs is not None
-                    else {},
-                }
-                run_settings_list.append(run_settings)
+            run_settings = {
+                "task": task_result.task_name,
+                "split": split,
+                "version": version_dict,
+                "encode_kwargs": json.loads(json.dumps(encode_kwargs, default=str))
+                if encode_kwargs is not None
+                else {},
+                "subsets": sorted(
+                    {
+                        score_entry.get("hf_subset", "default")
+                        for score_entry in split_scores
+                    }
+                ),
+            }
+            run_settings_list.append(run_settings)
 
         if run_settings_list:
             run_settings_path = result_path.parent / "run_settings.jsonl"

--- a/mteb/results/task_result.py
+++ b/mteb/results/task_result.py
@@ -34,7 +34,7 @@ from mteb.types import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Mapping
+    from collections.abc import Callable, Iterable, Iterator, Mapping
     from pathlib import Path
 
     from typing_extensions import Self
@@ -1099,53 +1099,60 @@ def _read_run_settings_from_file(path: Path) -> list[dict[str, Any]]:
     return run_settings
 
 
-def _split_run_settings_entry(
+def _expand_run_settings_entry(
     entry: dict[str, Any],
-) -> tuple[dict[str, Any], list[str]]:
-    """Split an entry into its settings (everything but the subsets) and its subsets."""
+) -> Iterator[tuple[tuple[str, str, str], str, dict[str, Any]]]:
+    """Expand an entry into one (task, split, subset), settings tuple per evaluated subset."""
     settings = dict(entry)
+    task = settings.pop("task", None)
+    # entries written before splits and subsets were combined stored a single "split" and "subset"
+    splits = settings.pop("splits", None)
+    if splits is None:
+        splits = [settings.pop("split", None)]
     subsets = settings.pop("subsets", None)
     if subsets is None:
-        # entries written before subsets were combined stored a single "subset"
-        subset = settings.pop("subset", None)
-        subsets = [subset] if subset is not None else []
-    return settings, list(subsets)
+        subsets = [settings.pop("subset", None)]
+
+    key = json.dumps(settings, sort_keys=True, default=str)
+    for split in splits:
+        for subset in subsets:
+            if split is not None and subset is not None:
+                yield (task, split, subset), key, settings
 
 
 def _write_and_merge_keyed_json(path: Path, entries: list[dict[str, Any]]) -> None:
     """Write entries to `.jsonl`, if it already exist it will merge it.
 
-    Entries sharing the same settings (task, split, version, encode_kwargs) are combined into a single row listing all
-    their subsets. Subsets of the new entries are removed from existing entries with the same task and split but
-    different settings.
+    Every (task, split, subset) is stored once, with the settings of the last entry that evaluated it. Rows are then
+    combined as far as possible: splits of a task sharing both their settings and their subsets are written as a single
+    row listing all of its splits and subsets.
     """
-    merged: dict[str, tuple[dict[str, Any], list[str]]] = {}
+    settings_by_key: dict[str, dict[str, Any]] = {}
+    # (task, split, subset) -> settings key, later entries overwrite the settings of earlier ones
+    run_settings: dict[tuple[str, str, str], str] = {}
+    for entry in [*_read_run_settings_from_file(path), *entries]:
+        for scope, key, settings in _expand_run_settings_entry(entry):
+            settings_by_key[key] = settings
+            run_settings[scope] = key
 
-    def add(entry: dict[str, Any], *, replace: bool) -> None:
-        settings, subsets = _split_run_settings_entry(entry)
-        key = json.dumps(settings, sort_keys=True, default=str)
-        if replace:
-            for other_key, (other_settings, other_subsets) in merged.items():
-                if other_key != key and (
-                    other_settings.get("task"),
-                    other_settings.get("split"),
-                ) == (settings.get("task"), settings.get("split")):
-                    merged[other_key] = (
-                        other_settings,
-                        [s for s in other_subsets if s not in subsets],
-                    )
-        current = merged.setdefault(key, (settings, []))[1]
-        current.extend(s for s in subsets if s not in current)
-
-    for entry in _read_run_settings_from_file(path):
-        add(entry, replace=False)
-    for entry in entries:
-        add(entry, replace=True)
+    # (task, settings key) -> split -> subsets
+    grouped: dict[tuple[str, str], dict[str, list[str]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+    for (task, split, subset), key in run_settings.items():
+        grouped[(task, key)][split].append(subset)
 
     with path.open("w", encoding="utf-8") as f:
-        for settings, subsets in merged.values():
-            if not subsets:
-                continue
-            f.write(
-                json.dumps({**settings, "subsets": sorted(subsets)}, default=str) + "\n"
-            )
+        for (task, key), splits in grouped.items():
+            # splits evaluated on the exact same subsets share a row
+            rows: dict[tuple[str, ...], list[str]] = defaultdict(list)
+            for split, subsets in splits.items():
+                rows[tuple(sorted(set(subsets)))].append(split)
+            for subsets, split_names in rows.items():
+                entry = {
+                    "task": task,
+                    "splits": sorted(split_names),
+                    **settings_by_key[key],
+                    "subsets": list(subsets),
+                }
+                f.write(json.dumps(entry, default=str) + "\n")

--- a/mteb/results/task_result.py
+++ b/mteb/results/task_result.py
@@ -1099,22 +1099,53 @@ def _read_run_settings_from_file(path: Path) -> list[dict[str, Any]]:
     return run_settings
 
 
-def _write_and_merge_keyed_json(
-    path: Path,
-    entries: list[dict[str, Any]],
-    *,
-    key_fields: tuple[str, str, str] = ("task", "split", "subset"),
-) -> None:
-    """Write entries to `.jsonl`, if it already exist it will merge it, replacing any existing entries with the same key."""
-    existing_entries = _read_run_settings_from_file(path)
-    new_keys = {tuple(entry.get(field) for field in key_fields) for entry in entries}
-    filtered_existing = [
-        entry
-        for entry in existing_entries
-        if tuple(entry.get(field) for field in key_fields) not in new_keys
-    ]
-    all_entries = filtered_existing + entries
+def _split_run_settings_entry(
+    entry: dict[str, Any],
+) -> tuple[dict[str, Any], list[str]]:
+    """Split an entry into its settings (everything but the subsets) and its subsets."""
+    settings = dict(entry)
+    subsets = settings.pop("subsets", None)
+    if subsets is None:
+        # entries written before subsets were combined stored a single "subset"
+        subset = settings.pop("subset", None)
+        subsets = [subset] if subset is not None else []
+    return settings, list(subsets)
+
+
+def _write_and_merge_keyed_json(path: Path, entries: list[dict[str, Any]]) -> None:
+    """Write entries to `.jsonl`, if it already exist it will merge it.
+
+    Entries sharing the same settings (task, split, version, encode_kwargs) are combined into a single row listing all
+    their subsets. Subsets of the new entries are removed from existing entries with the same task and split but
+    different settings.
+    """
+    merged: dict[str, tuple[dict[str, Any], list[str]]] = {}
+
+    def add(entry: dict[str, Any], *, replace: bool) -> None:
+        settings, subsets = _split_run_settings_entry(entry)
+        key = json.dumps(settings, sort_keys=True, default=str)
+        if replace:
+            for other_key, (other_settings, other_subsets) in merged.items():
+                if other_key != key and (
+                    other_settings.get("task"),
+                    other_settings.get("split"),
+                ) == (settings.get("task"), settings.get("split")):
+                    merged[other_key] = (
+                        other_settings,
+                        [s for s in other_subsets if s not in subsets],
+                    )
+        current = merged.setdefault(key, (settings, []))[1]
+        current.extend(s for s in subsets if s not in current)
+
+    for entry in _read_run_settings_from_file(path):
+        add(entry, replace=False)
+    for entry in entries:
+        add(entry, replace=True)
 
     with path.open("w", encoding="utf-8") as f:
-        for entry in all_entries:
-            f.write(json.dumps(entry, default=str) + "\n")
+        for settings, subsets in merged.values():
+            if not subsets:
+                continue
+            f.write(
+                json.dumps({**settings, "subsets": sorted(subsets)}, default=str) + "\n"
+            )

--- a/mteb/results/task_result.py
+++ b/mteb/results/task_result.py
@@ -1148,11 +1148,11 @@ def _write_and_merge_keyed_json(path: Path, entries: list[dict[str, Any]]) -> No
             rows: dict[tuple[str, ...], list[str]] = defaultdict(list)
             for split, subsets in splits.items():
                 rows[tuple(sorted(set(subsets)))].append(split)
-            for subsets, split_names in rows.items():
+            for row_subsets, split_names in rows.items():
                 entry = {
                     "task": task,
                     "splits": sorted(split_names),
                     **settings_by_key[key],
-                    "subsets": list(subsets),
+                    "subsets": list(row_subsets),
                 }
                 f.write(json.dumps(entry, default=str) + "\n")

--- a/tests/test_run_settings_jsonl.py
+++ b/tests/test_run_settings_jsonl.py
@@ -39,8 +39,48 @@ def test_save_to_cache_replaces_existing_run_settings_entry(tmp_path):
     assert len(entries) == 1
     assert entries[0]["task"] == "STS12"
     assert entries[0]["split"] == "test"
-    assert entries[0]["subset"] == "en"
+    assert entries[0]["subsets"] == ["en"]
     assert entries[0]["encode_kwargs"]["batch_size"] == 32
+
+
+def test_save_to_cache_combines_subsets_with_same_settings(tmp_path):
+    cache = ResultCache(cache_path=tmp_path)
+    for subset in ["en", "de"]:
+        cache.save_to_cache(
+            TaskResult.from_task_results(
+                task=mteb.get_task("MassiveIntentClassification"),
+                scores={"test": {subset: {"main_score": 0.5}}},
+                evaluation_time=100,
+            ),
+            "model",
+            model_revision="rev1",
+            encode_kwargs={"batch_size": 16},
+        )
+
+    run_settings_path = tmp_path / "results" / "model" / "rev1" / "run_settings.jsonl"
+    entries = _read_jsonl(run_settings_path)
+
+    assert len(entries) == 1
+    assert entries[0]["subsets"] == ["de", "en"]
+
+    # rerunning a single subset with other settings splits it out again
+    cache.save_to_cache(
+        TaskResult.from_task_results(
+            task=mteb.get_task("MassiveIntentClassification"),
+            scores={"test": {"en": {"main_score": 0.5}}},
+            evaluation_time=100,
+        ),
+        "model",
+        model_revision="rev1",
+        encode_kwargs={"batch_size": 32},
+    )
+    entries = _read_jsonl(run_settings_path)
+
+    assert len(entries) == 2
+    assert entries[0]["subsets"] == ["de"]
+    assert entries[0]["encode_kwargs"]["batch_size"] == 16
+    assert entries[1]["subsets"] == ["en"]
+    assert entries[1]["encode_kwargs"]["batch_size"] == 32
 
 
 def test_save_to_cache_serializes_non_json_serializable_encode_kwargs(tmp_path):

--- a/tests/test_run_settings_jsonl.py
+++ b/tests/test_run_settings_jsonl.py
@@ -38,7 +38,7 @@ def test_save_to_cache_replaces_existing_run_settings_entry(tmp_path):
 
     assert len(entries) == 1
     assert entries[0]["task"] == "STS12"
-    assert entries[0]["split"] == "test"
+    assert entries[0]["splits"] == ["test"]
     assert entries[0]["subsets"] == ["en"]
     assert entries[0]["encode_kwargs"]["batch_size"] == 32
 
@@ -82,6 +82,47 @@ def test_save_to_cache_combines_subsets_with_same_settings(tmp_path):
     assert entries[0]["encode_kwargs"]["batch_size"] == 16
     assert entries[1]["subsets"] == ["en"]
     assert entries[1]["encode_kwargs"]["batch_size"] == 32
+
+
+def test_save_to_cache_combines_splits_evaluated_on_the_same_subsets(tmp_path):
+    cache = ResultCache(cache_path=tmp_path)
+    scores = {"en": {"main_score": 0.5}, "de": {"main_score": 0.5}}
+    cache.save_to_cache(
+        TaskResult.from_task_results(
+            task=mteb.get_task("MassiveIntentClassification"),
+            scores={"test": scores, "validation": scores},
+            evaluation_time=100,
+        ),
+        "model",
+        model_revision="rev1",
+        encode_kwargs={"batch_size": 16},
+    )
+
+    run_settings_path = tmp_path / "results" / "model" / "rev1" / "run_settings.jsonl"
+    entries = _read_jsonl(run_settings_path)
+
+    assert len(entries) == 1
+    assert entries[0]["splits"] == ["test", "validation"]
+    assert entries[0]["subsets"] == ["de", "en"]
+
+    # a subset evaluated on a single split only breaks the shared row apart
+    cache.save_to_cache(
+        TaskResult.from_task_results(
+            task=mteb.get_task("MassiveIntentClassification"),
+            scores={"test": {"fr": {"main_score": 0.5}}},
+            evaluation_time=100,
+        ),
+        "model",
+        model_revision="rev1",
+        encode_kwargs={"batch_size": 16},
+    )
+    entries = sorted(_read_jsonl(run_settings_path), key=lambda e: e["splits"])
+
+    assert len(entries) == 2
+    assert entries[0]["splits"] == ["test"]
+    assert entries[0]["subsets"] == ["de", "en", "fr"]
+    assert entries[1]["splits"] == ["validation"]
+    assert entries[1]["subsets"] == ["de", "en"]
 
 
 def test_save_to_cache_serializes_non_json_serializable_encode_kwargs(tmp_path):

--- a/tests/test_run_settings_jsonl.py
+++ b/tests/test_run_settings_jsonl.py
@@ -75,6 +75,7 @@ def test_save_to_cache_combines_subsets_with_same_settings(tmp_path):
         encode_kwargs={"batch_size": 32},
     )
     entries = _read_jsonl(run_settings_path)
+    entries = sorted(entries, key=lambda e: e["encode_kwargs"]["batch_size"])
 
     assert len(entries) == 2
     assert entries[0]["subsets"] == ["de"]


### PR DESCRIPTION
closes #5098 
Added a fix to combine subsets in `run_settings.jsonl` instead of having it for subset+split, making it too large. 

In `result_cache.py` - `save_to_cache` now emits one entry per split with a subsets list instead of one entry per split+subset.
In `task_result.py` - `_write_and_merge_keyed_json` is rewritten. Existing rows and new entries are flattened into a `(task, split, subset) -> settings` map where later entries win, then rows are re-derived from that map: splits of a task that share both their settings and their exact subset list are written as one row.
Legacy singular `"split"` / `"subset"` rows are still read, so existing files migrate on the next write with no separate migration step.

The results repo's `collapse_run_settings` stays compatible — it keys on everything-but-subset, so a `splits` list is opaque key material to it.

Added coverage tests for subsets combining under equal settings, a rerun with different settings splitting a row apart, splits combining when subsets match exactly, and a subset added to one split only breaking a shared row apart.