### PR TITLE
Enable some ruff rules

### DIFF
--- a/docs/overview/create_available_models.py
+++ b/docs/overview/create_available_models.py
@@ -138,7 +138,7 @@ def required_memory_string(mem_in_mb: int | None) -> str:
 def format_model_entry(meta: ModelMeta) -> str:
     revision = meta.revision or "not specified"
     raw_license = meta.license or "not specified"
-    if raw_license.startswith("http://") or raw_license.startswith("https://"):
+    if raw_license.startswith(("http://", "https://")):
         license = f"[custom]({raw_license})"
     else:
         license = raw_license

--- a/docs/overview/create_available_tasks.py
+++ b/docs/overview/create_available_tasks.py
@@ -103,7 +103,7 @@ def format_task_entry(task: mteb.AbsTask) -> str:  # noqa: PLR0914
     if task.metadata.contributed_by:
         description += f" Contributed by {task.metadata.contributed_by}."
     raw_license = task.metadata.license or "not specified"
-    if raw_license.startswith("http://") or raw_license.startswith("https://"):
+    if raw_license.startswith(("http://", "https://")):
         license = f"[custom]({raw_license})"
     else:
         license = raw_license

--- a/mteb/_evaluators/evaluator.py
+++ b/mteb/_evaluators/evaluator.py
@@ -39,4 +39,3 @@ class Evaluator(ABC):
             encode_kwargs: kwargs to pass to the model's encode method
             num_proc: number of processes to use for data loading
         """
-        pass

--- a/mteb/abstasks/abstask.py
+++ b/mteb/abstasks/abstask.py
@@ -139,7 +139,6 @@ class AbsTask(ABC):  # noqa: PLR0904
             num_proc: Number of processes to use for the transformation.
             kwargs: Additional keyword arguments passed to the load_dataset function. Keep for forward compatibility.
         """
-        pass
 
     def evaluate(
         self,

--- a/mteb/cache/result_cache.py
+++ b/mteb/cache/result_cache.py
@@ -10,7 +10,7 @@ import subprocess
 import warnings
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
-from datetime import datetime
+from datetime import datetime, timezone
 from importlib.metadata import version
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -1228,7 +1228,7 @@ class ResultCache:
             >>> print(f"PR created: {submission['pr_url']}")
         """
         # Always create a new branch to keep the original branch clean
-        branch_name = f"mteb-results-{int(datetime.now().timestamp())}"
+        branch_name = f"mteb-results-{int(datetime.now(timezone.utc).timestamp())}"
         normalized_models = self._normalize_models(models)
 
         try:

--- a/mteb/deprecated_evaluator.py
+++ b/mteb/deprecated_evaluator.py
@@ -7,7 +7,7 @@ import sys
 import traceback
 import warnings
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, timezone
 from itertools import chain
 from pathlib import Path
 from time import time
@@ -559,7 +559,9 @@ class MTEB:
                     f"Please check all the error logs at: {self.err_logs_path}"
                 )
                 with self.err_logs_path.open("a") as f_out:
-                    f_out.write(f"{datetime.now()} >>> {task.metadata.name}\n")
+                    f_out.write(
+                        f"{datetime.now(timezone.utc)} >>> {task.metadata.name}\n"
+                    )
                     f_out.write(traceback.format_exc())
                     f_out.write("\n\n")
 

--- a/mteb/get_tasks.py
+++ b/mteb/get_tasks.py
@@ -84,6 +84,8 @@ _DEFAULT_PROPRIETIES = (
 class MTEBTasks(tuple[AbsTask]):
     """A tuple of tasks with additional methods to get an overview of the tasks."""
 
+    __slots__ = ()
+
     def __repr__(self) -> str:
         return "MTEBTasks" + super().__repr__()
 

--- a/mteb/models/model_implementations/ibm_granite_models.py
+++ b/mteb/models/model_implementations/ibm_granite_models.py
@@ -20,11 +20,11 @@ GRANITE_EMBEDDING_R2_CITATION = """@article{awasthy2025graniteembeddingr2models,
 }"""
 
 GRANITE_EMBEDDING_MULTILINGUAL_R2_CITATION = """@article{awasthy2026graniteembeddingmultilingualr2,
-      title={Granite Embedding Multilingual R2 Models}, 
+      title={Granite Embedding Multilingual R2 Models},
       author={Parul Awasthy and Aashka Trivedi and Yushu Yang and Ken Barker and Yulong Li and Bhavani Iyer and Martin Franz and Juergen Bross and Meet Doshi and Vignesh P and Vishwajeet Kumar and Todd Ward and Abraham Daniels and Madison Lee and Luis Lastras and Jaydeep Sen and Radu Florian},
       year={2026},
       journal={arXiv preprint arXiv:2605.13521}
-      url={https://arxiv.org/abs/2605.13521}, 
+      url={https://arxiv.org/abs/2605.13521},
 }"""
 
 GRANITE_LANGUAGES = [

--- a/mteb/models/model_implementations/kalm_reranker.py
+++ b/mteb/models/model_implementations/kalm_reranker.py
@@ -456,13 +456,13 @@ multilingual_langs = [
 ]
 
 KALM_RERANKER_V1_CITATION = """@misc{zhao2026kalmrerankerv1,
-      title={KaLM-Reranker-V1: Fast but Not Late Interaction for Compressed Document Reranking}, 
+      title={KaLM-Reranker-V1: Fast but Not Late Interaction for Compressed Document Reranking},
       author={Xinping Zhao and Jiaxin Xu and Ziqi Dai and Xin Zhang and Shouzheng Huang and Danyu Tang and Xinshuo Hu and Meishan Zhang and Baotian Hu and Min Zhang},
       year={2026},
       eprint={2606.22807},
       archivePrefix={arXiv},
       primaryClass={cs.CL},
-      url={https://arxiv.org/abs/2606.22807}, 
+      url={https://arxiv.org/abs/2606.22807},
 }"""
 
 

--- a/mteb/models/model_implementations/portuguese_models.py
+++ b/mteb/models/model_implementations/portuguese_models.py
@@ -17,7 +17,7 @@ PT_MATRYOSHKA_EMBEDDING_CITATION = """
 
 SERAFIM_CITATION = """
 @InProceedings{epia2024serafim,
-    title={Open Sentence Embeddings for Portuguese with the Serafim PT* encoders family}, 
+    title={Open Sentence Embeddings for Portuguese with the Serafim PT* encoders family},
     author={Luís Gomes and António Branco and João Silva and João Rodrigues and Rodrigo Santos},
     editor={Manuel Filipe Santos and José Machado and Paulo Novais and Paulo Cortez and Pedro Miguel Moreira},
     booktitle={Progress in Artificial Intelligence},

--- a/mteb/models/model_implementations/querit_models.py
+++ b/mteb/models/model_implementations/querit_models.py
@@ -218,13 +218,13 @@ querit_reranker_training_data = {
 }
 
 QUERIT_CITATION = """@misc{zhong2026queritrerankertrainingcompactmultilingual,
-      title={Querit-Reranker: Training Compact Multilingual Rerankers via Efficient Label-Free Distribution Adaptation}, 
+      title={Querit-Reranker: Training Compact Multilingual Rerankers via Efficient Label-Free Distribution Adaptation},
       author={Yunfei Zhong and Jun Yang and Wei Huang and Yinqiong Cai and Haosheng Qian and Yixing Fan and Ruqing Zhang and Lixin Su and Daiting Shi and Jiafeng Guo},
       year={2026},
       eprint={2606.19037},
       archivePrefix={arXiv},
       primaryClass={cs.IR},
-      url={https://arxiv.org/abs/2606.19037}, 
+      url={https://arxiv.org/abs/2606.19037},
 }"""
 
 Querit_Reranker_A0_4B = ModelMeta(

--- a/mteb/tasks/sts/eng/sts_benchmark_sts.py
+++ b/mteb/tasks/sts/eng/sts_benchmark_sts.py
@@ -38,9 +38,6 @@ class STSBenchmarkSTS(AbsTaskSTS):
         superseded_by="STSBenchmark.v2",
     )
 
-    min_score = 0
-    max_score = 5
-
 
 class STSBenchmarkSTSV2(AbsTaskSTS):
     min_score = 0

--- a/mteb/types/_encoder_io.py
+++ b/mteb/types/_encoder_io.py
@@ -151,8 +151,6 @@ class MultimodalInput(  # type: ignore[misc]
 ):
     """The input to the encoder for multimodal data."""
 
-    pass
-
 
 class OutputDType(HelpfulStrEnum):
     """Enum for valid compression levels.

--- a/mteb/types/statistics.py
+++ b/mteb/types/statistics.py
@@ -16,8 +16,6 @@ class SplitDescriptiveStatistics(TypedDict):
     :class:`DescriptiveStatistics`.
     """
 
-    pass
-
 
 class DescriptiveStatistics(SplitDescriptiveStatistics):
     """Multilingual wrapper for per-task descriptive statistics.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,6 +257,7 @@ select = [
     "F",  # pyflakes rules,
     "I",  # sorting for imports
     "E",  # formatting for docs
+    "W",  # pycodestyle warnings
     "D",  # formatting for docs
     "UP", # upgrade to latest syntax if possible
     "FA", # Future annotations
@@ -296,6 +297,16 @@ select = [
     "PL",      # pylint
     "S",       # flake8-bandit
     "FAST",       # fastapi
+    "ICN",     # import conventions, e.g. `import numpy as np`
+    "PIE",     # misc. lints, e.g. unnecessary `pass`
+    "PD",      # pandas-vet
+    "DTZ",     # require timezone-aware datetimes
+    "SLOT",    # __slots__ on str/tuple/namedtuple subclasses
+    "RSE",     # no unnecessary parens on raised exceptions
+    "YTT",     # correct sys.version checks
+    "EXE",     # shebang/executable-bit consistency
+    "INT",     # gettext f-string misuse
+    "ASYNC",   # blocking calls in async functions
 ]
 
 ignore = [
@@ -554,6 +565,8 @@ extend-ignore-words-re = [
     "thi",
     # ISO 15924 script codes
     "Beng",  # Bengali script
+    # dataset names
+    "Matix",  # Docmatix (HF dataset)
 
 ]
 extend-ignore-re = [

--- a/tests/mock_models.py
+++ b/tests/mock_models.py
@@ -34,7 +34,6 @@ class MockSentenceTransformer(SentenceTransformer):
 
     def __init__(self):
         self._modules = {}
-        pass
 
     def encode(  # noqa: PLR0913, PLR0917, PLR6301
         self,

--- a/tests/test_models/test_model_meta.py
+++ b/tests/test_models/test_model_meta.py
@@ -506,7 +506,7 @@ def test_model_meta_dependencies_not_existing_group():
     )
     with pytest.raises(
         ValueError,
-        match="Unknown extras group\(s\) for mteb: \['test_group'\]. .*",
+        match=r"Unknown extras group\(s\) for mteb: \['test_group'\]. .*",
     ):
         model_meta._check_requirements()
 

--- a/tests/test_results/test_benchmark_results.py
+++ b/tests/test_results/test_benchmark_results.py
@@ -196,7 +196,7 @@ def test_benchmark_results(cache_path: Path) -> None:
     assert "Classification" in df.columns
     assert "Retrieval" in df.columns
     assert df.shape[0] == 2
-    assert df.at[0, "Mean (Task)"] == pytest.approx(0.616616)
+    assert df.loc[0, "Mean (Task)"] == pytest.approx(0.616616)
 
 
 @pytest.mark.skipif(_POLARS_TOO_OLD, reason="requires polars >= 1.40.0")


### PR DESCRIPTION
As part of issue #2416 

### Rules enabled

`W`, `ICN`, `PIE`, `PD`, `DTZ`, `SLOT`, `RSE`, `YTT`, `EXE`, `INT`, `ASYNC`

### Violations fixed (24 across 17 files)

| Rule | Fix | Where |
|---|---|---|
| `W291` trailing-whitespace | 7× trailing whitespace, all inside BibTeX citation strings | `ibm_granite_models.py`, `kalm_reranker.py`, `portuguese_models.py`, `querit_models.py` |
| `W605` invalid-escape-sequence | 4× invalid escape (`\(`, `\)`, `\[`, `\]` in a non-raw regex) — a real latent bug | `tests/test_models/test_model_meta.py:509` |
| `PIE790` unnecessary-placeholder | 5× unnecessary `pass` after a docstring | `mteb/_evaluators/evaluator.py`, `mteb/abstasks/abstask.py`, `mteb/types/_encoder_io.py`, `mteb/types/statistics.py`, `tests/mock_models.py` |
| `PIE810` multiple-starts-ends-with | 2× `startswith(a) or startswith(b)` → `startswith((a, b))` | `docs/overview/create_available_models.py:141`, `docs/overview/create_available_tasks.py:106` |
| `PIE794` duplicate-class-field-definition | `min_score`/`max_score` defined twice in the same class; dead lines removed, values unchanged | `mteb/tasks/sts/eng/sts_benchmark_sts.py:41-42` |
| `SLOT001` no-slots-in-tuple-subclass | Added `__slots__ = ()` to the `tuple` subclass (verified nothing assigns instance attrs) | `mteb/get_tasks.py:86` |
| `PD008` pandas-use-of-dot-at | `df.at` → `df.loc` | `tests/test_results/test_benchmark_results.py:199` |
| `DTZ005` call-datetime-now-without-tzinfo | 2× `datetime.now()` → `datetime.now(timezone.utc)` | `mteb/cache/result_cache.py:1231`, `mteb/deprecated_evaluator.py:562` |

`ICN`, `RSE`, `YTT`, `EXE`, `INT`, `ASYNC` had **zero** violations — enabled purely as regression guards.

### Behavior note

`DTZ005`: the branch-name timestamp is unaffected (`.timestamp()` yields the same epoch value either way), but the deprecated evaluator's error-log line now prints UTC instead of local time.