### PR TITLE
model: add RAVENEA-CLIP

### DIFF
--- a/mteb/models/model_implementations/ravenea_models.py
+++ b/mteb/models/model_implementations/ravenea_models.py
@@ -1,0 +1,39 @@
+from mteb.models.model_implementations.clip_models import CLIPModel
+from mteb.models.model_meta import ModelMeta, ScoringFunction
+
+RAVENEA_CITATION = r"""
+@inproceedings{li2026ravenea,
+  author = {Jiaang Li and Yifei Yuan and Wenyan Li and Mohammad Aliannejadi and Daniel Hershcovich and Anders S{\o}gaard and Ivan Vuli{\'c} and Wenxuan Zhang and Paul Pu Liang and Yang Deng and Serge Belongie},
+  booktitle = {The Fourteenth International Conference on Learning Representations},
+  title = {{RAVENEA}: A Benchmark for Multimodal Retrieval-Augmented Visual Culture Understanding},
+  url = {https://openreview.net/forum?id=4zAbkxQ23i},
+  year = {2026},
+}
+"""
+
+
+ravenea_clip_vit_large_patch14 = ModelMeta(
+    loader=CLIPModel,
+    name="jaagli/ravenea-clip-vit-large-patch14",
+    model_type=["dense"],
+    languages=["eng-Latn"],
+    revision="890d85d3539a21fab2bb349d4874d5dfef5dd3ec",
+    release_date="2026-02-13",
+    modalities=["image", "text"],
+    n_parameters=427_616_513,
+    n_embedding_parameters=37_945_344,
+    memory_usage_mb=1631,
+    max_tokens=77,
+    embed_dim=768,
+    license=None,
+    open_weights=True,
+    public_training_code="https://github.com/yfyuan01/RAVENEA",
+    public_training_data="https://huggingface.co/datasets/jaagli/ravenea",
+    framework=["PyTorch", "Transformers", "safetensors"],
+    reference="https://huggingface.co/jaagli/ravenea-clip-vit-large-patch14",
+    similarity_fn_name=ScoringFunction.COSINE,
+    use_instructions=False,
+    training_datasets={"RAVENEAI2TRetrieval"},
+    adapted_from="openai/clip-vit-large-patch14",
+    citation=RAVENEA_CITATION,
+)

--- a/mteb_mock_run_results.md
+++ b/mteb_mock_run_results.md
@@ -1,0 +1,56 @@
+# MTEB Mock-Run Results for `jaagli/ravenea-clip-vit-large-patch14`
+
+| Task | Modality | Pass | Reason |
+| --- | --- | --- | --- |
+| MockMultilingualBitextMiningTask | text | ✓ | - |
+| MockMultilingualParallelBitextMiningTask | text | ✓ | - |
+| MockMultilingualClassificationTask | text | ✓ | - |
+| MockMultilingualClusteringTask | text | ✓ | - |
+| MockMultilingualClusteringFastTask | text | ✓ | - |
+| MockMultilingualPairClassificationTask | text | ✓ | - |
+| MockMultilingualRerankingTask | text | ✓ | - |
+| MockMultilingualRetrievalTask | text | ✓ | - |
+| MockMultilingualSTSTask | text | ✓ | - |
+| MockMultilingualMultilabelClassification | text | ✓ | - |
+| MockMultilingualSummarizationTask | text | ✓ | - |
+| MockMultilingualInstructionRetrieval | text | ✓ | - |
+| MockMultilingualInstructionReranking | text | ✓ | - |
+| MockBitextMiningTask | text | ✓ | - |
+| MockClassificationTask | text | ✓ | - |
+| MockRegressionTask | text | ✓ | - |
+| MockClusteringTask | text | ✓ | - |
+| LegacyMockClusteringFastTask | text | ✓ | - |
+| MockPairClassificationTask | text | ✓ | - |
+| MockRerankingTask | text | ✓ | - |
+| MockRetrievalTask | text | ✓ | - |
+| MockSTSTask | text | ✓ | - |
+| MockMultilabelClassification | text | ✓ | - |
+| MockSummarizationTask | text | ✓ | - |
+| MockInstructionRetrieval | text | ✓ | - |
+| MockInstructionReranking | text | ✓ | - |
+| MockRetrievalDialogTask | text | ✓ | - |
+| MockTextZeroShotClassification | text | ✓ | - |
+| MockAny2AnyRetrievalI2T | image, text | ✓ | - |
+| MockAny2AnyRetrievalT2I | image, text | ✓ | - |
+| MockVisionCentricQA | image, text | ✓ | - |
+| MockImageClassification | image | ✓ | - |
+| MockImageClustering | image | ✓ | - |
+| MockImageTextPairClassification | image, text | ✓ | - |
+| MockVisualSTS | image | ✓ | - |
+| MockZeroShotClassification | image, text | ✓ | - |
+| MockImageMultilabelClassification | image | ✓ | - |
+| MockMultilingualImageClassification | image | ✓ | - |
+| MockMultilingualImageTextPairClassification | image, text | ✓ | - |
+| MockMultilingualVisionCentricQA | image, text | ✓ | - |
+| MockImageClusteringFastTask | image | ✓ | - |
+| MockImageRegressionTask | image | ✓ | - |
+| MockPairImageClassificationTask | image | ✓ | - |
+
+## Summary by Modality
+
+| Pass      | Modality | Failures |
+| --------- | -------- | -------- |
+| ✓ (35/35) | text     |  |
+| ✓ (15/15) | image    |  |
+| skipped   | audio    |  |
+| skipped   | video    |  |


### PR DESCRIPTION
## Summary

Adds a `ModelMeta` for [`jaagli/ravenea-clip-vit-large-patch14`](https://huggingface.co/jaagli/ravenea-clip-vit-large-patch14), pinned to revision `890d85d3539a21fab2bb349d4874d5dfef5dd3ec`.

The model uses MTEB's existing `CLIPModel` wrapper, so this adds no custom loader or dependency. The metadata records the CLIP-L/14 base model, RAVENEA training resources, architecture details, and paper citation. The required mock-run report is included. The model repository does not declare a license, so `license=None` is preserved rather than inferring one.

## Paper reproduction

Evaluated on `RAVENEAI2TRetrieval` from #5135 using the official test split, corpus, graded judgments, and source-compatible metrics:

| MRR | P@1 | P@3 | P@5 | nDCG@1 | nDCG@3 | nDCG@5 |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 82.17 | 72.05 | 45.76 | 36.77 | 77.08 | 78.96 | 84.09 |

These values reproduce the RAVENEA-CLIP paper row after rounding.

## Validation

- `mteb.get_model(...)` and `mteb.get_model_meta(...)`
- `mteb mock-run`: 35/35 text and 15/15 image tasks passed
- 1,728 applicable model-metadata tests passed
- Ruff formatting/lint, typos, and mypy passed
- End-to-end RAVENEA evaluation reproduced the paper scores above

## Model checklist

- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [x] I have tested the implementation works on a representative set of tasks.
- [x] The model is public, i.e., is available either as an API or the weights are publicly available to download
- [x] I reproduced results from the original paper on at least one benchmark, and included the results above.

Related to #5135, #4954, and #4842.