### PR TITLE
model: add malteos/most-embed-de (German retrieval, Nemotron-3-Embed-1B fine-tune)

### DIFF
--- a/mteb/models/model_implementations/most_embed_models.py
+++ b/mteb/models/model_implementations/most_embed_models.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from mteb.models.model_meta import ModelMeta, ScoringFunction
+from mteb.models.sentence_transformer_wrapper import SentenceTransformerEncoderWrapper
+from mteb.types import OutputDType
+
+most_embed_de = ModelMeta(
+    loader=SentenceTransformerEncoderWrapper,
+    # Mirrors the `nvidia/Nemotron-3-Embed-1B-BF16` base model entry so that results stay
+    # directly comparable to the baseline on the leaderboard.
+    loader_kwargs=dict(processor_kwargs={"model_max_length": 4096}),
+    name="malteos/most-embed-de",
+    revision="30be696e29c09763afc3588ee9e04d6d0cbe8e43",
+    release_date="2026-08-11",
+    languages=["deu-Latn", "eng-Latn"],
+    n_parameters=1_140_918_272,
+    n_active_parameters_override=None,
+    n_embedding_parameters=268_435_456,
+    memory_usage_mb=2176,
+    max_tokens=32768,
+    embed_dim=2048,
+    license="cc-by-nc-4.0",
+    open_weights=True,
+    public_training_code=None,
+    public_training_data=None,
+    framework=["Sentence Transformers", "PyTorch", "Transformers"],
+    reference="https://huggingface.co/malteos/most-embed-de",
+    similarity_fn_name=ScoringFunction.COSINE,
+    # The model ships `query: ` / `passage: ` prompts in `config_sentence_transformers.json`,
+    # which `SentenceTransformerEncoderWrapper` picks up automatically.
+    use_instructions=True,
+    training_datasets=set(),  # proprietary German support corpora, no mteb task training splits
+    adapted_from="nvidia/Nemotron-3-Embed-1B-BF16",
+    superseded_by=None,
+    modalities=["text"],
+    model_type=["dense"],
+    citation=None,
+    contacts=None,
+    output_dtypes=OutputDType.BF16,
+    extra_requirements_groups=["nemotron-3-embed"],
+)


### PR DESCRIPTION
## Summary

Adds a `ModelMeta` for [`malteos/most-embed-de`](https://huggingface.co/malteos/most-embed-de), a 1.1B-parameter German retrieval embedding model fine-tuned from [`nvidia/Nemotron-3-Embed-1B-BF16`](https://huggingface.co/nvidia/Nemotron-3-Embed-1B-BF16). Evaluation results available on the model card and will be submitted to the mteb-results repo.

## Notes for reviewers

- **`use_instructions=True`** — this deliberately differs from the base model's `False`. The model ships `query: ` / `passage: ` prompts in `config_sentence_transformers.json`, which `SentenceTransformerEncoderWrapper` picks up automatically. Per the `ModelMeta` docstring, the field covers models that "require a specific format for input, such as `query: {document}`". Happy to flip it to `False` for consistency with the base entry if maintainers prefer that.
- **`loader_kwargs=dict(processor_kwargs={"model_max_length": 4096})`** mirrors the base model's entry exactly, so results are directly comparable with the Nemotron-3-Embed baseline. The architecture supports 32k, hence `max_tokens=32768` — same split as the base entry.

## Verification

`mteb mock-run -m malteos/most-embed-de` passes all 28 text mock tasks. Image/audio/video are
skipped, as expected for a text-only model.

```
| Pass      | Modality | Failures |
| --------- | -------- | -------- |
| ✓ (28/28) | text     |          |
```

## Checklist

- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [x] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e., is available either as an API or the weights are publicly available to download
- [ ] <strike>I reproduced results from the original paper (if applicable) on at least one benchmark, and I am including the results in the PR description.</strike>
