### PR TITLE
citation: credit the MorisienMTBitextMining task construction

### DIFF
--- a/mteb/tasks/bitext_mining/mfe/morisien_mt_bitext_mining.py
+++ b/mteb/tasks/bitext_mining/mfe/morisien_mt_bitext_mining.py
@@ -38,6 +38,14 @@ class MorisienMTBitextMining(AbsTaskBitextMining):
         dialect=[],
         sample_creation="found",
         bibtex_citation=r"""
+@misc{b2026morisienembed,
+  author = {B, Singaraj},
+  doi = {10.5281/zenodo.21877805},
+  publisher = {Zenodo},
+  title = {morisien-embed: A Dedicated Text Embedding Model and Benchmark for Mauritian Creole (Kreol Morisien)},
+  year = {2026},
+}
+
 @article{dabre2022morisienmt,
   author = {Dabre, Raj and Sukhoo, Aneerav},
   journal = {arXiv preprint arXiv:2206.02421},


### PR DESCRIPTION
### Summary

`MorisienMTBitextMining` currently carries only the upstream data citation (Dabre & Sukhoo 2022). That is correct for the underlying MorisienMT corpus, but it leaves no citation path for the MTEB task construction itself — the four directional `mfe` subsets, the repackaging, and the integration added in #5110.

This adds the Zenodo record for that work alongside the existing entry. The data citation is unchanged and remains authoritative for the corpus.

### Notes

- The entry ordering is `scripts/format_citations.py` output (alphabetical by key), not a deliberate reordering — running the formatter placed `b2026morisienembed` first.
- Uses the Zenodo **concept** DOI (`10.5281/zenodo.21877805`) so it tracks future versions rather than pinning to v1.
- Propagates to the leaderboard's "Cite this task" box and the dataset card, which both render from this field.

### Checks

- `ruff check` / `ruff format --check` pass at the repo-locked 0.16.0
- `scripts/format_citations.py tasks` reports the block as canonical
- Task loads and `metadata.bibtex_citation` contains both entries

cc @Samoed — you merged #5110 and #5125; this is the small follow-up to those.