### PR TITLE
rank stability from a paired task bootstrap

### DIFF
--- a/docs/api/benchmark.md
+++ b/docs/api/benchmark.md
@@ -26,3 +26,31 @@ This metadata includes a short description of the benchmark's intention, the ref
 ## The Benchmark Object
 
 :::mteb.Benchmark
+
+
+## Rank stability
+
+A benchmark score is a mean over the tasks that happen to be in the suite, and a
+ranking built from it can move when that suite does. `bootstrap_rank_stability`
+resamples the tasks — one draw shared by every model, so comparisons stay paired
+— and reports which parts of the ordering survive.
+
+```python
+import mteb
+from mteb.benchmarks.rank_stability import bootstrap_rank_stability
+
+benchmark = mteb.get_benchmark("MTEB(eng, v2)")
+wide = benchmark.load_results().to_dataframe(format="wide")
+
+report = bootstrap_rank_stability(wide)
+report.summary.head()  # mean + interval, rank + rank interval
+report.distinguishable_pairs()  # the comparisons the benchmark actually supports
+```
+
+Read a comparison off `win_probability`, not off whether two intervals in
+`summary` overlap: the intervals are marginal, while the resample is paired, so
+overlapping intervals routinely hide a difference that holds on every resample.
+
+:::mteb.benchmarks.rank_stability.bootstrap_rank_stability
+
+:::mteb.benchmarks.rank_stability.RankStabilityReport

--- a/mteb/benchmarks/rank_stability.py
+++ b/mteb/benchmarks/rank_stability.py
@@ -1,0 +1,294 @@
+"""Uncertainty on a benchmark's aggregate score, and on the ranking built from it.
+
+A benchmark mean is an average over the tasks that happen to be in the suite. Two
+models a few thousandths apart on that mean can swap places when the suite gains
+or loses a handful of tasks, and the leaderboard gives a reader no way to see it.
+
+This module resamples the *tasks* — the unit the aggregate averages over — and
+reports what survives:
+
+- a percentile confidence interval on each model's mean;
+- the range of ranks a model occupies across resamples;
+- for every pair of models, how often one beats the other.
+
+The resample is **paired**: one draw of tasks is applied to every model, so the
+cross-model correlation that makes comparisons much sharper than the marginal
+intervals is preserved. Two models whose intervals overlap almost entirely can
+still be separated on every resample, which is why the pairwise matrix is the
+thing to read for a comparison, not the overlap of two intervals.
+
+What this measures is sensitivity of the aggregate to benchmark composition. It
+is not the sampling error of the individual task scores, which would need the
+per-task sample sizes and lives at the task level.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+__all__ = ["RankStabilityReport", "bootstrap_rank_stability"]
+
+_MIN_TASKS = 2
+
+
+@dataclass(frozen=True, slots=True)
+class RankStabilityReport:
+    """Result of [bootstrap_rank_stability][mteb.benchmarks.rank_stability.bootstrap_rank_stability].
+
+    Attributes:
+        summary: One row per model, sorted best first. Columns: `mean` (the
+            aggregate over the tasks used), `ci_low` / `ci_high` (percentile
+            interval on that mean — the spread of the aggregate under a
+            different draw of tasks; two models are *not* to be compared by
+            whether these overlap, `win_probability` is the number for that),
+            `rank` (1 = best, ties share the lower number), and `rank_ci_low` /
+            `rank_ci_high` (the interval of ranks the model occupies across
+            resamples).
+        win_probability: Square frame; entry `(i, j)` is the share of resamples
+            in which model `i` scores above model `j`, ties counted as a half.
+            The diagonal is 0.5 and the matrix sums to 1 with its transpose.
+        n_models: Models in the report.
+        n_tasks: Tasks the report was computed over.
+        n_boot: Resamples drawn.
+        confidence_level: Level of the reported intervals.
+        seed: Seed the resampler ran with; the report is reproducible from it.
+        dropped_models: Models excluded because they were missing at least one
+            task, under `on_missing="drop_models"`.
+        dropped_tasks: Tasks excluded — ones no model ran, plus the rest of the
+            incomplete ones under `on_missing="drop_tasks"`.
+
+    Both dropped lists are named rather than counted so a caller can see what
+    the pairing cost.
+    """
+
+    summary: pd.DataFrame
+    win_probability: pd.DataFrame
+    n_models: int
+    n_tasks: int
+    n_boot: int
+    confidence_level: float
+    seed: int
+    dropped_models: tuple[str, ...]
+    dropped_tasks: tuple[str, ...]
+
+    def distinguishable_pairs(
+        self, threshold: float = 0.95
+    ) -> list[tuple[str, str, float]]:
+        """Pairs one model wins at least `threshold` of the time.
+
+        Args:
+            threshold: Win share a pair must reach to be listed.
+
+        Returns:
+            `(winner, loser, win_probability)` tuples, most decisive first.
+            Anything absent from this list is a pair the benchmark does not
+            separate at this level, however far apart the two means look.
+        """
+        models = list(self.win_probability.index)
+        values = self.win_probability.to_numpy()
+        pairs = [
+            (models[i], models[j], float(values[i, j]))
+            for i in range(len(models))
+            for j in range(len(models))
+            if i != j and values[i, j] >= threshold
+        ]
+        return sorted(pairs, key=lambda pair: -pair[2])
+
+
+def _validate(
+    n_boot: int, confidence_level: float, n_models: int, n_tasks: int
+) -> None:
+    """Reject arguments that would produce a confident-looking empty measurement."""
+    if n_boot < 1:
+        raise ValueError(f"n_boot must be at least 1, got {n_boot}")
+    if not 0 < confidence_level < 1:
+        raise ValueError(
+            f"confidence_level must lie strictly between 0 and 1, got {confidence_level}"
+        )
+    if n_models < 1:
+        raise ValueError("the score frame contains no models")
+    if n_tasks < _MIN_TASKS:
+        raise ValueError(
+            f"rank stability needs at least 2 tasks to resample over, got {n_tasks}"
+        )
+
+
+def _bootstrap_means(scores: np.ndarray, n_boot: int, seed: int) -> np.ndarray:
+    """Paired task-bootstrap of the per-model mean.
+
+    Draws multinomial task counts once per resample and applies the same draw to
+    every model — equivalent to sampling task indices with replacement, but it
+    keeps the working set at `(n_models, n_boot)` instead of materialising an
+    `(n_models, n_boot, n_tasks)` index expansion.
+
+    Returns:
+        Array of shape `(n_models, n_boot)`.
+    """
+    n_tasks = scores.shape[1]
+    rng = np.random.default_rng(seed)
+    counts = rng.multinomial(n_tasks, np.full(n_tasks, 1 / n_tasks), size=n_boot)
+    return scores @ counts.T / n_tasks
+
+
+def _ranks_and_win_probabilities(
+    boot_means: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Per-resample ranks and pairwise win shares from the bootstrap means.
+
+    One model at a time rather than an `(n_models, n_models, n_boot)` tensor, so
+    peak memory stays at one `(n_models, n_boot)` comparison for a leaderboard
+    with hundreds of models.
+
+    Returns:
+        `(boot_ranks, win_probability)` of shapes `(n_models, n_boot)` and
+        `(n_models, n_models)`.
+    """
+    n_models, n_boot = boot_means.shape
+    boot_ranks = np.empty((n_models, n_boot), dtype=np.int64)
+    win_probability = np.empty((n_models, n_models), dtype=float)
+    for i in range(n_models):
+        above = boot_means > boot_means[i]
+        equal = boot_means == boot_means[i]
+        # min-rank convention: 1 + how many models scored strictly higher.
+        boot_ranks[i] = 1 + above.sum(axis=0)
+        # ties split, so P(i beats j) + P(j beats i) == 1 exactly.
+        win_probability[i] = (~above & ~equal).mean(axis=1) + 0.5 * equal.mean(axis=1)
+    return boot_ranks, win_probability
+
+
+def _summary_frame(
+    models: list[str],
+    values: np.ndarray,
+    boot_means: np.ndarray,
+    boot_ranks: np.ndarray,
+    alpha: float,
+) -> pd.DataFrame:
+    """Per-model means, intervals and rank intervals, best first.
+
+    Rank intervals take integer quantiles (`inverted_cdf`) because a rank
+    halfway between two places is not a place a model can be shown in.
+    """
+    quantiles = [alpha, 1 - alpha]
+    means = values.mean(axis=1)
+    ci_low, ci_high = np.quantile(boot_means, quantiles, axis=1)
+    rank_low, rank_high = np.quantile(
+        boot_ranks, quantiles, axis=1, method="inverted_cdf"
+    )
+    return pd.DataFrame(
+        {
+            "mean": means,
+            "ci_low": ci_low,
+            "ci_high": ci_high,
+            # min-rank, matching the per-resample ranks.
+            "rank": 1 + (means[:, None] < means[None, :]).sum(axis=1),
+            "rank_ci_low": rank_low.astype(np.int64),
+            "rank_ci_high": rank_high.astype(np.int64),
+        },
+        index=pd.Index(models, name="model_name"),
+    ).sort_values("mean", ascending=False, kind="stable")
+
+
+def _make_complete(
+    numeric: pd.DataFrame, on_missing: str
+) -> tuple[pd.DataFrame, tuple[str, ...], tuple[str, ...]]:
+    """Reduce to a rectangle every model ran, and say what that cost.
+
+    A paired resample needs one common task set, so something has to give when
+    a model is missing a task. `"drop_models"` follows the leaderboard, whose
+    `Mean (Task)` is null for a model with a missing task — such a model is not
+    ranked by the mean in the first place. `"drop_tasks"` keeps every model at
+    the price of shrinking the benchmark. Either way both lists come back named.
+    """
+    if on_missing not in {"drop_models", "drop_tasks"}:
+        raise ValueError(
+            f'on_missing must be "drop_models" or "drop_tasks", got {on_missing!r}'
+        )
+    # A task nobody ran carries no information under either policy.
+    complete = numeric.dropna(axis="columns", how="all")
+    if on_missing == "drop_models":
+        kept = complete.dropna(axis="index", how="any")
+        dropped_models = tuple(
+            str(model) for model in complete.index.difference(kept.index)
+        )
+    else:
+        kept = complete.dropna(axis="columns", how="any")
+        dropped_models = ()
+    dropped_tasks = tuple(
+        str(task) for task in numeric.columns.difference(kept.columns)
+    )
+    return kept, dropped_models, dropped_tasks
+
+
+def bootstrap_rank_stability(
+    scores: pd.DataFrame,
+    *,
+    n_boot: int = 1000,
+    confidence_level: float = 0.95,
+    seed: int = 0,
+    on_missing: str = "drop_models",
+) -> RankStabilityReport:
+    """Confidence intervals and rank stability for a benchmark's aggregate score.
+
+    Args:
+        scores: Wide frame of scores, one row per model and one column per task
+            — the shape
+            [BenchmarkResults.to_dataframe][mteb.results.benchmark_results.BenchmarkResults.to_dataframe]
+            returns with `format="wide"`.
+        n_boot: Resamples to draw. The default is enough for the intervals;
+            reading a win probability out at three decimals wants more.
+        confidence_level: Level for the reported intervals.
+        seed: Seed for the resampler. The report is reproducible from it.
+        on_missing: How to reach the common task set the pairing needs.
+            `"drop_models"` (default) keeps the benchmark whole and drops models
+            with a missing task, matching the leaderboard's own `Mean (Task)`,
+            which is null for exactly those models. `"drop_tasks"` keeps every
+            model and drops the incomplete tasks instead.
+
+    Returns:
+        RankStabilityReport: intervals on the means, the range of ranks each
+            model occupies, and the pairwise win probabilities.
+
+    Raises:
+        ValueError: If no models or fewer than two tasks survive the
+            completeness filter, or if `n_boot`, `confidence_level` or
+            `on_missing` are out of range.
+
+    Examples:
+        >>> import mteb
+        >>> from mteb.benchmarks.rank_stability import bootstrap_rank_stability
+        >>> benchmark = mteb.get_benchmark("MTEB(eng, v2)")  # doctest: +SKIP
+        >>> wide = benchmark.load_results().to_dataframe(format="wide")  # doctest: +SKIP
+        >>> report = bootstrap_rank_stability(wide)  # doctest: +SKIP
+        >>> report.summary.head()  # doctest: +SKIP
+        >>> report.distinguishable_pairs()  # doctest: +SKIP
+    """
+    if scores.empty:
+        raise ValueError("the score frame contains no models")
+
+    numeric = scores.apply(pd.to_numeric, errors="coerce")
+    complete, dropped_models, dropped_tasks = _make_complete(numeric, on_missing)
+
+    _validate(n_boot, confidence_level, len(complete.index), complete.shape[1])
+
+    models = [str(model) for model in complete.index]
+    values = complete.to_numpy(dtype=float)
+
+    boot_means = _bootstrap_means(values, n_boot, seed)
+    boot_ranks, win_probability = _ranks_and_win_probabilities(boot_means)
+
+    return RankStabilityReport(
+        summary=_summary_frame(
+            models, values, boot_means, boot_ranks, (1 - confidence_level) / 2
+        ),
+        win_probability=pd.DataFrame(win_probability, index=models, columns=models),
+        n_models=len(models),
+        n_tasks=complete.shape[1],
+        n_boot=n_boot,
+        confidence_level=confidence_level,
+        seed=seed,
+        dropped_models=dropped_models,
+        dropped_tasks=dropped_tasks,
+    )

--- a/tests/test_benchmarks/test_rank_stability.py
+++ b/tests/test_benchmarks/test_rank_stability.py
@@ -1,0 +1,274 @@
+"""Tests for the paired task-bootstrap rank-stability report."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mteb.benchmarks.rank_stability import bootstrap_rank_stability
+
+N_BOOT = 2000
+SEED = 12345
+
+
+def _frame(scores: dict[str, list[float]], n_tasks: int | None = None) -> pd.DataFrame:
+    """Wide frame in `BenchmarkResults.to_dataframe(format="wide")` shape."""
+    n = n_tasks if n_tasks is not None else len(next(iter(scores.values())))
+    return pd.DataFrame(scores, index=[f"Task{i}" for i in range(n)]).T
+
+
+def test_report_states_its_own_sample_sizes() -> None:
+    """A report that does not say what it measured over cannot be checked.
+
+    Guards against the failure mode where an empty or truncated input silently
+    produces a clean-looking report.
+    """
+    rng = np.random.default_rng(SEED)
+    df = _frame(
+        {
+            "model/a": list(rng.normal(0.5, 0.1, 40)),
+            "model/b": list(rng.normal(0.5, 0.1, 40)),
+        }
+    )
+    report = bootstrap_rank_stability(df, n_boot=N_BOOT, seed=SEED)
+
+    assert report.n_models == 2
+    assert report.n_tasks == 40
+    assert report.n_boot == N_BOOT
+    assert report.dropped_models == ()
+    assert report.dropped_tasks == ()
+    assert len(report.summary) == 2
+    assert report.win_probability.shape == (2, 2)
+
+
+def test_mean_ci_matches_the_analytic_interval() -> None:
+    """Known-value rung: the bootstrap CI must reproduce an interval derived
+    independently of the bootstrap.
+
+    For a mean over n independent tasks the 95% interval is
+    ``mean +/- 1.96 * sd / sqrt(n)``. That value is computed here from the
+    normal quantile and the sample sd, never from the resampler under test.
+    """
+    n_tasks = 2000
+    rng = np.random.default_rng(SEED)
+    scores = rng.normal(0.5, 0.1, n_tasks)
+    df = _frame({"model/a": list(scores)})
+
+    report = bootstrap_rank_stability(df, n_boot=N_BOOT, seed=SEED)
+    row = report.summary.iloc[0]
+
+    analytic_half_width = 1.959963984540054 * scores.std(ddof=1) / np.sqrt(n_tasks)
+    bootstrap_half_width = (row["ci_high"] - row["ci_low"]) / 2
+
+    assert row["mean"] == pytest.approx(scores.mean(), abs=1e-12)
+    assert bootstrap_half_width == pytest.approx(analytic_half_width, rel=0.10)
+
+
+def test_identical_models_are_reported_as_indistinguishable() -> None:
+    """Negative control: no difference in the input, no difference in the output.
+
+    Two models with the same score on every task must land at a win probability
+    of exactly 0.5 and share the whole rank range.
+    """
+    rng = np.random.default_rng(SEED)
+    shared = list(rng.normal(0.5, 0.15, 60))
+    df = _frame({"model/a": shared, "model/b": list(shared)})
+
+    report = bootstrap_rank_stability(df, n_boot=N_BOOT, seed=SEED)
+
+    assert report.win_probability.loc["model/a", "model/b"] == pytest.approx(0.5)
+    assert report.win_probability.loc["model/b", "model/a"] == pytest.approx(0.5)
+    assert report.distinguishable_pairs() == []
+    # Exact ties share the top rank under the min-rank convention; the signal
+    # that they are not separated lives in the pairwise probability above.
+    for model in ("model/a", "model/b"):
+        assert report.summary.loc[model, "rank"] == 1
+
+
+def test_uniform_offset_is_decisive_even_though_the_marginal_cis_overlap() -> None:
+    """The reason the pairwise matrix exists rather than eyeballing the CIs.
+
+    Model A beats model B on every single task by the same margin, so the paired
+    comparison is decisive. The two marginal intervals still overlap almost
+    entirely, because across-task spread dwarfs the offset. Reading
+    "overlapping CIs" as "tied" would be wrong here, and this test pins both
+    halves of that claim.
+    """
+    rng = np.random.default_rng(SEED)
+    base = rng.normal(0.5, 0.2, 100)
+    df = _frame({"model/a": list(base + 0.02), "model/b": list(base)})
+
+    report = bootstrap_rank_stability(df, n_boot=N_BOOT, seed=SEED)
+    a = report.summary.loc["model/a"]
+    b = report.summary.loc["model/b"]
+
+    # the marginal intervals overlap ...
+    assert a["ci_low"] < b["ci_high"]
+    assert b["ci_low"] < a["ci_high"]
+    # ... and the paired comparison is still unanimous.
+    assert report.win_probability.loc["model/a", "model/b"] == 1.0
+    assert report.distinguishable_pairs() == [("model/a", "model/b", 1.0)]
+    assert a["rank_ci_low"] == a["rank_ci_high"] == 1
+    assert b["rank_ci_low"] == b["rank_ci_high"] == 2
+
+
+def test_noise_only_difference_is_not_called_a_win() -> None:
+    """Second negative control: a difference drawn from noise must not clear
+    the distinguishability threshold."""
+    rng = np.random.default_rng(SEED)
+    df = _frame(
+        {
+            "model/a": list(rng.normal(0.5, 0.2, 80)),
+            "model/b": list(rng.normal(0.5, 0.2, 80)),
+        }
+    )
+
+    report = bootstrap_rank_stability(df, n_boot=N_BOOT, seed=SEED)
+
+    assert report.distinguishable_pairs(threshold=0.95) == []
+    # and the instability shows up in the ranks: both models reach both places
+    for model in ("model/a", "model/b"):
+        row = report.summary.loc[model]
+        assert row["rank_ci_low"] == 1
+        assert row["rank_ci_high"] == 2
+
+
+def test_interval_narrows_as_the_task_count_grows() -> None:
+    rng = np.random.default_rng(SEED)
+    widths = []
+    for n_tasks in (25, 100, 400):
+        df = _frame({"model/a": list(rng.normal(0.5, 0.1, n_tasks))})
+        row = bootstrap_rank_stability(df, n_boot=N_BOOT, seed=SEED).summary.iloc[0]
+        widths.append(row["ci_high"] - row["ci_low"])
+
+    assert widths[0] > widths[1] > widths[2]
+
+
+def test_same_seed_reproduces_the_report_and_a_different_seed_does_not() -> None:
+    rng = np.random.default_rng(SEED)
+    df = _frame(
+        {
+            "model/a": list(rng.normal(0.5, 0.1, 50)),
+            "model/b": list(rng.normal(0.5, 0.1, 50)),
+        }
+    )
+
+    first = bootstrap_rank_stability(df, n_boot=500, seed=1).summary
+    again = bootstrap_rank_stability(df, n_boot=500, seed=1).summary
+    other = bootstrap_rank_stability(df, n_boot=500, seed=2).summary
+
+    pd.testing.assert_frame_equal(first, again)
+    assert not np.allclose(first["ci_low"].to_numpy(), other["ci_low"].to_numpy())
+
+
+def test_win_probabilities_are_antisymmetric() -> None:
+    rng = np.random.default_rng(SEED)
+    df = _frame({f"model/{i}": list(rng.normal(0.5, 0.1, 40)) for i in range(4)})
+
+    win = bootstrap_rank_stability(df, n_boot=N_BOOT, seed=SEED).win_probability
+    values = win.to_numpy()
+
+    assert np.allclose(np.diag(values), 0.5)
+    assert np.allclose(values + values.T, 1.0)
+
+
+def test_models_with_a_missing_task_are_dropped_and_named() -> None:
+    """Default policy follows the leaderboard: a model missing a task has no
+    `Mean (Task)` there either, so it leaves rather than shrinking the suite."""
+    df = _frame(
+        {
+            "model/a": [0.1, 0.2, 0.3, 0.4],
+            "model/b": [0.2, 0.3, 0.4, 0.5],
+            "model/incomplete": [0.2, np.nan, 0.1, 0.5],
+        }
+    )
+
+    report = bootstrap_rank_stability(df, n_boot=200, seed=SEED)
+
+    assert report.dropped_models == ("model/incomplete",)
+    assert report.dropped_tasks == ()
+    assert report.n_models == 2
+    assert report.n_tasks == 4
+
+
+def test_drop_tasks_policy_keeps_every_model_and_names_the_cost() -> None:
+    df = _frame(
+        {
+            "model/a": [0.1, 0.2, 0.3, 0.4],
+            "model/b": [0.2, np.nan, 0.1, 0.5],
+        }
+    )
+
+    report = bootstrap_rank_stability(
+        df, n_boot=200, seed=SEED, on_missing="drop_tasks"
+    )
+
+    assert report.dropped_models == ()
+    assert report.dropped_tasks == ("Task1",)
+    assert report.n_models == 2
+    assert report.n_tasks == 3
+
+
+def test_a_task_no_model_ran_is_dropped_under_either_policy() -> None:
+    df = _frame(
+        {
+            "model/a": [0.1, np.nan, 0.3, 0.4],
+            "model/b": [0.2, np.nan, 0.1, 0.5],
+        }
+    )
+
+    for policy in ("drop_models", "drop_tasks"):
+        report = bootstrap_rank_stability(df, n_boot=200, seed=SEED, on_missing=policy)
+        assert report.dropped_tasks == ("Task1",)
+        assert report.n_models == 2
+        assert report.n_tasks == 3
+
+
+def test_unknown_missing_policy_raises() -> None:
+    df = _frame({"model/a": [0.1, 0.2, 0.3], "model/b": [0.2, 0.3, 0.4]})
+
+    with pytest.raises(ValueError, match="on_missing"):
+        bootstrap_rank_stability(df, n_boot=200, seed=SEED, on_missing="ignore")
+
+
+def test_ranks_follow_the_scores() -> None:
+    df = _frame(
+        {
+            "model/low": list(np.full(30, 0.10)),
+            "model/high": list(np.full(30, 0.90)),
+            "model/mid": list(np.full(30, 0.50)),
+        }
+    )
+
+    summary = bootstrap_rank_stability(df, n_boot=200, seed=SEED).summary
+
+    assert list(summary.index) == ["model/high", "model/mid", "model/low"]
+    assert list(summary["rank"]) == [1, 2, 3]
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"n_boot": 0}, "n_boot"),
+        ({"confidence_level": 1.0}, "confidence_level"),
+        ({"confidence_level": 0.0}, "confidence_level"),
+    ],
+)
+def test_invalid_arguments_raise(kwargs: dict, match: str) -> None:
+    df = _frame({"model/a": [0.1, 0.2, 0.3], "model/b": [0.2, 0.3, 0.4]})
+
+    with pytest.raises(ValueError, match=match):
+        bootstrap_rank_stability(df, seed=SEED, **kwargs)
+
+
+def test_too_few_tasks_raises_rather_than_reporting_a_zero_width_interval() -> None:
+    df = _frame({"model/a": [0.1], "model/b": [0.2]})
+
+    with pytest.raises(ValueError, match="at least 2 tasks"):
+        bootstrap_rank_stability(df, n_boot=200, seed=SEED)
+
+
+def test_empty_input_raises() -> None:
+    with pytest.raises(ValueError, match="no models"):
+        bootstrap_rank_stability(pd.DataFrame(), n_boot=200, seed=SEED)


### PR DESCRIPTION
## What

The leaderboard ranks models by `Mean (Task)` — an average over the tasks that happen to be in the benchmark — and the table gives a reader no way to tell which parts of that ordering would survive a different draw of tasks.

This adds `bootstrap_rank_stability`, which resamples the tasks and reports what holds:

```python
import mteb
from mteb.benchmarks.rank_stability import bootstrap_rank_stability

benchmark = mteb.get_benchmark("MTEB(eng, v2)")
wide = benchmark.load_results().to_dataframe(format="wide")

report = bootstrap_rank_stability(wide)
report.summary                 # mean, interval, rank, rank interval
report.win_probability         # P(model i beats model j)
report.distinguishable_pairs() # the comparisons the benchmark supports
```

Nothing in the leaderboard changes. This is a function you can call on results you already have.

## What it says about MTEB(eng, v2)

Run over the 41 tasks and the 181 models with a complete run, taken from your own API (`/v1/benchmarks/MTEB(eng, v2)/scores`, fetched 2026-08-09), 10 000 resamples:

| | |
|---|---:|
| model pairs total | 16 290 |
| separated at 95% | **14 281 (87.7%)** |
| not separated | 2 009 |
| adjacent-rank pairs not separated | **175 / 180** |
| of the ten adjacent pairs at the top | **10 / 10** |

The benchmark is doing its job for most of the field — seven pairs in eight are decided. The undecided ones are concentrated exactly where people read the table:

```
                                         mean  ci_low  ci_high  rank  rank_ci_low  rank_ci_high
jcorners/ingot-8b-r3                   0.7598  0.6985   0.8173     1            1             4
Kingsoft-LLM/QZhou-Embedding           0.7597  0.6981   0.8167     2            1             6
Qwen/Qwen3-Embedding-8B                0.7523  0.6922   0.8087     3            2             7
ByteDance-Seed/Seed1.5-Embedding       0.7476  0.6877   0.8029     4            2             8
infgrad/Jasper-Token-Compression-600M  0.7475  0.6847   0.8064     5            3             9
Qwen/Qwen3-Embedding-4B                0.7461  0.6852   0.8034     6            3            12
```

The two top models are 0.00008 apart, and 1 beats 2 in 49.1% of resamples — the displayed order between them is a coin flip. Across all 181 models the median rank interval spans 18 places, and 140 of them span ten or more.

I want to be careful about what that does and does not mean. It is not "the leaderboard is wrong". It is that a rank is a statistic with a spread, the spread is currently invisible, and readers treat rank 3 and rank 7 as a difference when for this suite they often are not.

## Why the resample is paired

One draw of tasks is applied to every model, not an independent draw per model. That preserves the correlation across models — every model finds ArguAna hard — and it is the whole reason the comparison is sharper than the marginal intervals suggest.

The consequence is worth stating plainly, because it is the easy thing to get wrong when reading the output: **two overlapping intervals in `summary` do not mean two models are tied.** In this very run, 1 and 21 have intervals overlapping over 64% of their width, and 1 still wins 100.0% of resamples. The interval answers "how much does this model's aggregate depend on which tasks are in the suite"; the pairwise matrix answers "is this model better than that one". They are different questions and the docstrings say so. There is a test pinning both halves of that claim (`test_uniform_offset_is_decisive_even_though_the_marginal_cis_overlap`).

## Changes

- `mteb/benchmarks/rank_stability.py` (new): `bootstrap_rank_stability()` and the `RankStabilityReport` it returns. numpy and pandas only — no new dependency, no scipy. Deterministic given `seed`.
- `tests/test_benchmarks/test_rank_stability.py` (new): 18 tests.
- `docs/api/benchmark.md`: a section under Benchmark with the snippet above.

Implementation notes for review:

- The resample draws multinomial task counts and multiplies, rather than materialising an `(n_models, n_boot, n_tasks)` index expansion. For 181 models × 10 000 resamples the working set is one `(181, 10 000)` array; the whole run above takes a few seconds.
- Ranks use the min convention, matching `Rank (Borda)` in `_create_table.py`. Rank intervals take integer quantiles — a rank halfway between two places is not a place a model can be shown in.
- A paired resample needs one common task set. `on_missing="drop_models"` (default) follows the leaderboard, whose `Mean (Task)` is already null for a model with a missing task; `on_missing="drop_tasks"` keeps every model instead. Either way both dropped lists come back named, not counted.
- The report ranks by the mean. `Rank (Borda)` could be resampled the same way and I would be glad to add it — see below.

## Testing

18 tests pass. Rather than list them, the thing I would want to know as a reviewer is whether they can fail, so I ran the suite against five deliberately broken versions of the implementation:

| mutation | caught by |
|---|---|
| independent draw per model instead of one shared draw | the overlap test + the identical-models control |
| interval computed at the wrong tail (`alpha` not halved) | the analytic-value test |
| ties not split in the win probability | antisymmetry + the identical-models control |
| missing scores filled with 0 instead of dropped | the missing-data test |
| point rank ignoring ties | the identical-models control |

Each mutation fails the tests it should and no others. Two tests carry most of that weight:

- **an analytic rung** — for a mean over n independent tasks the 95% interval is `mean ± 1.96·sd/√n`, computed in the test from the normal quantile and the sample sd, never from the resampler under test. The bootstrap half-width matches it within 10% at n=2000.
- **a negative control** — two models with identical score vectors must come out at exactly 0.5, and `distinguishable_pairs()` must be empty. A resampler with broken pairing fails this immediately.

`ruff check` and `ruff format --check` are clean on the three files.

One honest limitation on my end: I could not get your full suite running locally (Python 3.14, and the torch/datasets stack does not install cleanly here), so the new tests were exercised in isolation against the module. They import only numpy, pandas and the new module, so they should be unremarkable in CI, but I have not watched them run there.

The leaderboard figures above were computed from your API's own `scoresByTask`, and separately reproduced from the `embeddings-benchmark/results` repository by re-deriving each task score from the raw JSON — the two agree to 1.1e-16 across 7 239 model×task cells, and the recomputed means match the API's `meanTask` exactly. Happy to attach that script if it is useful.

## Follow-ups I would be glad to do, in this PR or after

1. **`Rank (Borda)` stability.** The same resample applies; Borda is arguably the more interesting one since it is the default sort.
2. **A leaderboard surface.** A "±" on `Mean (Task)`, or shading the rank column where the pairwise probability against the neighbour is below a threshold. I left this out deliberately: what a reader should see is a product decision and yours to make, not something to smuggle in with the statistics.
3. **Per-task sampling error.** This PR measures sensitivity to benchmark composition. The other uncertainty — the sampling error within each task, from its number of examples — is a separate quantity and would compose with this one.

Related to #4368 only in spirit (both are "the table should say more about what it is showing"); no overlap in code.
