### PR TITLE
ci: add Copilot review workflow for new model PRs

### DIFF
--- a/.github/instructions/model-pr.instructions.md
+++ b/.github/instructions/model-pr.instructions.md
@@ -1,0 +1,49 @@
+# New Model PR Guidelines
+
+Ensure the PR description includes the evidence and context reviewers need to evaluate correctness and quality.
+
+## ModelMeta Completeness
+
+- The PR must include a `ModelMeta` object with all fields filled out to the extent possible.
+- Required fields: `name`, `loader`, `languages`, `open_weights`, `revision`, `release_date`, `n_parameters`, `memory_usage_mb`, `embed_dim`, `license`, `max_tokens`, `reference`, `similarity_fn_name`, `framework`.
+- Flag the PR if any required field is missing or set to a placeholder value without explanation.
+- The model must be public: either available via API or with publicly downloadable weights.
+
+## Model Loading
+
+- The PR must confirm the model loads correctly via:
+  - `mteb.get_model(model_name, revision)`
+  - `mteb.get_model_meta(model_name, revision)`
+- Flag the PR if there is no indication that loading was verified.
+
+## Mock Run Results
+
+- The PR must include the output of `mteb mock-run -m your_model_name` (or the equivalent Python call).
+- The resulting `mteb_mock_run_results.md` file should be committed with the PR.
+- Flag the PR if mock run results are missing or if `all_passed` is not confirmed.
+
+## Reproduction Results
+
+- If the model has an associated paper or published benchmark results, the PR must reproduce at least one benchmark score and compare it against the paper.
+- Results must be presented as a table, not as prose.
+- Columns: score source (e.g. "PR" and "Paper").
+- Rows: one row per benchmark or task.
+- Flag the PR if results are described only in paragraph form, or if the table is transposed (benchmarks as columns).
+- If the model has no associated paper or published results, the PR must include a note explaining this.
+
+Example of correct format:
+
+| Benchmark | PR | Paper |
+|---|---|---|
+| MTEB English | 64.2 | 64.5 |
+| BEIR | 51.3 | 51.0 |
+
+## AI-Generated Boilerplate
+
+- Flag PR descriptions that contain noise that appears AI-generated rather than human-written.
+- Common patterns to flag:
+  - Bullet lists of CI checks that passed (e.g. "Ruff, typos, mypy checks pass")
+  - Generic validation summaries (e.g. "all tests pass")
+  - Filler sections such as "Validation", "Testing Done", or "Checklist" filled with auto-generated text that adds no information for reviewers
+  - Verbose restatements of what the code does without any insight
+- The PR description should explain the model, its origin, and why it belongs in MTEB.

--- a/.github/workflows/copilot_dataset_review.yml
+++ b/.github/workflows/copilot_dataset_review.yml
@@ -18,6 +18,6 @@ jobs:
     steps:
       - name: Post Copilot review request
         run: |
-          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@github-copilot review
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@copilot review
 
           Please review this PR against the guidelines in \`.github/instructions/dataset-pr.instructions.md\`. Only report actionable issues. Include file/line references and a concrete suggested fix where possible."

--- a/.github/workflows/copilot_model_review.yml
+++ b/.github/workflows/copilot_model_review.yml
@@ -1,0 +1,23 @@
+name: Copilot model PR review
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  request-review:
+    if: github.event.label.name == 'new model'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Post Copilot review request
+        run: |
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@github-copilot review
+
+          Please review this PR against the guidelines in \`.github/instructions/model-pr.instructions.md\`. Only report actionable issues. Include file/line references and a concrete suggested fix where possible."

--- a/.github/workflows/copilot_model_review.yml
+++ b/.github/workflows/copilot_model_review.yml
@@ -18,6 +18,6 @@ jobs:
     steps:
       - name: Post Copilot review request
         run: |
-          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@github-copilot review
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@copilot review
 
           Please review this PR against the guidelines in \`.github/instructions/model-pr.instructions.md\`. Only report actionable issues. Include file/line references and a concrete suggested fix where possible."

--- a/docs/contributing/adding_a_dataset.md
+++ b/docs/contributing/adding_a_dataset.md
@@ -633,6 +633,18 @@ Once added, here is a checklist to ensure that everything works before you submi
 - [ ] I reproduced scores from the original paper (if applicable) and added them to the PR description for reference.
 ```
 
+The PR description must also include:
+
+- **Descriptive statistics**: Number of samples per split, average text length, label distribution, language breakdown — directly in the PR, not just a link to the dataset card.
+- **Model results table**: Scores for at least `mteb/baseline-random-encoder` and a small real model (e.g. `intfloat/multilingual-e5-small`). If reproduction results from a paper are included, present them as a table:
+
+  | Model | PR | Paper |
+  |---|---|---|
+  | model-a | 42.1 | 42.3 |
+  | model-b | 38.7 | 39.0 |
+
+  If there is no associated paper or no equivalent model in MTEB, include a note explaining this.
+
 An easy way to test it is using:
 
 === "Python"

--- a/docs/contributing/adding_a_model.md
+++ b/docs/contributing/adding_a_model.md
@@ -247,6 +247,17 @@ When submitting you models as a PR, please copy and paste the following checklis
 - [ ] I reproduced results from the original paper (if applicable) on at least one benchmark, and I am including the results in the PR description.
 ```
 
+The PR description must also include:
+
+- **Reproduction results table**: If the model has an associated paper or published benchmark results, include a table comparing your scores against the paper. If there is no paper or no equivalent benchmark, include a note explaining this.
+
+  | Benchmark | PR | Paper |
+  |---|---|---|
+  | MTEB English | 64.2 | 64.5 |
+  | BEIR | 51.3 | 51.0 |
+
+- **Mock run results**: Confirm that `mteb mock-run -m your_model_name` passes and commit the resulting `mteb_mock_run_results.md` file with the PR.
+
 
 ### Matryoshka embeddings
 


### PR DESCRIPTION
Adds a Copilot review workflow and instructions for new model PRs, mirroring the existing dataset PR review setup. Also updates both contributing guides to document PR description requirements.

**Changes:**
- `.github/workflows/copilot_model_review.yml`: triggers on `new model` label, posts `@copilot review` comment
- `.github/instructions/model-pr.instructions.md`: review guidelines covering ModelMeta completeness, loading verification, mock run results, reproduction results table, and AI-generated boilerplate
- `docs/contributing/adding_a_model.md`: adds PR description requirements (results table, mock run)
- `docs/contributing/adding_a_dataset.md`: adds PR description requirements (descriptive stats, results table)
- Both workflows updated to use `@copilot` instead of `@github-copilot`