### PR TITLE
[MOEB]fix: restore combined OVEN/InfoSeek candidate pool for retrieval

### DIFF
--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/InfoSeekIT2TRetrieval.v2.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/InfoSeekIT2TRetrieval.v2.json
@@ -1,0 +1,44 @@
+{
+    "test": {
+        "num_samples": 1299641,
+        "num_queries": 11323,
+        "num_documents": 1288318,
+        "number_of_characters": 715876759,
+        "documents_text_statistics": {
+            "total_text_length": 715308598,
+            "min_text_length": 2,
+            "average_text_length": 555.2267359456283,
+            "max_text_length": 60546,
+            "unique_texts": 1263223
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 568161,
+            "min_text_length": 23,
+            "average_text_length": 50.177603108716774,
+            "max_text_length": 270,
+            "unique_texts": 269
+        },
+        "queries_image_statistics": {
+            "min_image_width": 256,
+            "average_image_width": 307.8320233153758,
+            "max_image_width": 1365,
+            "min_image_height": 256,
+            "average_image_height": 271.4820277311666,
+            "max_image_height": 775,
+            "unique_images": 9353
+        },
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 73869,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 6.5238011127792985,
+            "max_relevant_docs_per_query": 66,
+            "unique_relevant_docs": 7799
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/OVENIT2TRetrieval.v2.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/OVENIT2TRetrieval.v2.json
@@ -1,0 +1,44 @@
+{
+    "test": {
+        "num_samples": 1338322,
+        "num_queries": 50004,
+        "num_documents": 1288318,
+        "number_of_characters": 716947312,
+        "documents_text_statistics": {
+            "total_text_length": 715308598,
+            "min_text_length": 2,
+            "average_text_length": 555.2267359456283,
+            "max_text_length": 60546,
+            "unique_texts": 1263223
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 1638714,
+            "min_text_length": 11,
+            "average_text_length": 32.771658267338616,
+            "max_text_length": 78,
+            "unique_texts": 1540
+        },
+        "queries_image_statistics": {
+            "min_image_width": 256,
+            "average_image_width": 285.66400687944963,
+            "max_image_width": 1365,
+            "min_image_height": 256,
+            "average_image_height": 266.91002719782415,
+            "max_image_height": 1079,
+            "unique_images": 49917
+        },
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 492654,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 9.852291816654668,
+            "max_relevant_docs_per_query": 174,
+            "unique_relevant_docs": 24471
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -178,7 +178,7 @@ from .hotpot_qa_retrieval import (
 )
 from .image_co_de_t2i_retrieval import ImageCoDeT2IRetrieval
 from .info_seek_it2it_retrieval import InfoSeekIT2ITRetrieval
-from .info_seek_it2t_retrieval import InfoSeekIT2TRetrieval
+from .info_seek_it2t_retrieval import InfoSeekIT2TRetrieval, InfoSeekIT2TRetrievalV2
 from .irpapers_t2i_retrieval import IRPapersT2IRetrieval
 from .irpapers_t2it_retrieval import IRPapersT2ITRetrieval
 from .jl_corpus import JLCorpusA2TRetrieval, JLCorpusT2ARetrieval
@@ -274,7 +274,7 @@ from .obliq_bench_retrieval import (
 )
 from .okvqa_it2t_retrieval import OKVQAIT2TRetrieval
 from .oven_it2it_retrieval import OVENIT2ITRetrieval
-from .oven_it2t_retrieval import OVENIT2TRetrieval
+from .oven_it2t_retrieval import OVENIT2TRetrieval, OVENIT2TRetrievalV2
 from .panda70m_retrieval import (
     Panda70MT2VARetrieval,
     Panda70MT2VRetrieval,
@@ -625,6 +625,7 @@ __all__ = [
     "ImageCoDeT2IRetrieval",
     "InfoSeekIT2ITRetrieval",
     "InfoSeekIT2TRetrieval",
+    "InfoSeekIT2TRetrievalV2",
     "JLCorpusA2TRetrieval",
     "JLCorpusT2ARetrieval",
     "KnowMeBench",
@@ -698,6 +699,7 @@ __all__ = [
     "OKVQAIT2TRetrieval",
     "OVENIT2ITRetrieval",
     "OVENIT2TRetrieval",
+    "OVENIT2TRetrievalV2",
     "Panda70MT2VARetrieval",
     "Panda70MT2VRetrieval",
     "Panda70MV2TRetrieval",

--- a/mteb/tasks/retrieval/eng/info_seek_it2t_retrieval.py
+++ b/mteb/tasks/retrieval/eng/info_seek_it2t_retrieval.py
@@ -36,4 +36,49 @@ class InfoSeekIT2TRetrieval(AbsTaskRetrieval):
         prompt={
             "query": "Find a paragraph from Wikipedia that answers my question about this image."
         },
+        superseded_by="InfoSeekIT2TRetrieval.v2",
+    )
+
+
+class InfoSeekIT2TRetrievalV2(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="InfoSeekIT2TRetrieval.v2",
+        description=(
+            "Retrieve source information to answer questions about images. "
+            "Version 2 restores the combined InfoSeek + OVEN candidate corpus "
+            "used by the original M-BEIR benchmark. Queries and qrels are "
+            "unchanged. For more information see "
+            "[Issue #5021](https://github.com/embeddings-benchmark/mteb/issues/5021)."
+        ),
+        reference="https://aclanthology.org/2023.emnlp-main.925",
+        dataset={
+            "path": "lxercode/mbeir_infoseek_task6_v2",
+            "revision": "2d68d6828333bedf9749af0c20269a9c15e64997",
+        },
+        type="Any2AnyRetrieval",
+        category="it2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2023-01-01", "2023-12-31"),
+        domains=["Encyclopaedic"],
+        task_subtypes=["Image Text Retrieval"],
+        license="cc-by-sa-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        modalities=["text", "image"],
+        sample_creation="found",
+        bibtex_citation=r"""
+@inproceedings{chen2023can,
+  author = {Chen, Yang and Hu, Hexiang and Luan, Yi and Sun, Haitian and Changpinyo, Soravit and Ritter, Alan and Chang, Ming-Wei},
+  booktitle = {Proceedings of the 2023 Conference on Empirical Methods in Natural Language Processing},
+  pages = {14948--14968},
+  title = {Can Pre-trained Vision and Language Models Answer Visual Information-Seeking Questions?},
+  year = {2023},
+}
+""",
+        prompt={
+            "query": "Find a paragraph from Wikipedia that answers my question about this image."
+        },
+        adapted_from=["InfoSeekIT2TRetrieval"],
     )

--- a/mteb/tasks/retrieval/eng/oven_it2t_retrieval.py
+++ b/mteb/tasks/retrieval/eng/oven_it2t_retrieval.py
@@ -36,4 +36,49 @@ class OVENIT2TRetrieval(AbsTaskRetrieval):
         prompt={
             "query": "Retrieve a Wikipedia paragraph that provides an answer to the given query about the image."
         },
+        superseded_by="OVENIT2TRetrieval.v2",
+    )
+
+
+class OVENIT2TRetrievalV2(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="OVENIT2TRetrieval.v2",
+        description=(
+            "Retrieve a Wikipedia passage that answers a query about an image. "
+            "Version 2 restores the combined OVEN + InfoSeek candidate corpus "
+            "used by the original M-BEIR benchmark. Queries and qrels are "
+            "unchanged. For more information see "
+            "[Issue #5021](https://github.com/embeddings-benchmark/mteb/issues/5021)."
+        ),
+        reference="https://openaccess.thecvf.com/content/ICCV2023/html/Hu_Open-domain_Visual_Entity_Recognition_Towards_Recognizing_Millions_of_Wikipedia_Entities_ICCV_2023_paper.html",
+        dataset={
+            "path": "lxercode/mbeir_oven_task6_v2",
+            "revision": "e5d8d4c302009ca706db8ade9f8c02edd417c290",
+        },
+        type="Any2AnyRetrieval",
+        category="it2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2023-01-01", "2023-12-31"),
+        domains=["Encyclopaedic"],
+        task_subtypes=["Image Text Retrieval"],
+        license="cc-by-sa-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        modalities=["text", "image"],
+        sample_creation="created",
+        bibtex_citation=r"""
+@inproceedings{hu2023open,
+  author = {Hu, Hexiang and Luan, Yi and Chen, Yang and Khandelwal, Urvashi and Joshi, Mandar and Lee, Kenton and Toutanova, Kristina and Chang, Ming-Wei},
+  booktitle = {Proceedings of the IEEE/CVF International Conference on Computer Vision},
+  pages = {12065--12075},
+  title = {Open-domain visual entity recognition: Towards recognizing millions of wikipedia entities},
+  year = {2023},
+}
+""",
+        prompt={
+            "query": "Retrieve a Wikipedia paragraph that provides an answer to the given query about the image."
+        },
+        adapted_from=["OVENIT2TRetrieval"],
     )

--- a/tests/test_tasks/test_task_quality.py
+++ b/tests/test_tasks/test_task_quality.py
@@ -165,6 +165,7 @@ KNOWN_ISSUES: dict[str, list[str]] = {
         "IndicCrosslingualSTS",
         "IndicLangClassification",
         "IndicNLPNewsClassification",
+        "InfoSeekIT2TRetrieval.v2",  # documents_text_statistics inherits OVEN's short min_text_length after the corpus union fix (#5021)
         "JDReview",
         "JDReview.v2",
         "JaGovFaqsRetrieval",
@@ -254,6 +255,7 @@ KNOWN_ISSUES: dict[str, list[str]] = {
         "NorQuadRetrieval",
         "NovelQA",
         "OVENIT2TRetrieval",
+        "OVENIT2TRetrieval.v2",  # same OVEN corpus text as v1; corpus completeness fix (#5021) doesn't touch text quality
         "Ocnli",
         "OdiaNewsClassification",
         "OmniVideoBenchVideoAudioCentricQA",
@@ -490,6 +492,7 @@ KNOWN_ISSUES: dict[str, list[str]] = {
         "IndonesianMongabayConservationClassification",
         "InfoSeekIT2ITRetrieval",
         "InfoSeekIT2TRetrieval",
+        "InfoSeekIT2TRetrieval.v2",  # queries unchanged from v1 (templated questions across images); corpus union also carries OVEN's document-level duplicates (#5021)
         "JDReview",
         "JQaRAReranking",
         "JaCWIRReranking",
@@ -565,6 +568,7 @@ KNOWN_ISSUES: dict[str, list[str]] = {
         "OKVQAIT2TRetrieval",
         "OVENIT2ITRetrieval",
         "OVENIT2TRetrieval",
+        "OVENIT2TRetrieval.v2",  # queries unchanged from v1 (templated questions across images); corpus union also carries INFOSEEK's document-level duplicates (#5021)
         "OnlineStoreReviewSentimentClassification",
         "OpenTenderRetrieval",
         "PIQA",
@@ -817,6 +821,7 @@ KNOWN_ISSUES: dict[str, list[str]] = {
         "ImageCoDeT2IRetrieval",
         "InfoSeekIT2ITRetrieval",
         "InfoSeekIT2TRetrieval",
+        "InfoSeekIT2TRetrieval.v2",  # queries unchanged from v1 (multiple questions per image) (#5021)
         "LLaVAIT2TRetrieval",
         "MMLongBenchDocRetrieval",  # official corpus contains repeated rendered pages; preserve IDs to match qrels
         "MomentSeekerTI2VRetrieval",


### PR DESCRIPTION

## Summary

OVEN and InfoSeek are intended to use a combined candidate pool in the original M-BEIR preprocessing, but the current MTEB exports retain cross-dataset qrels while only including the task-local corpus.

### Evidence

The original M-BEIR preprocessing explicitly builds a combined OVEN + InfoSeek candidate pool:

```python
combined_pool_dict = {**infoseek_cand_pool, **oven_1m_cand_dict}
````

The current OVEN export instead contains only OVEN (`5:`) corpus IDs, while its qrels also reference InfoSeek (`6:`) documents:

```text
corpus prefixes: {'5': 676667}
qrel prefixes:   {'5': 50004, '6': 442650}
```

This leaves valid qrel targets absent from the searchable corpus.

### Fix

This PR adds `.v2` tasks that restore the combined corpus while keeping queries and qrels unchanged.

Before the fix:

* OVEN: 21,689 missing qrel corpus IDs
* InfoSeek: 941 missing qrel corpus IDs

After the fix:

* 1,288,318 corpus entries
* 0 ID collisions
* 0 missing qrel corpus IDs for both tasks

The existing v1 tasks are preserved so previously published results are not silently changed.

Validation: metadata tests, task-quality tests, and ruff all pass.

Related to #5021.

```
```
