### PR TITLE
Enables `B` (flake8-bugbear) ruff rule

### DIFF
--- a/docs/overview/create_available_tasks.py
+++ b/docs/overview/create_available_tasks.py
@@ -215,11 +215,11 @@ def main(input_path: Path, output_path: Path) -> None:
     for tt, stt in _TASKTYPE2SIMPLIFIEDTASKTYPE.items():
         stask_types[stt].append(tt)
 
-    for stt, tt in stask_types.items():
+    for stt, task_types in stask_types.items():
         # For each simplified task type, combine the markdown entries of the corresponding task types, each consisting of the tasks of that type.
         mds = []
 
-        for tt in sorted(tt):  # noqa: PLW2901
+        for tt in sorted(task_types):
             tt_tasks = task_types2tasks.get(tt, [])
             if not tt_tasks:
                 continue

--- a/mteb/_evaluators/retrieval_metrics.py
+++ b/mteb/_evaluators/retrieval_metrics.py
@@ -21,6 +21,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Default abstention rates for the nAUC computation: 0.0, 0.1, ..., 0.9
+_DEFAULT_ABSTENTION_RATES = np.linspace(0, 1, 11)[:-1]
+
 
 def mrr(
     qrels: RelevantDocumentsType,
@@ -88,7 +91,7 @@ def hole(
 
     annotated_corpus = set()
     for _, docs in qrels.items():
-        for doc_id, score in docs.items():
+        for doc_id in docs:
             annotated_corpus.add(doc_id)
 
     k_max = max(k_values)
@@ -158,7 +161,7 @@ def calculate_pmrr(
             continue
         original_qid_run = original_run[qid + "-og"]
         new_qid_run = new_run[qid + "-changed"]
-        for idx, changed_doc in enumerate(cur_changed_qrels):
+        for changed_doc in cur_changed_qrels:
             original_rank, original_score = get_rank_from_dict(
                 original_qid_run, changed_doc
             )
@@ -294,7 +297,7 @@ def confidence_scores(sim_scores: list[float]) -> dict[str, float]:
 def nauc(
     conf_scores: NDArray[np.floating],
     metrics: NDArray[np.floating],
-    abstention_rates: NDArray[np.floating] = np.linspace(0, 1, 11)[:-1],
+    abstention_rates: NDArray[np.floating] = _DEFAULT_ABSTENTION_RATES,
 ) -> float:
     """Computes normalized Area Under the Curve (nAUC) on a set of evaluated instances as presented in the paper https://arxiv.org/abs/2402.12997
 
@@ -316,7 +319,7 @@ def nauc(
     def abstention_curve(
         conf_scores: NDArray[np.floating],
         metrics: NDArray[np.floating],
-        abstention_rates: NDArray[np.floating] = np.linspace(0, 1, 11)[:-1],
+        abstention_rates: NDArray[np.floating] = _DEFAULT_ABSTENTION_RATES,
     ) -> NDArray[np.floating]:
         """Computes the raw abstention curve for a given set of evaluated instances and corresponding confidence scores
 

--- a/mteb/_evaluators/text/bitext_mining_evaluator.py
+++ b/mteb/_evaluators/text/bitext_mining_evaluator.py
@@ -79,9 +79,7 @@ class BitextMiningEvaluator(Evaluator):
             subset=self.hf_subset,
             log_message="Finding nearest neighbors...",
         ):
-            for i, (key1, key2) in enumerate(
-                tqdm(self.pairs, desc="Matching sentences")
-            ):
+            for key1, key2 in tqdm(self.pairs, desc="Matching sentences"):
                 neighbours[f"{key1}-{key2}"] = self._similarity_search(
                     embeddings[key1], embeddings[key2], model
                 )

--- a/mteb/_helpful_enum.py
+++ b/mteb/_helpful_enum.py
@@ -17,4 +17,4 @@ class HelpfulStrEnum(str, Enum):
         except ValueError:
             raise ValueError(
                 f"'{value}' is not a valid {cls.__name__} value, must be one of {[e.value for e in cls]}"
-            )
+            ) from None

--- a/mteb/_reversible_workflow/git_actions.py
+++ b/mteb/_reversible_workflow/git_actions.py
@@ -228,7 +228,7 @@ class CreatePRAction:
         except ImportError:
             raise ImportError(
                 "PyGithub is required for CreatePRAction. To install it run `pip install mteb[github]`"
-            )
+            ) from None
 
         try:
             upstream = self.gh.get_repo(self.upstream_repo_name)

--- a/mteb/_reversible_workflow/git_utils.py
+++ b/mteb/_reversible_workflow/git_utils.py
@@ -98,7 +98,7 @@ def get_current_branch(repo_path: Path) -> str:
         logger.debug(f"Current branch: {branch}")
         return branch
     except subprocess.CalledProcessError as e:
-        raise RuntimeError(f"Failed to get current branch: {e}")
+        raise RuntimeError(f"Failed to get current branch: {e}") from e
 
 
 def restore_branch(repo_path: Path, original_branch: str) -> None:
@@ -122,7 +122,9 @@ def restore_branch(repo_path: Path, original_branch: str) -> None:
         )
         logger.info(f"Restored to original branch '{original_branch}'")
     except subprocess.CalledProcessError as e:
-        raise RuntimeError(f"Failed to restore to branch '{original_branch}': {e}")
+        raise RuntimeError(
+            f"Failed to restore to branch '{original_branch}': {e}"
+        ) from e
 
 
 def delete_branch(repo_path: Path, branch_name: str) -> None:
@@ -286,7 +288,7 @@ def create_pull_request(
     except ImportError:
         raise ImportError(
             "PyGithub is not installed. Please install it using `pip install 'mteb[github]'`"
-        )
+        ) from None
 
     logger.info("Creating PR using PyGithub")
     token = get_github_token()

--- a/mteb/abstasks/_data_filter/filters.py
+++ b/mteb/abstasks/_data_filter/filters.py
@@ -63,7 +63,7 @@ def filter_unclear_label(
     normalized: dict[str, set[str | tuple[str, ...]]] = {}
     logger.debug("[filter_controversial] scanning dataset for label conflicts...")
 
-    for split, ds in dataset_dict.items():
+    for ds in dataset_dict.values():
         for text, label in zip(ds[input_column], ds[label_column]):
             key = text.strip().lower()
             normalized.setdefault(key, set()).add(

--- a/mteb/abstasks/abstask.py
+++ b/mteb/abstasks/abstask.py
@@ -48,7 +48,7 @@ logger = logging.getLogger(__name__)
 def _multilabel_subsampling(
     dataset_dict: DatasetDict,
     seed: int,
-    splits: list[str] = ["test"],
+    splits: Sequence[str] = ("test",),
     label: str = "label",
     n_samples: int = 2048,
 ) -> DatasetDict:
@@ -129,7 +129,7 @@ class AbsTask(ABC):  # noqa: PLR0904
             logger.warning(msg)
             warnings.warn(msg)
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:  # noqa: B027 -- optional hook, deliberately not abstract
         """A transform operations applied to the dataset after loading.
 
         This method is useful when the dataset from Huggingface is not in an `mteb` compatible format.
@@ -306,7 +306,7 @@ class AbsTask(ABC):  # noqa: PLR0904
     def stratified_subsampling(
         dataset_dict: DatasetDict,
         seed: int,
-        splits: list[str] = ["test"],
+        splits: Sequence[str] = ("test",),
         label: str = "label",
         n_samples: int = 2048,
     ) -> DatasetDict:

--- a/mteb/abstasks/regression.py
+++ b/mteb/abstasks/regression.py
@@ -21,6 +21,8 @@ from ._statistics_calculation import _count_samples_in_train
 from .classification import AbsTaskClassification
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from datasets import Dataset
     from numpy.typing import NDArray
 
@@ -114,7 +116,7 @@ class AbsTaskRegression(AbsTaskClassification):
         dataset_dict: datasets.DatasetDict,
         *,
         seed: int,
-        splits: list[str] = ["test"],
+        splits: Sequence[str] = ("test",),
         label: str = "value",
         n_samples: int = 2048,
         n_bins: int = 10,

--- a/mteb/abstasks/task_metadata.py
+++ b/mteb/abstasks/task_metadata.py
@@ -738,7 +738,7 @@ class TaskMetadata(BaseModel):
         descriptive_stats = ""
         if self.descriptive_stats is not None:
             descriptive_stats_ = self.descriptive_stats
-            for split, split_stat in descriptive_stats_.items():
+            for split_stat in descriptive_stats_.values():
                 if len(split_stat.get("hf_subset_descriptive_stats", {})) > 10:
                     split_stat.pop("hf_subset_descriptive_stats", {})
             descriptive_stats = json.dumps(descriptive_stats_, indent=4)

--- a/mteb/abstasks/text/reranking.py
+++ b/mteb/abstasks/text/reranking.py
@@ -173,7 +173,9 @@ class AbsTaskReranking(AbsTaskRetrieval):
 
                 # Map the transformation function over the dataset
                 processed_dataset = enumerated_dataset.map(
-                    lambda example, idx: self._process_example(example, split, idx),
+                    lambda example, idx, split=split: self._process_example(
+                        example, split, idx
+                    ),
                     with_indices=True,
                     remove_columns=enumerated_dataset.column_names,
                 )

--- a/mteb/benchmarks/benchmark.py
+++ b/mteb/benchmarks/benchmark.py
@@ -608,10 +608,10 @@ class Benchmark:
                 for name, rank in zip(per_task_df.index, borda_list):
                     scores[name]["Rank"] = int(rank)
             else:
-                for name, model_scores in scores.items():
+                for model_scores in scores.values():
                     model_scores["Rank"] = None
         else:
-            for name, model_scores in scores.items():
+            for model_scores in scores.values():
                 model_scores["Rank"] = None
 
         return scores

--- a/mteb/cli/build_cli.py
+++ b/mteb/cli/build_cli.py
@@ -422,7 +422,7 @@ def _leaderboard(args: argparse.Namespace) -> None:
             "Seems like some dependencies are not installed. "
             "You can likely install these using: `pip install 'mteb[leaderboard]'`. "
             f"{e}"
-        )
+        ) from e
 
     cache_path = args.cache_path
 

--- a/mteb/deprecated_evaluator.py
+++ b/mteb/deprecated_evaluator.py
@@ -487,7 +487,7 @@ class MTEB:
                         except ImportError:
                             raise ImportError(
                                 "codecarbon is not installed. Please install it using `pip install 'mteb[codecarbon]'` to track CO₂ emissions."
-                            )
+                            ) from None
                         msg = "Evaluating multiple MTEB runs simultaneously will produce incorrect CO₂ results"
                         logger.warning(msg)
                         warnings.warn(msg)

--- a/mteb/evaluate.py
+++ b/mteb/evaluate.py
@@ -40,6 +40,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Shared default cache. Constructed at import time, exactly as the previous
+# `cache: ResultCache | None = ResultCache()` default argument was -- `cache=None`
+# means "no cache", so a None sentinel cannot be used here.
+_DEFAULT_CACHE = ResultCache()
+
 
 class OverwriteStrategy(HelpfulStrEnum):
     """Enum for the overwrite strategy when running a task.
@@ -71,9 +76,12 @@ def _sanitize_model(
         wrapped_model = CrossEncoderWrapper(model)
         meta = wrapped_model.mteb_model_meta
     elif hasattr(model, "mteb_model_meta"):
-        meta = getattr(model, "mteb_model_meta")
-        if not isinstance(meta, ModelMeta):
-            meta = ModelMeta.create_empty()
+        model_meta = model.mteb_model_meta
+        meta = (
+            model_meta
+            if isinstance(model_meta, ModelMeta)
+            else ModelMeta.create_empty()
+        )
         wrapped_model = cast("MTEBModels | ModelMeta", model)
     else:
         meta = ModelMeta.create_empty() if not isinstance(model, ModelMeta) else model
@@ -111,7 +119,7 @@ def _evaluate_task(  # noqa: PLR0913, PLR0914
             if co2_tracker is True:
                 raise ImportError(
                     "Codecarbon is required when co2_tracker=True. Please install it using `pip install mteb[codecarbon]` to track CO₂ emissions."
-                )
+                ) from None
             co2_tracker = False
         else:
             co2_tracker = True
@@ -431,7 +439,7 @@ def evaluate(  # noqa: PLR0913, PLR0914
     co2_tracker: bool | None = None,
     raise_error: bool = True,
     encode_kwargs: EncodeKwargs | None = None,
-    cache: ResultCache | None = ResultCache(),
+    cache: ResultCache | None = _DEFAULT_CACHE,
     overwrite_strategy: str | OverwriteStrategy = "only-missing",
     prediction_folder: Path | str | None = None,
     show_progress_bar: bool = True,
@@ -566,7 +574,7 @@ def evaluate(  # noqa: PLR0913, PLR0914
             desc="Evaluating tasks",
             disable=not show_progress_bar,
         )
-        for i, task in enumerate(tasks_tqdm):
+        for task in tasks_tqdm:
             tasks_tqdm.set_description(f"Evaluating task {task.metadata.name}")
             _res = evaluate(
                 model,

--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -45,6 +45,10 @@ from mteb.models.model_meta import MODEL_TYPES
 from mteb.results.benchmark_results import BenchmarkResults
 
 logger = logging.getLogger(__name__)
+
+# Shared default cache, constructed at import time exactly as the previous
+# `cache: ResultCache = ResultCache()` default argument was.
+_DEFAULT_CACHE = ResultCache()
 event_logger = EventLogger()
 
 
@@ -416,7 +420,7 @@ def on_page_load(request: gr.Request):
 
 
 def get_leaderboard_app(  # noqa: PLR0914
-    cache: ResultCache = ResultCache(),
+    cache: ResultCache = _DEFAULT_CACHE,
     rebuild: bool = False,
     cache_repo_id: str = "mteb/results",
 ) -> gr.Blocks:

--- a/mteb/mocks/mock_tasks/create_mock_samples.py
+++ b/mteb/mocks/mock_tasks/create_mock_samples.py
@@ -47,7 +47,7 @@ def create_mock_video_bytes(
         try:
             import av
         except ImportError:
-            raise ImportError("Please, install av to run mock video tasks")
+            raise ImportError("Please, install av to run mock video tasks") from None
 
     import av
 

--- a/mteb/models/cache_wrappers/cache_backends/faiss_cache.py
+++ b/mteb/models/cache_wrappers/cache_backends/faiss_cache.py
@@ -55,12 +55,12 @@ class FaissCache:
 
         start_id = len(self.hash_to_index)
         vectors_to_add = []
-        for i, (item, vectors) in enumerate(zip(items, vectors)):
+        for i, (item, vector) in enumerate(zip(items, vectors)):
             item_hash = _hash_item(item)
             if item_hash in self.hash_to_index:
                 continue
             self.hash_to_index[item_hash] = start_id + i
-            vectors_to_add.append(vectors)
+            vectors_to_add.append(vector)
         if len(vectors_to_add) > 0:
             vectors_array = np.vstack(vectors_to_add).astype(np.float32)
             self.index.add(vectors_array)

--- a/mteb/models/instruct_wrapper.py
+++ b/mteb/models/instruct_wrapper.py
@@ -122,8 +122,8 @@ def instruct_wrapper(
             )
             embeddings = super().encode(  # type: ignore[safe-super,call-arg]
                 _inputs,  # type: ignore[arg-type]
-                instruction=instruction,
                 *args,
+                instruction=instruction,
                 **kwargs,
             )
             if isinstance(embeddings, torch.Tensor):

--- a/mteb/models/model_implementations/cde_models.py
+++ b/mteb/models/model_implementations/cde_models.py
@@ -63,7 +63,7 @@ class CDEWrapper(SentenceTransformerEncoderWrapper):
     ) -> None:
         from transformers import AutoConfig
 
-        super().__init__(model, revision=revision, device=device, *args, **kwargs)
+        super().__init__(model, *args, revision=revision, device=device, **kwargs)
         model_config = AutoConfig.from_pretrained(model, trust_remote_code=True)
         self.max_sentences = model_config.transductive_corpus_size
 

--- a/mteb/models/model_implementations/evaclip_models.py
+++ b/mteb/models/model_implementations/evaclip_models.py
@@ -37,7 +37,7 @@ def evaclip_loader(model_name, **kwargs):
             "`pip install ninja timm`"
             "`pip install -v -U git+https://github.com/facebookresearch/xformers.git@main#egg=xformers`"
             "`git clone https://github.com/NVIDIA/apex && cd apex && pip install -v --disable-pip-version-check --no-build-isolation --no-cache-dir ./`"
-        )
+        ) from None
 
     class EvaCLIPWrapper(AbsEncoder):
         def __init__(

--- a/mteb/models/model_implementations/mcinext_models.py
+++ b/mteb/models/model_implementations/mcinext_models.py
@@ -289,7 +289,7 @@ class HakimModelWrapper(AbsEncoder):
                     f"API request failed (attempt {attempt + 1}/{self.max_retries}): {e}"
                 )
                 if status_code and 400 <= status_code < 500 and status_code != 429:
-                    raise APIError(f"Client error: {e}", status_code)
+                    raise APIError(f"Client error: {e}", status_code) from e
                 time.sleep(self.retry_delay * (2**attempt))
 
         raise APIError(f"API request failed after {self.max_retries} attempts.")

--- a/mteb/models/model_implementations/seed_1_6_embedding_models.py
+++ b/mteb/models/model_implementations/seed_1_6_embedding_models.py
@@ -19,6 +19,8 @@ from mteb.models.model_meta import ModelMeta
 from mteb.types import PromptType
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from PIL import Image
 
     from mteb.abstasks.task_metadata import TaskMetadata
@@ -156,7 +158,7 @@ class Seed16EmbeddingWrapper(AbsEncoder):
         max_tokens: int,
         tokenizer_name: str = "cl100k_base",
         embed_dim: int | None = None,
-        available_embed_dims: list[int | None] = [None],
+        available_embed_dims: Sequence[int | None] = (None,),
         **kwargs,
     ) -> None:
         """Wrapper for Seed embedding API."""

--- a/mteb/models/model_implementations/seed_models.py
+++ b/mteb/models/model_implementations/seed_models.py
@@ -16,6 +16,8 @@ from .bge_models import bge_chinese_training_data
 from .nvidia_models import nvidia_training_datasets
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from mteb.types import Array
 
 logger = logging.getLogger(__name__)
@@ -42,7 +44,7 @@ class SeedTextEmbeddingModel(AbsEncoder):
         max_tokens: int,
         tokenizer_name: str = "cl100k_base",
         embed_dim: int | None = None,
-        available_embed_dims: list[int | None] = [None],
+        available_embed_dims: Sequence[int | None] = (None,),
         **kwargs,
     ) -> None:
         """Wrapper for Seed embedding API."""
@@ -127,9 +129,7 @@ class SeedTextEmbeddingModel(AbsEncoder):
 
         all_embeddings = []
 
-        for i, sublist in enumerate(
-            tqdm(sublists, leave=False, disable=not show_progress_bar)
-        ):
+        for sublist in tqdm(sublists, leave=False, disable=not show_progress_bar):
             while retries > 0:
                 try:
                     embedding = self._encode(sublist, task_name, prompt_type)

--- a/mteb/models/model_implementations/vista_models.py
+++ b/mteb/models/model_implementations/vista_models.py
@@ -28,7 +28,7 @@ def vista_loader(model_name, **kwargs):
     except ImportError:
         raise ImportError(
             "Please install `visual_bge`, refer to https://github.com/FlagOpen/FlagEmbedding/tree/master/research/visual_bge#install-flagembedding."
-        )
+        ) from None
 
     class VisualizedBGEWrapper(Visualized_BGE, AbsEncoder):
         """Setting up VISTA

--- a/mteb/results/task_result.py
+++ b/mteb/results/task_result.py
@@ -34,7 +34,7 @@ from mteb.types import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Iterator, Mapping
+    from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
     from pathlib import Path
 
     from typing_extensions import Self
@@ -239,7 +239,7 @@ class TaskResult(BaseModel):  # noqa: PLR0904
     def _validate_scores(
         cls, v: dict[SplitName, list[ScoresDict]]
     ) -> dict[SplitName, list[ScoresDict]]:
-        for split, hf_subset_scores in v.items():
+        for hf_subset_scores in v.values():
             for hf_subset_score in hf_subset_scores:
                 if not isinstance(hf_subset_score, dict):
                     raise ValueError("Scores should be a dictionary")
@@ -270,13 +270,13 @@ class TaskResult(BaseModel):  # noqa: PLR0904
         try:
             _ = json.dumps(scores)
         except Exception as e:
-            raise ValueError(f"Scores are not json serializable: {e}")
+            raise ValueError(f"Scores are not json serializable: {e}") from e
 
     @property
     def languages(self) -> list[str]:
         """The languages present in the scores."""
         langs = []
-        for split, split_res in self.scores.items():
+        for split_res in self.scores.values():
             for entry in split_res:
                 langs.extend([lang.split("-")[0] for lang in entry["languages"]])
         return list(set(langs))
@@ -315,7 +315,7 @@ class TaskResult(BaseModel):  # noqa: PLR0904
     def hf_subsets(self) -> list[str]:
         """The hf_subsets present in the scores."""
         hf_subsets = set()
-        for split, split_res in self.scores.items():
+        for split_res in self.scores.values():
             for entry in split_res:
                 hf_subsets.add(entry["hf_subset"])
         return list(hf_subsets)
@@ -400,7 +400,7 @@ class TaskResult(BaseModel):  # noqa: PLR0904
             except Exception as e:
                 raise ValueError(
                     f"Error loading TaskResult from disk. You can try to load historic data by setting `load_historic_data=True`. Error: {e}"
-                )
+                ) from e
         data = json.loads(json_str)
         min_version = cls._parse_mteb_version_min(data.get("mteb_version"))
         pre_1_11_load = (
@@ -437,7 +437,7 @@ class TaskResult(BaseModel):  # noqa: PLR0904
             task = get_task(obj.task_name)
 
         if task.metadata.type == "PairClassification":  # noqa: PLR1702
-            for split, split_scores in obj.scores.items():
+            for split_scores in obj.scores.values():
                 for hf_subset_scores in split_scores:
                     # concatenate score e.g. ["max"]["ap"] -> ["max_ap"]
                     for key in list(hf_subset_scores.keys()):
@@ -463,7 +463,7 @@ class TaskResult(BaseModel):  # noqa: PLR0904
 
         # calculate evaluation time across all splits (move to top level)
         evaluation_time = 0
-        for split, split_score in scores.items():
+        for split_score in scores.values():
             if "evaluation_time" in split_score:
                 evaluation_time += split_score.pop("evaluation_time")
 
@@ -493,8 +493,8 @@ class TaskResult(BaseModel):  # noqa: PLR0904
 
         # make sure that main score exists
         main_score = task.metadata.main_score
-        for split, split_score in scores.items():
-            for hf_subset, hf_subset_scores in split_score.items():
+        for split_score in scores.values():
+            for hf_subset_scores in split_score.values():
                 for name, prev_name in [
                     (ScoringFunction.COSINE.value, "cos_sim"),
                     (ScoringFunction.MANHATTAN.value, "manhattan"),
@@ -758,9 +758,7 @@ class TaskResult(BaseModel):  # noqa: PLR0904
     def is_mergeable(
         self,
         result: TaskResult | AbsTask,
-        criteria: list[str] | list[Criteria] = [
-            "dataset_revision",
-        ],
+        criteria: Sequence[str] | Sequence[Criteria] = ("dataset_revision",),
         raise_error: bool = False,
     ) -> bool:
         """Checks if the TaskResult object can be merged with another TaskResult or Task.
@@ -816,9 +814,7 @@ class TaskResult(BaseModel):  # noqa: PLR0904
     def merge(
         self,
         new_results: TaskResult,
-        criteria: list[str] | list[Criteria] = [
-            "dataset_revision",
-        ],
+        criteria: Sequence[str] | Sequence[Criteria] = ("dataset_revision",),
     ) -> TaskResult:
         """Merges two TaskResult objects.
 

--- a/mteb/tasks/classification/multilingual/afri_hate_classification.py
+++ b/mteb/tasks/classification/multilingual/afri_hate_classification.py
@@ -106,18 +106,18 @@ Wang, Lu},
         * column **text**: tweet content (str)
         * column **label**: int (0=normal, 1=abusive, 2=hate)
         """
+        # Map label strings to integers
+        label_map = {"Normal": 0, "Abuse": 1, "Hate": 2}
+
+        def transform_labels(example):
+            return {
+                "text": example["tweet"],
+                "label": label_map[example["label"]],
+            }
+
         for lang in self.dataset:
             for split in self.dataset[lang]:
                 ds = self.dataset[lang][split]
-
-                # Map label strings to integers
-                label_map = {"Normal": 0, "Abuse": 1, "Hate": 2}
-
-                def transform_labels(example):
-                    return {
-                        "text": example["tweet"],
-                        "label": label_map[example["label"]],
-                    }
 
                 ds = ds.map(
                     transform_labels,

--- a/mteb/tasks/classification/multilingual/scala_classification.py
+++ b/mteb/tasks/classification/multilingual/scala_classification.py
@@ -63,5 +63,6 @@ Fishel, Mark},
             labels = self.dataset[lang]["train"]["label"]
             lab2idx = {lab: idx for idx, lab in enumerate(set(labels))}
             self.dataset[lang] = self.dataset[lang].map(
-                lambda x: {"label": lab2idx[x["label"]]}, remove_columns=["label"]
+                lambda x, lab2idx=lab2idx: {"label": lab2idx[x["label"]]},
+                remove_columns=["label"],
             )

--- a/mteb/tasks/classification/multilingual/sib200_classification.py
+++ b/mteb/tasks/classification/multilingual/sib200_classification.py
@@ -321,7 +321,7 @@ class SIB200ClassificationV2(AbsTaskClassification):
                 )
                 lab_col = next(c for c in ("label", "labels", "category") if c in cols)
 
-                def to_mteb(example):
+                def to_mteb(example, lab_col=lab_col, text_col=text_col):
                     raw_label = example[lab_col]
                     if isinstance(raw_label, str):
                         label = _TOPIC2ID[raw_label]

--- a/mteb/tasks/clustering/eng/meld_clustering.py
+++ b/mteb/tasks/clustering/eng/meld_clustering.py
@@ -67,7 +67,7 @@ class MELDEmotionAudioVideoClustering(AbsTaskClustering):
         for split in self.metadata.eval_splits:
             ds = self.dataset[split]
             neutral_id = ds.features["emotion"].str2int("neutral")
-            ds = ds.filter(lambda x: x["emotion"] != neutral_id)
+            ds = ds.filter(lambda x, neutral_id=neutral_id: x["emotion"] != neutral_id)
             self.dataset[split] = ds.select_columns(["video", "audio", "emotion"])
 
 
@@ -103,7 +103,7 @@ class MELDEmotionVideoClustering(AbsTaskClustering):
         for split in self.metadata.eval_splits:
             ds = self.dataset[split]
             neutral_id = ds.features["emotion"].str2int("neutral")
-            ds = ds.filter(lambda x: x["emotion"] != neutral_id)
+            ds = ds.filter(lambda x, neutral_id=neutral_id: x["emotion"] != neutral_id)
             self.dataset[split] = ds.select_columns(["video", "emotion"])
 
 

--- a/mteb/tasks/multichoice/eng/blink_it2i_multi_choice.py
+++ b/mteb/tasks/multichoice/eng/blink_it2i_multi_choice.py
@@ -37,10 +37,10 @@ class BLINKIT2IMultiChoice(AbsTaskRetrieval):
     )
 
     def dataset_transform(self, **kwargs):
-        for subset, split_data in self.dataset.items():
-            for split, dataset in split_data.items():
+        for split_data in self.dataset.values():
+            for dataset in split_data.values():
                 top_ranked = defaultdict(list)
                 for query_id, relevant in dataset["relevant_docs"].items():
-                    for corpus_id, score in relevant.items():
+                    for corpus_id in relevant:
                         top_ranked[query_id].append(corpus_id)
                 dataset["top_ranked"] = top_ranked

--- a/mteb/tasks/multichoice/eng/blink_it2t_multi_choice.py
+++ b/mteb/tasks/multichoice/eng/blink_it2t_multi_choice.py
@@ -37,10 +37,10 @@ class BLINKIT2TMultiChoice(AbsTaskRetrieval):
     )
 
     def dataset_transform(self, **kwargs):
-        for subset, split_data in self.dataset.items():
-            for split, dataset in split_data.items():
+        for split_data in self.dataset.values():
+            for dataset in split_data.values():
                 top_ranked = defaultdict(list)
                 for query_id, relevant in dataset["relevant_docs"].items():
-                    for corpus_id, score in relevant.items():
+                    for corpus_id in relevant:
                         top_ranked[query_id].append(corpus_id)
                 dataset["top_ranked"] = top_ranked

--- a/mteb/tasks/multichoice/eng/cv_bench.py
+++ b/mteb/tasks/multichoice/eng/cv_bench.py
@@ -42,7 +42,7 @@ def _load_data(
         )
 
         queries[split] = split_dataset.map(
-            lambda x, idx: {
+            lambda x, idx, split=split: {
                 "id": f"query-{split}-{idx}",
                 "text": x["question"],
                 "modality": "image,text",
@@ -79,7 +79,7 @@ def _load_data(
         corpus[split] = Dataset.from_list(corpus_records)
 
         for query_id, relevant in relevant_docs[split].items():
-            for corpus_id, score in relevant.items():
+            for corpus_id in relevant:
                 top_ranked[split][query_id].append(corpus_id)
 
     return corpus, queries, relevant_docs, top_ranked

--- a/mteb/tasks/retrieval/code/code_rag.py
+++ b/mteb/tasks/retrieval/code/code_rag.py
@@ -139,7 +139,7 @@ class CodeRAGOnlineTutorialsRetrieval(AbsTaskRetrieval):
         texts = ds["text"]
         parsed = ds["parsed"]
         id = 0
-        for title, text, mt in zip(titles, texts, parsed):
+        for title, text, _mt in zip(titles, texts, parsed):
             # in code-rag-bench,
             # query=doc(code)
             # text=query+doc(code)

--- a/mteb/tasks/retrieval/eng/lemb_needle_retrieval.py
+++ b/mteb/tasks/retrieval/eng/lemb_needle_retrieval.py
@@ -60,7 +60,9 @@ class LEMBNeedleRetrieval(AbsTaskRetrieval):
                 "queries"
             ]  # dict_keys(['qid', 'text'])
             query_list = query_list.filter(
-                lambda x: x["context_length"] == context_length
+                lambda x, context_length=context_length: (
+                    x["context_length"] == context_length
+                )
             )
             queries = {row["qid"]: row["text"] for row in query_list}
 
@@ -68,7 +70,9 @@ class LEMBNeedleRetrieval(AbsTaskRetrieval):
                 "corpus"
             ]  # dict_keys(['doc_id', 'text'])
             corpus_list = corpus_list.filter(
-                lambda x: x["context_length"] == context_length
+                lambda x, context_length=context_length: (
+                    x["context_length"] == context_length
+                )
             )
             corpus = {row["doc_id"]: {"text": row["text"]} for row in corpus_list}
 
@@ -76,7 +80,9 @@ class LEMBNeedleRetrieval(AbsTaskRetrieval):
                 "qrels"
             ]  # dict_keys(['qid', 'doc_id'])
             qrels_list = qrels_list.filter(
-                lambda x: x["context_length"] == context_length
+                lambda x, context_length=context_length: (
+                    x["context_length"] == context_length
+                )
             )
             qrels = {row["qid"]: {row["doc_id"]: 1} for row in qrels_list}
 

--- a/mteb/tasks/retrieval/eng/memotion_i2t_retrieval.py
+++ b/mteb/tasks/retrieval/eng/memotion_i2t_retrieval.py
@@ -53,7 +53,7 @@ def _load_data(path: str, splits: str, revision: str | None = None):
         split_dataset = split_datasets[split]
 
         queries[split] = split_dataset.map(
-            lambda x, idx: {
+            lambda x, idx, split=split: {
                 "id": f"query-{split}-{idx}",
                 "modality": "image",
             },

--- a/mteb/tasks/retrieval/eng/memotion_t2i_retrieval.py
+++ b/mteb/tasks/retrieval/eng/memotion_t2i_retrieval.py
@@ -51,7 +51,7 @@ def _load_data(path: str, splits: str, revision: str | None = None):
         corpus[split] = shared_corpus
         split_dataset = split_datasets[split]
         queries[split] = split_dataset.map(
-            lambda x, idx: {
+            lambda x, idx, split=split: {
                 "id": f"query-{split}-{idx}",
                 "text": x["text_corrected"],
                 "modality": "text",

--- a/mteb/tasks/retrieval/eng/mm_long_bench_doc_retrieval.py
+++ b/mteb/tasks/retrieval/eng/mm_long_bench_doc_retrieval.py
@@ -23,7 +23,7 @@ def _load_data(
             num_proc=num_proc,
         )
         queries[split] = query_ds.map(
-            lambda row: {
+            lambda row, split=split: {
                 "id": f"query-{split}-{row['query-id']}",
                 "text": row["query"],
             },
@@ -39,7 +39,7 @@ def _load_data(
             num_proc=num_proc,
         )
         corpus[split] = corpus_ds.map(
-            lambda row: {
+            lambda row, split=split: {
                 "id": f"corpus-{split}-{row['corpus-id']}",
             },
             remove_columns=["corpus-id"],

--- a/mteb/tasks/retrieval/eng/sci_mmir_i2t_retrieval.py
+++ b/mteb/tasks/retrieval/eng/sci_mmir_i2t_retrieval.py
@@ -18,7 +18,7 @@ def _load_data(path: str, splits: str, revision: str | None = None):
         split_dataset = dataset[split]
 
         corpus[split] = split_dataset.map(
-            lambda x, idx: {
+            lambda x, idx, split=split: {
                 "id": f"corpus-{split}-{idx}",
                 "modality": "text",
             },
@@ -33,7 +33,7 @@ def _load_data(path: str, splits: str, revision: str | None = None):
         )
 
         queries[split] = split_dataset.map(
-            lambda x, idx: {
+            lambda x, idx, split=split: {
                 "id": f"query-{split}-{idx}",
                 "modality": "image",
             },

--- a/mteb/tasks/retrieval/eng/sci_mmir_t2i_retrieval.py
+++ b/mteb/tasks/retrieval/eng/sci_mmir_t2i_retrieval.py
@@ -18,7 +18,7 @@ def _load_data(path: str, splits: str, revision: str | None = None):
         split_dataset = dataset[split]
 
         corpus[split] = split_dataset.map(
-            lambda x, idx: {
+            lambda x, idx, split=split: {
                 "id": f"corpus-{split}-{idx}",
                 "modality": "image",
             },
@@ -33,7 +33,7 @@ def _load_data(path: str, splits: str, revision: str | None = None):
         )
 
         queries[split] = split_dataset.map(
-            lambda x, idx: {
+            lambda x, idx, split=split: {
                 "id": f"query-{split}-{idx}",
                 "modality": "text",
             },

--- a/mteb/tasks/retrieval/eng/vidore_bench_retrieval.py
+++ b/mteb/tasks/retrieval/eng/vidore_bench_retrieval.py
@@ -21,7 +21,7 @@ def _load_data(
             revision=revision,
         )
         query_ds = query_ds.map(
-            lambda x: {
+            lambda x, split=split: {
                 "id": f"query-{split}-{x['query-id']}",
                 "text": x["query"],
                 "modality": "text",
@@ -37,7 +37,7 @@ def _load_data(
             revision=revision,
         )
         corpus_ds = corpus_ds.map(
-            lambda x: {
+            lambda x, split=split: {
                 "id": f"corpus-{split}-{x['corpus-id']}",
                 "modality": "image",
             },

--- a/mteb/tasks/retrieval/multilingual/miracl_vision_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/miracl_vision_retrieval.py
@@ -63,7 +63,7 @@ def _load_miracl_data(  # noqa: PLR0914
         }
 
         images_data = images_data.map(
-            lambda x: {
+            lambda x, imgid2docid=imgid2docid: {
                 "id": imgid2docid[str(x["file_name"])],
                 "modality": "image",
             },

--- a/mteb/tasks/retrieval/multilingual/vdr_multilingual_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/vdr_multilingual_retrieval.py
@@ -37,7 +37,7 @@ def _load_vdr_multilingual_data(
         queries_records = []
         relevant_dict = {}
 
-        for idx, record in enumerate(dataset):
+        for record in dataset:
             doc_id = f"doc-{record['id']}"
             query_id = f"query-{record['id']}"
             has_query = record.get("query") is not None

--- a/mteb/tasks/retrieval/multilingual/vidore2_bench_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/vidore2_bench_retrieval.py
@@ -36,7 +36,7 @@ def _load_data(
             num_proc=num_proc,
         )
         query_ds = query_ds.map(
-            lambda x: {
+            lambda x, split=split: {
                 "id": f"query-{split}-{x['query-id']}",
                 "text": x["query"],
                 "modality": "text",
@@ -53,7 +53,7 @@ def _load_data(
             num_proc=num_proc,
         )
         corpus_ds = corpus_ds.map(
-            lambda x: {
+            lambda x, split=split: {
                 "id": f"corpus-{split}-{x['corpus-id']}",
                 "modality": "image",
             },
@@ -82,7 +82,9 @@ def _load_data(
                 relevant_docs[split][qid][did] = int(row["score"])
         else:
             for lang in langs:
-                filtered_query_ds = query_ds.filter(lambda x: x["language"] == lang)
+                filtered_query_ds = query_ds.filter(
+                    lambda x, lang=lang: x["language"] == lang
+                )
                 queries[lang][split] = filtered_query_ds.select_columns(["id", "text"])
 
                 corpus[lang][split] = corpus_ds

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -312,6 +312,7 @@ select = [
     "INT",     # gettext f-string misuse
     "ASYNC",   # blocking calls in async functions
     "ISC",     # implicit string concatenation
+    "B",       # flake8-bugbear
 ]
 
 ignore = [
@@ -334,6 +335,9 @@ ignore = [
     "PLR0915",  # too many statements
     "PLW0717",  # too-many-statements-in-try-clause
     "ISC001",   # single-line implicit concat; conflicts with `ruff format`
+    # TODO: enable in a follow-up PR; each needs a per-site `strict=` / `stacklevel=` decision
+    "B905",     # zip-without-explicit-strict
+    "B028",     # no-explicit-stacklevel
 ]
 future-annotations = true  # For TC rules
 typing-modules = ["typing_extensions", "mteb.types", "collections.abc"]

--- a/tests/test_get_tasks.py
+++ b/tests/test_get_tasks.py
@@ -159,7 +159,7 @@ def _get_duplicate_citations() -> list[tuple[str, str, str, str, str, str]]:
             by_title[norm].append((f"benchmark:{benchmark.name}", cid, title))
 
     duplicates = []
-    for norm_title, items in by_title.items():
+    for items in by_title.values():
         id_to_raw = {cid: raw for _, cid, raw in items}
         id_to_item = {cid: item for item, cid, raw in items}
         if len(id_to_raw) < 2:

--- a/tests/test_tasks/test_dataset_on_hf.py
+++ b/tests/test_tasks/test_dataset_on_hf.py
@@ -62,6 +62,6 @@ def test_dataset_on_hf(dataset_revision: tuple[str, str]):
         huggingface_hub.errors.RepositoryNotFoundError,
         huggingface_hub.errors.RevisionNotFoundError,
     ):
-        assert False, f"Dataset {repo_id} - {revision} not available"
+        raise AssertionError(f"Dataset {repo_id} - {revision} not available") from None
     except Exception as e:
-        assert False, f"Dataset {repo_id} - {revision} failed with {e}"
+        raise AssertionError(f"Dataset {repo_id} - {revision} failed with {e}") from e


### PR DESCRIPTION
refs #2416.

Takes the bug classes and solves them. `B905` (114 occurrence places) and `B028` (39 occurrence places) are deferred to a follow-up with a TODO in the ignore list — each needs a per-site `strict=` / `stacklevel=` decision.

### 84 fixes

| Rule | n | Pattern applied |
|---|---|---|
| `B007` unused-loop-control-variable | 26 | `for k, v in d.items()` → `.values()` when the key is unused (and `for k in d` when the value is); dropped `enumerate()` where the index was never read |
| `B023` function-uses-loop-variable | 25 | Bound the loop variable as a default arg (`lambda x, split=split: ...`) |
| `B904` raise-without-from | 14 | `except ... as e` → `from e`; unbound optional-dependency guards → `from None` |
| `B006` mutable-argument-default | 7 | List defaults → tuples, annotated `Sequence[...]` (matches the existing convention elsewhere in the package) |
| `B008` function-call-in-default | 4 | Module-level singletons |
| `B020` loop-var-overrides-iterator | 2 | Renamed the shadowing loop variable |
| `B026` star-arg-after-keyword | 2 | Moved `*args` ahead of the keyword arguments |
| `B011` assert-false | 2 | `assert False, msg` → `raise AssertionError(msg)` |
| `B009` getattr-with-constant | 1 | Direct attribute access |
| `B027` empty-method-in-ABC | 1 | `noqa` — deliberate optional hook, not abstract |

### Notes

- **`B023` sites are not live bugs.** `datasets.map()`/`.filter()` are eager, so each iteration already sees its own value. change makes the capture explicit rather than incidental.
- **`B006`** required widening `list[str]` → `Sequence[str]` . Backward-compatible. None of the defaults are mutated.
- **`B008`** uses module-level singletons rather than a `None` sentinel. Both are constructed at import time, so behaviour is unchanged.