### PR TITLE
ci: add Copilot dataset PR review via label trigger

### DIFF
--- a/.github/instructions/dataset-pr.instructions.md
+++ b/.github/instructions/dataset-pr.instructions.md
@@ -1,0 +1,51 @@
+---
+applyTo: "**"
+---
+
+# New Dataset PR Guidelines
+
+## Purpose
+
+These instructions apply only when the PR title starts with `task:` or `dataset:`, or when the PR adds or modifies files under `mteb/tasks/`. If neither condition is met, ignore all instructions in this file.
+
+For matching PRs, ensure the PR description includes the evidence and context reviewers need to evaluate correctness and quality.
+
+## Descriptive Statistics
+
+- The PR description must include descriptive statistics for the dataset directly (e.g. number of samples per split, average text length, label distribution, language breakdown).
+- A reference to the dataset card is not sufficient — the stats must appear in the PR itself.
+
+## Results Table Format
+
+- Reproduction results from the paper must be presented as a table, not as prose.
+- Columns: score source (e.g. "PR" and "Paper").
+- Rows: one row per model.
+- Flag the PR if results are described only in paragraph form, or if the table is transposed (models as columns).
+
+Example of correct format:
+
+| Model | PR | Paper |
+|---|---|---|
+| model-a | 42.1 | 42.3 |
+| model-b | 38.7 | 39.0 |
+
+## Random Encoder Baseline
+
+- The PR must report scores for a random encoder (random embeddings or equivalent baseline) alongside the main results.
+- This confirms performance is neither trivially high (suggesting task is too easy or data is leaked) nor at chance level (suggesting the task or metric is misconfigured).
+- Flag the PR if no random baseline is present.
+
+## AI-Generated Boilerplate
+
+- Flag PR descriptions that contain noise that appears AI-generated rather than human-written.
+- Common patterns to flag:
+  - Bullet lists of CI checks that passed (e.g. "Ruff, typos, mypy, media decoding, ID/qrel integrity checks pass")
+  - Generic validation summaries (e.g. "6,724 practical tests pass")
+  - Filler sections such as "Validation", "Testing Done", or "Checklist" filled with auto-generated text that adds no information for reviewers
+  - Verbose restatements of what the code does without any insight
+- The PR description should explain the dataset, its origin, and why it belongs in MTEB.
+
+## Data Upload Script
+
+- If the Hugging Face dataset is hosted under a username that matches the PR author's GitHub username, check whether a corresponding upload script exists under `scripts/data/`.
+- If no such script is present, ask the author to add one showing how the data was created and uploaded to Hugging Face.

--- a/.github/instructions/dataset-pr.instructions.md
+++ b/.github/instructions/dataset-pr.instructions.md
@@ -9,10 +9,11 @@ Ensure the PR description includes the evidence and context reviewers need to ev
 
 ## Results Table Format
 
-- Reproduction results from the paper must be presented as a table, not as prose.
+- If reproduction results from a paper are included, they must be presented as a table, not as prose.
 - Columns: score source (e.g. "PR" and "Paper").
 - Rows: one row per model.
 - Flag the PR if results are described only in paragraph form, or if the table is transposed (models as columns).
+- If the dataset has no associated paper, or no equivalent model exists in MTEB to compare against, the PR must include a note explaining this.
 
 Example of correct format:
 
@@ -23,8 +24,11 @@ Example of correct format:
 
 ## Random Encoder Baseline
 
-- The PR must report scores for a random encoder (random embeddings or equivalent baseline) alongside the main results.
-- This confirms performance is neither trivially high (suggesting task is too easy or data is leaked) nor at chance level (suggesting the task or metric is misconfigured).
+- The PR must report scores for a random encoder alongside the main results. Run it with:
+  ```
+  mteb run -m mteb/baseline-random-encoder -t {task_name}
+  ```
+- This confirms performance is neither trivially high (suggesting the task is too easy or data is leaked) nor at chance level (suggesting the task or metric is misconfigured).
 - Flag the PR if no random baseline is present.
 
 ## AI-Generated Boilerplate

--- a/.github/instructions/dataset-pr.instructions.md
+++ b/.github/instructions/dataset-pr.instructions.md
@@ -1,14 +1,6 @@
----
-applyTo: "**"
----
-
 # New Dataset PR Guidelines
 
-## Purpose
-
-These instructions apply only when the PR title starts with `task:` or `dataset:`, or when the PR adds or modifies files under `mteb/tasks/`. If neither condition is met, ignore all instructions in this file.
-
-For matching PRs, ensure the PR description includes the evidence and context reviewers need to evaluate correctness and quality.
+Ensure the PR description includes the evidence and context reviewers need to evaluate correctness and quality.
 
 ## Descriptive Statistics
 

--- a/.github/instructions/dataset-pr.instructions.md
+++ b/.github/instructions/dataset-pr.instructions.md
@@ -2,10 +2,20 @@
 
 Ensure the PR description includes the evidence and context reviewers need to evaluate correctness and quality.
 
+## Gap in MTEB
+
+- The PR description must explain why this dataset fills an existing gap in MTEB (e.g. new language, domain, task type, or modality not yet covered).
+- A generic statement that the dataset is "useful" is not sufficient — the gap must be stated concretely. A tagged issue is acceptable.
+
 ## Descriptive Statistics
 
 - The PR description must include descriptive statistics for the dataset directly (e.g. number of samples per split, average text length, label distribution, language breakdown).
 - A reference to the dataset card is not sufficient — the stats must appear in the PR itself.
+
+## Dataset Size
+
+- Flag the PR if the dataset appears oversized for its task type without justification (e.g. more than ~2048 examples for binary classification).
+- The author should note whether the size was deliberately reduced.
 
 ## Results Table Format
 
@@ -22,14 +32,14 @@ Example of correct format:
 | model-a | 42.1 | 42.3 |
 | model-b | 38.7 | 39.0 |
 
-## Random Encoder Baseline
+## Model Results
 
-- The PR must report scores for a random encoder alongside the main results. Run it with:
-  ```
-  mteb run -m mteb/baseline-random-encoder -t {task_name}
-  ```
-- This confirms performance is neither trivially high (suggesting the task is too easy or data is leaked) nor at chance level (suggesting the task or metric is misconfigured).
-- Flag the PR if no random baseline is present.
+- The PR must report scores for at least two models:
+  - `mteb/baseline-random-encoder` (random baseline)
+  - A small real model, e.g. `intfloat/multilingual-e5-small`
+  - These can be run with: `mteb run -m {model_name} -t {task_name}`
+- The random baseline confirms performance is neither trivially high (suggesting the task is too easy or data is leaked) nor at chance level (suggesting the task or metric is misconfigured).
+- Flag the PR if either model result is missing.
 
 ## AI-Generated Boilerplate
 

--- a/.github/workflows/copilot_dataset_review.yml
+++ b/.github/workflows/copilot_dataset_review.yml
@@ -1,0 +1,23 @@
+name: Copilot dataset PR review
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  request-review:
+    if: github.event.label.name == 'new dataset'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Post Copilot review request
+        run: |
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@github-copilot review
+
+          Please review this PR against the guidelines in \`.github/instructions/dataset-pr.instructions.md\`. Only report actionable issues. Include file/line references and a concrete suggested fix where possible."


### PR DESCRIPTION
Adds a GitHub Actions workflow and a Copilot instructions file to automate dataset PR reviews.

**How it works:** when the `new dataset` label is added to a PR, the workflow posts a comment that triggers a Copilot review against `.github/instructions/dataset-pr.instructions.md`.

Checks enforced:
- Descriptive stats present in the PR description
- Paper reproduction results in a table (models as rows, score source as columns)
- Random encoder baseline reported
- No AI-generated boilerplate in the description
- Upload script in `scripts/data/` when the HF dataset username matches the PR author