### PR TITLE
dataset: add MMLongBench-Doc

### DIFF
--- a/mteb/descriptive_stats/Image/DocumentUnderstanding/MMLongBenchDocRetrieval.json
+++ b/mteb/descriptive_stats/Image/DocumentUnderstanding/MMLongBenchDocRetrieval.json
@@ -1,0 +1,38 @@
+{
+    "test": {
+        "num_samples": 7330,
+        "num_queries": 838,
+        "num_documents": 6492,
+        "number_of_characters": 79518,
+        "documents_text_statistics": null,
+        "documents_image_statistics": {
+            "min_image_width": 341,
+            "average_image_width": 642.3644485520641,
+            "max_image_width": 1191,
+            "min_image_height": 354,
+            "average_image_height": 708.1418669131239,
+            "max_image_height": 1293,
+            "unique_images": 6236
+        },
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 79518,
+            "min_text_length": 16,
+            "average_text_length": 94.89021479713604,
+            "max_text_length": 361,
+            "unique_texts": 838
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 40850,
+            "min_relevant_docs_per_query": 9,
+            "average_relevant_docs_per_query": 48.747016706443915,
+            "max_relevant_docs_per_query": 468,
+            "unique_relevant_docs": 6492
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -226,6 +226,7 @@ from .memotion_t2i_retrieval import MemotionT2IRetrieval
 from .met_i2i_retrieval import METI2IRetrieval
 from .miao_retrieval import MIAOA2IRetrieval, MIAOI2ARetrieval
 from .ml_questions import MLQuestionsRetrieval
+from .mm_long_bench_doc_retrieval import MMLongBenchDocRetrieval
 from .mmdocir_t2i_retrieval import MMDocIRT2IRetrieval
 from .mmdocir_t2it_retrieval import MMDocIRT2ITRetrieval
 from .moment_seeker import MomentSeekerTI2VRetrieval, MomentSeekerTV2VRetrieval
@@ -650,6 +651,7 @@ __all__ = [
     "MLQuestionsRetrieval",
     "MMDocIRT2IRetrieval",
     "MMDocIRT2ITRetrieval",
+    "MMLongBenchDocRetrieval",
     "MSCOCOI2TRetrieval",
     "MSCOCOT2IRetrieval",
     "MSMARCOHardNegatives",

--- a/mteb/tasks/retrieval/eng/mm_long_bench_doc_retrieval.py
+++ b/mteb/tasks/retrieval/eng/mm_long_bench_doc_retrieval.py
@@ -1,0 +1,111 @@
+from datasets import load_dataset
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+def _load_data(
+    path: str,
+    splits: list[str],
+    revision: str | None = None,
+    num_proc: int | None = None,
+):
+    corpus = {}
+    queries = {}
+    relevant_docs = {}
+
+    for split in splits:
+        query_ds = load_dataset(
+            path,
+            "queries",
+            split=split,
+            revision=revision,
+            num_proc=num_proc,
+        )
+        queries[split] = query_ds.map(
+            lambda row: {
+                "id": f"query-{split}-{row['query-id']}",
+                "text": row["query"],
+            },
+            remove_columns=query_ds.column_names,
+            num_proc=num_proc,
+        )
+
+        corpus_ds = load_dataset(
+            path,
+            "corpus",
+            split=split,
+            revision=revision,
+            num_proc=num_proc,
+        )
+        corpus[split] = corpus_ds.map(
+            lambda row: {
+                "id": f"corpus-{split}-{row['corpus-id']}",
+            },
+            remove_columns=["corpus-id"],
+            num_proc=num_proc,
+        ).select_columns(["id", "image"])
+
+        qrels_ds = load_dataset(
+            path,
+            "qrels",
+            split=split,
+            revision=revision,
+            num_proc=num_proc,
+        )
+        relevant_docs[split] = {}
+        for row in qrels_ds:
+            query_id = f"query-{split}-{row['query-id']}"
+            corpus_id = f"corpus-{split}-{row['corpus-id']}"
+            relevant_docs[split].setdefault(query_id, {})[corpus_id] = int(row["score"])
+
+    return corpus, queries, relevant_docs
+
+
+class MMLongBenchDocRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="MMLongBenchDocRetrieval",
+        description="MMLongBench-Doc is a long-context, multimodal document understanding benchmark built from lengthy PDFs with rich layouts and content including text, tables, charts, and images. This retrieval adaptation asks models to retrieve pages from the source document for a question, assigning higher graded relevance to annotated evidence pages.",
+        reference="https://arxiv.org/abs/2407.01523",
+        dataset={
+            "path": "VLM2Vec/MMLongBench-doc",
+            "revision": "1c2ee8f611a6c552d4bd90daca3a92d7a55ff806",
+        },
+        type="DocumentUnderstanding",
+        category="t2i",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_5",
+        date=("2024-01-01", "2024-07-01"),
+        domains=["Academic", "Government", "Legal", "Financial", "Engineering"],
+        task_subtypes=["Image Text Retrieval"],
+        license="cc-by-nc-4.0",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        modalities=["text", "image"],
+        sample_creation="multiple",
+        bibtex_citation=r"""
+@misc{ma2024mmlongbenchdocbenchmarkinglongcontextdocument,
+  archiveprefix = {arXiv},
+  author = {Yubo Ma and Yuhang Zang and Liangyu Chen and Meiqi Chen and Yizhu Jiao and Xinze Li and Xinyuan Lu and Ziyu Liu and Yan Ma and Xiaoyi Dong and Pan Zhang and Liangming Pan and Yu-Gang Jiang and Jiaqi Wang and Yixin Cao and Aixin Sun},
+  eprint = {2407.01523},
+  primaryclass = {cs.CV},
+  title = {MMLongBench-Doc: Benchmarking Long-context Document Understanding with Visualizations},
+  url = {https://arxiv.org/abs/2407.01523},
+  year = {2024},
+}
+""",
+        prompt={"query": "Find a document image that matches the given query."},
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        if self.data_loaded:
+            return
+
+        self.corpus, self.queries, self.relevant_docs = _load_data(
+            path=self.metadata.dataset["path"],
+            splits=self.metadata.eval_splits,
+            revision=self.metadata.dataset["revision"],
+            num_proc=num_proc,
+        )
+        self.data_loaded = True

--- a/tests/test_tasks/test_task_quality.py
+++ b/tests/test_tasks/test_task_quality.py
@@ -818,6 +818,7 @@ KNOWN_ISSUES: dict[str, list[str]] = {
         "InfoSeekIT2ITRetrieval",
         "InfoSeekIT2TRetrieval",
         "LLaVAIT2TRetrieval",
+        "MMLongBenchDocRetrieval",  # official corpus contains repeated rendered pages; preserve IDs to match qrels
         "MomentSeekerTI2VRetrieval",
         "OVENIT2ITRetrieval",
         "PatchCamelyon",  # adjacent, overlapping WSI patches are inherent to the source data


### PR DESCRIPTION
Closes #5123, Related to #4842

## Checklist

- [x] I have outlined why this dataset is filling an existing gap in `mteb`
- [x] I have tested that the dataset runs with the `mteb` package.
- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
  - [x] `mteb/baseline-random encoder`
  - [x] `vidore/colpali-v1.3`
- [x] I have checked that the performance is neither trivial (close to perfect scores) nor random.
- [x] I have considered the size of the dataset and reduced it if it is too big (e.g. 2048 examples for binary classification)
- [x] I reproduced scores from the original paper (if applicable) and added them to the PR description for reference.

## Results

| Model | Metric | Paper | Reprod | Diff |
|---|---:|---:|---:|---:|
| ColPali v1.3 | NDCG@5 | 52.5 | 53.2 | +0.7 |