### PR TITLE
model: add Cosmos-Embed1 (nvidia/Cosmos-Embed1-224p/336p/448p)

### DIFF
--- a/mteb/models/model_implementations/cosmos_embed_models.py
+++ b/mteb/models/model_implementations/cosmos_embed_models.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import torch
+from tqdm.auto import tqdm
+
+from mteb.models.abs_encoder import AbsEncoder
+from mteb.models.modality_collators import FramesCollator
+from mteb.models.model_meta import ModelMeta, ScoringFunction
+
+if TYPE_CHECKING:
+    from torch.utils.data import DataLoader
+
+    from mteb.abstasks.task_metadata import TaskMetadata
+    from mteb.types import Array, BatchedInput, PromptType
+
+
+def _proj(output, attr: str) -> torch.Tensor:
+    """Pull the projected embedding off a Cosmos-Embed1 output object."""
+    value = getattr(output, attr, None)
+    if not isinstance(value, torch.Tensor):
+        raise ValueError(
+            f"Expected a tensor at {type(output).__name__}.{attr}, got {type(value).__name__}"
+        )
+    return value
+
+
+class CosmosEmbed1Model(AbsEncoder):
+    """Wrapper for NVIDIA Cosmos-Embed1 joint video-text embedders."""
+
+    def __init__(
+        self,
+        model_name: str,
+        revision: str,
+        device: str = "cuda" if torch.cuda.is_available() else "cpu",
+        num_frames: int = 8,
+        **kwargs: Any,
+    ) -> None:
+        from transformers import AutoModel, AutoProcessor
+
+        self.model_name = model_name
+        self.device = device
+        self.num_frames = num_frames
+        dtype = torch.bfloat16 if device.startswith("cuda") else torch.float32
+        self.model = AutoModel.from_pretrained(
+            model_name,
+            revision=revision,
+            trust_remote_code=True,
+            torch_dtype=dtype,
+        ).to(self.device)
+        self.model.eval()
+        self.processor = AutoProcessor.from_pretrained(
+            model_name,
+            revision=revision,
+            trust_remote_code=True,
+        )
+
+    def _move(self, batch: Any) -> dict[str, Any]:
+        return {
+            key: (value.to(self.device) if hasattr(value, "to") else value)
+            for key, value in dict(batch).items()
+        }
+
+    @torch.no_grad()
+    def get_text_embeddings(
+        self,
+        texts: DataLoader[BatchedInput],
+        show_progress_bar: bool = True,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        all_embeddings = []
+        for batch in tqdm(texts, disable=not show_progress_bar, desc="Text Encoding"):
+            inputs = self._move(self.processor(text=batch["text"], return_tensors="pt"))
+            output = self.model.get_text_embeddings(**inputs)
+            embeddings = _proj(output, "text_proj")
+            all_embeddings.append(embeddings.float().cpu())
+        return torch.cat(all_embeddings, dim=0)
+
+    @torch.no_grad()
+    def get_video_embeddings(
+        self,
+        videos: DataLoader[BatchedInput],
+        show_progress_bar: bool = True,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        all_embeddings = []
+        for batch in tqdm(videos, disable=not show_progress_bar, desc="Video Encoding"):
+            # The collator already hands us [T, C, H, W] uint8 frames, which
+            # is the BTCHW layout the processor wants once stacked. It requires
+            # exactly num_frames frames per clip.
+            frames = torch.stack(
+                [
+                    video.to(torch.uint8)
+                    if isinstance(video, torch.Tensor)
+                    else torch.as_tensor(video, dtype=torch.uint8)
+                    for video in batch["video"]
+                ]
+            )
+            inputs = self._move(self.processor(videos=frames, return_tensors="pt"))
+            output = self.model.get_video_embeddings(**inputs)
+            embeddings = _proj(output, "visual_proj")
+            all_embeddings.append(embeddings.float().cpu())
+        return torch.cat(all_embeddings, dim=0)
+
+    def encode(
+        self,
+        inputs: DataLoader[BatchedInput],
+        *,
+        task_metadata: TaskMetadata,
+        hf_split: str,
+        hf_subset: str,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
+    ) -> Array:
+        has_text = "text" in inputs.dataset.features
+        has_video = "video" in inputs.dataset.features
+
+        if has_video:
+            inputs.collate_fn = FramesCollator(num_frames=self.num_frames)
+
+        text_embeddings = None
+        video_embeddings = None
+
+        if has_text:
+            text_embeddings = self.get_text_embeddings(inputs, **kwargs)
+        if has_video:
+            video_embeddings = self.get_video_embeddings(inputs, **kwargs)
+
+        if text_embeddings is not None and video_embeddings is not None:
+            if len(text_embeddings) != len(video_embeddings):
+                raise ValueError(
+                    "The number of texts and videos must have the same length"
+                )
+            return text_embeddings + video_embeddings
+        if text_embeddings is not None:
+            return text_embeddings
+        if video_embeddings is not None:
+            return video_embeddings
+
+        raise ValueError(
+            f"No supported modality found in dataset features: {list(inputs.dataset.features.keys())}"
+        )
+
+
+COSMOS_EMBED1_CITATION = """
+@misc{nvidia2025cosmosembed1,
+  title={Cosmos-Embed1: A Joint Video-Text Embedding Model for Physical AI},
+  author={NVIDIA},
+  year={2025},
+  url={https://research.nvidia.com/labs/cosmos-lab/cosmos-embed1/}
+}"""
+
+_COSMOS_COMMON = dict(
+    loader=CosmosEmbed1Model,
+    model_type=["dense"],
+    languages=["eng-Latn"],
+    release_date="2025-06-11",
+    modalities=["video", "text"],
+    license="https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/",
+    open_weights=True,
+    public_training_code=None,
+    public_training_data=None,
+    framework=["PyTorch", "Transformers"],
+    similarity_fn_name=ScoringFunction.COSINE,
+    use_instructions=False,
+    max_tokens=128,
+    training_datasets={
+        "Kinetics400V",
+        "Kinetics400VA",
+        "Kinetics400ZeroShot",
+        "Kinetics400VAZeroShot",
+    },
+    citation=COSMOS_EMBED1_CITATION,
+    loader_kwargs=dict(num_frames=8),
+    extra_requirements_groups=["cosmos-embed1"],
+)
+
+cosmos_embed1_224p = ModelMeta(
+    name="nvidia/Cosmos-Embed1-224p",
+    revision="787e0b996f5260a71ad474a283c90539a2e12986",
+    n_parameters=1_172_696_698,
+    n_embedding_parameters=23_834_880,
+    memory_usage_mb=4473,
+    embed_dim=256,
+    reference="https://huggingface.co/nvidia/Cosmos-Embed1-224p",
+    **_COSMOS_COMMON,
+)
+
+cosmos_embed1_336p = ModelMeta(
+    name="nvidia/Cosmos-Embed1-336p",
+    revision="0e8a28f7bf370f2dcb3b9b61d23e167d0d6b0e6f",
+    n_parameters=1_173_934_714,
+    n_embedding_parameters=23_834_880,
+    memory_usage_mb=4478,
+    embed_dim=768,
+    reference="https://huggingface.co/nvidia/Cosmos-Embed1-336p",
+    **_COSMOS_COMMON,
+)
+
+cosmos_embed1_448p = ModelMeta(
+    name="nvidia/Cosmos-Embed1-448p",
+    revision="f60ec73636eb7c9cc25267367713b7b1b0cffaf3",
+    n_parameters=1_174_565_498,
+    n_embedding_parameters=23_834_880,
+    memory_usage_mb=4481,
+    embed_dim=768,
+    reference="https://huggingface.co/nvidia/Cosmos-Embed1-448p",
+    **_COSMOS_COMMON,
+)

--- a/mteb/models/model_implementations/cosmos_embed_models.py
+++ b/mteb/models/model_implementations/cosmos_embed_models.py
@@ -33,16 +33,20 @@ class CosmosEmbed1Model(AbsEncoder):
         self,
         model_name: str,
         revision: str,
-        device: str = "cuda" if torch.cuda.is_available() else "cpu",
+        device: str | int | torch.device | None = None,
         num_frames: int = 8,
         **kwargs: Any,
     ) -> None:
         from transformers import AutoModel, AutoProcessor
 
         self.model_name = model_name
-        self.device = device
         self.num_frames = num_frames
-        dtype = torch.bfloat16 if device.startswith("cuda") else torch.float32
+        if device is None:
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+        # mteb's CLI passes an int device index, torch.device normalises it
+        self.device = torch.device(device)
+        dtype = torch.bfloat16 if self.device.type == "cuda" else torch.float32
+        self.dtype = dtype
         self.model = AutoModel.from_pretrained(
             model_name,
             revision=revision,
@@ -57,10 +61,21 @@ class CosmosEmbed1Model(AbsEncoder):
         )
 
     def _move(self, batch: Any) -> dict[str, Any]:
-        return {
-            key: (value.to(self.device) if hasattr(value, "to") else value)
-            for key, value in dict(batch).items()
-        }
+        moved: dict[str, Any] = {}
+        for key, value in dict(batch).items():
+            if isinstance(value, torch.Tensor):
+                # The processor returns float32 pixel values while the weights
+                # may be bfloat16. Integer tensors such as input_ids and
+                # attention masks must keep their dtype.
+                if value.is_floating_point():
+                    moved[key] = value.to(self.device, dtype=self.dtype)
+                else:
+                    moved[key] = value.to(self.device)
+            elif hasattr(value, "to"):
+                moved[key] = value.to(self.device)
+            else:
+                moved[key] = value
+        return moved
 
     @torch.no_grad()
     def get_text_embeddings(
@@ -86,18 +101,25 @@ class CosmosEmbed1Model(AbsEncoder):
     ) -> torch.Tensor:
         all_embeddings = []
         for batch in tqdm(videos, disable=not show_progress_bar, desc="Video Encoding"):
-            # The collator already hands us [T, C, H, W] uint8 frames, which
-            # is the BTCHW layout the processor wants once stacked. It requires
-            # exactly num_frames frames per clip.
-            frames = torch.stack(
-                [
+            # Source clips vary in resolution, so they cannot be stacked
+            # before preprocessing. The processor resizes each clip to the
+            # model's input size, after which they concatenate cleanly.
+            processed: list[dict[str, torch.Tensor]] = []
+            for video in batch["video"]:
+                clip = (
                     video.to(torch.uint8)
                     if isinstance(video, torch.Tensor)
                     else torch.as_tensor(video, dtype=torch.uint8)
-                    for video in batch["video"]
-                ]
+                )
+                processed.append(
+                    dict(self.processor(videos=clip.unsqueeze(0), return_tensors="pt"))
+                )
+            inputs = self._move(
+                {
+                    key: torch.cat([item[key] for item in processed], dim=0)
+                    for key in processed[0]
+                }
             )
-            inputs = self._move(self.processor(videos=frames, return_tensors="pt"))
             output = self.model.get_video_embeddings(**inputs)
             embeddings = _proj(output, "visual_proj")
             all_embeddings.append(embeddings.float().cpu())

--- a/mteb/models/model_implementations/cosmos_embed_models.py
+++ b/mteb/models/model_implementations/cosmos_embed_models.py
@@ -143,19 +143,11 @@ class CosmosEmbed1Model(AbsEncoder):
         )
 
 
-COSMOS_EMBED1_CITATION = """
-@misc{nvidia2025cosmosembed1,
-  title={Cosmos-Embed1: A Joint Video-Text Embedding Model for Physical AI},
-  author={NVIDIA},
-  year={2025},
-  url={https://research.nvidia.com/labs/cosmos-lab/cosmos-embed1/}
-}"""
-
 _COSMOS_COMMON = dict(
     loader=CosmosEmbed1Model,
     model_type=["dense"],
     languages=["eng-Latn"],
-    release_date="2025-06-11",
+    release_date="2025-05-26",
     modalities=["video", "text"],
     license="https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/",
     open_weights=True,
@@ -170,8 +162,16 @@ _COSMOS_COMMON = dict(
         "Kinetics400VA",
         "Kinetics400ZeroShot",
         "Kinetics400VAZeroShot",
+        "Kinetics600V",
+        "Kinetics600VA",
+        "Kinetics600VZeroShot",
+        "Kinetics600VAZeroShot",
+        "Kinetics700V",
+        "Kinetics700VA",
+        "Kinetics700VZeroShot",
+        "Kinetics700VAZeroShot",
     },
-    citation=COSMOS_EMBED1_CITATION,
+    citation=None,
     loader_kwargs=dict(num_frames=8),
     extra_requirements_groups=["cosmos-embed1"],
 )

--- a/mteb/models/model_implementations/cosmos_embed_models.py
+++ b/mteb/models/model_implementations/cosmos_embed_models.py
@@ -16,16 +16,6 @@ if TYPE_CHECKING:
     from mteb.types import Array, BatchedInput, PromptType
 
 
-def _proj(output, attr: str) -> torch.Tensor:
-    """Pull the projected embedding off a Cosmos-Embed1 output object."""
-    value = getattr(output, attr, None)
-    if not isinstance(value, torch.Tensor):
-        raise ValueError(
-            f"Expected a tensor at {type(output).__name__}.{attr}, got {type(value).__name__}"
-        )
-    return value
-
-
 class CosmosEmbed1Model(AbsEncoder):
     """Wrapper for NVIDIA Cosmos-Embed1 joint video-text embedders."""
 
@@ -88,7 +78,7 @@ class CosmosEmbed1Model(AbsEncoder):
         for batch in tqdm(texts, disable=not show_progress_bar, desc="Text Encoding"):
             inputs = self._move(self.processor(text=batch["text"], return_tensors="pt"))
             output = self.model.get_text_embeddings(**inputs)
-            embeddings = _proj(output, "text_proj")
+            embeddings = output.text_proj
             all_embeddings.append(embeddings.float().cpu())
         return torch.cat(all_embeddings, dim=0)
 
@@ -121,7 +111,7 @@ class CosmosEmbed1Model(AbsEncoder):
                 }
             )
             output = self.model.get_video_embeddings(**inputs)
-            embeddings = _proj(output, "visual_proj")
+            embeddings = output.visual_proj
             all_embeddings.append(embeddings.float().cpu())
         return torch.cat(all_embeddings, dim=0)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ torch-vggish-yamnet = ["torch-vggish-yamnet==0.2.1"]
 vllm = ["vllm>=0.11.1"]
 moca = ["transformers>=4.49.0,<4.53"]
 transformers-v4 = ["transformers<5"]
+cosmos-embed1 = ["transformers<5", "einops>=0.8.0", "torchvision>=0.16.0"]
 siglip = ["sentencepiece>=0.2.0","protobuf>=3.0.0"]
 tipsv2 = ["sentencepiece>=0.2.0", "protobuf>=3.0.0"]
 qwen-vl = ["transformers>=4.57.0", "qwen-vl-utils>=0.0.14"]
@@ -470,6 +471,7 @@ conflicts = [
         { extra = "muq" },
         { extra = "moca" }, # needs transformers with _update_causal_mask
         { extra = "transformers-v4" },
+        { extra = "cosmos-embed1" }, # remote code needs transformers<5
         { extra = "qwen-vl" },
         # { extra = "omnivinci" },
         { extra = "embeddinggemma" },


### PR DESCRIPTION
Adds NVIDIA Cosmos-Embed1, a joint video-text embedder, in three checkpoints (224p, 336p, 448p). Part of the MOEB video track, see #4842. Video and text share one embedding space, so it covers t2v, v2t and v2v, filling the thin video-to-video direction.

### Implementation notes

- **Wrapper**: follows the XCLIP pattern, with `get_text_embeddings` and `get_video_embeddings` feeding a shared `encode` dispatch. Projections come off `visual_proj` and `text_proj`.
- **transformers 4 pin**: the remote code imports `find_pruneable_heads_and_indices`, removed in transformers 5. Added a `cosmos-embed1` extra pinning `transformers<5` plus einops and torchvision, registered in the uv conflicts list like `moca` and `visrag-ret`.
- **Frames**: the processor requires exactly 8 frames and raises otherwise, so `loader_kwargs` pins `num_frames=8`. `FramesCollator` repeats frames for shorter videos.
- **Metadata**: params and memory measured per checkpoint. `training_datasets` covers all 12 Kinetics 400/600/700 tasks, which the card lists in the training pool. No BibTeX is published, so `citation` is None.

### Validation

Kinetics-400 zero-shot on 224p: **82.05** accuracy in mteb vs **83.06** F1 on the card. Not an exact comparison (accuracy vs F1, subset vs full val). MSR-VTT numbers and the three GPU-path fixes are in the comment below. `mteb mock-run` passes 31/31 text and 7/7 video.

### Checklist

- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [x] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e., is available either as an API or the weights are publicly available to download
- [x] I reproduced results from the original paper (if applicable) on at least one benchmark, and I am including the results in the PR description.