### PR TITLE
task: add ADVANCE audio-image retrieval (a2i, i2a)

### DIFF
--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/ADVANCEA2IRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/ADVANCEA2IRetrieval.json
@@ -1,0 +1,42 @@
+{
+    "test": {
+        "num_samples": 10150,
+        "num_queries": 5075,
+        "num_documents": 5075,
+        "number_of_characters": 0,
+        "documents_text_statistics": null,
+        "documents_image_statistics": {
+            "min_image_width": 512,
+            "average_image_width": 512.0,
+            "max_image_width": 512,
+            "min_image_height": 512,
+            "average_image_height": 512.0,
+            "max_image_height": 512,
+            "unique_images": 5075
+        },
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": null,
+        "queries_audio_statistics": {
+            "total_duration_seconds": 50750.0,
+            "min_duration_seconds": 10.0,
+            "average_duration_seconds": 10.0,
+            "max_duration_seconds": 10.0,
+            "unique_audios": 5075,
+            "average_sampling_rate": 22050.0,
+            "sampling_rates": {
+                "22050": 5075
+            }
+        },
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 5075,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 5075
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/ADVANCEI2ARetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/ADVANCEI2ARetrieval.json
@@ -1,0 +1,42 @@
+{
+    "test": {
+        "num_samples": 10150,
+        "num_queries": 5075,
+        "num_documents": 5075,
+        "number_of_characters": 0,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": {
+            "total_duration_seconds": 50750.0,
+            "min_duration_seconds": 10.0,
+            "average_duration_seconds": 10.0,
+            "max_duration_seconds": 10.0,
+            "unique_audios": 5075,
+            "average_sampling_rate": 22050.0,
+            "sampling_rates": {
+                "22050": 5075
+            }
+        },
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": {
+            "min_image_width": 512,
+            "average_image_width": 512.0,
+            "max_image_width": 512,
+            "min_image_height": 512,
+            "average_image_height": 512.0,
+            "max_image_height": 512,
+            "unique_images": 5075
+        },
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 5075,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 5075
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -2,6 +2,7 @@ from .activitynet_captions_retrieval import (
     ActivityNetCaptionsT2VRetrieval,
     ActivityNetCaptionsV2TRetrieval,
 )
+from .advance import ADVANCEA2IRetrieval, ADVANCEI2ARetrieval
 from .aila_casedocs_retrieval import AILACasedocs
 from .aila_statutes_retrieval import AILAStatutes
 from .alpha_nli_retrieval import AlphaNLI
@@ -415,6 +416,8 @@ __all__ = [
     "TRECCOVID",
     "TRECDL2019",
     "TRECDL2020",
+    "ADVANCEA2IRetrieval",
+    "ADVANCEI2ARetrieval",
     "AILACasedocs",
     "AILAStatutes",
     "ARCChallenge",

--- a/mteb/tasks/retrieval/eng/advance.py
+++ b/mteb/tasks/retrieval/eng/advance.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.task_metadata import TaskMetadata
+
+_REFERENCE = "https://arxiv.org/abs/2005.08449"
+_BIBTEX = r"""
+@inproceedings{hu2020cross,
+  author = {Hu, Di and Li, Xuhong and Mou, Lichao and Jin, Pu and Chen, Dong and Jing, Liping and Zhu, Xiaoxiang and Dou, Dejing},
+  booktitle = {European Conference on Computer Vision},
+  organization = {Springer},
+  pages = {68--84},
+  title = {Cross-task transfer for geotagged audiovisual aerial scene recognition},
+  year = {2020},
+}
+"""
+_DESCRIPTION = (
+    "ADVANCE pairs geotagged field recordings sourced from FreeSound with "
+    "co-located 512x512 aerial imagery extracted from Google Earth; every "
+    "location contributes exactly one image and one recording, giving "
+    "instance-level cross-modal ground truth across 5,075 locations spanning "
+    "13 land-cover scene categories. Note: at original resolution this "
+    "dataset is ~6.7GB. "
+)
+
+
+class ADVANCEA2IRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="ADVANCEA2IRetrieval",
+        description=_DESCRIPTION
+        + "Queries are field recordings and the corpus contains the aerial "
+        "images; the goal is to retrieve the image of the location where "
+        "the recording was made.",
+        reference=_REFERENCE,
+        dataset={
+            "path": "yaswanth169/ADVANCE-A2I",
+            "revision": "38ef2712ff91da1b9c63c14c373a88006dfc1e4f",
+        },
+        type="Any2AnyRetrieval",
+        category="a2i",
+        modalities=["audio", "image"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2020-01-01", "2020-08-23"),
+        domains=["AudioScene", "Scene"],
+        task_subtypes=["Cross-Modal Retrieval"],
+        license="cc-by-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        is_beta=True,
+        bibtex_citation=_BIBTEX,
+        prompt={
+            "query": "Retrieve the aerial image of the location where this field recording was made."
+        },
+    )
+
+
+class ADVANCEI2ARetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="ADVANCEI2ARetrieval",
+        description=_DESCRIPTION
+        + "Queries are aerial images and the corpus contains the field "
+        "recordings; the goal is to retrieve the recording made at the "
+        "depicted location.",
+        reference=_REFERENCE,
+        dataset={
+            "path": "yaswanth169/ADVANCE-I2A",
+            "revision": "487e3c58d14bc659a5d5a32b6f3eeaf75841f9aa",
+        },
+        type="Any2AnyRetrieval",
+        category="i2a",
+        modalities=["image", "audio"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2020-01-01", "2020-08-23"),
+        domains=["AudioScene", "Scene"],
+        task_subtypes=["Cross-Modal Retrieval"],
+        license="cc-by-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        is_beta=True,
+        bibtex_citation=_BIBTEX,
+        prompt={
+            "query": "Retrieve the field recording made at the location shown in this aerial image."
+        },
+    )

--- a/scripts/build_advance_datasets.py
+++ b/scripts/build_advance_datasets.py
@@ -1,0 +1,44 @@
+"""Construction script for ADVANCE-A2I and ADVANCE-I2A.
+
+Reshapes blanchon/ADVANCE (5,075 rows of image/audio/label pairs) into
+BEIR-style corpus/queries/qrels layout, one push per retrieval direction.
+Each location contributes exactly one image and one audio recording, so
+`id` gives clean 1:1 instance-level ground truth for qrels.
+"""
+
+from datasets import Dataset, DatasetDict, load_dataset
+
+ds = load_dataset("blanchon/ADVANCE", split="train")
+n = len(ds)
+ids = [f"loc{i}" for i in range(n)]
+ds = ds.add_column("id", ids)
+
+# A2I: query = audio, corpus = image
+a2i_queries = ds.select_columns(["id", "audio"])
+a2i_corpus = ds.select_columns(["id", "image"])
+a2i_qrels = Dataset.from_dict({"query-id": ids, "corpus-id": ids, "score": [1] * n})
+
+DatasetDict({"test": a2i_queries}).push_to_hub(
+    "yaswanth169/ADVANCE-A2I", config_name="queries"
+)
+DatasetDict({"test": a2i_corpus}).push_to_hub(
+    "yaswanth169/ADVANCE-A2I", config_name="corpus"
+)
+DatasetDict({"test": a2i_qrels}).push_to_hub(
+    "yaswanth169/ADVANCE-A2I", config_name="qrels"
+)
+
+# I2A: query = image, corpus = audio (mirror of the above)
+i2a_queries = ds.select_columns(["id", "image"])
+i2a_corpus = ds.select_columns(["id", "audio"])
+i2a_qrels = Dataset.from_dict({"query-id": ids, "corpus-id": ids, "score": [1] * n})
+
+DatasetDict({"test": i2a_queries}).push_to_hub(
+    "yaswanth169/ADVANCE-I2A", config_name="queries"
+)
+DatasetDict({"test": i2a_corpus}).push_to_hub(
+    "yaswanth169/ADVANCE-I2A", config_name="corpus"
+)
+DatasetDict({"test": i2a_qrels}).push_to_hub(
+    "yaswanth169/ADVANCE-I2A", config_name="qrels"
+)


### PR DESCRIPTION
- [x] I have outlined why this dataset is filling an existing gap in mteb
- [x] I have tested that the dataset runs with the mteb package.
- [x] I have run the following models on the task (adding the results to the pr). These can be run using the mteb run -m {model_name} -t {task_name} command.
  - [x] mteb/baseline-random-encoder
  - [x] jinaai/jina-embeddings-v5-omni-nano (990M params — closest available small/mid-size audio+image model in the mteb zoo; intfloat/multilingual-e5-small is text-only and doesn't apply to this audio↔image task)
- [x] I have checked that the performance is neither trivial (close to perfect scores) nor random.
- [ ] I have considered the size of the dataset and reduced it if it is too big — kept at original resolution (~6.7GB), deliberately not downsampled; flagging for maintainer input rather than assuming this is fine.
- [x] I reproduced scores from the original paper (if applicable) — not applicable; the original ADVANCE paper reports classification accuracy, not retrieval metrics, so there's no directly comparable number to reproduce.
