### PR TITLE
Add NSynth instrument family clustering task

### DIFF
--- a/mteb/descriptive_stats/AudioClustering/NSynthInstrumentFamilyClustering.json
+++ b/mteb/descriptive_stats/AudioClustering/NSynthInstrumentFamilyClustering.json
@@ -1,0 +1,57 @@
+{
+    "test": {
+        "num_samples": 3002,
+        "text_statistics": null,
+        "image_statistics": null,
+        "audio_statistics": {
+            "total_duration_seconds": 12008.0,
+            "min_duration_seconds": 4.0,
+            "average_duration_seconds": 4.0,
+            "max_duration_seconds": 4.0,
+            "unique_audios": 2970,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 3002
+            }
+        },
+        "video_statistics": null,
+        "labels_statistics": {
+            "min_labels_per_text": 1,
+            "average_label_per_text": 1.0,
+            "max_labels_per_text": 1,
+            "unique_labels": 10,
+            "labels": {
+                "5": {
+                    "count": 151
+                },
+                "3": {
+                    "count": 480
+                },
+                "6": {
+                    "count": 375
+                },
+                "8": {
+                    "count": 217
+                },
+                "0": {
+                    "count": 608
+                },
+                "4": {
+                    "count": 572
+                },
+                "7": {
+                    "count": 172
+                },
+                "1": {
+                    "count": 195
+                },
+                "2": {
+                    "count": 125
+                },
+                "10": {
+                    "count": 107
+                }
+            }
+        }
+    }
+}

--- a/mteb/tasks/clustering/zxx/__init__.py
+++ b/mteb/tasks/clustering/zxx/__init__.py
@@ -2,6 +2,7 @@ from .bird_clef_clustering import BirdCLEFSpeciesClustering
 from .esc50_clustering import ESC50Clustering
 from .gtzan_genre_clustering import GTZANGenreClustering
 from .music_genre import MusicGenreClustering
+from .n_synth_clustering import NSynthInstrumentFamilyClustering
 from .urban_sound8k_clustering import UrbanSound8kClustering
 from .vehicle_sound_clustering import VehicleSoundClustering
 from .vim_sketch_clustering import VimSketchImitationClustering
@@ -11,6 +12,7 @@ __all__ = [
     "ESC50Clustering",
     "GTZANGenreClustering",
     "MusicGenreClustering",
+    "NSynthInstrumentFamilyClustering",
     "UrbanSound8kClustering",
     "VehicleSoundClustering",
     "VimSketchImitationClustering",

--- a/mteb/tasks/clustering/zxx/n_synth_clustering.py
+++ b/mteb/tasks/clustering/zxx/n_synth_clustering.py
@@ -1,0 +1,50 @@
+from mteb.abstasks import AbsTaskClustering
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class NSynthInstrumentFamilyClustering(AbsTaskClustering):
+    label_column_name: str = "instrument_family"
+    input_column_name: str = "audio"
+    max_fraction_of_documents_to_embed = None
+    metadata = TaskMetadata(
+        name="NSynthInstrumentFamilyClustering",
+        description=(
+            "Audio clustering of NSynth musical notes by instrument family: bass, "
+            "brass, flute, guitar, keyboard, mallet, organ, reed, string and vocal. "
+            "Each clip is a single four-second note, and the task evaluates whether "
+            "unsupervised grouping recovers the instrument family that produced it. "
+            "This is distinct from the existing NSynth classification task, which "
+            "predicts instrument source (acoustic, electronic or synthetic) rather "
+            "than instrument family."
+        ),
+        reference="https://arxiv.org/abs/1704.01279",
+        dataset={
+            "path": "mteb/nsynth-mini",
+            "revision": "e32dfe9b65e121e64229a821fe1ff177e8962635",
+        },
+        type="AudioClustering",
+        category="a2a",
+        eval_splits=["test"],
+        eval_langs=["zxx-Zxxx"],
+        main_score="v_measure",
+        date=("2017-04-05", "2017-04-05"),
+        domains=["Music"],
+        task_subtypes=["Music Instrument Recognition"],
+        license="cc-by-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["audio"],
+        sample_creation="created",
+        adapted_from=["NSynth"],
+        bibtex_citation=r"""
+@misc{engel2017neuralaudiosynthesismusical,
+  archiveprefix = {arXiv},
+  author = {Jesse Engel and Cinjon Resnick and Adam Roberts and Sander Dieleman and Douglas Eck and Karen Simonyan and Mohammad Norouzi},
+  eprint = {1704.01279},
+  primaryclass = {cs.LG},
+  title = {Neural Audio Synthesis of Musical Notes with WaveNet Autoencoders},
+  url = {https://arxiv.org/abs/1704.01279},
+  year = {2017},
+}
+""",
+    )

--- a/tests/test_tasks/test_task_quality.py
+++ b/tests/test_tasks/test_task_quality.py
@@ -856,6 +856,7 @@ KNOWN_ISSUES: dict[str, list[str]] = {
         "Kinetics700VA",
         "Kinetics700VAZeroShot",
         "NSynth",  # repeated notes across instrument/pitch/velocity combinations
+        "NSynthInstrumentFamilyClustering",  # same upstream duplicate notes as NSynth
         "SpeechCommands",  # many repeated recordings of the same short command word
         "SpeechCommandsZeroshotv0.01",
         "SpeechCommandsZeroshotv0.02",


### PR DESCRIPTION
## Summary

This PR adds `NSynthInstrumentFamilyClustering`, an audio clustering task derived from the NSynth dataset.

The task evaluates whether audio embeddings naturally cluster by **instrument family** across 10 families in the NSynth test split.

This is distinct from the existing `NSynth` classification task, which predicts **instrument source** (acoustic, electronic, or synthetic) rather than instrument family.

## Task

- Type: `AudioClustering`
- Modality: audio
- Main score: `v_measure`
- Evaluation split: `test`
- Samples: 3,002
- Clusters: 10
- Labels: `instrument_family`
- Uses the standard MTEB clustering loader with no custom data transformation

The task embeds the full evaluation split (`max_fraction_of_documents_to_embed = None`) and uses the existing `mteb/nsynth-mini` dataset at a pinned revision.

## Validation

- Descriptive statistics generated and included
- Metadata and registry tests pass
- Clustering pipeline verified end-to-end
- The NSynth test split contains 2,970 unique audio contents among 3,002 rows; the byte-identical duplicates are present in the upstream dataset and are not introduced by this task

Related to #4997

