### PR TITLE
dataset: add SpokenCOCO

### DIFF
--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/SpokenCOCOA2IRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/SpokenCOCOA2IRetrieval.json
@@ -1,0 +1,42 @@
+{
+    "test": {
+        "num_samples": 30031,
+        "num_queries": 25031,
+        "num_documents": 5000,
+        "number_of_characters": 0,
+        "documents_text_statistics": null,
+        "documents_image_statistics": {
+            "min_image_width": 176,
+            "average_image_width": 575.4466,
+            "max_image_width": 640,
+            "min_image_height": 144,
+            "average_image_height": 486.273,
+            "max_image_height": 640,
+            "unique_images": 5000
+        },
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": null,
+        "queries_audio_statistics": {
+            "total_duration_seconds": 108435.1856875,
+            "min_duration_seconds": 1.1946875,
+            "average_duration_seconds": 4.332035703227997,
+            "max_duration_seconds": 24.8918125,
+            "unique_audios": 25031,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 25031
+            }
+        },
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 25031,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 5000
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/SpokenCOCOI2ARetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/SpokenCOCOI2ARetrieval.json
@@ -1,0 +1,42 @@
+{
+    "test": {
+        "num_samples": 30031,
+        "num_queries": 5000,
+        "num_documents": 25031,
+        "number_of_characters": 0,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": {
+            "total_duration_seconds": 108435.1856875,
+            "min_duration_seconds": 1.1946875,
+            "average_duration_seconds": 4.332035703227997,
+            "max_duration_seconds": 24.8918125,
+            "unique_audios": 25031,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 25031
+            }
+        },
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": {
+            "min_image_width": 176,
+            "average_image_width": 575.4466,
+            "max_image_width": 640,
+            "min_image_height": 144,
+            "average_image_height": 486.273,
+            "max_image_height": 640,
+            "unique_images": 5000
+        },
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 25031,
+            "min_relevant_docs_per_query": 5,
+            "average_relevant_docs_per_query": 5.0062,
+            "max_relevant_docs_per_query": 6,
+            "unique_relevant_docs": 25031
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -324,6 +324,7 @@ from .sop_i2i_retrieval import SOPI2IRetrieval
 from .sounding_earth import SoundingEarthA2IRetrieval, SoundingEarthI2ARetrieval
 from .spart_qa_retrieval import SpartQA
 from .speech_coco import SpeechCocoA2IRetrieval, SpeechCocoI2ARetrieval
+from .spoken_coco_retrieval import SpokenCOCOA2IRetrieval, SpokenCOCOI2ARetrieval
 from .spoken_s_qu_ad import SpokenSQuADT2ARetrieval
 from .stanford_cars_i2i_retrieval import StanfordCarsI2I
 from .temp_reason_l1_retrieval import TempReasonL1
@@ -720,6 +721,8 @@ __all__ = [
     "SpartQA",
     "SpeechCocoA2IRetrieval",
     "SpeechCocoI2ARetrieval",
+    "SpokenCOCOA2IRetrieval",
+    "SpokenCOCOI2ARetrieval",
     "SpokenSQuADT2ARetrieval",
     "StanfordCarsI2I",
     "TUBerlinT2IRetrieval",

--- a/mteb/tasks/retrieval/eng/spoken_coco_retrieval.py
+++ b/mteb/tasks/retrieval/eng/spoken_coco_retrieval.py
@@ -1,0 +1,77 @@
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.task_metadata import TaskMetadata
+
+_REFERENCE = "https://aclanthology.org/2021.acl-long.411/"
+_BIBTEX = r"""
+@inproceedings{hsu-etal-2021-text,
+  author = {Hsu, Wei-Ning and Harwath, David and Miller, Tyler and Song, Christopher and Glass, James},
+  booktitle = {Proceedings of the 59th Annual Meeting of the Association for Computational Linguistics and the 11th International Joint Conference on Natural Language Processing (Volume 1: Long Papers)},
+  doi = {10.18653/v1/2021.acl-long.411},
+  pages = {5284--5300},
+  title = {Text-Free Image-to-Speech Synthesis Using Learned Segmental Units},
+  year = {2021},
+}
+"""
+_DESCRIPTION = (
+    "SpokenCOCO pairs MS COCO images with recordings of human speakers reading "
+    "the corresponding English captions. This task uses the 5,000-image Karpathy "
+    "test split with 25,031 spoken captions. "
+)
+
+
+class SpokenCOCOA2IRetrieval(AbsTaskRetrieval):
+    metadata: TaskMetadata = TaskMetadata(
+        name="SpokenCOCOA2IRetrieval",
+        description=_DESCRIPTION
+        + "Queries are spoken captions and the corpus contains images; the goal is "
+        "to retrieve the image described by each recording.",
+        reference=_REFERENCE,
+        dataset={
+            "path": "whybe-choi/SpokenCOCOA2IRetrieval",
+            "revision": "72731c49562b73ea7e1cbd296c40f3924a4e5fad",
+        },
+        type="Any2AnyRetrieval",
+        category="a2i",
+        modalities=["audio", "image"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2014-01-01", "2020-12-03"),
+        domains=["Scene", "Spoken"],
+        task_subtypes=["Cross-Modal Retrieval"],
+        license="cc-by-sa-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="created",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find the image described by the spoken caption."},
+    )
+
+
+class SpokenCOCOI2ARetrieval(AbsTaskRetrieval):
+    metadata: TaskMetadata = TaskMetadata(
+        name="SpokenCOCOI2ARetrieval",
+        description=_DESCRIPTION
+        + "Queries are images and the corpus contains spoken captions; the goal is "
+        "to retrieve the recordings that describe each image.",
+        reference=_REFERENCE,
+        dataset={
+            "path": "whybe-choi/SpokenCOCOI2ARetrieval",
+            "revision": "d9bb53ec91142fbc8a1bcefea200d835bd916a8b",
+        },
+        type="Any2AnyRetrieval",
+        category="i2a",
+        modalities=["image", "audio"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2014-01-01", "2020-12-03"),
+        domains=["Scene", "Spoken"],
+        task_subtypes=["Cross-Modal Retrieval"],
+        license="cc-by-sa-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="created",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find the spoken captions that describe this image."},
+    )


### PR DESCRIPTION
Closes #5114, Related to #4842

## Checklist

- [x] I have outlined why this dataset is filling an existing gap in `mteb`
- [x] I have tested that the dataset runs with the `mteb` package.
- [x] I have run the following models on the task (adding the results to the PR). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
  - [x] `mteb/baseline-random-encoder`
  - [x] `jinaai/jina-embeddings-v5-omni-nano`
- [x] I have checked that the performance is neither trivial (close to perfect scores) nor random.
- [x] I have considered the size of the dataset and reduced it if it is too big (e.g. 2048 examples for binary classification).
- [x] I reproduced scores from the original paper (if applicable) and added them to the PR description for reference.

## Results

| Model | Task | nDCG@5 | nDCG@10 | Recall@5 | Recall@10 |
|---|---|---:|---:|---:|---:|
| `mteb/baseline-random-encoder` | `SpokenCOCOA2IRetrieval` | 0.00089 | 0.00126 | 0.00128 | 0.00248 |
| `mteb/baseline-random-encoder` | `SpokenCOCOI2ARetrieval` | 0.00046 | 0.00064 | 0.00036 | 0.00068 |
| `jinaai/jina-embeddings-v5-omni-nano` | `SpokenCOCOA2IRetrieval` | 0.17449 | 0.20468 | 0.24526 | 0.33894 |
| `jinaai/jina-embeddings-v5-omni-nano` | `SpokenCOCOI2ARetrieval` | 0.08184 | 0.10293 | 0.07343 | 0.11233 |

## Note

The SpokenCOCO paper explicitly states in Appendix B.1: “We follow the data splits used in [...] (Karpathy and Fei-Fei, 2015) for Flickr8k and SpokenCOCO (the ‘Karpathy split’).” Accordingly, these tasks use the complete 5,000-image Karpathy test split and its 25,031 spoken captions.

The original paper studies text-free image-to-speech synthesis: generating a spoken caption directly from an image without using text as an intermediate representation. It evaluates caption generation and speech quality using metrics such as BLEU-4, METEOR, SPICE/M-SPICE, MOS, and WER. 

The A2I and I2A retrieval tasks introduced here are **new adaptations of SpokenCOCO**, so the paper does not provide directly comparable retrieval scores to reproduce.

References: [Karpathy and Fei-Fei (2015)](https://cs.stanford.edu/people/karpathy/cvpr2015.pdf), [SpokenCOCO paper](https://aclanthology.org/2021.acl-long.411/)