### PR TITLE
model: add Singaraj/morisien-embed (Mauritian Creole, mfe)

### DIFF
--- a/mteb/models/model_implementations/morisien_models.py
+++ b/mteb/models/model_implementations/morisien_models.py
@@ -1,0 +1,35 @@
+"""Text embedding models for Mauritian Creole (Kreol Morisien, mfe)."""
+
+from mteb.models.model_meta import ModelMeta, ScoringFunction
+from mteb.models.sentence_transformer_wrapper import SentenceTransformerEncoderWrapper
+
+morisien_embed = ModelMeta(
+    loader=SentenceTransformerEncoderWrapper,
+    name="Singaraj/morisien-embed",
+    model_type=["dense"],
+    languages=["mfe-Latn", "eng-Latn", "fra-Latn"],
+    open_weights=True,
+    revision="3187caaa709a8ea65a27342bddf87429e29d35f6",
+    release_date="2026-08-09",
+    n_parameters=278_043_648,
+    n_embedding_parameters=192_001_536,
+    memory_usage_mb=1061,
+    embed_dim=768,
+    license="mit",
+    max_tokens=512,
+    reference="https://huggingface.co/Singaraj/morisien-embed",
+    similarity_fn_name=ScoringFunction.COSINE,
+    framework=["Sentence Transformers", "PyTorch", "ONNX", "safetensors"],
+    use_instructions=False,
+    superseded_by=None,
+    adapted_from="intfloat/multilingual-e5-base",
+    training_datasets={"MorisienMTBitextMining"},
+    public_training_code="https://github.com/LK-maker-007/morisien-embed",
+    public_training_data=None,
+    citation="""@misc{b2026morisienembed,
+  title={morisien-embed: a dedicated text embedding model for Mauritian Creole},
+  author={B, Singaraj},
+  year={2026},
+  url={https://huggingface.co/Singaraj/morisien-embed},
+}""",
+)


### PR DESCRIPTION
Adds a `ModelMeta` for [`Singaraj/morisien-embed`](https://huggingface.co/Singaraj/morisien-embed), a dedicated text embedding model for Mauritian Creole (Kreol Morisien, `mfe`), fine-tuned from `intfloat/multilingual-e5-base`. It pairs with the `MorisienMTBitextMining` task added in #5110.

Metadata is taken from the model repo: 278M parameters, 768-dim embeddings, cosine similarity, MIT license, and `use_instructions=False` (no prompt/prefix — confirmed by the model's `config_sentence_transformers.json` and card).

`training_datasets` declares `MorisienMTBitextMining`: the model was trained on the MorisienMT corpus that this benchmark's test split is drawn from, so it is in-domain (not zero-shot) on that task. Disclosed here rather than claimed as zero-shot.

Validation run locally:
- `ruff check` clean
- `mteb.get_model_meta("Singaraj/morisien-embed")` resolves
- `pytest tests/test_models/test_model_meta.py` — 2438 passed

A results submission to `embeddings-benchmark/results` will follow.
