### PR TITLE
model: add facebook/SONAR text+speech wrapper

### DIFF
--- a/mteb/models/model_implementations/sonar_models.py
+++ b/mteb/models/model_implementations/sonar_models.py
@@ -1,4 +1,138 @@
+from __future__ import annotations
+
+import tempfile
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import torch
+from tqdm.auto import tqdm
+
+from mteb.models.abs_encoder import AbsEncoder
 from mteb.models.model_meta import ModelMeta, ScoringFunction
+from mteb.types import PromptType
+
+if TYPE_CHECKING:
+    from torch.utils.data import DataLoader
+
+    from mteb import TaskMetadata
+    from mteb.types import Array, BatchedInput
+
+
+class SONARWrapper(AbsEncoder):
+    """MTEB wrapper for Meta's SONAR text + speech embedding model.
+
+    Loads the text pipeline eagerly and the speech pipeline lazily (only if
+    a task actually passes audio), since the speech encoder is a separate
+    checkpoint download that text-only tasks don't need.
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        revision: str | None = None,
+        device: str | None = None,
+        text_encoder: str = "text_sonar_basic_encoder",
+        speech_encoder: str = "sonar_speech_encoder_eng",
+        **kwargs: Any,
+    ) -> None:
+        from sonar.inference_pipelines.text import TextToEmbeddingModelPipeline
+
+        self.device = device or (
+            "cuda"
+            if torch.cuda.is_available()
+            else "mps"
+            if torch.backends.mps.is_available()
+            else "cpu"
+        )
+        self.speech_encoder = speech_encoder
+        self._speech_model = None
+
+        self.text_model = TextToEmbeddingModelPipeline(
+            encoder=text_encoder,
+            tokenizer=text_encoder,
+            device=torch.device(self.device),
+        )
+
+    @property
+    def speech_model(self):
+        if self._speech_model is None:
+            from sonar.inference_pipelines.speech import (
+                SpeechToEmbeddingModelPipeline,
+            )
+
+            self._speech_model = SpeechToEmbeddingModelPipeline(
+                encoder=self.speech_encoder,
+                device=torch.device(self.device),
+            )
+        return self._speech_model
+
+    @staticmethod
+    def _to_sonar_lang(hf_subset: str | None, prompt_type: PromptType | None) -> str:
+        """Resolve the SONAR-format language code ('eng_Latn') for this batch.
+
+        Bitext-mining hf_subset names are 'srcLang_Script-tgtLang_Script'
+        (e.g. 'eng_Latn-fra_Latn'); queries use the source side, documents
+        use the target side. Monolingual tasks/subsets fall back to the
+        single code present, or English if nothing is resolvable.
+        """
+        if not hf_subset or hf_subset == "default":
+            return "eng_Latn"
+        parts = hf_subset.split("-")
+        # Each side is itself 'lang_Script', i.e. two underscore-joined
+        # tokens; a full bitext subset is four tokens total.
+        if len(parts) == 2 and all(p.count("_") == 1 for p in parts):
+            return parts[1] if prompt_type == PromptType.document else parts[0]
+        return parts[0]
+
+    def _encode_audio_batch(self, audio_items: list) -> torch.Tensor:
+        import soundfile as sf
+
+        embeddings = []
+        for item in audio_items:
+            array = np.asarray(item["array"])
+            sr = item["sampling_rate"]
+            with tempfile.NamedTemporaryFile(suffix=".wav", delete=True) as tmp:
+                sf.write(tmp.name, array, sr)
+                emb = self.speech_model.predict([tmp.name])
+            embeddings.append(emb[0])
+        return torch.stack(embeddings)
+
+    @torch.inference_mode()
+    def encode(
+        self,
+        inputs: DataLoader[BatchedInput],
+        *,
+        task_metadata: TaskMetadata,
+        hf_split: str,
+        hf_subset: str,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
+    ) -> Array:
+        has_text = "text" in inputs.dataset.features
+        has_audio = "audio" in inputs.dataset.features
+        source_lang = self._to_sonar_lang(hf_subset, prompt_type)
+
+        all_embeddings: list[torch.Tensor] = []
+        for batch in tqdm(inputs, desc="Encoding"):
+            embs: list[torch.Tensor] = []
+            if has_text and batch.get("text"):
+                text_emb = self.text_model.predict(
+                    batch["text"], source_lang=source_lang
+                )
+                embs.append(text_emb)
+            if has_audio and batch.get("audio"):
+                audio_emb = self._encode_audio_batch(batch["audio"])
+                embs.append(audio_emb)
+
+            if not embs:
+                raise ValueError(
+                    f"No supported modality found in batch: {list(batch.keys())}"
+                )
+            batch_emb = embs[0] if len(embs) == 1 else sum(embs[1:], embs[0])
+            all_embeddings.append(batch_emb.cpu())
+
+        return torch.cat(all_embeddings, dim=0).float().numpy()
+
 
 SONAR_CITATION = """@misc{Duquenne:2023:sonar_arxiv,
   author = {Paul-Ambroise Duquenne and Holger Schwenk and Benoit Sagot},
@@ -216,7 +350,7 @@ sonar_langs = [
 ]
 
 sonar = ModelMeta(
-    loader=None,
+    loader=SONARWrapper,
     name="facebook/SONAR",
     model_type=["dense"],
     languages=sonar_langs,
@@ -228,10 +362,11 @@ sonar = ModelMeta(
     n_embedding_parameters=None,  # it is really multiple models so not sure how to calculate this
     max_tokens=512,  # https://github.com/facebookresearch/SONAR/blob/549d287466443bd8720f938047882630c1c5c3f7/sonar/models/sonar_text/builder.py#L139
     embed_dim=1024,
-    license="mit",
+    license="cc-by-nc-4.0",
     memory_usage_mb=None,
     similarity_fn_name=ScoringFunction.COSINE,
     framework=["PyTorch"],
+    modalities=["text", "audio"],
     reference="https://ai.meta.com/research/publications/sonar-sentence-level-multimodal-and-language-agnostic-representations/",
     training_datasets=set(
         # "FloresBitextMining", # I believe it only used for evaluation
@@ -240,4 +375,5 @@ sonar = ModelMeta(
     public_training_code="https://github.com/facebookresearch/SONAR",
     public_training_data=None,  # couldn't find this
     citation=SONAR_CITATION,
+    extra_requirements_groups=["sonar"],
 )

--- a/mteb/models/model_implementations/sonar_models.py
+++ b/mteb/models/model_implementations/sonar_models.py
@@ -61,21 +61,31 @@ class SONARWrapper(AbsEncoder):
         """Resolve the SONAR-format language code ('eng_Latn') for this batch.
 
         Uses the task's own eval_langs rather than parsing hf_subset, since
-        subset names have no guaranteed format. For bitext subsets this list
-        has two entries (source, target); queries use the source side,
-        documents use the target side. eval_langs uses BCP47 ('eng-Latn'),
-        SONAR wants underscore-joined FLORES-200-style codes ('eng_Latn').
+        subset names have no guaranteed format. eval_langs uses BCP47
+        ('eng-Latn'), SONAR wants underscore-joined FLORES-200-style codes
+        ('eng_Latn').
 
-        Tasks with `parallel_subsets=True` (e.g. FLORES) instead pass a
-        single already-resolved language code as hf_subset -- one per
-        dataset column, not a key into eval_langs -- so it's used as-is.
+        Tasks with `parallel_subsets=True` (e.g. FLORES, the task SONAR is
+        reproduced against) pass a single already-resolved language code as
+        hf_subset directly -- one per dataset column, not a key into
+        eval_langs -- so that case is unambiguous and used as-is.
+
+        For a subset whose eval_langs entry has two languages (a bitext
+        pair), there is *no* framework-enforced ordering: FLORES/BUCC name
+        the subset to match [source, target], but DiaBLa defines the same
+        pair both ways ("fr-en": [fra, eng] and "en-fr": [eng, fra]), and
+        mteb's BitextMiningEvaluator calls encode() once per dataset column
+        with the *same* hf_subset and no prompt_type for either column, so
+        there's no signal here to tell which physical column is being
+        encoded. langs[0]/langs[-1] by prompt_type is therefore a
+        best-effort heuristic (right whenever the subset name matches the
+        list order, which held for every case checked), not a guarantee --
+        a genuinely reliable fix needs mteb's evaluator to pass which
+        column/side is being encoded, which it currently doesn't.
         """
         langscripts = task_metadata.hf_subsets_to_langscripts
         if hf_subset in langscripts:
             langs = langscripts[hf_subset]
-            # Position-based, not name-based: bitext eval_langs lists are
-            # always [source, target] by convention, so index 0/-1 holds
-            # regardless of how the subset itself happens to be named.
             lang = langs[-1] if prompt_type == PromptType.document else langs[0]
         else:
             lang = hf_subset or "eng_Latn"

--- a/mteb/models/model_implementations/sonar_models.py
+++ b/mteb/models/model_implementations/sonar_models.py
@@ -19,12 +19,7 @@ if TYPE_CHECKING:
 
 
 class SONARWrapper(AbsEncoder):
-    """MTEB wrapper for Meta's SONAR text + speech embedding model.
-
-    Loads the text pipeline eagerly and the speech pipeline lazily (only if
-    a task actually passes audio), since the speech encoder is a separate
-    checkpoint download that text-only tasks don't need.
-    """
+    """MTEB wrapper for Meta's SONAR text + speech embedding model."""
 
     def __init__(
         self,
@@ -35,6 +30,7 @@ class SONARWrapper(AbsEncoder):
         speech_encoder: str = "sonar_speech_encoder_eng",
         **kwargs: Any,
     ) -> None:
+        from sonar.inference_pipelines.speech import SpeechToEmbeddingModelPipeline
         from sonar.inference_pipelines.text import TextToEmbeddingModelPipeline
 
         self.device = device or (
@@ -44,45 +40,42 @@ class SONARWrapper(AbsEncoder):
             if torch.backends.mps.is_available()
             else "cpu"
         )
-        self.speech_encoder = speech_encoder
-        self._speech_model = None
 
         self.text_model = TextToEmbeddingModelPipeline(
             encoder=text_encoder,
             tokenizer=text_encoder,
             device=torch.device(self.device),
         )
-
-    @property
-    def speech_model(self):
-        if self._speech_model is None:
-            from sonar.inference_pipelines.speech import (
-                SpeechToEmbeddingModelPipeline,
-            )
-
-            self._speech_model = SpeechToEmbeddingModelPipeline(
-                encoder=self.speech_encoder,
-                device=torch.device(self.device),
-            )
-        return self._speech_model
+        self.speech_model = SpeechToEmbeddingModelPipeline(
+            encoder=speech_encoder,
+            device=torch.device(self.device),
+        )
 
     @staticmethod
-    def _to_sonar_lang(hf_subset: str | None, prompt_type: PromptType | None) -> str:
+    def _to_sonar_lang(
+        task_metadata: TaskMetadata,
+        hf_subset: str | None,
+        prompt_type: PromptType | None,
+    ) -> str:
         """Resolve the SONAR-format language code ('eng_Latn') for this batch.
 
-        Bitext-mining hf_subset names are 'srcLang_Script-tgtLang_Script'
-        (e.g. 'eng_Latn-fra_Latn'); queries use the source side, documents
-        use the target side. Monolingual tasks/subsets fall back to the
-        single code present, or English if nothing is resolvable.
+        Uses the task's own eval_langs rather than parsing hf_subset, since
+        subset names have no guaranteed format. For bitext subsets this list
+        has two entries (source, target); queries use the source side,
+        documents use the target side. eval_langs uses BCP47 ('eng-Latn'),
+        SONAR wants underscore-joined FLORES-200-style codes ('eng_Latn').
+
+        Tasks with `parallel_subsets=True` (e.g. FLORES) instead pass a
+        single already-resolved language code as hf_subset -- one per
+        dataset column, not a key into eval_langs -- so it's used as-is.
         """
-        if not hf_subset or hf_subset == "default":
-            return "eng_Latn"
-        parts = hf_subset.split("-")
-        # Each side is itself 'lang_Script', i.e. two underscore-joined
-        # tokens; a full bitext subset is four tokens total.
-        if len(parts) == 2 and all(p.count("_") == 1 for p in parts):
-            return parts[1] if prompt_type == PromptType.document else parts[0]
-        return parts[0]
+        langscripts = task_metadata.hf_subsets_to_langscripts
+        if hf_subset in langscripts:
+            langs = langscripts[hf_subset]
+            lang = langs[-1] if prompt_type == PromptType.document else langs[0]
+        else:
+            lang = hf_subset or "eng_Latn"
+        return lang.replace("-", "_")
 
     def _encode_audio_batch(self, audio_items: list) -> torch.Tensor:
         import soundfile as sf
@@ -110,7 +103,7 @@ class SONARWrapper(AbsEncoder):
     ) -> Array:
         has_text = "text" in inputs.dataset.features
         has_audio = "audio" in inputs.dataset.features
-        source_lang = self._to_sonar_lang(hf_subset, prompt_type)
+        source_lang = self._to_sonar_lang(task_metadata, hf_subset, prompt_type)
 
         all_embeddings: list[torch.Tensor] = []
         for batch in tqdm(inputs, desc="Encoding"):

--- a/mteb/models/model_implementations/sonar_models.py
+++ b/mteb/models/model_implementations/sonar_models.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
-import tempfile
 from typing import TYPE_CHECKING, Any
 
-import numpy as np
 import torch
 from tqdm.auto import tqdm
 
 from mteb.models.abs_encoder import AbsEncoder
+from mteb.models.modality_collators import AudioCollator
 from mteb.models.model_meta import ModelMeta, ScoringFunction
 from mteb.types import PromptType
+
+_SONAR_SPEECH_SAMPLING_RATE = 16_000
 
 if TYPE_CHECKING:
     from torch.utils.data import DataLoader
@@ -72,23 +73,30 @@ class SONARWrapper(AbsEncoder):
         langscripts = task_metadata.hf_subsets_to_langscripts
         if hf_subset in langscripts:
             langs = langscripts[hf_subset]
+            # Position-based, not name-based: bitext eval_langs lists are
+            # always [source, target] by convention, so index 0/-1 holds
+            # regardless of how the subset itself happens to be named.
             lang = langs[-1] if prompt_type == PromptType.document else langs[0]
         else:
             lang = hf_subset or "eng_Latn"
         return lang.replace("-", "_")
 
     def _encode_audio_batch(self, audio_items: list) -> torch.Tensor:
-        import soundfile as sf
+        """Encode a batch of audio in a single SONAR call.
 
-        embeddings = []
-        for item in audio_items:
-            array = np.asarray(item["array"])
-            sr = item["sampling_rate"]
-            with tempfile.NamedTemporaryFile(suffix=".wav", delete=True) as tmp:
-                sf.write(tmp.name, array, sr)
-                emb = self.speech_model.predict([tmp.name])
-            embeddings.append(emb[0])
-        return torch.stack(embeddings)
+        SONAR's speech pipeline accepts raw waveform tensors directly (in
+        addition to file paths) and batches them internally, so there's no
+        need to round-trip through temp WAV files one item at a time. Its
+        tensor path assumes a fixed 16kHz input and a (channels, samples)
+        shape (github.com/facebookresearch/SONAR speech.py's _decode_audio),
+        so items are resampled to 16kHz via AudioCollator upstream and
+        reshaped to add the channel dimension here.
+        """
+        waveforms = [
+            torch.as_tensor(item["array"], dtype=torch.float32).unsqueeze(0)
+            for item in audio_items
+        ]
+        return self.speech_model.predict(waveforms, batch_size=len(waveforms))
 
     @torch.inference_mode()
     def encode(
@@ -104,6 +112,10 @@ class SONARWrapper(AbsEncoder):
         has_text = "text" in inputs.dataset.features
         has_audio = "audio" in inputs.dataset.features
         source_lang = self._to_sonar_lang(task_metadata, hf_subset, prompt_type)
+        if has_audio:
+            inputs.collate_fn = AudioCollator(
+                target_sampling_rate=_SONAR_SPEECH_SAMPLING_RATE
+            )
 
         all_embeddings: list[torch.Tensor] = []
         for batch in tqdm(inputs, desc="Encoding"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,7 +165,7 @@ uembed = ["transformers>=5.4.0,<6.0.0"]
 # omnivinci = ["transformers==4.46.0", "torch==2.8.*", "einops>=0.8.0", "openai-whisper>=20240930", "soundfile>=0.13.1", "opencv-python-headless>=4.0.0", "kaldiio>=2.18.0", "decord>=0.6.0", "librosa>=0.10.0", "beartype>=0.18.0", "accelerate>=1.0.0", "s2wrapper @ git+https://github.com/bfshi/scaling_on_scales", "deepspeed>=0.9.0", "torchvision>=0.15.0", "torchaudio>=2.0.0", "torchcodec==0.7.0", "av>=10.0.0", "numpy>=1.23.0,<2.0.0", "flash-attn>=2.6.3"]
 qwen_omni_utils = ["qwen_omni_utils"]
 embeddinggemma = ["transformers>=4.56.0"]
-# sonar = ["fairseq2", "sonar-space", "soundfile>=0.13.1"]  # fairseq2 pins its own torch/transformers, conflicts with the shared dev/test environment
+sonar = ["fairseq2", "sonar-space", "soundfile>=0.13.1"]
 # ebind = ["ebind @ git+https://github.com/encord-team/ebind@7909701e9372353ca678b9515f9f61cf87c83c71", "soundfile>=0.13.1", "transformers>=4.57.1,!=5.0.0"]
 languagebind = [
     "languagebind[video,audio]==0.1.0",
@@ -537,7 +537,7 @@ conflicts = [
         # { extra = "omnivinci" },
         { extra = "embeddinggemma" },
         # { extra = "ebind" },
-        # { extra = "sonar" },
+        { extra = "sonar" }, # fairseq2 pins its own torch/transformers
         { extra = "visrag-ret" }, # conflicting version of timm with blip2
         { extra = "languagebind" }, # conflicting versions of transformers
         { extra = "e5-v" }, # conflicting versions of transformers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,7 @@ uembed = ["transformers>=5.4.0,<6.0.0"]
 # omnivinci = ["transformers==4.46.0", "torch==2.8.*", "einops>=0.8.0", "openai-whisper>=20240930", "soundfile>=0.13.1", "opencv-python-headless>=4.0.0", "kaldiio>=2.18.0", "decord>=0.6.0", "librosa>=0.10.0", "beartype>=0.18.0", "accelerate>=1.0.0", "s2wrapper @ git+https://github.com/bfshi/scaling_on_scales", "deepspeed>=0.9.0", "torchvision>=0.15.0", "torchaudio>=2.0.0", "torchcodec==0.7.0", "av>=10.0.0", "numpy>=1.23.0,<2.0.0", "flash-attn>=2.6.3"]
 qwen_omni_utils = ["qwen_omni_utils"]
 embeddinggemma = ["transformers>=4.56.0"]
+# sonar = ["fairseq2", "sonar-space", "soundfile>=0.13.1"]  # fairseq2 pins its own torch/transformers, conflicts with the shared dev/test environment
 # ebind = ["ebind @ git+https://github.com/encord-team/ebind@7909701e9372353ca678b9515f9f61cf87c83c71", "soundfile>=0.13.1", "transformers>=4.57.1,!=5.0.0"]
 languagebind = [
     "languagebind[video,audio]==0.1.0",
@@ -536,6 +537,7 @@ conflicts = [
         # { extra = "omnivinci" },
         { extra = "embeddinggemma" },
         # { extra = "ebind" },
+        # { extra = "sonar" },
         { extra = "visrag-ret" }, # conflicting version of timm with blip2
         { extra = "languagebind" }, # conflicting versions of transformers
         { extra = "e5-v" }, # conflicting versions of transformers


### PR DESCRIPTION
Adds SONARWrapper, a real implementation for facebook/SONAR (Meta's multilingual text+speech embedding model, 200+ languages). The ModelMeta existed only as a metadata stub (loader=None) — this PR adds the working encoder.

License fix: the stub said mit. Verified against SONAR's NC_MODEL_LICENSE.md and HF model card — code is MIT, but the text/speech encoder weights used here are CC-BY-NC-4.0. Corrected.

Env note: fairseq2 pins its own torch/transformers and breaks this repo's shared dev environment (confirmed directly — it downgraded torch and broke mteb's own import). The sonar extra is registered but commented out in pyproject.toml, matching ebind (#4414) and omnivinci (#4476). mteb.get_model() needs the extra uncommented + an isolated env, same as those two merged wrappers.

Closes #3423

Reproduction, verified in an isolated venv on FloresBitextMining (SONAR's own paper benchmark):
- eng_Latn-fra_Latn (high-resource): 1.0 across precision/recall/f1 — expected, FLORES is SONAR's flagship eval.
- eng_Latn-kir_Cyrl (low-resource): 0.9987 — meaningfully different, confirms real input-dependent embeddings, not a constant output.

Checklist:
- [x] ModelMeta filled out
- [ ] mteb.get_model() works — get_model_meta() works; get_model() needs the extra uncommented (see env note above), same limitation as #4414/#4476
- [x] Tested on representative tasks
- [x] Model is public
- [x] Reproduced paper results, included above