### PR TITLE
fix: require datasets>=4.0.0 for video extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ api = [
 og = [
     "playwright>=1.49.0",
 ]
-video = ["torchcodec"]
+video = ["datasets>=4.0.0", "torchcodec"]
 github = ["PyGithub>=1.60"]
 
 # model specific optional dependencies:


### PR DESCRIPTION
Related to #5116

I used `datasets>=4.0.0` rather than `>=3.1.0`. Although the `Video` feature was introduced in 3.1.0, it only switched to the `torchcodec` backend in datasets 4.0.0. This keeps the `video` extra internally consistent.