### PR TITLE
Add NSynth instrument family audio retrieval task

### DIFF
--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/NSynthInstrumentFamilyA2ARetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/NSynthInstrumentFamilyA2ARetrieval.json
@@ -1,43 +1,43 @@
 {
     "test": {
-        "num_samples": 3002,
-        "num_queries": 1519,
-        "num_documents": 1483,
+        "num_samples": 2970,
+        "num_queries": 1518,
+        "num_documents": 1452,
         "number_of_characters": 0,
         "documents_text_statistics": null,
         "documents_image_statistics": null,
         "documents_audio_statistics": {
-            "total_duration_seconds": 5932.0,
+            "total_duration_seconds": 5808.0,
             "min_duration_seconds": 4.0,
             "average_duration_seconds": 4.0,
             "max_duration_seconds": 4.0,
             "unique_audios": 1452,
             "average_sampling_rate": 16000.0,
             "sampling_rates": {
-                "16000": 1483
+                "16000": 1452
             }
         },
         "documents_video_statistics": null,
         "queries_text_statistics": null,
         "queries_image_statistics": null,
         "queries_audio_statistics": {
-            "total_duration_seconds": 6076.0,
+            "total_duration_seconds": 6072.0,
             "min_duration_seconds": 4.0,
             "average_duration_seconds": 4.0,
             "max_duration_seconds": 4.0,
             "unique_audios": 1518,
             "average_sampling_rate": 16000.0,
             "sampling_rates": {
-                "16000": 1519
+                "16000": 1518
             }
         },
         "queries_video_statistics": null,
         "relevant_docs_statistics": {
-            "num_relevant_docs": 303638,
+            "num_relevant_docs": 300105,
             "min_relevant_docs_per_query": 30,
-            "average_relevant_docs_per_query": 199.8933508887426,
+            "average_relevant_docs_per_query": 197.69762845849803,
             "max_relevant_docs_per_query": 306,
-            "unique_relevant_docs": 1483
+            "unique_relevant_docs": 1452
         },
         "top_ranked_statistics": null
     }

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/NSynthInstrumentFamilyA2ARetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/NSynthInstrumentFamilyA2ARetrieval.json
@@ -1,0 +1,44 @@
+{
+    "test": {
+        "num_samples": 3002,
+        "num_queries": 1519,
+        "num_documents": 1483,
+        "number_of_characters": 0,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": {
+            "total_duration_seconds": 5932.0,
+            "min_duration_seconds": 4.0,
+            "average_duration_seconds": 4.0,
+            "max_duration_seconds": 4.0,
+            "unique_audios": 1452,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 1483
+            }
+        },
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": null,
+        "queries_audio_statistics": {
+            "total_duration_seconds": 6076.0,
+            "min_duration_seconds": 4.0,
+            "average_duration_seconds": 4.0,
+            "max_duration_seconds": 4.0,
+            "unique_audios": 1518,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 1519
+            }
+        },
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 303638,
+            "min_relevant_docs_per_query": 30,
+            "average_relevant_docs_per_query": 199.8933508887426,
+            "max_relevant_docs_per_query": 306,
+            "unique_relevant_docs": 1483
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/tasks/retrieval/zxx/__init__.py
+++ b/mteb/tasks/retrieval/zxx/__init__.py
@@ -1,5 +1,6 @@
 from .lp_music_caps import LPMusicCapsMTTA2TRetrieval, LPMusicCapsMTTT2ARetrieval
 from .music_caps import MusicCapsA2TRetrieval, MusicCapsT2ARetrieval
+from .n_synth_retrieval import NSynthInstrumentFamilyA2ARetrieval
 from .song_describer import SongDescriberA2TRetrieval, SongDescriberT2ARetrieval
 from .sound_descs import SoundDescsA2TRetrieval, SoundDescsT2ARetrieval
 from .urban_sound8k_retrieval import UrbanSound8KA2TRetrieval, UrbanSound8KT2ARetrieval
@@ -11,6 +12,7 @@ __all__ = [
     "LPMusicCapsMTTT2ARetrieval",
     "MusicCapsA2TRetrieval",
     "MusicCapsT2ARetrieval",
+    "NSynthInstrumentFamilyA2ARetrieval",
     "SongDescriberA2TRetrieval",
     "SongDescriberT2ARetrieval",
     "SoundDescsA2TRetrieval",

--- a/mteb/tasks/retrieval/zxx/n_synth_retrieval.py
+++ b/mteb/tasks/retrieval/zxx/n_synth_retrieval.py
@@ -1,12 +1,28 @@
 from __future__ import annotations
 
+import hashlib
 from collections import defaultdict
 
-from datasets import load_dataset
+from datasets import Audio, Dataset, load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.retrieval_dataset_loaders import RetrievalSplitData
 from mteb.abstasks.task_metadata import TaskMetadata
+
+
+def _audio_payload_hashes(ds: Dataset) -> list[str]:
+    """MD5 of the stored audio payload of every row.
+
+    Duplicate audio is defined in mteb as two clips whose decoded sample arrays
+    are byte-identical. Hashing the encoded payload instead avoids decoding the
+    whole split; for this pinned revision the two agree exactly (both leave 2970
+    distinct clips out of the 3002 test rows).
+    """
+    undecoded = ds.select_columns(["audio"]).cast_column("audio", Audio(decode=False))
+    return [
+        hashlib.md5(row["audio"]["bytes"], usedforsecurity=False).hexdigest()
+        for row in undecoded
+    ]
 
 
 class NSynthInstrumentFamilyA2ARetrieval(AbsTaskRetrieval):
@@ -67,9 +83,24 @@ class NSynthInstrumentFamilyA2ARetrieval(AbsTaskRetrieval):
         for split in self.metadata.eval_splits:
             ds = load_dataset(**self.metadata.dataset, split=split)
 
+            # NSynth-mini stores a few physical recordings under several
+            # metadata rows: 32 `brass_acoustic_046` rows spanning 19 pitches
+            # and 5 velocities all carry one waveform, and 2
+            # `mallet_acoustic_047` rows carry another. Deduplicating before the
+            # query/corpus split keeps every distinct recording exactly once on
+            # exactly one side. The row kept per waveform is the one with the
+            # smallest note_str, so the choice does not depend on row order.
+            note_ids = ds["note_str"]
+            kept_per_hash: dict[str, int] = {}
+            for idx, audio_hash in enumerate(_audio_payload_hashes(ds)):
+                kept = kept_per_hash.get(audio_hash)
+                if kept is None or note_ids[idx] < note_ids[kept]:
+                    kept_per_hash[audio_hash] = idx
+            ds = ds.select(sorted(kept_per_hash.values()))
+
             # Group the row indices by instrument family, then by the individual
-            # instrument. Only the label columns are touched, the audio column is
-            # never materialised here.
+            # instrument. Only the label columns are touched, the audio is never
+            # decoded anywhere in this loader.
             grouped: dict[str, dict[str, list[int]]] = defaultdict(
                 lambda: defaultdict(list)
             )

--- a/mteb/tasks/retrieval/zxx/n_synth_retrieval.py
+++ b/mteb/tasks/retrieval/zxx/n_synth_retrieval.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from collections import defaultdict
+
+from datasets import load_dataset
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.retrieval_dataset_loaders import RetrievalSplitData
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class NSynthInstrumentFamilyA2ARetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="NSynthInstrumentFamilyA2ARetrieval",
+        description=(
+            "Audio-to-audio instrument family retrieval built from the NSynth test "
+            "split: given a single musical note (query), retrieve notes played by "
+            "instruments of the same instrument family (bass, brass, flute, guitar, "
+            "keyboard, mallet, organ, reed, string, vocal). Queries and corpus are "
+            "instrument-disjoint: within each family the individual instruments are "
+            "sorted by name and assigned alternately to the query side and the corpus "
+            "side, so no instrument contributes clips to both sides. A model therefore "
+            "cannot succeed by recognising the exact same instrument and must "
+            "generalise across timbres within a family."
+        ),
+        reference="https://arxiv.org/abs/1704.01279",
+        dataset={
+            "path": "mteb/nsynth-mini",
+            "revision": "e32dfe9b65e121e64229a821fe1ff177e8962635",
+        },
+        type="Any2AnyRetrieval",
+        category="a2a",
+        modalities=["audio"],
+        eval_splits=["test"],
+        eval_langs=["zxx-Zxxx"],
+        main_score="ndcg_at_10",
+        date=("2017-04-05", "2017-04-05"),
+        domains=["Music"],
+        task_subtypes=["Music Instrument Recognition"],
+        license="cc-by-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="created",
+        adapted_from=["NSynth"],
+        is_beta=True,
+        prompt={
+            "query": "Retrieve notes played by instruments of the same instrument family as the given audio clip."
+        },
+        bibtex_citation=r"""
+@misc{engel2017neuralaudiosynthesismusical,
+  archiveprefix = {arXiv},
+  author = {Jesse Engel and Cinjon Resnick and Adam Roberts and Sander Dieleman and Douglas Eck and Karen Simonyan and Mohammad Norouzi},
+  eprint = {1704.01279},
+  primaryclass = {cs.LG},
+  title = {Neural Audio Synthesis of Musical Notes with WaveNet Autoencoders},
+  url = {https://arxiv.org/abs/1704.01279},
+  year = {2017},
+}
+""",
+    )
+
+    def load_data(self, **kwargs) -> None:
+        if self.data_loaded:
+            return
+
+        self.dataset = {"default": {}}
+        for split in self.metadata.eval_splits:
+            ds = load_dataset(**self.metadata.dataset, split=split)
+
+            # Group the row indices by instrument family, then by the individual
+            # instrument. Only the label columns are touched, the audio column is
+            # never materialised here.
+            grouped: dict[str, dict[str, list[int]]] = defaultdict(
+                lambda: defaultdict(list)
+            )
+            for idx, (family, instrument) in enumerate(
+                zip(ds["instrument_family_str"], ds["instrument_str"])
+            ):
+                grouped[family][instrument].append(idx)
+
+            # Deterministic instrument-disjoint split. Within every family the
+            # instruments are sorted lexicographically (NSynth ids are zero-padded,
+            # so this matches numeric order) and assigned alternately: even
+            # position -> query side, odd position -> corpus side. Whole
+            # instruments are assigned, so the notes of one instrument never end
+            # up on both sides. No randomness is involved.
+            note_ids = ds["note_str"]
+            query_indices: list[int] = []
+            corpus_indices: list[int] = []
+            query_ids_per_family: dict[str, list[str]] = defaultdict(list)
+            corpus_ids_per_family: dict[str, list[str]] = defaultdict(list)
+            for family in sorted(grouped):
+                for position, instrument in enumerate(sorted(grouped[family])):
+                    indices = grouped[family][instrument]
+                    if position % 2 == 0:
+                        query_indices.extend(indices)
+                        query_ids_per_family[family].extend(
+                            note_ids[i] for i in indices
+                        )
+                    else:
+                        corpus_indices.extend(indices)
+                        corpus_ids_per_family[family].extend(
+                            note_ids[i] for i in indices
+                        )
+
+            # Relevance is instrument-family equality, so each query is relevant to
+            # every corpus clip of its own family (full cross-product, score 1).
+            relevant_docs = {
+                query_id: dict.fromkeys(corpus_ids_per_family[family], 1)
+                for family, query_ids in query_ids_per_family.items()
+                for query_id in query_ids
+            }
+
+            # note_str is NSynth's unique per-clip identifier.
+            ds = ds.rename_column("note_str", "id")
+            self.dataset["default"][split] = RetrievalSplitData(
+                queries=ds.select(query_indices).select_columns(["id", "audio"]),
+                corpus=ds.select(corpus_indices).select_columns(["id", "audio"]),
+                relevant_docs=relevant_docs,
+                top_ranked=None,
+            )
+
+        self.data_loaded = True


### PR DESCRIPTION
## Summary

This PR adds `NSynthInstrumentFamilyA2ARetrieval`, an audio-to-audio retrieval task derived from the NSynth dataset.

The task evaluates instrument-family retrieval while keeping the specific instruments used for queries and corpus disjoint.

Closes #4996

## Construction

- Uses the `test` split of `mteb/nsynth-mini`
- Deduplicates by audio content before splitting: the source dataset stores a few physical recordings under several metadata rows (32 `brass_acoustic_046` rows spanning 19 pitches and 5 velocities share one waveform, and 2 `mallet_acoustic_047` rows share another), so one row per distinct waveform is kept, choosing the smallest `note_str` so the choice does not depend on row order
- Groups clips by instrument family and specific instrument
- Deterministically assigns whole instruments to either the query or corpus side
- Uses all remaining clips from the split without sampling
- Defines relevance by matching instrument family
- Produces 1,518 queries and 1,452 corpus items, with 300,105 qrels

## Task

- Modality: audio → audio
- Category: `a2a`
- Main score: `ndcg_at_10`
- 10 instrument families
- Instrument IDs are disjoint between query and corpus
- Unique audio count equals the row count on both the query and the corpus side
- Includes generated descriptive statistics
