### PR TITLE
model: add OmniRet (chuonghm/OmniRet)

### DIFF
--- a/mteb/models/model_implementations/omniret.py
+++ b/mteb/models/model_implementations/omniret.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import torch
+from tqdm.auto import tqdm
+
+from mteb.models.abs_encoder import AbsEncoder
+from mteb.models.modality_collators import AudioCollator, VideoCollator
+from mteb.models.model_meta import ModelMeta, ScoringFunction
+
+if TYPE_CHECKING:
+    from torch.utils.data import DataLoader
+
+    from mteb.abstasks.task_metadata import TaskMetadata
+    from mteb.types import Array, BatchedInput, PromptType
+
+# OmniRet's Qwen-Audio tower expects 16 kHz mono; its whisper-style frontend
+# consumes a 30 second window.
+OMNIRET_SAMPLING_RATE = 16_000
+OMNIRET_MAX_AUDIO_SECONDS = 30
+# omniret.config.OmniRetModelConfig.max_video_frames is 8 and the model
+# re-subsamples above that, so sample 8 at the collator to save decode work.
+OMNIRET_MAX_VIDEO_FRAMES = 8
+
+
+class OmniRetWrapper(AbsEncoder):
+    """Wrapper for OmniRet, an instruction-aware text/image/audio/video retriever.
+
+    Every input maps to one L2-normalized 4096-d vector via Attention Sliced
+    Wasserstein Pooling, so cosine similarity is the scoring function.
+
+    This calls ``OmniRetModel.encode_raw_media_batch`` and ``encode_batch``
+    directly rather than ``OmniRetEmbedder.process``, because ``process`` only
+    accepts filesystem paths or HTTP URLs and would force a temp-file write per
+    item. The two-call path accepts in-memory PIL images, frame lists, and audio
+    arrays, which is what mteb's collators already produce.
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        revision: str | None = None,
+        device: str | None = None,
+        max_audio_length_seconds: int = OMNIRET_MAX_AUDIO_SECONDS,
+        num_frames: int = OMNIRET_MAX_VIDEO_FRAMES,
+        **kwargs: Any,
+    ) -> None:
+        from huggingface_hub import snapshot_download
+
+        try:
+            from omniret import OmniRetEmbedder
+        except ImportError as error:
+            raise ImportError(
+                "OmniRetWrapper requires the `omniret` package, which is not on PyPI. "
+                "Install it into a Python 3.10 CUDA 12.8 environment with "
+                "`uv pip install --no-deps git+https://github.com/hmchuong/OmniRet` "
+                "after installing torch 2.9.1+cu128 from the pytorch cu128 index."
+            ) from error
+
+        self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+        self.num_frames = num_frames
+        self.sampling_rate = OMNIRET_SAMPLING_RATE
+        self.max_samples = int(max_audio_length_seconds * self.sampling_rate)
+
+        # OmniRetEmbedder does not take a revision, so resolve the snapshot
+        # ourselves and hand it the pinned local directory. Base encoder
+        # revisions are pinned separately inside the checkpoint's config.json.
+        model_dir = snapshot_download(repo_id=model_name, revision=revision)
+
+        # sdpa keeps flash-attn out of the dependency set entirely; OmniRet only
+        # forwards this to the text tower and already hardcodes sdpa elsewhere.
+        embedder = OmniRetEmbedder(
+            model_dir,
+            device=self.device,
+            attn_implementation=kwargs.pop("attn_implementation", "sdpa"),
+            **kwargs,
+        )
+        self.model = embedder.model
+        self.model.eval()
+
+    @staticmethod
+    def _row_modality(video: Any, audio: Any) -> str:
+        """Pick the single media slot for a row. OmniRet allows at most one."""
+        if video is not None:
+            return "video"
+        if audio is not None:
+            return "audio"
+        # Text-only rows are labelled "image" and carry no media, matching the
+        # default in OmniRetEmbedder.process.
+        return "image"
+
+    @staticmethod
+    def _format_text(
+        instruction: str, modality: str, text: str, has_media: bool
+    ) -> str:
+        """Reproduce omniret.embedding._format_input exactly.
+
+        The '<image>' / '<video>' / '<audio>' placeholder is where
+        _expand_media_placeholders splices media tokens, and the 'Query:\\n'
+        marker is what _without_instruction_prefix keys off. Both strings are
+        part of the model's trained input format, so do not reformat them.
+        """
+        pieces = []
+        if has_media:
+            pieces.append(f"{modality.title()}: <{modality}>")
+        if text:
+            pieces.append(text)
+        body = "\n".join(pieces)
+        return f"Instruct: {instruction}\nQuery:\n{body}" if instruction else body
+
+    def _prepare_batch(
+        self, batch: BatchedInput, instruction: str
+    ) -> tuple[list[str], list[str], list[Any]]:
+        """Split a collated batch into aligned text, modality, and media lists."""
+        columns = {
+            key: batch.get(key) or [] for key in ("text", "image", "audio", "video")
+        }
+        size = max(len(value) for value in columns.values())
+
+        formatted: list[str] = []
+        modalities: list[str] = []
+        media: list[Any] = []
+        for index in range(size):
+            row = {
+                key: value[index] if index < len(value) else None
+                for key, value in columns.items()
+            }
+            modality = self._row_modality(row["video"], row["audio"])
+            item = row[modality]
+            media.append(item)
+            modalities.append(modality)
+            formatted.append(
+                self._format_text(
+                    instruction, modality, row["text"] or "", item is not None
+                )
+            )
+        return formatted, modalities, media
+
+    @torch.no_grad()
+    def encode(
+        self,
+        inputs: DataLoader[BatchedInput],
+        *,
+        task_metadata: TaskMetadata,
+        hf_split: str,
+        hf_subset: str,
+        prompt_type: PromptType | None = None,
+        **kwargs: Any,
+    ) -> Array:
+        features = inputs.dataset.features
+        if "video" in features:
+            inputs.collate_fn = VideoCollator(
+                target_sampling_rate=self.sampling_rate,
+                num_frames=self.num_frames,
+                max_samples=self.max_samples,
+            )
+        elif "audio" in features:
+            inputs.collate_fn = AudioCollator(
+                target_sampling_rate=self.sampling_rate,
+                max_samples=self.max_samples,
+            )
+
+        instruction = self.get_task_instruction(task_metadata, prompt_type)
+
+        all_embeddings: list[torch.Tensor] = []
+        for batch in tqdm(inputs, desc="Encoding"):
+            formatted, modalities, media = self._prepare_batch(batch, instruction)
+
+            raw = None
+            if any(item is not None for item in media):
+                raw = self.model.encode_raw_media_batch(media, modalities)
+            tokens, media_mask = raw if isinstance(raw, tuple) else (raw, None)
+
+            embeddings, _ = self.model.encode_batch(
+                formatted,
+                tokens,
+                modalities,
+                media_mask,
+                exclude_instruction_prefix=bool(instruction),
+            )
+            all_embeddings.append(embeddings.float().cpu())
+
+        return torch.cat(all_embeddings, dim=0)
+
+
+omniret = ModelMeta(
+    loader=OmniRetWrapper,
+    name="chuonghm/OmniRet",
+    revision="main",  # TODO pin to a commit sha from the HF repo
+    release_date="2026-03-02",  # TODO confirm against the HF repo's first commit
+    languages=["eng-Latn"],
+    n_parameters=None,  # TODO fill from the measurement command
+    memory_usage_mb=None,  # TODO fill from the measurement command
+    n_embedding_parameters=None,  # TODO fill from the measurement command
+    max_tokens=1024,  # omniret.config text_max_length
+    embed_dim=4096,
+    license="mit",  # code is MIT; encoders retain upstream terms per NOTICE
+    open_weights=True,
+    public_training_code="https://github.com/hmchuong/OmniRet",
+    public_training_data="https://huggingface.co/datasets/chuonghm/OmniRet-train",
+    framework=["PyTorch", "safetensors"],
+    reference="https://huggingface.co/chuonghm/OmniRet",
+    similarity_fn_name=ScoringFunction.COSINE,
+    use_instructions=True,
+    training_datasets=None,  # TODO map the M-BEIR/UniIR + audio corpora
+    adapted_from="Alibaba-NLP/gte-Qwen2-1.5B-instruct",
+    superseded_by=None,
+    modalities=["text", "image", "audio", "video"],
+    model_type=["dense"],
+    extra_requirements_groups=["omniret"],
+    contacts=["hubielu"],
+    citation="""
+@inproceedings{huynh2026omniret,
+    title={Efficient and High-Fidelity Omni Modality Retrieval},
+    author={Huynh, Chuong and Luong, Manh and Shrivastava, Abhinav},
+    booktitle={Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR)},
+    year={2026}
+}""",
+)

--- a/mteb/models/model_implementations/omniret.py
+++ b/mteb/models/model_implementations/omniret.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 import torch
+import torch.nn.functional as F
 from tqdm.auto import tqdm
 
 from mteb.models.abs_encoder import AbsEncoder
@@ -109,6 +110,60 @@ class OmniRetWrapper(AbsEncoder):
         body = "\n".join(pieces)
         return f"Instruct: {instruction}\nQuery:\n{body}" if instruction else body
 
+    @staticmethod
+    def _coerce_video(item: Any) -> Any:
+        """Reduce mteb's video payload to the PIL frame list _load_video returns.
+
+        VideoCollator yields a uint8 NCHW torch.Tensor from torchcodec, but
+        OmniRet's _raw_video_frames evaluates ``video or []``, which raises on a
+        multi-element tensor. Its vision path feeds frames straight to the SigLIP
+        image processor, so PIL RGB is the shape that matches the reference path.
+        """
+        from PIL import Image
+
+        if item is None or isinstance(item, (list, tuple)):
+            return item
+        if isinstance(item, dict):
+            return item.get("video", item.get("image"))
+        if not torch.is_tensor(item):
+            return item
+
+        frames = item.detach().cpu()
+        if frames.ndim == 3:
+            frames = frames.unsqueeze(0)
+        if frames.shape[1] in {1, 3} and frames.shape[-1] not in {1, 3}:
+            frames = frames.permute(0, 2, 3, 1)
+        if frames.dtype != torch.uint8:
+            scale = 255.0 if frames.max() <= 1.0 else 1.0
+            frames = (frames.float() * scale).clamp(0, 255).to(torch.uint8)
+        return [Image.fromarray(frame.numpy()).convert("RGB") for frame in frames]
+
+    @staticmethod
+    def _coerce_audio(item: Any) -> Any:
+        """Reduce mteb's audio payload to the 1-D float32 waveform _load_wav returns.
+
+        OmniRet's _prepare_qwen_audio reads ``item["audio"]``, so mteb's
+        ``{"array": ..., "sampling_rate": ...}`` resolves to None and is silently
+        replaced with N_SAMPLES of zeros. It also treats any 2-D tensor as a
+        precomputed log-mel spectrogram, so a (channels, samples) array would be
+        misread rather than raising.
+        """
+        if isinstance(item, dict):
+            item = item.get("array", item.get("audio"))
+        if item is None:
+            return None
+        waveform = (
+            item.detach().to(torch.float32)
+            if torch.is_tensor(item)
+            else torch.as_tensor(item, dtype=torch.float32)
+        )
+        if waveform.ndim > 2:
+            waveform = waveform.reshape(waveform.shape[0], -1)
+        if waveform.ndim == 2:
+            # mteb and torchaudio use (channels, samples); downmix to mono.
+            waveform = waveform.mean(dim=0)
+        return waveform.flatten()
+
     def _prepare_batch(
         self, batch: BatchedInput, instruction: str
     ) -> tuple[list[str], list[str], list[Any]]:
@@ -128,11 +183,18 @@ class OmniRetWrapper(AbsEncoder):
             }
             modality = self._row_modality(row["video"], row["audio"])
             item = row[modality]
+            if modality == "audio":
+                item = self._coerce_audio(item)
+            elif modality == "video":
+                item = self._coerce_video(item)
             media.append(item)
             modalities.append(modality)
             formatted.append(
                 self._format_text(
-                    instruction, modality, row["text"] or "", item is not None
+                    instruction,
+                    modality,
+                    str(row["text"] or "").strip(),
+                    item is not None,
                 )
             )
         return formatted, modalities, media
@@ -179,7 +241,9 @@ class OmniRetWrapper(AbsEncoder):
                 media_mask,
                 exclude_instruction_prefix=bool(instruction),
             )
-            all_embeddings.append(embeddings.float().cpu())
+            # process() normalizes as its final step; match it so cosine
+            # scoring and any dot-product consumer agree.
+            all_embeddings.append(F.normalize(embeddings.float(), dim=-1).cpu())
 
         return torch.cat(all_embeddings, dim=0)
 
@@ -187,15 +251,15 @@ class OmniRetWrapper(AbsEncoder):
 omniret = ModelMeta(
     loader=OmniRetWrapper,
     name="chuonghm/OmniRet",
-    revision="main",  # TODO pin to a commit sha from the HF repo
-    release_date="2026-03-02",  # TODO confirm against the HF repo's first commit
+    revision="13a87d6dead2ecabad5f181c8dfc0fe0cb4df314",
+    release_date="2026-08-07",
     languages=["eng-Latn"],
-    n_parameters=None,  # TODO fill from the measurement command
-    memory_usage_mb=None,  # TODO fill from the measurement command
-    n_embedding_parameters=None,  # TODO fill from the measurement command
+    n_parameters=2_697_128_513,
+    memory_usage_mb=5148,
+    n_embedding_parameters=232_928_256,
     max_tokens=1024,  # omniret.config text_max_length
     embed_dim=4096,
-    license="mit",  # code is MIT; encoders retain upstream terms per NOTICE
+    license="https://github.com/hmchuong/OmniRet/blob/main/NOTICE",
     open_weights=True,
     public_training_code="https://github.com/hmchuong/OmniRet",
     public_training_data="https://huggingface.co/datasets/chuonghm/OmniRet-train",

--- a/mteb/models/model_implementations/omniret.py
+++ b/mteb/models/model_implementations/omniret.py
@@ -267,7 +267,33 @@ omniret = ModelMeta(
     reference="https://huggingface.co/chuonghm/OmniRet",
     similarity_fn_name=ScoringFunction.COSINE,
     use_instructions=True,
-    training_datasets=None,  # TODO map the M-BEIR/UniIR + audio corpora
+    training_datasets={
+        # M-BEIR / UniIR train collection
+        "MSCOCOI2TRetrieval",
+        "MSCOCOT2IRetrieval",
+        "Fashion200kI2TRetrieval",
+        "Fashion200kT2IRetrieval",
+        "FashionIQIT2IRetrieval",
+        "VisualNewsI2TRetrieval",
+        "VisualNewsT2IRetrieval",
+        "NIGHTSI2IRetrieval",
+        "WebQAT2ITRetrieval",
+        "WebQAT2TRetrieval",
+        "EDIST2ITRetrieval",
+        "CIRRIT2IRetrieval",
+        "OVENIT2ITRetrieval",
+        "OVENIT2TRetrieval",
+        "InfoSeekIT2ITRetrieval",
+        "InfoSeekIT2TRetrieval",
+        # audio additions
+        "AudioCapsA2TRetrieval",
+        "AudioCapsT2ARetrieval",
+        "ClothoA2TRetrieval",
+        "ClothoT2ARetrieval",
+        # WavCaps, WavText5K and VGGSound have no mteb task yet. VGGSound is the
+        # one to watch: OmniRet trains on its audio-visual pairs and the ACM
+        # benchmark is curated from VGG-Sound, so add it if #5016 merges.
+    },
     adapted_from="Alibaba-NLP/gte-Qwen2-1.5B-instruct",
     superseded_by=None,
     modalities=["text", "image", "audio", "video"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -503,6 +503,7 @@ conflicts = [
         { extra = "embeddinggemma" },
         # { extra = "ebind" },
         { extra = "visrag-ret" }, # conflicting version of timm with blip2
+        { extra = "omniret" }, # pins transformers>=5.13
     ],
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,13 +150,7 @@ siglip = ["sentencepiece>=0.2.0","protobuf>=3.0.0"]
 tipsv2 = ["sentencepiece>=0.2.0", "protobuf>=3.0.0"]
 ps3 = ["ps3-torch>=0.1.3", "timm==1.0.15", "torchvision>=0.22.1"] # timm 1.0.16+ changed the ViT Block signature that ps3 subclasses
 qwen-vl = ["transformers>=4.57.0", "qwen-vl-utils>=0.0.14"]
-omniret = [
-    # OmniRet itself is not on PyPI and its own metadata pins torch==2.9.1+cu128,
-    # which cannot resolve from PyPI. Install it separately, see the model docstring.
-    "transformers>=5.13.0,<6.0.0",
-    "peft>=0.19.1",
-    "imageio-ffmpeg>=0.6.0",
-]
+# omniret = ["omniret @ git+https://github.com/hmchuong/OmniRet@202e399fc8e8a6f1b1ddb169e860e8a8a6dc7440", "transformers>=5.13.0,<6.0.0", "peft>=0.19.1", "imageio-ffmpeg>=0.6.0"]  # not on PyPI, and pins torch==2.9.1+cu128 which cannot resolve from PyPI
 # omnivinci = ["transformers==4.46.0", "torch==2.8.*", "einops>=0.8.0", "openai-whisper>=20240930", "soundfile>=0.13.1", "opencv-python-headless>=4.0.0", "kaldiio>=2.18.0", "decord>=0.6.0", "librosa>=0.10.0", "beartype>=0.18.0", "accelerate>=1.0.0", "s2wrapper @ git+https://github.com/bfshi/scaling_on_scales", "deepspeed>=0.9.0", "torchvision>=0.15.0", "torchaudio>=2.0.0", "torchcodec==0.7.0", "av>=10.0.0", "numpy>=1.23.0,<2.0.0", "flash-attn>=2.6.3"]
 qwen_omni_utils = ["qwen_omni_utils"]
 embeddinggemma = ["transformers>=4.56.0"]
@@ -503,7 +497,7 @@ conflicts = [
         { extra = "embeddinggemma" },
         # { extra = "ebind" },
         { extra = "visrag-ret" }, # conflicting version of timm with blip2
-        { extra = "omniret" }, # pins transformers>=5.13
+        # { extra = "omniret" },
     ],
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,13 @@ siglip = ["sentencepiece>=0.2.0","protobuf>=3.0.0"]
 tipsv2 = ["sentencepiece>=0.2.0", "protobuf>=3.0.0"]
 ps3 = ["ps3-torch>=0.1.3", "timm==1.0.15", "torchvision>=0.22.1"] # timm 1.0.16+ changed the ViT Block signature that ps3 subclasses
 qwen-vl = ["transformers>=4.57.0", "qwen-vl-utils>=0.0.14"]
+omniret = [
+    # OmniRet itself is not on PyPI and its own metadata pins torch==2.9.1+cu128,
+    # which cannot resolve from PyPI. Install it separately, see the model docstring.
+    "transformers>=5.13.0,<6.0.0",
+    "peft>=0.19.1",
+    "imageio-ffmpeg>=0.6.0",
+]
 # omnivinci = ["transformers==4.46.0", "torch==2.8.*", "einops>=0.8.0", "openai-whisper>=20240930", "soundfile>=0.13.1", "opencv-python-headless>=4.0.0", "kaldiio>=2.18.0", "decord>=0.6.0", "librosa>=0.10.0", "beartype>=0.18.0", "accelerate>=1.0.0", "s2wrapper @ git+https://github.com/bfshi/scaling_on_scales", "deepspeed>=0.9.0", "torchvision>=0.15.0", "torchaudio>=2.0.0", "torchcodec==0.7.0", "av>=10.0.0", "numpy>=1.23.0,<2.0.0", "flash-attn>=2.6.3"]
 qwen_omni_utils = ["qwen_omni_utils"]
 embeddinggemma = ["transformers>=4.56.0"]


### PR DESCRIPTION
Adds `chuonghm/OmniRet` (CVPR 2026), a trained omni-modal retriever over text,
image, audio and video. One normalized 4096-d vector per input. Closes #5201.

### Reproduction: ACM, the paper's own benchmark

Via their `omniret.evaluate_acm`. Integer query counts, since the percentages
are dense:

| direction | R@1 / R@5 / R@10 (README) | this run |
|---|---|---|
| A,T→A (4,251 q) | 290 / 950 / 1396 | 284 / 955 / **1396** |
| A→I (1,292 q) | 98 / 284 / 423 | **98** / 286 / 422 |

Largest deviation is 6 queries out of 4,251, consistent with near-tie reordering
under bf16.

### Wrapper is bit-identical to their reference path

Same inputs through `OmniRetEmbedder.process()` and through `encode()`, cosine
and max abs diff:

| text | image | audio | video |
|---|---|---|---|
| 1.000000 / 0e+00 | 1.000000 / 0e+00 | 1.000000 / 0e+00 | 1.000000 / 0e+00 |

Noise floor (same input twice) is also 1.000000, so exact, not within tolerance.
`NIGHTSI2IRetrieval`, an extended M-BEIR task from the paper, runs end to end at
batch 8: ndcg@10 0.21673, R@10 0.44340.

### Implementation notes

Uses `encode_raw_media_batch` + `encode_batch` rather than `process()`, which
only accepts file paths. Two container mismatches needed handling:
`_prepare_qwen_audio` reads `item["audio"]`, so mteb's `{"array": ...}` resolved
to None and silently embedded zeros; and `VideoCollator` yields a uint8 NCHW
tensor where `_raw_video_frames` evaluates `video or []`, which raises.

### Caveats

Python 3.10, CUDA 12.8, `transformers==5.13.0`, and not on PyPI. Its
`torch==2.9.1+cu128` pin cannot resolve from PyPI, so the extra carries only
resolvable deps and the loader raises with git install instructions. torchcodec
also needs `libnppicc.so.12`, which the cu128 torch wheels don't ship, affecting
any video task. One media item per input max, video capped at 8 frames.