### PR TITLE
fix: break MRR ties by doc id to match pytrec_eval

### DIFF
--- a/mteb/_evaluators/retrieval_metrics.py
+++ b/mteb/_evaluators/retrieval_metrics.py
@@ -32,8 +32,10 @@ def mrr(
     k_max, top_hits = max(k_values), {}
 
     for query_id, doc_scores in results.items():
+        # tie-break by doc id descending to match pytrec_eval; a score-only sort is
+        # stable, so tied docs kept dict insertion order and leaked into the rank (#5092)
         top_hits[query_id] = sorted(
-            doc_scores.items(), key=lambda item: item[1], reverse=True
+            doc_scores.items(), key=lambda item: (item[1], item[0]), reverse=True
         )[0:k_max]
 
     for query_id in top_hits:
@@ -60,9 +62,9 @@ def recall_cap(
     k_max = max(k_values)
 
     for query_id, doc_scores in results.items():
-        top_hits = sorted(doc_scores.items(), key=lambda item: item[1], reverse=True)[
-            0:k_max
-        ]
+        top_hits = sorted(
+            doc_scores.items(), key=lambda item: (item[1], item[0]), reverse=True
+        )[0:k_max]
         query_relevant_docs = [
             doc_id for doc_id in qrels[query_id] if qrels[query_id][doc_id] > 0
         ]
@@ -92,9 +94,9 @@ def hole(
     k_max = max(k_values)
 
     for _, scores in results.items():
-        top_hits = sorted(scores.items(), key=lambda item: item[1], reverse=True)[
-            0:k_max
-        ]
+        top_hits = sorted(
+            scores.items(), key=lambda item: (item[1], item[0]), reverse=True
+        )[0:k_max]
         for k in k_values:
             hole_docs = [
                 row[0] for row in top_hits[0:k] if row[0] not in annotated_corpus
@@ -116,7 +118,7 @@ def top_k_accuracy(
         top_hits[query_id] = [
             item[0]
             for item in sorted(
-                doc_scores.items(), key=lambda item: item[1], reverse=True
+                doc_scores.items(), key=lambda item: (item[1], item[0]), reverse=True
             )[0:k_max]
         ]
 

--- a/tests/test_evaluators/test_evaluation_metrics.py
+++ b/tests/test_evaluators/test_evaluation_metrics.py
@@ -1,4 +1,32 @@
-from mteb._evaluators.retrieval_metrics import calculate_pmrr
+import pytrec_eval
+
+from mteb._evaluators.retrieval_metrics import calculate_pmrr, mrr
+
+
+def test_mrr_tiebreak_independent_of_insertion_order():
+    # regression for #5092: with tied scores a stable score-only sort ranked docs by
+    # dict insertion order, so a constant scorer scored MRR@10 = 1.0 on tasks that list
+    # the positive candidate first.
+    qrels = {"q1": {"d_pos": 1}}
+    tied = {"d_pos": 0.5, "d_x": 0.5, "d_y": 0.5}
+
+    forward = mrr(qrels, {"q1": tied}, [10])["MRR@10"][0]
+    reversed_order = mrr(qrels, {"q1": dict(reversed(tied.items()))}, [10])["MRR@10"][0]
+    assert forward == reversed_order
+
+
+def test_mrr_tiebreak_matches_pytrec_eval():
+    # MRR must break ties the same way as the pytrec_eval metrics (by doc id, descending)
+    # so a single ranking backs every metric. Positive is listed first but has the
+    # lowest doc id, so insertion order and the correct order disagree.
+    qrels = {"q1": {"d_a": 1}}
+    results = {"q1": {"d_a": 0.5, "d_x": 0.5, "d_y": 0.5}}
+
+    got = mrr(qrels, results, [10])["MRR@10"][0]
+    evaluator = pytrec_eval.RelevanceEvaluator(qrels, {"recip_rank"})
+    expected = evaluator.evaluate(results)["q1"]["recip_rank"]
+
+    assert got == expected == 1 / 3
 
 
 def test_p_mrr():


### PR DESCRIPTION
Fixes #5092. `mrr` ranked candidates with a plain score sort, and since Python's `sorted` is stable, tied docs kept their dict insertion order. Everything else (`ndcg`/`map`/`recall`/…) goes through `pytrec_eval`, which breaks ties by doc id. On tasks that list the positive candidate first — `WebLINXCandidatesReranking` — that handed a constant scorer `MRR@10 = 1.0` while `nDCG@10` stayed at 0.

Switched the sort key to `(score, doc_id)` with `reverse=True`, so ties break by descending doc id and MRR shares one ranking with the pytrec_eval metrics — the direction @Samoed and @KennethEnevoldsen landed on in the thread. Applied the same one-line change to `recall_cap`, `hole` and `top_k_accuracy`, which had the identical stable-sort pattern.

Verified against `pytrec_eval`'s `recip_rank` on a few thousand random tie-heavy queries: the new key matches in every case, the old one diverged on ~45%. Added two tests — one that MRR no longer depends on insertion order, one that it agrees with `recip_rank` when the positive isn't the highest doc id.

This does shift previously reported `mrr_at_k` numbers on the two tasks that use it as `main_score` (`WebLINXCandidatesReranking`, `GermanQuAD-Retrieval`). Left the call on migrating existing results to you.
