### PR TITLE
fix: Add support for more metrics in ZeroShot classification

### DIFF
--- a/mteb/abstasks/zeroshot_classification.py
+++ b/mteb/abstasks/zeroshot_classification.py
@@ -240,7 +240,6 @@ class AbsTaskZeroShotClassification(AbsTask):
             ap_weighted=None,
         )
 
-        # if binary classification, also report average precision using the
         if len(np.unique(labels)) == 2:
             positive_scores = probs[:, 1]
             scores["ap"] = metrics.average_precision_score(

--- a/mteb/abstasks/zeroshot_classification.py
+++ b/mteb/abstasks/zeroshot_classification.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, TypedDict, cast
 
+import numpy as np
 import torch
 from datasets import Dataset
 from sklearn import metrics
@@ -22,6 +23,8 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from pathlib import Path
 
+    from numpy.typing import NDArray
+
     from mteb.models import MTEBModels
     from mteb.timing import TimingStack
     from mteb.types import EncodeKwargs, Modalities
@@ -34,9 +37,25 @@ class ZeroShotClassificationMetrics(TypedDict):
 
     Attributes:
         accuracy: Accuracy of the model.
+        f1: F1 score (macro).
+        f1_weighted: Weighted F1 score.
+        precision: Precision score (macro).
+        precision_weighted: Weighted precision score.
+        recall: Recall score (macro).
+        recall_weighted: Weighted recall score.
+        ap: Average precision score (macro) for binary classification.
+        ap_weighted: Weighted average precision score for binary classification.
     """
 
     accuracy: float
+    f1: float
+    f1_weighted: float
+    precision: float
+    precision_weighted: float
+    recall: float
+    recall_weighted: float
+    ap: float | None
+    ap_weighted: float | None
 
 
 class AbsTaskZeroShotClassification(AbsTask):
@@ -153,11 +172,14 @@ class AbsTaskZeroShotClassification(AbsTask):
                 hf_split=hf_split,
             )
 
+        probs_array = (
+            probs.cpu().numpy() if torch.is_tensor(probs) else np.asarray(probs)
+        )
         return self._calculate_scores(
             self._normalize_labels(
                 data_split[self.label_column_name], candidate_labels
             ),
-            torch.tensor(probs).argmax(dim=1).tolist(),
+            probs_array,
         )
 
     @staticmethod
@@ -199,11 +221,35 @@ class AbsTaskZeroShotClassification(AbsTask):
     def _calculate_scores(  # noqa: PLR6301
         self,
         labels: list[int],
-        predictions: list[int],
+        probs: NDArray[np.floating],
     ) -> ZeroShotClassificationMetrics:
-        return ZeroShotClassificationMetrics(
+        predictions = probs.argmax(axis=1)
+        scores = ZeroShotClassificationMetrics(
             accuracy=metrics.accuracy_score(labels, predictions),
+            f1=metrics.f1_score(labels, predictions, average="macro"),
+            f1_weighted=metrics.f1_score(labels, predictions, average="weighted"),
+            precision=metrics.precision_score(labels, predictions, average="macro"),
+            precision_weighted=metrics.precision_score(
+                labels, predictions, average="weighted"
+            ),
+            recall=metrics.recall_score(labels, predictions, average="macro"),
+            recall_weighted=metrics.recall_score(
+                labels, predictions, average="weighted"
+            ),
+            ap=None,
+            ap_weighted=None,
         )
+
+        # if binary classification, also report average precision using the
+        if len(np.unique(labels)) == 2:
+            positive_scores = probs[:, 1]
+            scores["ap"] = metrics.average_precision_score(
+                labels, positive_scores, average="macro"
+            )
+            scores["ap_weighted"] = metrics.average_precision_score(
+                labels, positive_scores, average="weighted"
+            )
+        return scores
 
     def _push_dataset_to_hub(
         self,

--- a/mteb/abstasks/zeroshot_classification.py
+++ b/mteb/abstasks/zeroshot_classification.py
@@ -4,7 +4,6 @@ import logging
 from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 import numpy as np
-import torch
 from datasets import Dataset
 from sklearn import metrics
 
@@ -23,11 +22,9 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from pathlib import Path
 
-    from numpy.typing import NDArray
-
     from mteb.models import MTEBModels
     from mteb.timing import TimingStack
-    from mteb.types import EncodeKwargs, Modalities
+    from mteb.types import Array, EncodeKwargs, Modalities
 
 logger = logging.getLogger(__name__)
 
@@ -172,14 +169,12 @@ class AbsTaskZeroShotClassification(AbsTask):
                 hf_split=hf_split,
             )
 
-        probs_array = (
-            probs.cpu().numpy() if torch.is_tensor(probs) else np.asarray(probs)
-        ).astype(np.float64)
         return self._calculate_scores(
             self._normalize_labels(
-                data_split[self.label_column_name], candidate_labels
+                data_split[self.label_column_name],
+                candidate_labels,
             ),
-            probs_array,
+            probs,
         )
 
     @staticmethod
@@ -221,9 +216,9 @@ class AbsTaskZeroShotClassification(AbsTask):
     def _calculate_scores(  # noqa: PLR6301
         self,
         labels: list[int],
-        probs: NDArray[np.floating],
+        probs: Array,
     ) -> ZeroShotClassificationMetrics:
-        predictions = probs.argmax(axis=1)
+        predictions = probs.argmax(1)
         scores = ZeroShotClassificationMetrics(
             accuracy=metrics.accuracy_score(labels, predictions),
             f1=metrics.f1_score(labels, predictions, average="macro"),

--- a/mteb/abstasks/zeroshot_classification.py
+++ b/mteb/abstasks/zeroshot_classification.py
@@ -174,7 +174,7 @@ class AbsTaskZeroShotClassification(AbsTask):
 
         probs_array = (
             probs.cpu().numpy() if torch.is_tensor(probs) else np.asarray(probs)
-        )
+        ).astype(np.float64)
         return self._calculate_scores(
             self._normalize_labels(
                 data_split[self.label_column_name], candidate_labels

--- a/tests/test_abstasks/test_zeroshot_classification.py
+++ b/tests/test_abstasks/test_zeroshot_classification.py
@@ -4,7 +4,9 @@ import pytest
 
 import mteb
 from mteb.abstasks import AbsTaskZeroShotClassification
-from mteb.mocks.mock_tasks import MockTextZeroShotClassificationTask
+from mteb.mocks.mock_tasks import (
+    MockTextZeroShotClassificationTask,
+)
 
 
 def test_normalize_labels_keeps_integer_labels():
@@ -38,4 +40,13 @@ def test_zeroshot_classification_scores_with_string_labels():
         model, MockTextZeroShotClassificationTask(), cache=None, co2_tracker=False
     )
 
-    assert results[0].scores["test"][0]["accuracy"] == 1.0
+    scores = results[0].scores["test"][0]
+    assert scores["accuracy"] == 1.0
+    assert scores["f1"] == 1.0
+    assert scores["f1_weighted"] == 1.0
+    assert scores["precision"] == 1.0
+    assert scores["precision_weighted"] == 1.0
+    assert scores["recall"] == 1.0
+    assert scores["recall_weighted"] == 1.0
+    assert scores["ap"] == 1.0
+    assert scores["ap_weighted"] == 1.0

--- a/tests/test_integrations/test_encode_args_passed.py
+++ b/tests/test_integrations/test_encode_args_passed.py
@@ -93,7 +93,7 @@ def test_task_metadata_passed_encoder(task: mteb.AbsTask, tmp_path: Path):
             assert task_metadata.name == _task_name
             assert isinstance(hf_split, str)
             assert isinstance(hf_subset, str)
-            return np.zeros((len(inputs.dataset), 10))
+            return np.ones((len(inputs.dataset), 10))
 
     mteb.evaluate(
         MockEncoder(),


### PR DESCRIPTION
Currently ZeroShotClassification reports only accuracy, but after https://github.com/embeddings-benchmark/mteb/pull/4790 is possible to use any sklearn metric. Added same metrics as in Classification task