### PR TITLE
data: add FGMCaps

### DIFF
--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/FGMCapsA2TRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/FGMCapsA2TRetrieval.json
@@ -1,0 +1,40 @@
+{
+    "test": {
+        "num_samples": 20000,
+        "num_queries": 10000,
+        "num_documents": 10000,
+        "number_of_characters": 1791361,
+        "documents_text_statistics": {
+            "total_text_length": 1791361,
+            "min_text_length": 73,
+            "average_text_length": 179.1361,
+            "max_text_length": 488,
+            "unique_texts": 10000
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": null,
+        "queries_audio_statistics": {
+            "total_duration_seconds": 99999.03095833333,
+            "min_duration_seconds": 9.953583333333333,
+            "average_duration_seconds": 9.999903095833332,
+            "max_duration_seconds": 10.0,
+            "unique_audios": 10000,
+            "average_sampling_rate": 24000.0,
+            "sampling_rates": {
+                "24000": 10000
+            }
+        },
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 10000,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 10000
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/FGMCapsT2ARetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/FGMCapsT2ARetrieval.json
@@ -1,0 +1,40 @@
+{
+    "test": {
+        "num_samples": 20000,
+        "num_queries": 10000,
+        "num_documents": 10000,
+        "number_of_characters": 1791361,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": {
+            "total_duration_seconds": 99999.03095833333,
+            "min_duration_seconds": 9.953583333333333,
+            "average_duration_seconds": 9.999903095833332,
+            "max_duration_seconds": 10.0,
+            "unique_audios": 10000,
+            "average_sampling_rate": 24000.0,
+            "sampling_rates": {
+                "24000": 10000
+            }
+        },
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 1791361,
+            "min_text_length": 73,
+            "average_text_length": 179.1361,
+            "max_text_length": 488,
+            "unique_texts": 10000
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 10000,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 10000
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -149,6 +149,7 @@ from .fashion200k_i2t_retrieval import Fashion200kI2TRetrieval
 from .fashion200k_t2i_retrieval import Fashion200kT2IRetrieval
 from .fashion_iq_it2i_retrieval import FashionIQIT2IRetrieval
 from .feedback_qa_retrieval import FeedbackQARetrieval
+from .fgmcaps_retrieval import FGMCapsA2TRetrieval, FGMCapsT2ARetrieval
 from .fever_retrieval import FEVER, FEVERHardNegatives, FEVERHardNegativesV2
 from .fi_qa2018_retrieval import FiQA2018
 from .fin_qa_retrieval import FinQARetrieval
@@ -611,6 +612,8 @@ __all__ = [
     "Fashion200kT2IRetrieval",
     "FashionIQIT2IRetrieval",
     "FeedbackQARetrieval",
+    "FGMCapsA2TRetrieval",
+    "FGMCapsT2ARetrieval",
     "FiQA2018",
     "FinQARetrieval",
     "FinanceBenchRetrieval",

--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -149,8 +149,8 @@ from .fashion200k_i2t_retrieval import Fashion200kI2TRetrieval
 from .fashion200k_t2i_retrieval import Fashion200kT2IRetrieval
 from .fashion_iq_it2i_retrieval import FashionIQIT2IRetrieval
 from .feedback_qa_retrieval import FeedbackQARetrieval
-from .fgmcaps_retrieval import FGMCapsA2TRetrieval, FGMCapsT2ARetrieval
 from .fever_retrieval import FEVER, FEVERHardNegatives, FEVERHardNegativesV2
+from .fgmcaps_retrieval import FGMCapsA2TRetrieval, FGMCapsT2ARetrieval
 from .fi_qa2018_retrieval import FiQA2018
 from .fin_qa_retrieval import FinQARetrieval
 from .finance_bench_retrieval import FinanceBenchRetrieval
@@ -604,6 +604,8 @@ __all__ = [
     "EnglishHealthcare1Retrieval",
     "FEVERHardNegatives",
     "FEVERHardNegativesV2",
+    "FGMCapsA2TRetrieval",
+    "FGMCapsT2ARetrieval",
     "FLAREAudioT2VARetrieval",
     "FLAREUnifiedT2VARetrieval",
     "FLAREVisionT2VRetrieval",
@@ -612,8 +614,6 @@ __all__ = [
     "Fashion200kT2IRetrieval",
     "FashionIQIT2IRetrieval",
     "FeedbackQARetrieval",
-    "FGMCapsA2TRetrieval",
-    "FGMCapsT2ARetrieval",
     "FiQA2018",
     "FinQARetrieval",
     "FinanceBenchRetrieval",

--- a/mteb/tasks/retrieval/eng/fgmcaps_retrieval.py
+++ b/mteb/tasks/retrieval/eng/fgmcaps_retrieval.py
@@ -1,0 +1,141 @@
+from datasets import load_dataset
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.task_metadata import TaskMetadata
+
+_BIBTEX = r"""
+@inproceedings{figma2026,
+  author = {Anand, Nishit and Seth, Ashish and Ghosh, Sreyan and Manocha, Dinesh and Duraiswami, Ramani},
+  booktitle = {Proceedings of the 64th Annual Meeting of the Association for Computational Linguistics},
+  title = {FIGMA: Towards FIne-Grained Music retrievAl},
+  url = {https://arxiv.org/abs/2606.06615},
+  year = {2026},
+}
+"""
+
+
+def _load_data(
+    path: str,
+    splits: list[str],
+    revision: str | None = None,
+    num_proc: int | None = None,
+    *,
+    audio_to_text: bool = False,
+):
+    corpus = {}
+    queries = {}
+    relevant_docs = {}
+
+    for split in splits:
+        dataset = load_dataset(
+            path,
+            split=split,
+            revision=revision,
+            num_proc=num_proc,
+        )
+        text_dataset = dataset.select_columns(["id", "caption"]).rename_column(
+            "caption", "text"
+        )
+        audio_dataset = dataset.select_columns(["id", "audio"])
+
+        if audio_to_text:
+            queries[split] = audio_dataset
+            corpus[split] = text_dataset
+        else:
+            queries[split] = text_dataset
+            corpus[split] = audio_dataset
+
+        relevant_docs[split] = {id_: {id_: 1} for id_ in dataset["id"]}
+
+    return corpus, queries, relevant_docs
+
+
+class FGMCapsT2ARetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="FGMCapsT2ARetrieval",
+        description=(
+            "FGMCaps-Test is a fine-grained music retrieval benchmark containing "
+            "10,000 10-second music clips. Each clip is paired with an English "
+            "caption describing precise musical attributes such as tempo, key, "
+            "chord progression, and time signature. Text-to-audio retrieval uses "
+            "each caption to retrieve its corresponding music clip."
+        ),
+        reference="https://arxiv.org/abs/2606.06615",
+        dataset={
+            "path": "nishitanand/FGMCaps-benchmark",
+            "revision": "a2f3b8bccc85b7e63563a0976b155e48e7be5278",
+        },
+        type="Any2AnyRetrieval",
+        category="t2a",
+        modalities=["text", "audio"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="recall_at_10",
+        date=("2026-06-01", "2026-06-30"),
+        domains=["Music"],
+        task_subtypes=["Music Caption Retrieval"],
+        license="cc-by-nc-sa-4.0",
+        annotations_creators="LM-generated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Retrieve the music clip described by this caption."},
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        if self.data_loaded:
+            return
+
+        self.corpus, self.queries, self.relevant_docs = _load_data(
+            path=self.metadata.dataset["path"],
+            splits=self.metadata.eval_splits,
+            revision=self.metadata.dataset["revision"],
+            num_proc=num_proc,
+        )
+        self.data_loaded = True
+
+
+class FGMCapsA2TRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="FGMCapsA2TRetrieval",
+        description=(
+            "FGMCaps-Test is a fine-grained music retrieval benchmark containing "
+            "10,000 10-second music clips. Each clip is paired with an English "
+            "caption describing precise musical attributes such as tempo, key, "
+            "chord progression, and time signature. Audio-to-text retrieval uses "
+            "each music clip to retrieve its corresponding caption."
+        ),
+        reference="https://arxiv.org/abs/2606.06615",
+        dataset={
+            "path": "nishitanand/FGMCaps-benchmark",
+            "revision": "a2f3b8bccc85b7e63563a0976b155e48e7be5278",
+        },
+        type="Any2AnyRetrieval",
+        category="a2t",
+        modalities=["audio", "text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="recall_at_10",
+        date=("2026-06-01", "2026-06-30"),
+        domains=["Music"],
+        task_subtypes=["Music Caption Retrieval"],
+        license="cc-by-nc-sa-4.0",
+        annotations_creators="LM-generated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Retrieve the caption that describes this music clip."},
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        if self.data_loaded:
+            return
+
+        self.corpus, self.queries, self.relevant_docs = _load_data(
+            path=self.metadata.dataset["path"],
+            splits=self.metadata.eval_splits,
+            revision=self.metadata.dataset["revision"],
+            num_proc=num_proc,
+            audio_to_text=True,
+        )
+        self.data_loaded = True


### PR DESCRIPTION
Closes #5178, Related to #4842

## Checklist

- [x] I have outlined why this dataset is filling an existing gap in `mteb`
- [x] I have tested that the dataset runs with the `mteb` package.
- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
  - [x] `mteb/baseline-random encoder`
  - [x] `laion/larger_clap_general`
- [x] I have checked that the performance is neither trivial (close to perfect scores) nor random.
- [x] I have considered the size of the dataset and reduced it if it is too big (e.g. 2048 examples for binary classification)
- [x] I reproduced scores from the original paper (if applicable) and added them to the PR description for reference.

## Result

| Task | R@1 | Diff (vs Paper) | R@5 | Diff (vs Paper) | R@10 | Diff (vs Paper) | R@20 | Diff (vs Paper) |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| FGMCapsT2ARetrieval | 0.0018 | +0.0009 | 0.0070 | +0.0030 | 0.0119 | +0.0051 | 0.0194 | +0.0064 |
| FGMCapsA2TRetrieval | 0.0024 | 0.0000 | 0.0116 | +0.0024 | 0.0198 | +0.0043 | 0.0340 | +0.0045 |