### PR TITLE
fix: cap retrieval top-k search depth to available results

### DIFF
--- a/mteb/abstasks/retrieval.py
+++ b/mteb/abstasks/retrieval.py
@@ -108,7 +108,7 @@ class AbsTaskRetrieval(AbsTask):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self._top_k = max(self.k_values)
+        self._top_k: int = max(self.k_values)
 
     def convert_v1_dataset_format_to_v2(
         self,

--- a/mteb/abstasks/retrieval.py
+++ b/mteb/abstasks/retrieval.py
@@ -100,12 +100,15 @@ class AbsTaskRetrieval(AbsTask):
     ignore_identical_ids: bool = False
     abstask_prompt = "Retrieve text based on user query."
     k_values: Sequence[int] = (1, 3, 5, 10, 20, 100, 1000)
-    _top_k: int = max(k_values)
     dataset: dict[str, dict[str, RetrievalSplitData]]
     _support_cross_encoder: bool = True
     _support_search: bool = True
     _previous_results_model_meta: dict[str, Any] | None = None
     skip_first_result: bool = False
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._top_k = max(self.k_values)
 
     def convert_v1_dataset_format_to_v2(
         self,

--- a/mteb/mocks/mock_tasks/retrieval.py
+++ b/mteb/mocks/mock_tasks/retrieval.py
@@ -104,7 +104,6 @@ _VIDEO_TEXTS = [
 
 
 class MockRetrievalTask(AbsTaskRetrieval):
-    _top_k = 2
     expected_stats = {
         "val": {
             "num_samples": 4,
@@ -192,7 +191,6 @@ class MockRetrievalTask(AbsTaskRetrieval):
 
 
 class MockRetrievalDialogTask(AbsTaskRetrieval):
-    _top_k = 1
     expected_stats = {
         "val": {
             "num_samples": 4,

--- a/mteb/models/search_encoder_index/search_indexes/faiss_search_index.py
+++ b/mteb/models/search_encoder_index/search_indexes/faiss_search_index.py
@@ -114,7 +114,8 @@ class FaissSearchIndex:
                 query_idx_to_id=query_idx_to_id,
             )
         else:
-            sim_array, id_array = self.index.search(embeddings_f32, top_k)
+            capped_top_k = min(top_k, self.index.ntotal)
+            sim_array, id_array = self.index.search(embeddings_f32, capped_top_k)
             similarities = sim_array.tolist()
             ids = id_array.tolist()
 


### PR DESCRIPTION
Correctlly select `top_k` value from `k_values` for retrieaval tasks. Fix faiss retrieval when number of documents less than `top_k`. Previosly when number of documents less than `top_k` faiss returned additional `-1` indexes.