### PR TITLE
model: add UNITE (friedrichor/Unite-Base-Qwen2-VL-2B)

### DIFF
--- a/mteb/models/model_implementations/unite_models.py
+++ b/mteb/models/model_implementations/unite_models.py
@@ -117,15 +117,16 @@ def _build_unite_model(model_name: str, revision: str | None, **kwargs):
 
 
 class UniteWrapper(AbsEncoder):
-    def __init__(
+    def __init__(  # noqa: PLR0913, PLR0917 - video sampling options are configurable
         self,
         model_name: str,
         revision: str,
         device: str | None = None,
         min_image_tokens: int = 256,
         max_image_tokens: int = 1280,
-        fps: float = 1.0,
-        max_frames: int = 32,
+        fps: float | None = None,
+        max_frames: int | None = None,
+        num_frames: int | None = 32,
         target_sampling_rate: int = 16000,
         video_max_pixels: int = 360 * 420,
         **kwargs: Any,
@@ -135,6 +136,7 @@ class UniteWrapper(AbsEncoder):
         self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
         self.fps = fps
         self.max_frames = max_frames
+        self.num_frames = num_frames
         self.target_sampling_rate = target_sampling_rate
         self.video_max_pixels = video_max_pixels
 
@@ -235,7 +237,7 @@ class UniteWrapper(AbsEncoder):
                 target_sampling_rate=self.target_sampling_rate,
                 fps=self.fps,
                 max_frames=self.max_frames,
-                num_frames=None,  # fps mode; both set would let num_frames win
+                num_frames=self.num_frames,
             )
 
         all_embeddings = []

--- a/mteb/models/model_implementations/unite_models.py
+++ b/mteb/models/model_implementations/unite_models.py
@@ -46,9 +46,13 @@ def _fit(video, max_pixels: int):
     scale = (max_pixels / (h * w)) ** 0.5
     nh = max(28, int(h * scale) // 28 * 28)
     nw = max(28, int(w * scale) // 28 * 28)
-    return torch.nn.functional.interpolate(
-        video.float(), size=(nh, nw), mode="bilinear", align_corners=False
-    ).clamp(0, 255).to(torch.uint8)
+    return (
+        torch.nn.functional.interpolate(
+            video.float(), size=(nh, nw), mode="bilinear", align_corners=False
+        )
+        .clamp(0, 255)
+        .to(torch.uint8)
+    )
 
 
 def _unwrap(out):
@@ -91,13 +95,21 @@ def _unite_embed(model, inputs) -> torch.Tensor:
 
     if inputs.get("pixel_values") is not None:
         inputs_embeds = _scatter(
-            model, inputs_embeds, input_ids, inputs["pixel_values"],
-            inputs["image_grid_thw"], model.config.image_token_id,
+            model,
+            inputs_embeds,
+            input_ids,
+            inputs["pixel_values"],
+            inputs["image_grid_thw"],
+            model.config.image_token_id,
         )
     if inputs.get("pixel_values_videos") is not None:
         inputs_embeds = _scatter(
-            model, inputs_embeds, input_ids, inputs["pixel_values_videos"],
-            inputs["video_grid_thw"], model.config.video_token_id,
+            model,
+            inputs_embeds,
+            input_ids,
+            inputs["pixel_values_videos"],
+            inputs["video_grid_thw"],
+            model.config.video_token_id,
         )
 
     out = model.model.language_model(

--- a/mteb/models/model_implementations/unite_models.py
+++ b/mteb/models/model_implementations/unite_models.py
@@ -269,5 +269,4 @@ unite_base_qwen2vl_2b = ModelMeta(
     training_datasets=unite_training_datasets,
     adapted_from="Qwen/Qwen2-VL-2B-Instruct",
     citation=UNITE_CITATION,
-    contacts=["hubielu"],
 )

--- a/mteb/models/model_implementations/unite_models.py
+++ b/mteb/models/model_implementations/unite_models.py
@@ -27,8 +27,10 @@ UNITE_CITATION = """@article{kong2025modality,
 
 # Vendored from https://github.com/friedrichor/UNITE/blob/main/inference/modeling_unite.py
 # The HF repos ship no auto_map, so trust_remote_code is not available.
-# Two lines differ from upstream, both required by the transformers >=4.52
-# Qwen2VL refactor; each is marked inline.
+# UNITE ships modeling_unite.py as a Qwen2VLForConditionalGeneration subclass.
+# On transformers 5.x that subclass misses the checkpoint key remapping and the
+# language model loads randomly initialized without erroring, so we use the base
+# class and reproduce UNITE's pooling in _unite_embed.
 
 
 def _unwrap(out):

--- a/mteb/models/model_implementations/unite_models.py
+++ b/mteb/models/model_implementations/unite_models.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import torch
+from tqdm.autonotebook import tqdm
+
+from mteb.models.abs_encoder import AbsEncoder
+from mteb.models.modality_collators import VideoCollator
+from mteb.models.model_meta import ModelMeta, ScoringFunction
+from mteb.types import PromptType
+
+if TYPE_CHECKING:
+    from torch.utils.data import DataLoader
+
+    from mteb.abstasks.task_metadata import TaskMetadata
+    from mteb.types import Array, BatchedInput
+
+logger = logging.getLogger(__name__)
+
+UNITE_CITATION = """@article{kong2025modality,
+  title={Modality Curation: Building Universal Embeddings for Advanced Multimodal Information Retrieval},
+  author={Kong, Fanheng and Zhang, Jingyuan and Liu, Yahui and Zhang, Hongzhi and Feng, Shi and Yang, Xiaocui and Wang, Daling and Tian, Yu and W., Victoria and Zhang, Fuzheng and Zhou, Guorui},
+  journal={arXiv preprint arXiv:2505.19650},
+  year={2025}
+}"""
+
+# Vendored from https://github.com/friedrichor/UNITE/blob/main/inference/modeling_unite.py
+# The HF repos ship no auto_map, so trust_remote_code is not available.
+# Two lines differ from upstream, both required by the transformers >=4.52
+# Qwen2VL refactor; each is marked inline.
+
+
+def _build_unite_model(model_name: str, revision: str | None, **kwargs):
+    from transformers import Qwen2VLForConditionalGeneration
+
+    class UniteQwen2VL(Qwen2VLForConditionalGeneration):
+        def __init__(self, config):
+            super().__init__(config)
+            self.normalize = True
+
+        def forward(
+            self,
+            input_ids=None,
+            attention_mask=None,
+            position_ids=None,
+            past_key_values=None,
+            inputs_embeds=None,
+            pixel_values=None,
+            pixel_values_videos=None,
+            image_grid_thw=None,
+            video_grid_thw=None,
+            pooling_mask=None,
+            **unused,
+        ) -> torch.Tensor:
+            if inputs_embeds is None:
+                # Upstream: self.model.embed_tokens(input_ids).
+                # tf>=4.52 moved embed_tokens under self.model.language_model.
+                inputs_embeds = self.get_input_embeddings()(input_ids)
+                if pixel_values is not None:
+                    pixel_values = pixel_values.type(self.visual.get_dtype())
+                    image_embeds = self.visual(pixel_values, grid_thw=image_grid_thw)
+                    mask = (
+                        (input_ids == self.config.image_token_id)
+                        .unsqueeze(-1)
+                        .expand_as(inputs_embeds)
+                        .to(inputs_embeds.device)
+                    )
+                    image_embeds = image_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
+                    inputs_embeds = inputs_embeds.masked_scatter(mask, image_embeds)
+                if pixel_values_videos is not None:
+                    pixel_values_videos = pixel_values_videos.type(self.visual.get_dtype())
+                    video_embeds = self.visual(pixel_values_videos, grid_thw=video_grid_thw)
+                    mask = (
+                        (input_ids == self.config.video_token_id)
+                        .unsqueeze(-1)
+                        .expand_as(inputs_embeds)
+                        .to(inputs_embeds.device)
+                    )
+                    video_embeds = video_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
+                    inputs_embeds = inputs_embeds.masked_scatter(mask, video_embeds)
+                if attention_mask is not None:
+                    attention_mask = attention_mask.to(inputs_embeds.device)
+
+            # Upstream: self.model(...), which was the text decoder in tf 4.47.
+            # In tf>=4.52 that name is the multimodal wrapper and would recompute
+            # position ids via get_rope_index; language_model is the 4.47 self.model.
+            outputs = self.model.language_model(
+                input_ids=None,
+                position_ids=position_ids,
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                inputs_embeds=inputs_embeds,
+            )
+
+            pooling_mask = attention_mask if pooling_mask is None else pooling_mask
+            h = outputs.last_hidden_state
+            left_padding = pooling_mask[:, -1].sum() == pooling_mask.shape[0]
+            if left_padding:
+                embeddings = h[:, -1]
+            else:
+                idx = pooling_mask.sum(dim=1) - 1
+                embeddings = h[torch.arange(h.shape[0], device=h.device), idx]
+            if self.normalize:
+                embeddings = torch.nn.functional.normalize(embeddings, p=2, dim=1)
+            return embeddings.contiguous()
+
+    return UniteQwen2VL.from_pretrained(model_name, revision=revision, **kwargs)
+
+
+class UniteWrapper(AbsEncoder):
+    def __init__(
+        self,
+        model_name: str,
+        revision: str,
+        device: str | None = None,
+        min_image_tokens: int = 256,
+        max_image_tokens: int = 1280,
+        fps: float = 1.0,
+        max_frames: int = 32,
+        num_frames: int = 32,
+        target_sampling_rate: int = 16000,
+        **kwargs: Any,
+    ) -> None:
+        from transformers import AutoProcessor
+
+        self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+        self.fps = fps
+        self.max_frames = max_frames
+        self.num_frames = num_frames
+        self.target_sampling_rate = target_sampling_rate
+
+        self.model = _build_unite_model(
+            model_name,
+            revision,
+            torch_dtype=torch.bfloat16,
+        )
+        self.model.eval().to(self.device)
+        self.processor = AutoProcessor.from_pretrained(
+            model_name,
+            revision=revision,
+            min_pixels=min_image_tokens * 28 * 28,
+            max_pixels=max_image_tokens * 28 * 28,
+        )
+
+    @staticmethod
+    def _suffix(has_text: bool, has_image: bool, has_video: bool) -> str:
+        if has_video and has_text:
+            return "\nSummary above sentence and video in one word:"
+        if has_video:
+            return "\nSummary above video in one word:"
+        if has_image and has_text:
+            return "\nSummary above sentence and image in one word:"
+        if has_image:
+            return "\nSummary above image in one word:"
+        return "\nSummary above sentence in one word:"
+
+    def _embed_one(self, text=None, image=None, video=None) -> torch.Tensor:
+        content = []
+        if video is not None:
+            content.append({"type": "video", "video": ""})
+        elif image is not None:
+            content.append({"type": "image", "image": ""})
+        if text:
+            content.append({"type": "text", "text": text})
+        content.append(
+            {
+                "type": "text",
+                "text": self._suffix(bool(text), image is not None, video is not None),
+            }
+        )
+        messages = [{"role": "user", "content": content}]
+        prompt = (
+            self.processor.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            )
+            + "<|endoftext|>"
+        )
+        inputs = self.processor(
+            text=[prompt],
+            images=[image] if image is not None else None,
+            videos=[video] if video is not None else None,
+            padding=True,
+            return_tensors="pt",
+        ).to(self.device)
+        with torch.inference_mode():
+            return self.model(**inputs)
+
+    def encode(
+        self,
+        inputs: DataLoader[BatchedInput],
+        *,
+        task_metadata: TaskMetadata,
+        hf_split: str,
+        hf_subset: str,
+        prompt_type: PromptType | None = None,
+        show_progress_bar: bool = True,
+        **kwargs: Any,
+    ) -> Array:
+        if "video" in inputs.dataset.features:
+            inputs.collate_fn = VideoCollator(
+                target_sampling_rate=self.target_sampling_rate,
+                fps=self.fps,
+                max_frames=self.max_frames,
+                num_frames=self.num_frames,
+            )
+
+        all_embeddings = []
+        for batch in tqdm(inputs, disable=not show_progress_bar, desc="UNITE Encoding"):
+            texts = batch.get("text")
+            images = batch.get("image")
+            videos = batch.get("video")
+            n = len(texts or images or videos)
+            for i in range(n):
+                emb = self._embed_one(
+                    text=texts[i] if texts is not None else None,
+                    image=images[i] if images is not None else None,
+                    video=videos[i] if videos is not None else None,
+                )
+                all_embeddings.append(emb.float().cpu())
+        return torch.cat(all_embeddings, dim=0)
+
+
+unite_base_qwen2vl_2b = ModelMeta(
+    loader=UniteWrapper,
+    name="friedrichor/Unite-Base-Qwen2-VL-2B",
+    model_type=["dense"],
+    languages=["eng-Latn"],
+    open_weights=True,
+    revision="850056e7a4b4129768e1c76795eac3c4331de76d",
+    release_date="2025-05-28",
+    modalities=["image", "text", "video"],
+    n_parameters=2_208_985_600,
+    n_embedding_parameters=233_373_696,
+    memory_usage_mb=4214,
+    embed_dim=1536,
+    license="apache-2.0",
+    max_tokens=32768,
+    reference="https://huggingface.co/friedrichor/Unite-Base-Qwen2-VL-2B",
+    similarity_fn_name=ScoringFunction.COSINE,
+    framework=["PyTorch", "safetensors", "Transformers"],
+    use_instructions=False,
+    public_training_code="https://github.com/friedrichor/UNITE",
+    public_training_data="https://huggingface.co/datasets/friedrichor/Unite-Base-Retrieval-Train",
+    training_datasets=None,
+    adapted_from="Qwen/Qwen2-VL-2B-Instruct",
+    citation=UNITE_CITATION,
+    contacts=["hubielu"],
+)

--- a/mteb/models/model_implementations/unite_models.py
+++ b/mteb/models/model_implementations/unite_models.py
@@ -213,7 +213,6 @@ class UniteWrapper(AbsEncoder):
         with torch.inference_mode():
             return self.model(**inputs)
 
-
     def encode(
         self,
         inputs: DataLoader[BatchedInput],

--- a/mteb/models/model_implementations/unite_models.py
+++ b/mteb/models/model_implementations/unite_models.py
@@ -136,7 +136,6 @@ class UniteWrapper(AbsEncoder):
         max_image_tokens: int = 1280,
         fps: float = 1.0,
         max_frames: int = 32,
-        num_frames: int | None = None,  # None so fps mode applies
         target_sampling_rate: int = 16000,
         video_max_pixels: int = 360 * 420,
         **kwargs: Any,
@@ -146,7 +145,6 @@ class UniteWrapper(AbsEncoder):
         self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
         self.fps = fps
         self.max_frames = max_frames
-        self.num_frames = num_frames
         self.target_sampling_rate = target_sampling_rate
         self.video_max_pixels = video_max_pixels
 
@@ -219,7 +217,7 @@ class UniteWrapper(AbsEncoder):
                 target_sampling_rate=self.target_sampling_rate,
                 fps=self.fps,
                 max_frames=self.max_frames,
-                num_frames=self.num_frames,
+                num_frames=None,  # fps mode; both set would let num_frames win
             )
 
         all_embeddings = []

--- a/mteb/models/model_implementations/unite_models.py
+++ b/mteb/models/model_implementations/unite_models.py
@@ -31,20 +31,24 @@ UNITE_CITATION = """@article{kong2025modality,
 # Qwen2VL refactor; each is marked inline.
 
 
-def _fit(frame, max_pixels: int):
-    """Downscale a video frame to at most max_pixels, keeping aspect ratio.
+def _fit(video, max_pixels: int):
+    """Downscale video frames to at most max_pixels each, keeping aspect ratio.
 
-    UNITE's reference inference passes video through qwen_vl_utils with
-    max_pixels=360*420, far below the image budget. Without this, video items
-    carry ~6x the visual tokens they should and encoding is ~6x slower.
+    mteb's VideoCollator yields a (T, C, H, W) uint8 tensor. CaReBench frames are
+    720x1280, while UNITE's reference inference caps video at 360*420 via
+    qwen_vl_utils. Without this the model sees ~6x the visual tokens per frame.
     """
-    w, h = frame.size
-    if w * h <= max_pixels:
-        return frame
-    scale = (max_pixels / (w * h)) ** 0.5
-    nw = max(28, int(w * scale) // 28 * 28)
+    if not hasattr(video, "shape") or video.ndim != 4:
+        return video
+    h, w = video.shape[-2], video.shape[-1]
+    if h * w <= max_pixels:
+        return video
+    scale = (max_pixels / (h * w)) ** 0.5
     nh = max(28, int(h * scale) // 28 * 28)
-    return frame.resize((nw, nh))
+    nw = max(28, int(w * scale) // 28 * 28)
+    return torch.nn.functional.interpolate(
+        video.float(), size=(nh, nw), mode="bilinear", align_corners=False
+    ).clamp(0, 255).to(torch.uint8)
 
 
 def _unwrap(out):
@@ -120,7 +124,7 @@ class UniteWrapper(AbsEncoder):
         max_image_tokens: int = 1280,
         fps: float = 1.0,
         max_frames: int = 32,
-        num_frames: int = 32,
+        num_frames: int | None = None,  # None so fps mode applies
         target_sampling_rate: int = 16000,
         video_max_pixels: int = 360 * 420,
         **kwargs: Any,
@@ -158,7 +162,7 @@ class UniteWrapper(AbsEncoder):
     def _embed_one(self, text=None, image=None, video=None) -> torch.Tensor:
         content = []
         if video is not None:
-            video = [_fit(f, self.video_max_pixels) for f in video]
+            video = _fit(video, self.video_max_pixels)
             content.append({"type": "video", "video": ""})
         elif image is not None:
             content.append({"type": "image", "image": ""})

--- a/mteb/models/model_implementations/unite_models.py
+++ b/mteb/models/model_implementations/unite_models.py
@@ -222,6 +222,15 @@ class UniteWrapper(AbsEncoder):
         return torch.cat(all_embeddings, dim=0)
 
 
+unite_training_datasets = set(
+    # Stage 1, retrieval adaptation: friedrichor/Unite-Base-Retrieval-Train
+    # (includes Tarsier2-Recap-585K video captions)
+    # Stage 2, instruction tuning: TIGER-Lab/MMEB-train
+    # Following the VLM2Vec precedent, MMEB-train components are not enumerated
+    # here even though mteb ships tasks matching several of them.
+)
+
+
 unite_base_qwen2vl_2b = ModelMeta(
     loader=UniteWrapper,
     name="friedrichor/Unite-Base-Qwen2-VL-2B",
@@ -233,7 +242,7 @@ unite_base_qwen2vl_2b = ModelMeta(
     modalities=["image", "text", "video"],
     n_parameters=2_208_985_600,
     n_embedding_parameters=233_373_696,
-    memory_usage_mb=4214,
+    memory_usage_mb=8427,
     embed_dim=1536,
     license="apache-2.0",
     max_tokens=32768,
@@ -243,7 +252,7 @@ unite_base_qwen2vl_2b = ModelMeta(
     use_instructions=False,
     public_training_code="https://github.com/friedrichor/UNITE",
     public_training_data="https://huggingface.co/datasets/friedrichor/Unite-Base-Retrieval-Train",
-    training_datasets=None,
+    training_datasets=unite_training_datasets,
     adapted_from="Qwen/Qwen2-VL-2B-Instruct",
     citation=UNITE_CITATION,
     contacts=["hubielu"],

--- a/mteb/models/model_implementations/unite_models.py
+++ b/mteb/models/model_implementations/unite_models.py
@@ -31,6 +31,22 @@ UNITE_CITATION = """@article{kong2025modality,
 # Qwen2VL refactor; each is marked inline.
 
 
+def _fit(frame, max_pixels: int):
+    """Downscale a video frame to at most max_pixels, keeping aspect ratio.
+
+    UNITE's reference inference passes video through qwen_vl_utils with
+    max_pixels=360*420, far below the image budget. Without this, video items
+    carry ~6x the visual tokens they should and encoding is ~6x slower.
+    """
+    w, h = frame.size
+    if w * h <= max_pixels:
+        return frame
+    scale = (max_pixels / (w * h)) ** 0.5
+    nw = max(28, int(w * scale) // 28 * 28)
+    nh = max(28, int(h * scale) // 28 * 28)
+    return frame.resize((nw, nh))
+
+
 def _unwrap(out):
     """tf 4.52 vision tower returns a tensor; tf 5.x returns an output object."""
     return out.pooler_output if hasattr(out, "pooler_output") else out
@@ -106,6 +122,7 @@ class UniteWrapper(AbsEncoder):
         max_frames: int = 32,
         num_frames: int = 32,
         target_sampling_rate: int = 16000,
+        video_max_pixels: int = 360 * 420,
         **kwargs: Any,
     ) -> None:
         from transformers import AutoProcessor
@@ -115,6 +132,7 @@ class UniteWrapper(AbsEncoder):
         self.max_frames = max_frames
         self.num_frames = num_frames
         self.target_sampling_rate = target_sampling_rate
+        self.video_max_pixels = video_max_pixels
 
         self.model = _load_base(model_name, revision)
         self.model.eval().to(self.device)
@@ -140,6 +158,7 @@ class UniteWrapper(AbsEncoder):
     def _embed_one(self, text=None, image=None, video=None) -> torch.Tensor:
         content = []
         if video is not None:
+            video = [_fit(f, self.video_max_pixels) for f in video]
             content.append({"type": "video", "video": ""})
         elif image is not None:
             content.append({"type": "image", "image": ""})

--- a/mteb/models/model_implementations/unite_models.py
+++ b/mteb/models/model_implementations/unite_models.py
@@ -213,13 +213,6 @@ class UniteWrapper(AbsEncoder):
         with torch.inference_mode():
             return self.model(**inputs)
 
-    def _embed_one(self, text=None, image=None, video=None) -> torch.Tensor:
-        """Single-item convenience wrapper, used by tests."""
-        return self._embed_batch(
-            texts=[text] if text is not None else None,
-            images=[image] if image is not None else None,
-            videos=[video] if video is not None else None,
-        )
 
     def encode(
         self,

--- a/mteb/models/model_implementations/unite_models.py
+++ b/mteb/models/model_implementations/unite_models.py
@@ -31,89 +31,67 @@ UNITE_CITATION = """@article{kong2025modality,
 # Qwen2VL refactor; each is marked inline.
 
 
-def _build_unite_model(model_name: str, revision: str | None, **kwargs):
+def _unwrap(out):
+    """tf 4.52 vision tower returns a tensor; tf 5.x returns an output object."""
+    return out.pooler_output if hasattr(out, "pooler_output") else out
+
+
+def _load_base(model_name: str, revision: str | None):
     from transformers import Qwen2VLForConditionalGeneration
 
-    class UniteQwen2VL(Qwen2VLForConditionalGeneration):
-        def __init__(self, config):
-            super().__init__(config)
-            self.normalize = True
+    # UNITE ships modeling_unite.py as a Qwen2VLForConditionalGeneration subclass,
+    # but subclassing breaks checkpoint key remapping on transformers 5.x: the
+    # language model silently loads with random weights. We keep the base class and
+    # reproduce UNITE's pooling in _unite_embed instead.
+    try:
+        return Qwen2VLForConditionalGeneration.from_pretrained(
+            model_name, revision=revision, dtype=torch.bfloat16
+        )
+    except TypeError:
+        return Qwen2VLForConditionalGeneration.from_pretrained(
+            model_name, revision=revision, torch_dtype=torch.bfloat16
+        )
 
-        def forward(  # noqa: PLR0913, PLR0917 - signature mirrors upstream Qwen2VLForConditionalGeneration
-            self,
-            input_ids=None,
-            attention_mask=None,
-            position_ids=None,
-            past_key_values=None,
-            inputs_embeds=None,
-            pixel_values=None,
-            pixel_values_videos=None,
-            image_grid_thw=None,
-            video_grid_thw=None,
-            pooling_mask=None,
-            **unused,
-        ) -> torch.Tensor:
-            if inputs_embeds is None:
-                # Upstream: self.model.embed_tokens(input_ids).
-                # tf>=4.52 moved embed_tokens under self.model.language_model.
-                inputs_embeds = self.get_input_embeddings()(input_ids)
-                if pixel_values is not None:
-                    pixel_values = pixel_values.type(self.visual.get_dtype())
-                    image_embeds = self.visual(pixel_values, grid_thw=image_grid_thw)
-                    mask = (
-                        (input_ids == self.config.image_token_id)
-                        .unsqueeze(-1)
-                        .expand_as(inputs_embeds)
-                        .to(inputs_embeds.device)
-                    )
-                    image_embeds = image_embeds.to(
-                        inputs_embeds.device, inputs_embeds.dtype
-                    )
-                    inputs_embeds = inputs_embeds.masked_scatter(mask, image_embeds)
-                if pixel_values_videos is not None:
-                    pixel_values_videos = pixel_values_videos.type(
-                        self.visual.get_dtype()
-                    )
-                    video_embeds = self.visual(
-                        pixel_values_videos, grid_thw=video_grid_thw
-                    )
-                    mask = (
-                        (input_ids == self.config.video_token_id)
-                        .unsqueeze(-1)
-                        .expand_as(inputs_embeds)
-                        .to(inputs_embeds.device)
-                    )
-                    video_embeds = video_embeds.to(
-                        inputs_embeds.device, inputs_embeds.dtype
-                    )
-                    inputs_embeds = inputs_embeds.masked_scatter(mask, video_embeds)
-                if attention_mask is not None:
-                    attention_mask = attention_mask.to(inputs_embeds.device)
 
-            # Upstream: self.model(...), which was the text decoder in tf 4.47.
-            # In tf>=4.52 that name is the multimodal wrapper and would recompute
-            # position ids via get_rope_index; language_model is the 4.47 self.model.
-            outputs = self.model.language_model(
-                input_ids=None,
-                position_ids=position_ids,
-                attention_mask=attention_mask,
-                past_key_values=past_key_values,
-                inputs_embeds=inputs_embeds,
-            )
+def _scatter(model, inputs_embeds, input_ids, pixels, grid, token_id):
+    tower = model.model.visual
+    embeds = _unwrap(tower(pixels.type(tower.dtype), grid_thw=grid))
+    mask = (input_ids == token_id).unsqueeze(-1).expand_as(inputs_embeds)
+    return inputs_embeds.masked_scatter(
+        mask.to(inputs_embeds.device),
+        embeds.to(inputs_embeds.device, inputs_embeds.dtype),
+    )
 
-            pooling_mask = attention_mask if pooling_mask is None else pooling_mask
-            h = outputs.last_hidden_state
-            left_padding = pooling_mask[:, -1].sum() == pooling_mask.shape[0]
-            if left_padding:
-                embeddings = h[:, -1]
-            else:
-                idx = pooling_mask.sum(dim=1) - 1
-                embeddings = h[torch.arange(h.shape[0], device=h.device), idx]
-            if self.normalize:
-                embeddings = torch.nn.functional.normalize(embeddings, p=2, dim=1)
-            return embeddings.contiguous()
 
-    return UniteQwen2VL.from_pretrained(model_name, revision=revision, **kwargs)
+def _unite_embed(model, inputs) -> torch.Tensor:
+    """UNITE's forward: embed, scatter visual features, decode, last-token pool."""
+    input_ids = inputs["input_ids"]
+    attention_mask = inputs["attention_mask"]
+    inputs_embeds = model.get_input_embeddings()(input_ids)
+
+    if inputs.get("pixel_values") is not None:
+        inputs_embeds = _scatter(
+            model, inputs_embeds, input_ids, inputs["pixel_values"],
+            inputs["image_grid_thw"], model.config.image_token_id,
+        )
+    if inputs.get("pixel_values_videos") is not None:
+        inputs_embeds = _scatter(
+            model, inputs_embeds, input_ids, inputs["pixel_values_videos"],
+            inputs["video_grid_thw"], model.config.video_token_id,
+        )
+
+    out = model.model.language_model(
+        input_ids=None,
+        attention_mask=attention_mask.to(inputs_embeds.device),
+        inputs_embeds=inputs_embeds,
+    )
+    h = out.last_hidden_state
+    if attention_mask[:, -1].sum() == attention_mask.shape[0]:
+        emb = h[:, -1]
+    else:
+        idx = attention_mask.sum(dim=1) - 1
+        emb = h[torch.arange(h.shape[0], device=h.device), idx]
+    return torch.nn.functional.normalize(emb, p=2, dim=1).contiguous()
 
 
 class UniteWrapper(AbsEncoder):
@@ -138,11 +116,7 @@ class UniteWrapper(AbsEncoder):
         self.num_frames = num_frames
         self.target_sampling_rate = target_sampling_rate
 
-        self.model = _build_unite_model(
-            model_name,
-            revision,
-            torch_dtype=torch.bfloat16,
-        )
+        self.model = _load_base(model_name, revision)
         self.model.eval().to(self.device)
         self.processor = AutoProcessor.from_pretrained(
             model_name,
@@ -192,7 +166,7 @@ class UniteWrapper(AbsEncoder):
             return_tensors="pt",
         ).to(self.device)
         with torch.inference_mode():
-            return self.model(**inputs)
+            return _unite_embed(self.model, inputs)
 
     def encode(
         self,

--- a/mteb/models/model_implementations/unite_models.py
+++ b/mteb/models/model_implementations/unite_models.py
@@ -9,13 +9,12 @@ from tqdm.autonotebook import tqdm
 from mteb.models.abs_encoder import AbsEncoder
 from mteb.models.modality_collators import VideoCollator
 from mteb.models.model_meta import ModelMeta, ScoringFunction
-from mteb.types import PromptType
 
 if TYPE_CHECKING:
     from torch.utils.data import DataLoader
 
     from mteb.abstasks.task_metadata import TaskMetadata
-    from mteb.types import Array, BatchedInput
+    from mteb.types import Array, BatchedInput, PromptType
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +39,7 @@ def _build_unite_model(model_name: str, revision: str | None, **kwargs):
             super().__init__(config)
             self.normalize = True
 
-        def forward(
+        def forward(  # noqa: PLR0913, PLR0917 - signature mirrors upstream Qwen2VLForConditionalGeneration
             self,
             input_ids=None,
             attention_mask=None,
@@ -67,18 +66,26 @@ def _build_unite_model(model_name: str, revision: str | None, **kwargs):
                         .expand_as(inputs_embeds)
                         .to(inputs_embeds.device)
                     )
-                    image_embeds = image_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
+                    image_embeds = image_embeds.to(
+                        inputs_embeds.device, inputs_embeds.dtype
+                    )
                     inputs_embeds = inputs_embeds.masked_scatter(mask, image_embeds)
                 if pixel_values_videos is not None:
-                    pixel_values_videos = pixel_values_videos.type(self.visual.get_dtype())
-                    video_embeds = self.visual(pixel_values_videos, grid_thw=video_grid_thw)
+                    pixel_values_videos = pixel_values_videos.type(
+                        self.visual.get_dtype()
+                    )
+                    video_embeds = self.visual(
+                        pixel_values_videos, grid_thw=video_grid_thw
+                    )
                     mask = (
                         (input_ids == self.config.video_token_id)
                         .unsqueeze(-1)
                         .expand_as(inputs_embeds)
                         .to(inputs_embeds.device)
                     )
-                    video_embeds = video_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
+                    video_embeds = video_embeds.to(
+                        inputs_embeds.device, inputs_embeds.dtype
+                    )
                     inputs_embeds = inputs_embeds.masked_scatter(mask, video_embeds)
                 if attention_mask is not None:
                     attention_mask = attention_mask.to(inputs_embeds.device)

--- a/mteb/models/model_implementations/unite_models.py
+++ b/mteb/models/model_implementations/unite_models.py
@@ -27,72 +27,93 @@ UNITE_CITATION = """@article{kong2025modality,
 
 # Vendored from https://github.com/friedrichor/UNITE/blob/main/inference/modeling_unite.py
 # The HF repos ship no auto_map, so trust_remote_code is not available.
-# UNITE ships modeling_unite.py as a Qwen2VLForConditionalGeneration subclass.
-# On transformers 5.x that subclass misses the checkpoint key remapping and the
-# language model loads randomly initialized without erroring, so we use the base
-# class and reproduce UNITE's pooling in _unite_embed.
+# Two lines differ from upstream, both required by the transformers >=4.52
+# Qwen2VL refactor; each is marked inline.
 
 
-def _unwrap(out):
-    """tf 4.52 vision tower returns a tensor; tf 5.x returns an output object."""
-    return out.pooler_output if hasattr(out, "pooler_output") else out
-
-
-def _load_base(model_name: str, revision: str | None):
+def _build_unite_model(model_name: str, revision: str | None, **kwargs):
     from transformers import Qwen2VLForConditionalGeneration
 
-    return Qwen2VLForConditionalGeneration.from_pretrained(
-        model_name, revision=revision, torch_dtype=torch.bfloat16
-    )
+    class UniteQwen2VL(Qwen2VLForConditionalGeneration):
+        def __init__(self, config):
+            super().__init__(config)
+            self.normalize = True
 
+        def forward(  # noqa: PLR0913, PLR0917 - signature mirrors upstream Qwen2VLForConditionalGeneration
+            self,
+            input_ids=None,
+            attention_mask=None,
+            position_ids=None,
+            past_key_values=None,
+            inputs_embeds=None,
+            pixel_values=None,
+            pixel_values_videos=None,
+            image_grid_thw=None,
+            video_grid_thw=None,
+            pooling_mask=None,
+            **unused,
+        ) -> torch.Tensor:
+            if inputs_embeds is None:
+                # Upstream: self.model.embed_tokens(input_ids).
+                # tf>=4.52 moved embed_tokens under self.model.language_model.
+                inputs_embeds = self.get_input_embeddings()(input_ids)
+                if pixel_values is not None:
+                    pixel_values = pixel_values.type(self.visual.get_dtype())
+                    image_embeds = self.visual(pixel_values, grid_thw=image_grid_thw)
+                    mask = (
+                        (input_ids == self.config.image_token_id)
+                        .unsqueeze(-1)
+                        .expand_as(inputs_embeds)
+                        .to(inputs_embeds.device)
+                    )
+                    image_embeds = image_embeds.to(
+                        inputs_embeds.device, inputs_embeds.dtype
+                    )
+                    inputs_embeds = inputs_embeds.masked_scatter(mask, image_embeds)
+                if pixel_values_videos is not None:
+                    pixel_values_videos = pixel_values_videos.type(
+                        self.visual.get_dtype()
+                    )
+                    video_embeds = self.visual(
+                        pixel_values_videos, grid_thw=video_grid_thw
+                    )
+                    mask = (
+                        (input_ids == self.config.video_token_id)
+                        .unsqueeze(-1)
+                        .expand_as(inputs_embeds)
+                        .to(inputs_embeds.device)
+                    )
+                    video_embeds = video_embeds.to(
+                        inputs_embeds.device, inputs_embeds.dtype
+                    )
+                    inputs_embeds = inputs_embeds.masked_scatter(mask, video_embeds)
+                if attention_mask is not None:
+                    attention_mask = attention_mask.to(inputs_embeds.device)
 
-def _scatter(model, inputs_embeds, input_ids, pixels, grid, token_id):
-    tower = model.model.visual
-    embeds = _unwrap(tower(pixels.type(tower.dtype), grid_thw=grid))
-    mask = (input_ids == token_id).unsqueeze(-1).expand_as(inputs_embeds)
-    return inputs_embeds.masked_scatter(
-        mask.to(inputs_embeds.device),
-        embeds.to(inputs_embeds.device, inputs_embeds.dtype),
-    )
+            # Upstream: self.model(...), which was the text decoder in tf 4.47.
+            # In tf>=4.52 that name is the multimodal wrapper and would recompute
+            # position ids via get_rope_index; language_model is the 4.47 self.model.
+            outputs = self.model.language_model(
+                input_ids=None,
+                position_ids=position_ids,
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                inputs_embeds=inputs_embeds,
+            )
 
+            pooling_mask = attention_mask if pooling_mask is None else pooling_mask
+            h = outputs.last_hidden_state
+            left_padding = pooling_mask[:, -1].sum() == pooling_mask.shape[0]
+            if left_padding:
+                embeddings = h[:, -1]
+            else:
+                idx = pooling_mask.sum(dim=1) - 1
+                embeddings = h[torch.arange(h.shape[0], device=h.device), idx]
+            if self.normalize:
+                embeddings = torch.nn.functional.normalize(embeddings, p=2, dim=1)
+            return embeddings.contiguous()
 
-def _unite_embed(model, inputs) -> torch.Tensor:
-    """UNITE's forward: embed, scatter visual features, decode, last-token pool."""
-    input_ids = inputs["input_ids"]
-    attention_mask = inputs["attention_mask"]
-    inputs_embeds = model.get_input_embeddings()(input_ids)
-
-    if inputs.get("pixel_values") is not None:
-        inputs_embeds = _scatter(
-            model,
-            inputs_embeds,
-            input_ids,
-            inputs["pixel_values"],
-            inputs["image_grid_thw"],
-            model.config.image_token_id,
-        )
-    if inputs.get("pixel_values_videos") is not None:
-        inputs_embeds = _scatter(
-            model,
-            inputs_embeds,
-            input_ids,
-            inputs["pixel_values_videos"],
-            inputs["video_grid_thw"],
-            model.config.video_token_id,
-        )
-
-    out = model.model.language_model(
-        input_ids=None,
-        attention_mask=attention_mask.to(inputs_embeds.device),
-        inputs_embeds=inputs_embeds,
-    )
-    h = out.last_hidden_state
-    if attention_mask[:, -1].sum() == attention_mask.shape[0]:
-        emb = h[:, -1]
-    else:
-        idx = attention_mask.sum(dim=1) - 1
-        emb = h[torch.arange(h.shape[0], device=h.device), idx]
-    return torch.nn.functional.normalize(emb, p=2, dim=1).contiguous()
+    return UniteQwen2VL.from_pretrained(model_name, revision=revision, **kwargs)
 
 
 class UniteWrapper(AbsEncoder):
@@ -117,7 +138,11 @@ class UniteWrapper(AbsEncoder):
         self.target_sampling_rate = target_sampling_rate
         self.video_max_pixels = video_max_pixels
 
-        self.model = _load_base(model_name, revision)
+        self.model = _build_unite_model(
+            model_name,
+            revision,
+            torch_dtype=torch.bfloat16,
+        )
         self.model.eval().to(self.device)
         self.processor = AutoProcessor.from_pretrained(
             model_name,
@@ -184,7 +209,7 @@ class UniteWrapper(AbsEncoder):
             return_tensors="pt",
         ).to(self.device)
         with torch.inference_mode():
-            return _unite_embed(self.model, inputs)
+            return self.model(**inputs)
 
     def _embed_one(self, text=None, image=None, video=None) -> torch.Tensor:
         """Single-item convenience wrapper, used by tests."""
@@ -256,4 +281,5 @@ unite_base_qwen2vl_2b = ModelMeta(
     training_datasets=unite_training_datasets,
     adapted_from="Qwen/Qwen2-VL-2B-Instruct",
     citation=UNITE_CITATION,
+    extra_requirements_groups=["transformers-v4"],
 )

--- a/mteb/models/model_implementations/unite_models.py
+++ b/mteb/models/model_implementations/unite_models.py
@@ -39,18 +39,9 @@ def _unwrap(out):
 def _load_base(model_name: str, revision: str | None):
     from transformers import Qwen2VLForConditionalGeneration
 
-    # UNITE ships modeling_unite.py as a Qwen2VLForConditionalGeneration subclass,
-    # but subclassing breaks checkpoint key remapping on transformers 5.x: the
-    # language model silently loads with random weights. We keep the base class and
-    # reproduce UNITE's pooling in _unite_embed instead.
-    try:
-        return Qwen2VLForConditionalGeneration.from_pretrained(
-            model_name, revision=revision, dtype=torch.bfloat16
-        )
-    except TypeError:
-        return Qwen2VLForConditionalGeneration.from_pretrained(
-            model_name, revision=revision, torch_dtype=torch.bfloat16
-        )
+    return Qwen2VLForConditionalGeneration.from_pretrained(
+        model_name, revision=revision, torch_dtype=torch.bfloat16
+    )
 
 
 def _scatter(model, inputs_embeds, input_ids, pixels, grid, token_id):

--- a/mteb/models/model_implementations/unite_models.py
+++ b/mteb/models/model_implementations/unite_models.py
@@ -31,30 +31,6 @@ UNITE_CITATION = """@article{kong2025modality,
 # Qwen2VL refactor; each is marked inline.
 
 
-def _fit(video, max_pixels: int):
-    """Downscale video frames to at most max_pixels each, keeping aspect ratio.
-
-    mteb's VideoCollator yields a (T, C, H, W) uint8 tensor. CaReBench frames are
-    720x1280, while UNITE's reference inference caps video at 360*420 via
-    qwen_vl_utils. Without this the model sees ~6x the visual tokens per frame.
-    """
-    if not hasattr(video, "shape") or video.ndim != 4:
-        return video
-    h, w = video.shape[-2], video.shape[-1]
-    if h * w <= max_pixels:
-        return video
-    scale = (max_pixels / (h * w)) ** 0.5
-    nh = max(28, int(h * scale) // 28 * 28)
-    nw = max(28, int(w * scale) // 28 * 28)
-    return (
-        torch.nn.functional.interpolate(
-            video.float(), size=(nh, nw), mode="bilinear", align_corners=False
-        )
-        .clamp(0, 255)
-        .to(torch.uint8)
-    )
-
-
 def _unwrap(out):
     """tf 4.52 vision tower returns a tensor; tf 5.x returns an output object."""
     return out.pooler_output if hasattr(out, "pooler_output") else out
@@ -157,6 +133,15 @@ class UniteWrapper(AbsEncoder):
             max_pixels=max_image_tokens * 28 * 28,
         )
 
+        # UNITE's reference inference caps video at 360*420 via qwen_vl_utils, well
+        # below the image budget. tf>=5 exposes this as video_processor.size; on
+        # older versions the video branch shares the image processor settings.
+        vp = getattr(self.processor, "video_processor", None)
+        if vp is not None:
+            size = dict(getattr(vp, "size", None) or {})
+            size["longest_edge"] = video_max_pixels
+            vp.size = size
+
     @staticmethod
     def _suffix(has_text: bool, has_image: bool, has_video: bool) -> str:
         if has_video and has_text:
@@ -169,37 +154,52 @@ class UniteWrapper(AbsEncoder):
             return "\nSummary above image in one word:"
         return "\nSummary above sentence in one word:"
 
-    def _embed_one(self, text=None, image=None, video=None) -> torch.Tensor:
+    def _build_prompt(self, text=None, has_image=False, has_video=False) -> str:
         content = []
-        if video is not None:
-            video = _fit(video, self.video_max_pixels)
+        if has_video:
             content.append({"type": "video", "video": ""})
-        elif image is not None:
+        elif has_image:
             content.append({"type": "image", "image": ""})
         if text:
             content.append({"type": "text", "text": text})
         content.append(
-            {
-                "type": "text",
-                "text": self._suffix(bool(text), image is not None, video is not None),
-            }
+            {"type": "text", "text": self._suffix(bool(text), has_image, has_video)}
         )
         messages = [{"role": "user", "content": content}]
-        prompt = (
+        return (
             self.processor.apply_chat_template(
                 messages, tokenize=False, add_generation_prompt=True
             )
             + "<|endoftext|>"
         )
+
+    def _embed_batch(self, texts=None, images=None, videos=None) -> torch.Tensor:
+        n = len(texts or images or videos)
+        prompts = [
+            self._build_prompt(
+                text=texts[i] if texts is not None else None,
+                has_image=images is not None,
+                has_video=videos is not None,
+            )
+            for i in range(n)
+        ]
         inputs = self.processor(
-            text=[prompt],
-            images=[image] if image is not None else None,
-            videos=[video] if video is not None else None,
+            text=prompts,
+            images=list(images) if images is not None else None,
+            videos=list(videos) if videos is not None else None,
             padding=True,
             return_tensors="pt",
         ).to(self.device)
         with torch.inference_mode():
             return _unite_embed(self.model, inputs)
+
+    def _embed_one(self, text=None, image=None, video=None) -> torch.Tensor:
+        """Single-item convenience wrapper, used by tests."""
+        return self._embed_batch(
+            texts=[text] if text is not None else None,
+            images=[image] if image is not None else None,
+            videos=[video] if video is not None else None,
+        )
 
     def encode(
         self,
@@ -225,14 +225,8 @@ class UniteWrapper(AbsEncoder):
             texts = batch.get("text")
             images = batch.get("image")
             videos = batch.get("video")
-            n = len(texts or images or videos)
-            for i in range(n):
-                emb = self._embed_one(
-                    text=texts[i] if texts is not None else None,
-                    image=images[i] if images is not None else None,
-                    video=videos[i] if videos is not None else None,
-                )
-                all_embeddings.append(emb.float().cpu())
+            emb = self._embed_batch(texts=texts, images=images, videos=videos)
+            all_embeddings.append(emb.float().cpu())
         return torch.cat(all_embeddings, dim=0)
 
 


### PR DESCRIPTION
Closes #5185. Claimed in #4842 (Video row).

Adds UNITE (arXiv:2505.19650), a universal embedder for text, image, video, and fused queries. Qwen2-VL-2B backbone, E5-V style prompting, last-token pooling, L2 normalization, 1536-d embeddings.

## Reference run

CaReBench, using 32-frame video sampling:

| Task | nDCG@10 | R@1 | R@5 | R@10 |
|---|---:|---:|---:|---:|
| CaReBenchT2VRetrieval | 89.03 | 79.00 | 95.80 | 97.80 |
| CaReBenchV2TRetrieval | 90.13 | 80.30 | 96.50 | 98.60 |

`Unite-Base-Qwen2-VL-2B` @ `850056e7`, bf16, 1x A6000, 32 sampled frames, video capped at `360*420`.

MTEB uses the CaRe-General queries. The paper reports:

- T→V: 78.1 / 95.5 / 97.8
- V→T: 80.8 / 96.4 / 98.7

for R@1/R@5/R@10, so the reproduction is within 0.9 R@1 points and essentially matches R@5/R@10. The earlier gap came from fps-based sampling.

Separately reproduced upstream demo similarities closely: text-image 0.7539 (0.7500 reported), text-video 0.5625 (0.5664 reported).

## Note on loading

UNITE ships `UniteQwen2VL`, a `Qwen2VLForConditionalGeneration` subclass, without an `auto_map`.

On transformers 5.x, the base class loaded the checkpoint correctly, but the UNITE subclass did not receive the same key remapping and loaded only 391/729 weights, producing invalid embeddings.

The final implementation restores UNITE's subclass/forward behavior and uses MTEB's existing `transformers-v4` requirement group.

## Video / batching

Video resizing is applied through the processor with `max_pixels=360*420`. Default sampling is 32 frames, while `fps`, `max_frames`, and `num_frames` remain configurable.

Batch encoding is supported. On 16 CaReBench videos, bs=1 was fastest (3.59 s/item vs. 3.92/4.21/5.16 for bs=2/4/8), so batch size remains configurable.

## Follow-up

Instruct checkpoints can be added separately as additional `ModelMeta` entries.