### PR TITLE
docker: drop the unused data-cache COPY from the og-builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,11 @@
 #                 ``~/.cache/mteb/leaderboard/`` so the runtime first
 #                 request skips ~30s of cold work. DATA_REFRESH busts
 #                 the cache of these layers daily.
-#   og-builder  — extends `og-deps`, copies the warmed caches from
-#                 `data`, renders one OG hero PNG per benchmark / task
-#                 / model into /og-cache, then exits. Nothing
-#                 downstream of this stage ships.
+#   og-builder  — extends `og-deps`, renders one OG hero PNG per
+#                 benchmark / task / model into /og-cache, then exits.
+#                 Registry metadata only, so it does not depend on
+#                 `data` and builds alongside it. Nothing downstream
+#                 of this stage ships.
 #   runtime     — extends `data`, copies the rendered PNG files out of
 #                 og-builder. Stays small: no Playwright, no Chromium,
 #                 no Node. FastAPI serves the cached PNG files at /og.
@@ -81,9 +82,10 @@ FROM base AS data
 # earlier layer) is unchanged.
 ARG DATA_REFRESH=0
 
-# Pre-warm the HF dataset cache from mteb/results so the OG builder
-# (which calls warmup_blocking()) and the runtime first request both
-# skip the multi-minute cold clone.
+# Pre-warm the HF dataset cache from mteb/results so the runtime first
+# request skips the multi-minute cold clone. The OG builder does not
+# read this cache: `_load_catalogue` walks the static registries and
+# never calls warmup_blocking().
 RUN echo "data refresh: ${DATA_REFRESH}" \
  && hf download mteb/results --repo-type dataset || true
 
@@ -99,10 +101,6 @@ RUN python -c "from mteb.api.frames import _load_per_benchmark_frames; _load_per
 
 # ─── Stage: og-builder ──────────────────────────────────────────────
 FROM og-deps AS og-builder
-
-# Merge the warmed HF + leaderboard caches from the data stage next to
-# the Playwright browser cache already present in og-deps.
-COPY --from=data --chown=user:user /home/user/.cache /home/user/.cache
 
 RUN python scripts/generate_og_images.py --out=/og-cache
 


### PR DESCRIPTION
### What

Removes one `COPY --from=data` from `og-builder`, and fixes the comment that
explains it.

### Why

The `data` stage warms the HF cache "so the OG builder (which calls
`warmup_blocking()`) and the runtime first request both skip the multi-minute
cold clone". The OG builder does not call it: `git grep warmup_blocking` has one
call site, `mteb/api/app.py:39`, the FastAPI lifespan. The generator says so
itself -- `_load_catalogue` "deliberately skip[s] ... `warmup_blocking`" so it
"never depends on the results dataset being downloaded". It reads
`get_benchmarks()` / `get_tasks()` / `get_model_metas()`, which walk static
in-process registries.

So `og-builder` copies 312,116,769 bytes (95,665,594 + 216,451,175, measured on the
published amd64 image `sha256:2f9f88fb8a5b3df4839a1a49607b9d54f807d40520d0d14335ea9d7604d7b7ca`) into a stage that never reads them. More to the
point: that COPY is the only edge from `data` to `og-builder`, so the dataset
warmup and the Chromium render run in sequence today rather than concurrently.

### What this is not

* **No image-size win.** `og-builder` does not ship; only `/og-cache` leaves it.
* **No layer-cache win.** My first theory was that `DATA_REFRESH` was busting
  the OG render through this COPY. It is wrong: `base` does
  `COPY . /home/user/app`, and across the last 20 daily builds that layer's
  digest changes every time, so `og-builder` re-runs daily either way.
* `runtime` keeps both caches -- that path really does call `warmup_blocking()`.

### Risk

If a registry call did reach `$HF_HOME`, the build would need the network where
it had a warm cache. I have no Docker daemon here, so I read the call paths
instead -- but `Test Build API Docker` builds and boots the image on this PR once
a maintainer approves the run (mine sit at `action_required`). If it goes red,
the premise is wrong and the PR should be closed.

Written by an automated agent.
