### PR TITLE
Use `AutoModelForImageTextToText` to make GmeQwen2VL transformers 5 compatible

### DIFF
--- a/mteb/models/model_implementations/gme_v_models.py
+++ b/mteb/models/model_implementations/gme_v_models.py
@@ -151,10 +151,10 @@ class GmeQwen2VL(AbsEncoder):
         max_length=1800,
         **kwargs,
     ) -> None:
-        from transformers import AutoModelForVision2Seq, AutoProcessor
+        from transformers import AutoModelForImageTextToText, AutoProcessor
 
         model_name = model_path or model_name
-        base = AutoModelForVision2Seq.from_pretrained(
+        base = AutoModelForImageTextToText.from_pretrained(
             model_name, revision=revision, torch_dtype=torch.float16, **kwargs
         )
         min_pixels = min_image_tokens * 28 * 28


### PR DESCRIPTION
Use AutoModelForImageTextToText to make GmeQwenVL compatible to transformers 5.X

If you add a model or a dataset, please add the corresponding checklist:

* [dataset checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_dataset/#submit-a-pull-request)
* [model checklist](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_model/#submitting-your-model-as-a-pr)
