### PR TITLE
dataset: add DanRAG-Bench retrieval tasks

### DIFF
--- a/mteb/descriptive_stats/Image/DocumentUnderstanding/DanRAGT2IRetrieval.json
+++ b/mteb/descriptive_stats/Image/DocumentUnderstanding/DanRAGT2IRetrieval.json
@@ -1,0 +1,38 @@
+{
+    "test": {
+        "num_samples": 820,
+        "num_queries": 471,
+        "num_documents": 349,
+        "number_of_characters": 30259,
+        "documents_text_statistics": null,
+        "documents_image_statistics": {
+            "min_image_width": 2479,
+            "average_image_width": 2492.5128939828082,
+            "max_image_width": 3508,
+            "min_image_height": 2481,
+            "average_image_height": 3496.4355300859597,
+            "max_image_height": 3509,
+            "unique_images": 348
+        },
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 30259,
+            "min_text_length": 27,
+            "average_text_length": 64.24416135881104,
+            "max_text_length": 133,
+            "unique_texts": 469
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 608,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.2908704883227176,
+            "max_relevant_docs_per_query": 10,
+            "unique_relevant_docs": 271
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Image/DocumentUnderstanding/DanRAGT2ITRetrieval.json
+++ b/mteb/descriptive_stats/Image/DocumentUnderstanding/DanRAGT2ITRetrieval.json
@@ -1,0 +1,44 @@
+{
+    "test": {
+        "num_samples": 820,
+        "num_queries": 471,
+        "num_documents": 349,
+        "number_of_characters": 820525,
+        "documents_text_statistics": {
+            "total_text_length": 790266,
+            "min_text_length": 0,
+            "average_text_length": 2264.3724928366764,
+            "max_text_length": 5511,
+            "unique_texts": 341
+        },
+        "documents_image_statistics": {
+            "min_image_width": 2479,
+            "average_image_width": 2492.5128939828082,
+            "max_image_width": 3508,
+            "min_image_height": 2481,
+            "average_image_height": 3496.4355300859597,
+            "max_image_height": 3509,
+            "unique_images": 348
+        },
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 30259,
+            "min_text_length": 27,
+            "average_text_length": 64.24416135881104,
+            "max_text_length": 133,
+            "unique_texts": 469
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 608,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.2908704883227176,
+            "max_relevant_docs_per_query": 10,
+            "unique_relevant_docs": 271
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/tasks/retrieval/dan/__init__.py
+++ b/mteb/tasks/retrieval/dan/__init__.py
@@ -1,4 +1,5 @@
 from .dan_fever_retrieval import DanFever, DanFeverRetrieval
+from .danrag_retrieval import DanRAGT2IRetrieval, DanRAGT2ITRetrieval
 from .lex_retrieval import LexRetrievalv1
 from .tv2_nordretrieval import TV2Nordretrieval
 from .twitter_hjerne_retrieval import TwitterHjerneRetrieval
@@ -6,6 +7,8 @@ from .twitter_hjerne_retrieval import TwitterHjerneRetrieval
 __all__ = [
     "DanFever",
     "DanFeverRetrieval",
+    "DanRAGT2IRetrieval",
+    "DanRAGT2ITRetrieval",
     "LexRetrievalv1",
     "TV2Nordretrieval",
     "TwitterHjerneRetrieval",

--- a/mteb/tasks/retrieval/dan/danrag_retrieval.py
+++ b/mteb/tasks/retrieval/dan/danrag_retrieval.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from typing import Any
+
+from datasets import load_dataset
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.task_metadata import TaskMetadata
+from mteb.timing import TimingStack
+
+_SOURCE_REVISION = "408cf48d4b78182878f06eb445b20de201d58d74"
+
+_CITATION = r"""
+@misc{schmidt2025danragbench,
+  author = {Johan Hausted Schmidt},
+  institution = {IT University of Copenhagen},
+  title = {DanRAG-Bench: A Danish Multimodal Document Retrieval Benchmark Across Five Sectors},
+  year = {2025},
+}
+"""
+
+
+def _load_danrag_data(
+    task: AbsTaskRetrieval,
+    include_text: bool,
+    num_proc: int | None,
+    timer: TimingStack | None = None,
+) -> None:
+    if task.data_loaded:
+        return
+
+    path = task.metadata.dataset["path"]
+    revision = task.metadata.dataset["revision"]
+    splits = task.metadata.eval_splits
+    dataset: dict[str, dict[str, dict[str, Any]]] = {"default": {}}
+
+    timer = timer or TimingStack()
+    with timer("Data loading", log_message=f"Loading dataset {task.metadata.name}..."):
+        for split in splits:
+            corpus_columns = ["page_id", "image"]
+            if include_text:
+                corpus_columns.insert(1, "text")
+
+            corpus = load_dataset(
+                path,
+                data_files={split: "corpus/*.parquet"},
+                split=split,
+                revision=revision,
+                num_proc=num_proc,
+            )
+            corpus = corpus.select_columns(corpus_columns).rename_column(
+                "page_id", "id"
+            )
+
+            raw_queries = load_dataset(
+                path,
+                data_files={split: "queries/*.parquet"},
+                split=split,
+                revision=revision,
+                num_proc=num_proc,
+            )
+            queries = raw_queries.select_columns(["id", "query"]).rename_column(
+                "query", "text"
+            )
+            relevant_docs = {
+                query_id: dict.fromkeys(valid_pages, 1)
+                for query_id, valid_pages in zip(
+                    raw_queries["id"], raw_queries["valid_pages"]
+                )
+            }
+
+            dataset["default"][split] = {
+                "corpus": corpus,
+                "queries": queries,
+                "relevant_docs": relevant_docs,
+                "top_ranked": None,
+            }
+
+        task.dataset = dataset
+    with timer("Dataset transform"):
+        task.dataset_transform(num_proc=num_proc)
+    task.data_loaded = True
+
+
+_COMMON_METADATA = {
+    "reference": "https://huggingface.co/datasets/Johanschmidt/DanRAG-Bench",
+    "dataset": {
+        "path": "Johanschmidt/DanRAG-Bench",
+        "revision": _SOURCE_REVISION,
+    },
+    "type": "DocumentUnderstanding",
+    "eval_splits": ["test"],
+    "eval_langs": ["dan-Latn"],
+    "main_score": "ndcg_at_5",
+    "date": ("2023-01-01", "2024-12-31"),
+    "domains": ["Government", "Financial", "Medical", "Legal", "Non-fiction"],
+    "task_subtypes": ["Image Text Retrieval"],
+    "license": "mit",
+    "annotations_creators": "LM-generated and reviewed",
+    "dialect": [],
+    "modalities": ["text", "image"],
+    "sample_creation": "LM-generated and verified",
+    "bibtex_citation": _CITATION,
+    "contributed_by": "Johan Hausted Schmidt",
+}
+
+
+class DanRAGT2IRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="DanRAGT2IRetrieval",
+        description="DanRAG-Bench evaluates Danish visual document retrieval over 349 page images from eight public-sector documents spanning energy, finance, health, law, and municipalities. Its 471 manually verified queries ask for factual information; the retrieval goal is to find every page containing evidence for each answer.",
+        category="t2i",
+        prompt={"query": "Find a screenshot that is relevant to the user's question."},
+        **_COMMON_METADATA,
+    )
+
+    def load_data(
+        self,
+        num_proc: int | None = None,
+        *,
+        timer: TimingStack | None = None,
+        **kwargs: Any,
+    ) -> None:
+        _load_danrag_data(self, include_text=False, num_proc=num_proc, timer=timer)
+
+
+class DanRAGT2ITRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="DanRAGT2ITRetrieval",
+        description="DanRAG-Bench evaluates Danish multimodal document retrieval over the extracted text and page images of 349 pages from eight public-sector documents spanning energy, finance, health, law, and municipalities. Its 471 manually verified queries ask for factual information; the retrieval goal is to find every page containing evidence for each answer.",
+        category="t2it",
+        prompt={
+            "query": "Find a document page that is relevant to the user's question."
+        },
+        **_COMMON_METADATA,
+    )
+
+    def load_data(
+        self,
+        num_proc: int | None = None,
+        *,
+        timer: TimingStack | None = None,
+        **kwargs: Any,
+    ) -> None:
+        _load_danrag_data(self, include_text=True, num_proc=num_proc, timer=timer)

--- a/tests/test_tasks/test_task_quality.py
+++ b/tests/test_tasks/test_task_quality.py
@@ -109,6 +109,7 @@ KNOWN_ISSUES: dict[str, list[str]] = {
         "DKHateClassification",
         "DanishMedicinesAgencyBitextMining",
         "DanishPoliticalCommentsClassification",
+        "DanRAGT2ITRetrieval",  # some image-bearing pages have no extracted text
         "DiaBlaBitextMining",
         "DuRetrieval",
         "DutchNewsArticlesRetrieval",
@@ -451,6 +452,7 @@ KNOWN_ISSUES: dict[str, list[str]] = {
         "DS1000Retrieval",
         "DalajClassification",
         "DanishPoliticalCommentsClassification",
+        "DanRAGT2ITRetrieval",  # repeated page text is present in the source benchmark
         "DeepSentiPers",
         "EDIST2ITRetrieval",
         "ESCIReranking",


### PR DESCRIPTION
Closes #4687.

Adds two DanRAG-Bench tasks for Danish multimodal document retrieval: text-to-image and text-to-image-text. This fills a language and modality gap in MTEB.

| Model | T2I nDCG@5 | T2IT nDCG@5 |
|---|---:|---:|
| Random baseline | 0.00620 | 0.00524 |
| ColQwen2 | 0.78774 | 0.86535 |

The source reports 0.832 T2I nDCG@5; our pinned-revision run produced 0.78774.

- [x] Fills an existing MTEB gap
- [x] Runs with MTEB
- [x] Evaluated with random and ColQwen2
- [x] Performance is non-trivial and non-random
- [x] Full dataset retained after size review (471 queries, 349 documents)
- [x] Compared with the reported source score