### PR TITLE
fix: Enable B905 and B028 Ruff rules

### DIFF
--- a/mteb/_create_dataloaders.py
+++ b/mteb/_create_dataloaders.py
@@ -108,6 +108,7 @@ def _convert_conv_history_to_query(
         warnings.warn(
             "Conversations are a list of strings. Used 'user' role for all turns.",
             category=UserWarning,
+            stacklevel=2,
         )
     # otherwise, it's a list of dictionaries, which we need to convert to strings
     elif isinstance(conversation, list) and isinstance(conversation[0], dict):

--- a/mteb/_evaluators/image/imagetext_pairclassification_evaluator.py
+++ b/mteb/_evaluators/image/imagetext_pairclassification_evaluator.py
@@ -164,7 +164,9 @@ class ImageTextPairClassificationEvaluator(Evaluator):
         all_scores = []
 
         with self.timer("Scoring", split=self.hf_split, subset=self.hf_subset):
-            for img_emb, txt_emb in zip(norm_image_embeddings, norm_text_embeddings):
+            for img_emb, txt_emb in zip(
+                norm_image_embeddings, norm_text_embeddings, strict=True
+            ):
                 scores = (
                     img_emb @ txt_emb.t()
                 )  # shape = (num_images_per_sample x num_texts_per_sample)

--- a/mteb/_evaluators/text/bitext_mining_evaluator.py
+++ b/mteb/_evaluators/text/bitext_mining_evaluator.py
@@ -156,6 +156,7 @@ class BitextMiningEvaluator(Evaluator):
                     for sub_corpus_id, score in zip(
                         cos_scores_top_k_idx[query_itr],
                         cos_scores_top_k_values[query_itr],
+                        strict=True,
                     ):
                         corpus_id = corpus_start_idx + sub_corpus_id
                         query_id = query_start_idx + query_itr

--- a/mteb/_evaluators/text/summarization_evaluator.py
+++ b/mteb/_evaluators/text/summarization_evaluator.py
@@ -173,7 +173,9 @@ class SummarizationEvaluator(Evaluator):
             for i, (embs_human_summaries, embs_machine_summaries) in tqdm(
                 enumerate(
                     zip(
-                        embs_human_summaries_all_split, embs_machine_summaries_all_split
+                        embs_human_summaries_all_split,
+                        embs_machine_summaries_all_split,
+                        strict=True,
                     )
                 ),
                 desc="Scoring",
@@ -185,7 +187,7 @@ class SummarizationEvaluator(Evaluator):
                 human_scores = []  # Human score for a summary
 
                 for emb_machine_summary, human_eval_score in zip(
-                    embs_machine_summaries, self.gold_scores[i]
+                    embs_machine_summaries, self.gold_scores[i], strict=True
                 ):  # Iterate through all machine summaries + scores for a single sample
                     cosine_scores = cos_sim(emb_machine_summary, embs_human_summaries)
                     dot_scores = dot_score(emb_machine_summary, embs_human_summaries)

--- a/mteb/abstasks/_data_filter/filters.py
+++ b/mteb/abstasks/_data_filter/filters.py
@@ -64,7 +64,7 @@ def filter_unclear_label(
     logger.debug("[filter_controversial] scanning dataset for label conflicts...")
 
     for ds in dataset_dict.values():
-        for text, label in zip(ds[input_column], ds[label_column]):
+        for text, label in zip(ds[input_column], ds[label_column], strict=True):
             key = text.strip().lower()
             normalized.setdefault(key, set()).add(
                 label if isinstance(label, (str, int, float)) else tuple(label)  # type: ignore[arg-type]

--- a/mteb/abstasks/_statistics_calculation.py
+++ b/mteb/abstasks/_statistics_calculation.py
@@ -516,7 +516,7 @@ def calculate_pair_modality_statistics(
     s2, all_h2 = _compute_side_statistics(
         col_modalities2, load_col, n, max_workers=max_workers
     )
-    pairs = ((tuple(r1), tuple(r2)) for r1, r2 in zip(all_h1, all_h2))
+    pairs = ((tuple(r1), tuple(r2)) for r1, r2 in zip(all_h1, all_h2, strict=True))
     if symmetric:
         unique_pairs = len(
             {(left, right) if left <= right else (right, left) for left, right in pairs}

--- a/mteb/abstasks/abstask.py
+++ b/mteb/abstasks/abstask.py
@@ -120,14 +120,14 @@ class AbsTask(ABC):  # noqa: PLR0904
         if self.metadata.is_beta:
             msg = f"The task '{self.metadata.name}' is currently in beta. This means that the dataset is still being tested and may be subject to changes. This means that the scores of this dataset is liable to change and should be used with caution."
             logger.warning(msg)
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=2)
 
     def check_if_dataset_is_superseded(self) -> None:
         """Check if the dataset is superseded by a newer version."""
         if self.superseded_by:
             msg = f"The task '{self.metadata.name}' is superseded by '{self.superseded_by}'. We recommend using the newer version of the task unless you are running a specific benchmark. See `get_task('{self.superseded_by}').metadata.description` to get a description of the task and changes."
             logger.warning(msg)
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=2)
 
     def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:  # noqa: B027 -- optional hook, deliberately not abstract
         """A transform operations applied to the dataset after loading.

--- a/mteb/abstasks/aggregated_task.py
+++ b/mteb/abstasks/aggregated_task.py
@@ -142,7 +142,7 @@ class AbsTaskAggregate(AbsTask):
         if len(mteb_versions) != 1:
             msg = f"All tasks of {self.metadata.name} is not run using the same version. different versions found are: {mteb_versions}"
             logger.warning(msg)
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=2)
         task_res.mteb_version = TaskResult._compute_top_level_mteb_version(
             task_res.scores
         )

--- a/mteb/abstasks/clustering.py
+++ b/mteb/abstasks/clustering.py
@@ -384,7 +384,7 @@ def _convert_to_fast(
                     "The clusters are not sampled from the same distribution as they have different labels."
                 )
 
-            for l, s in zip(lab, sents):
+            for l, s in zip(lab, sents, strict=True):
                 if s not in sent_set:
                     labels.append(l)
                     sentences.append(s)

--- a/mteb/abstasks/multilabel_classification.py
+++ b/mteb/abstasks/multilabel_classification.py
@@ -151,7 +151,7 @@ class AbsTaskMultilabelClassification(AbsTaskClassification):
                 **encode_kwargs,
             )
         unique_train_embeddings = dict(
-            zip(unique_train_indices, _unique_train_embeddings)
+            zip(unique_train_indices, _unique_train_embeddings, strict=True)
         )
         # Stratified subsampling of test set to 2000 examples.
         test_dataset = eval_split

--- a/mteb/abstasks/pair_classification.py
+++ b/mteb/abstasks/pair_classification.py
@@ -309,7 +309,7 @@ class AbsTaskPairClassification(AbsTask):
         labels: NDArray[np.int64],
         high_score_more_similar: bool,
     ) -> tuple[float, float]:
-        rows = list(zip(scores, labels))
+        rows = list(zip(scores, labels, strict=True))
         rows = sorted(rows, key=lambda x: x[0], reverse=high_score_more_similar)
 
         max_acc = 0
@@ -335,7 +335,7 @@ class AbsTaskPairClassification(AbsTask):
     ) -> tuple[float, float, float, float]:
         scores = np.asarray(scores)
 
-        rows = list(zip(scores, labels))
+        rows = list(zip(scores, labels, strict=True))
 
         rows = sorted(rows, key=lambda x: x[0], reverse=high_score_more_similar)
 

--- a/mteb/abstasks/retrieval_dataset_loaders.py
+++ b/mteb/abstasks/retrieval_dataset_loaders.py
@@ -215,7 +215,7 @@ class RetrievalDatasetLoader:
         qrels_ds = qrels_ds.to_polars()
         # filter queries with no qrels
         qrels_dict = {
-            query_id[0]: dict(zip(group["corpus-id"], group["score"]))
+            query_id[0]: dict(zip(group["corpus-id"], group["score"], strict=True))
             for query_id, group in qrels_ds.group_by("query-id", maintain_order=False)
         }
 
@@ -244,7 +244,7 @@ class RetrievalDatasetLoader:
 
         queries = top_ranked_ds["query-id"].to_list()
         corpus_lists = top_ranked_ds["corpus-ids"].to_list()
-        top_ranked_dict = dict(zip(queries, corpus_lists))
+        top_ranked_dict = dict(zip(queries, corpus_lists, strict=True))
         logger.info(f"Top ranked loaded: {len(top_ranked_ds)}")
         return top_ranked_dict
 

--- a/mteb/abstasks/text/bitext_mining.py
+++ b/mteb/abstasks/text/bitext_mining.py
@@ -245,7 +245,10 @@ class AbsTaskBitextMining(AbsTask):
 
         text1_statistics = calculate_text_statistics(sentence1)
         text2_statistics = calculate_text_statistics(sentence2)
-        unique_pairs = len(set(zip(sentence1, sentence2, strict=True)))
+        # Not strict: BUCC (superseded by BUCC.v2) filters `sentence1` down to the
+        # gold pairs while keeping the full `sentence2` corpus, so the two sides are
+        # deliberately ragged and the zip truncates to the shorter one.
+        unique_pairs = len(set(zip(sentence1, sentence2, strict=False)))
 
         return BitextDescriptiveStatistics(
             num_samples=len(sentence1),

--- a/mteb/abstasks/text/bitext_mining.py
+++ b/mteb/abstasks/text/bitext_mining.py
@@ -155,7 +155,7 @@ class AbsTaskBitextMining(AbsTask):
         )
         # NOTE: used only by BUCC
         gold = (
-            list(zip(range(len(data_split)), range(len(data_split))))
+            list(zip(range(len(data_split)), range(len(data_split)), strict=True))
             if "gold" not in data_split
             else data_split["gold"]
         )
@@ -245,7 +245,7 @@ class AbsTaskBitextMining(AbsTask):
 
         text1_statistics = calculate_text_statistics(sentence1)
         text2_statistics = calculate_text_statistics(sentence2)
-        unique_pairs = len(set(zip(sentence1, sentence2)))
+        unique_pairs = len(set(zip(sentence1, sentence2, strict=True)))
 
         return BitextDescriptiveStatistics(
             num_samples=len(sentence1),

--- a/mteb/abstasks/text/reranking.py
+++ b/mteb/abstasks/text/reranking.py
@@ -187,7 +187,10 @@ class AbsTaskReranking(AbsTaskRetrieval):
 
                     # Add documents and relevance information
                     for doc_id, doc_text, relevance in zip(
-                        item["doc_ids"], item["doc_texts"], item["relevance_scores"]
+                        item["doc_ids"],
+                        item["doc_texts"],
+                        item["relevance_scores"],
+                        strict=True,
                     ):
                         corpus.append(
                             {

--- a/mteb/api/aggregators.py
+++ b/mteb/api/aggregators.py
@@ -121,7 +121,7 @@ def _trained_on_map_cached(bench_name: str) -> dict[str, tuple[str, ...]]:
     return {
         mn: tuple(tasks)
         for mn, tasks in zip(
-            grouped["model_name"].to_list(), grouped["task_name"].to_list()
+            grouped["model_name"].to_list(), grouped["task_name"].to_list(), strict=True
         )
     }
 
@@ -379,7 +379,7 @@ def _build_per_language_rows(
     codes = grouped["language"].to_list()
     scores = grouped["score"].to_list()
     rows: dict[str, dict[str, float]] = {}
-    for mn, code, score in zip(model_names, codes, scores):
+    for mn, code, score in zip(model_names, codes, scores, strict=True):
         if not mn or code is None or score is None:
             continue
         rows.setdefault(mn, {})[language_label(code)] = score
@@ -434,7 +434,9 @@ def build_task_scores(name: str) -> TaskScoresSchema:  # noqa: PLR0914
         subset_col = deduped["subset"].to_list()
         split_col = deduped["split"].to_list()
         score_col = deduped["score"].to_list()
-        for mn, subset, split, s in zip(model_names, subset_col, split_col, score_col):
+        for mn, subset, split, s in zip(
+            model_names, subset_col, split_col, score_col, strict=True
+        ):
             seen.setdefault(mn, {}).setdefault(subset, {})[split] = s
 
     rows: list[TaskScoreRowSchema] = []
@@ -521,7 +523,7 @@ async def build_model_scores(name: str) -> ModelScoresSchema:
     model_meta: ModelMetaSchema | None = None
     rows: list[ModelScoreRowSchema] = []
 
-    for bench, summary in zip(all_benchmarks, results):
+    for bench, summary in zip(all_benchmarks, results, strict=True):
         if isinstance(summary, BaseException):
             continue
         row = _summary_row_index(bench.name, summary).get(name)

--- a/mteb/api/routes.py
+++ b/mteb/api/routes.py
@@ -213,7 +213,9 @@ def _task_num_models_map() -> dict[str, int]:
         .agg(pl.col("model_name").n_unique().alias("n"))
         .collect()
     )
-    return dict(zip(grouped["task_name"].to_list(), (int(n) for n in grouped["n"])))
+    return dict(
+        zip(grouped["task_name"].to_list(), (int(n) for n in grouped["n"]), strict=True)
+    )
 
 
 _S = TypeVar("_S", BenchmarkSchema, TaskMetaSchema)

--- a/mteb/benchmarks/benchmark.py
+++ b/mteb/benchmarks/benchmark.py
@@ -605,7 +605,7 @@ class Benchmark:
                 borda_list = (
                     per_task_pl.select(_get_borda_rank(task_cols)).to_series().to_list()
                 )
-                for name, rank in zip(per_task_df.index, borda_list):
+                for name, rank in zip(per_task_df.index, borda_list, strict=True):
                     scores[name]["Rank"] = int(rank)
             else:
                 for model_scores in scores.values():

--- a/mteb/cache/result_cache.py
+++ b/mteb/cache/result_cache.py
@@ -300,7 +300,7 @@ class ResultCache:
         if model_revision is None:
             msg = "`model_revision` is not specified, attempting to load the latest revision. To disable this behavior, specify the 'model_revision` explicitly."
             logger.warning(msg)
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=2)
             # get revs from paths
             revisions = [p for p in model_path.glob("*") if p.is_dir()]
             if not revisions:
@@ -704,7 +704,7 @@ class ResultCache:
         else:
             msg = f"Cache directory `{self.cache_path}` does not exist."
             logger.warning(msg)
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=2)
 
     def _load_from_cache(
         self,
@@ -1023,7 +1023,9 @@ class ResultCache:
                 model_name_and_revision.append((model_name, revision, experiment_name))
             return [
                 p
-                for model_revision, p in zip(model_name_and_revision, paths)
+                for model_revision, p in zip(
+                    model_name_and_revision, paths, strict=True
+                )
                 if model_revision in name_and_revision
             ]
 
@@ -1367,7 +1369,8 @@ class ResultCache:
         ):
             warnings.warn(
                 "experiment_kwargs is specified but load_experiments is not set to MATCH_KWARGS."
-                "No results will be loaded."
+                "No results will be loaded.",
+                stacklevel=2,
             )
 
         models_as_model_meta = models is not None and isinstance(

--- a/mteb/cli/build_cli.py
+++ b/mteb/cli/build_cli.py
@@ -82,6 +82,7 @@ def run(args: argparse.Namespace) -> None:
         warnings.warn(
             "`--overwrite` is deprecated, please use `--overwrite-strategy 'always'` instead.",
             DeprecationWarning,
+            stacklevel=2,
         )
         overwrite_strategy = OverwriteStrategy.ALWAYS.value
 
@@ -90,6 +91,7 @@ def run(args: argparse.Namespace) -> None:
         warnings.warn(
             "`--save_predictions` is deprecated, please use `--prediction-folder` instead.",
             DeprecationWarning,
+            stacklevel=2,
         )
         prediction_folder = args.output_folder
 
@@ -294,7 +296,7 @@ def _create_meta(args: argparse.Namespace) -> None:
     if output_path.exists() and overwrite:
         msg = "Output path already exists, overwriting."
         logger.warning(msg)
-        warnings.warn(msg)
+        warnings.warn(msg, stacklevel=2)
     elif output_path.exists():
         raise FileExistsError(
             "Output path already exists, use --overwrite to overwrite."

--- a/mteb/deprecated_evaluator.py
+++ b/mteb/deprecated_evaluator.py
@@ -490,7 +490,7 @@ class MTEB:
                             ) from None
                         msg = "Evaluating multiple MTEB runs simultaneously will produce incorrect CO₂ results"
                         logger.warning(msg)
-                        warnings.warn(msg)
+                        warnings.warn(msg, stacklevel=2)
                         with EmissionsTracker(
                             save_to_file=False,
                             save_to_api=False,

--- a/mteb/evaluate.py
+++ b/mteb/evaluate.py
@@ -190,7 +190,7 @@ def _evaluate_task(  # noqa: PLR0913, PLR0914
                     "Make sure you have access to the dataset and that you have set up the authentication correctly. To disable this warning set `public_only=False`"
                 )
                 logger.warning(msg)
-                warnings.warn(msg)
+                warnings.warn(msg, stacklevel=2)
                 return TaskError(
                     task_name=task.metadata.name,
                     exception=str(e),

--- a/mteb/get_tasks.py
+++ b/mteb/get_tasks.py
@@ -359,7 +359,7 @@ def get_task(
         _task_name = _TASK_RENAMES[task_name]
         msg = f"The task with the given name '{task_name}' has been renamed to '{_task_name}'. To prevent this warning use the new name."
         logger.warning(msg)
-        warnings.warn(msg)
+        warnings.warn(msg, stacklevel=2)
 
     if task_name not in _TASKS_REGISTRY:
         close_matches = difflib.get_close_matches(task_name, _TASKS_REGISTRY.keys())

--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -986,7 +986,8 @@ def get_leaderboard_app(  # noqa: PLR0914
                 "desc",
             )
             sizes = {
-                n: _estimate_payload_size(o) for n, o in zip(output_names, outputs)
+                n: _estimate_payload_size(o)
+                for n, o in zip(output_names, outputs, strict=True)
             }
             total_size = sum(s for s in sizes.values() if s > 0)
             t9 = time.time()

--- a/mteb/models/abs_encoder.py
+++ b/mteb/models/abs_encoder.py
@@ -171,7 +171,7 @@ class AbsEncoder(ABC):
                 except KeyError:
                     msg = f"Task name {task_name} is not valid. {valid_keys_msg}"
                     logger.warning(msg)
-                    warnings.warn(msg)
+                    warnings.warn(msg, stacklevel=2)
                     invalid_task_messages.add(msg)
                     invalid_keys.add(task_key)
 
@@ -219,7 +219,7 @@ class AbsEncoder(ABC):
                 return prompt[prompt_type.value]
             msg = f"Prompt type '{prompt_type}' not found in task metadata for task '{task_metadata.name}'."
             logger.warning(msg)
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=2)
             return ""
 
         if prompt:

--- a/mteb/models/cache_wrappers/cache_backends/faiss_cache.py
+++ b/mteb/models/cache_wrappers/cache_backends/faiss_cache.py
@@ -55,7 +55,7 @@ class FaissCache:
 
         start_id = len(self.hash_to_index)
         vectors_to_add = []
-        for i, (item, vector) in enumerate(zip(items, vectors)):
+        for i, (item, vector) in enumerate(zip(items, vectors, strict=True)):
             item_hash = _hash_item(item)
             if item_hash in self.hash_to_index:
                 continue
@@ -81,7 +81,7 @@ class FaissCache:
         except Exception:
             msg = f"Vector id {idx} missing for hash {item_hash}"
             logger.warning(msg)
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=2)
             return None
 
     def save(self) -> None:

--- a/mteb/models/cache_wrappers/cache_backends/numpy_cache.py
+++ b/mteb/models/cache_wrappers/cache_backends/numpy_cache.py
@@ -48,12 +48,12 @@ class NumpyCache:
                     "Vectors file not initialized. Call _initialize_vectors_file() first."
                 )
 
-            for item, vec in zip(items, vectors):
+            for item, vec in zip(items, vectors, strict=True):
                 item_hash = _hash_item(item)
                 if item_hash in self.hash_to_index:
                     msg = f"Hash collision or duplicate item for hash {item_hash}. Overwriting existing vector."
                     logger.warning(msg)
-                    warnings.warn(msg)
+                    warnings.warn(msg, stacklevel=2)
                     index = self.hash_to_index[item_hash]
                 else:
                     index = len(self.hash_to_index)
@@ -127,7 +127,7 @@ class NumpyCache:
         else:
             msg = "Dimension file not found. Vector dimension remains uninitialized."
             logger.warning(msg)
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=2)
 
     def save(self) -> None:
         """Persist VectorCacheMap to disk."""
@@ -173,12 +173,12 @@ class NumpyCache:
                 else:
                     msg = "Vector dimension not set. Unable to load vectors file."
                     logger.warning(msg)
-                    warnings.warn(msg)
+                    warnings.warn(msg, stacklevel=2)
                 logger.info(f"Loaded VectorCacheMap from {self.directory}")
             else:
                 msg = "No existing files found. Initialized empty VectorCacheMap."
                 logger.warning(msg)
-                warnings.warn(msg)
+                warnings.warn(msg, stacklevel=2)
         except Exception as e:
             logger.error(f"Error loading VectorCacheMap: {str(e)}")
             raise

--- a/mteb/models/cache_wrappers/cache_wrapper.py
+++ b/mteb/models/cache_wrappers/cache_wrapper.py
@@ -132,7 +132,9 @@ class CachedEmbeddingWrapper:
                     new_vectors = new_vectors.cpu().numpy()
                 cache.add(uncached_items, new_vectors)
                 cache.save()
-                for vector, original_idx in zip(new_vectors, uncached_indices):
+                for vector, original_idx in zip(
+                    new_vectors, uncached_indices, strict=True
+                ):
                     newly_encoded[original_idx] = vector
             else:
                 logger.info("All items found in cache")

--- a/mteb/models/compression_wrappers/compression_wrapper.py
+++ b/mteb/models/compression_wrappers/compression_wrapper.py
@@ -77,7 +77,7 @@ class CompressionWrapper:
                 f"directly by the model."
             )
             logger.warning(msg)
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=2)
         logger.info("Initialized CompressionWrapper.")
 
     @property
@@ -211,7 +211,7 @@ class CompressionWrapper:
                 f"{len(embeddings)}). Parameters are likely unstable and results might not generalize."
             )
             logger.warning(msg)
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=2)
 
         mins, maxs = (
             torch.min(embeddings, dim=0).values,

--- a/mteb/models/hybrid_wrappers.py
+++ b/mteb/models/hybrid_wrappers.py
@@ -240,7 +240,7 @@ def fuse_dbsf(
             normalized = (raw_scores - lower_limit) / denom
             normalized = np.clip(normalized, 0.0, 1.0)
 
-        for doc_id, norm_score in zip(doc_ids, normalized):
+        for doc_id, norm_score in zip(doc_ids, normalized, strict=True):
             fused[doc_id] = fused.get(doc_id, 0.0) + weight * float(norm_score)
 
     return fused
@@ -281,7 +281,7 @@ def fuse_relative_score_fusion(
         else:
             normalized = (raw_scores - min_s) / (max_s - min_s)
 
-        for doc_id, norm_score in zip(doc_ids, normalized):
+        for doc_id, norm_score in zip(doc_ids, normalized, strict=True):
             fused[doc_id] = fused.get(doc_id, 0.0) + weight * float(norm_score)
 
     return fused

--- a/mteb/models/instruct_wrapper.py
+++ b/mteb/models/instruct_wrapper.py
@@ -333,8 +333,8 @@ class InstructSentenceTransformerModel(AbsEncoder):
             for batch in tqdm(inputs, desc="Building multimodal embeddings"):
                 modality_batch = {k: v for k, v in batch.items() if k in _modality_keys}
                 batched_input = [
-                    dict(zip(modality_batch, sample))
-                    for sample in zip(*modality_batch.values())
+                    dict(zip(modality_batch, sample, strict=True))
+                    for sample in zip(*modality_batch.values(), strict=True)
                 ]
 
                 embeddings = self.model.encode(

--- a/mteb/models/model_implementations/bm25.py
+++ b/mteb/models/model_implementations/bm25.py
@@ -449,7 +449,7 @@ class BM25Search:
             )
 
             # Iterate over results
-            for doc_idx, score in zip(query_results, scores):
+            for doc_idx, score in zip(query_results, scores, strict=True):
                 doc_id = self.corpus_idx_to_id[doc_idx]
 
                 # handle reranking with a filtered set of documents

--- a/mteb/models/model_implementations/geevec_models.py
+++ b/mteb/models/model_implementations/geevec_models.py
@@ -397,7 +397,9 @@ class GeeVecAPIModel(AbsEncoder):
         api_model_name = self._resolve_api_model_name(effective_domain)
 
         mask_sents = [(i, t) for i, t in enumerate(sentences) if t.strip()]
-        mask, no_empty_sent = list(zip(*mask_sents)) if mask_sents else ([], [])
+        mask, no_empty_sent = (
+            list(zip(*mask_sents, strict=True)) if mask_sents else ([], [])
+        )
 
         no_empty_embeddings = []
         for i in range(0, len(no_empty_sent), max_batch_size):

--- a/mteb/models/model_implementations/gme_v_models.py
+++ b/mteb/models/model_implementations/gme_v_models.py
@@ -113,7 +113,7 @@ class Encoder(torch.nn.Module):
         instruction = instruction or self.default_instruction
         # Inputs must be batched
         input_texts, input_images = [], []
-        for t, i in zip(texts, images):
+        for t, i in zip(texts, images, strict=True):
             input_str = ""
             if i is None:
                 input_images = None  # All examples in the same batch are consistent
@@ -266,7 +266,7 @@ def smart_resize(
     if max(h_bar, w_bar) / min(h_bar, w_bar) > MAX_RATIO:
         msg = f"Absolute aspect ratio must be smaller than {MAX_RATIO}, got {max(h_bar, w_bar) / min(h_bar, w_bar)}"
         logger.warning(msg)
-        warnings.warn(msg)
+        warnings.warn(msg, stacklevel=2)
         if h_bar > w_bar:
             h_bar = w_bar * MAX_RATIO
         else:

--- a/mteb/models/model_implementations/google_gemini.py
+++ b/mteb/models/model_implementations/google_gemini.py
@@ -279,12 +279,12 @@ class GoogleGeminiEmbeddingModel(AbsEncoder):
         if has_text and has_image:
             contents = []
             for batch in inputs:
-                for text, image in zip(batch["text"], batch["image"]):
+                for text, image in zip(batch["text"], batch["image"], strict=True):
                     contents.append([text, image])
         elif has_text and has_audio:
             contents = []
             for batch in inputs:
-                for text, audio_item in zip(batch["text"], batch["audio"]):
+                for text, audio_item in zip(batch["text"], batch["audio"], strict=True):
                     wav_bytes = _audio_to_wav_bytes(audio_item)
                     contents.append(
                         [text, Part.from_bytes(data=wav_bytes, mime_type="audio/wav")]
@@ -294,7 +294,7 @@ class GoogleGeminiEmbeddingModel(AbsEncoder):
             for batch in inputs:
                 texts = batch["text"]
                 titles = batch["title"] if has_title else [None] * len(texts)
-                for text, title in zip(texts, titles):
+                for text, title in zip(texts, titles, strict=True):
                     contents.append(
                         _format_gemini_embedding_2_text(
                             text, google_task_type, prompt_type, title

--- a/mteb/models/model_implementations/google_text_embedding.py
+++ b/mteb/models/model_implementations/google_text_embedding.py
@@ -90,7 +90,7 @@ class GoogleTextEmbeddingModel(AbsEncoder):
                 TextEmbeddingInput(
                     text if text else " ", task_type=google_task_type, title=title
                 )
-                for text, title in zip(texts, titles)
+                for text, title in zip(texts, titles, strict=True)
             ]
         else:
             inputs = [

--- a/mteb/models/model_implementations/jina_models.py
+++ b/mteb/models/model_implementations/jina_models.py
@@ -300,7 +300,7 @@ class JinaRerankerV3Wrapper(CrossEncoderWrapper):
 
         sentences_count = len(all_corpus)
         query_groups: dict[str, list[tuple[int, str]]] = defaultdict(list)
-        for idx, (query, doc) in enumerate(zip(all_queries, all_corpus)):
+        for idx, (query, doc) in enumerate(zip(all_queries, all_corpus, strict=True)):
             query_groups[query].append((idx, doc))
 
         rerank_parameters = inspect.signature(self.model.rerank).parameters
@@ -312,7 +312,7 @@ class JinaRerankerV3Wrapper(CrossEncoderWrapper):
 
         results = np.zeros(sentences_count, dtype=np.float32)
         for query, doc_infos in query_groups.items():
-            original_indices, docs = zip(*doc_infos)
+            original_indices, docs = zip(*doc_infos, strict=True)
 
             scores = self.model.rerank(query, list(docs), **rerank_kwargs)
             for scr in scores:
@@ -534,7 +534,9 @@ class JinaV4Wrapper(AbsEncoder):
             if self.vector_type == "multi_vector":
                 embeddings = [
                     torch.cat([text_emb, image_emb], dim=0)
-                    for text_emb, image_emb in zip(text_embeddings, image_embeddings)
+                    for text_emb, image_emb in zip(
+                        text_embeddings, image_embeddings, strict=True
+                    )
                 ]
             else:
                 embeddings = text_embeddings + image_embeddings

--- a/mteb/models/model_implementations/kalm_reranker.py
+++ b/mteb/models/model_implementations/kalm_reranker.py
@@ -207,7 +207,9 @@ class KaLMRerankerWrapper:
         encoder_texts = [f"<Document>: {document}" for _, document in pairs]
         decoder_texts = [
             self._decoder_text(query, inst)
-            for query, inst in zip([pair[0] for pair in pairs], instructions)
+            for query, inst in zip(
+                [pair[0] for pair in pairs], instructions, strict=True
+            )
         ]
 
         encoder_batch = self.tokenizer(
@@ -285,7 +287,10 @@ class KaLMRerankerWrapper:
         """Return ``P(yes)`` scores in the same order as ``pairs``."""
         queries = [text for batch in inputs1 for text in batch["text"]]
         documents = [text for batch in inputs2 for text in batch["text"]]
-        pairs = [(query, document) for query, document in zip(queries, documents)]
+        pairs = [
+            (query, document)
+            for query, document in zip(queries, documents, strict=True)
+        ]
         validated_pairs = self._validate_pairs(pairs)
         if not validated_pairs:
             return []

--- a/mteb/models/model_implementations/lighton_rerank_models.py
+++ b/mteb/models/model_implementations/lighton_rerank_models.py
@@ -270,7 +270,7 @@ class LightOnListwiseRerankerWrapper:
             if not windows:
                 continue
             permutations = self._rank_windows_batched(windows, batch_size=batch_size)
-            for (query_idx, p, end), perm in zip(meta, permutations):
+            for (query_idx, p, end), perm in zip(meta, permutations, strict=True):
                 order = orders[query_idx]
                 order[p:end] = [order[p + j] for j in perm]
         return orders
@@ -310,7 +310,7 @@ class LightOnListwiseRerankerWrapper:
             documents.extend(images if images is not None else texts)
         group_queries: list[str] = []
         group_docs: list[list[str | Image.Image]] = []
-        for query, document in zip(queries, documents):
+        for query, document in zip(queries, documents, strict=True):
             if not group_queries or query != group_queries[-1]:
                 group_queries.append(query)
                 group_docs.append([])

--- a/mteb/models/model_implementations/listconranker.py
+++ b/mteb/models/model_implementations/listconranker.py
@@ -64,7 +64,7 @@ class ListConRanker(RerankerWrapper):
         query = queries[0]
         tmp_passages = []
         if kwargs.get("traditional_inference"):
-            for q, p in zip(queries, passages):
+            for q, p in zip(queries, passages, strict=True):
                 if query == q:
                     tmp_passages.append(p)
                 else:
@@ -78,7 +78,7 @@ class ListConRanker(RerankerWrapper):
                 scores = self.model.multi_passage(query_passages_tuples)
                 final_scores += scores
         else:
-            for q, p in zip(queries, passages):
+            for q, p in zip(queries, passages, strict=True):
                 if query == q:
                     tmp_passages.append(p)
                 else:

--- a/mteb/models/model_implementations/mcinext_models.py
+++ b/mteb/models/model_implementations/mcinext_models.py
@@ -252,7 +252,7 @@ class HakimModelWrapper(AbsEncoder):
         if not task_prompt:
             msg = f"Unknown dataset: {task_name}, no preprocessing applied."
             logger.warning(msg)
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=2)
             return sample
 
         task_prompt = f"مسئله : {task_prompt}"

--- a/mteb/models/model_implementations/nanovdr_models.py
+++ b/mteb/models/model_implementations/nanovdr_models.py
@@ -182,7 +182,7 @@ class NanoVDRWrapper(AbsEncoder):
 
                 videos, video_metadata = None, None
                 if video_inputs is not None:
-                    videos, video_metadata = zip(*video_inputs)
+                    videos, video_metadata = zip(*video_inputs, strict=True)
                     videos, video_metadata = list(videos), list(video_metadata)
 
                 processed = self._doc_processor(

--- a/mteb/models/model_implementations/openai_models.py
+++ b/mteb/models/model_implementations/openai_models.py
@@ -84,7 +84,9 @@ class OpenAIModel(AbsEncoder):
         sentences = [text for batch in inputs for text in batch["text"]]
 
         mask_sents = [(i, t) for i, t in enumerate(sentences) if t.strip()]
-        mask, no_empty_sent = list(zip(*mask_sents)) if mask_sents else ([], [])
+        mask, no_empty_sent = (
+            list(zip(*mask_sents, strict=True)) if mask_sents else ([], [])
+        )
         trimmed_sentences = []
         for sentence in no_empty_sent:
             encoded_sentence = self._encoding.encode(sentence)

--- a/mteb/models/model_implementations/querit_models.py
+++ b/mteb/models/model_implementations/querit_models.py
@@ -147,7 +147,9 @@ class QueritWrapper(RerankerWrapper):
                 )
                 pairs = [
                     self.format_instruction(instr, query, doc)
-                    for instr, query, doc in zip(batch_instructions, batch_q, batch_d)
+                    for instr, query, doc in zip(
+                        batch_instructions, batch_q, batch_d, strict=True
+                    )
                 ]
                 enc = self.process_inputs(pairs)
                 out = self.model(**enc)

--- a/mteb/models/model_implementations/qwen3_reranker.py
+++ b/mteb/models/model_implementations/qwen3_reranker.py
@@ -141,7 +141,7 @@ class Qwen3RerankerWrapper:
             pairs = [
                 self.format_instruction(instr, query, doc)
                 for instr, query, doc in zip(
-                    batch_instructions, batch_queries, batch_passages
+                    batch_instructions, batch_queries, batch_passages, strict=True
                 )
             ]
 

--- a/mteb/models/model_implementations/random_baseline.py
+++ b/mteb/models/model_implementations/random_baseline.py
@@ -333,7 +333,7 @@ class RandomCrossEncoderBaseline:
         embeddings1 = _batch_to_embeddings(inputs1, self.embedding_dim)
         embeddings2 = _batch_to_embeddings(inputs2, self.embedding_dim)
         similarities = []
-        for emb1, emb2 in zip(embeddings1, embeddings2):
+        for emb1, emb2 in zip(embeddings1, embeddings2, strict=True):
             norm1 = np.linalg.norm(emb1)
             norm2 = np.linalg.norm(emb2)
             normalized1 = emb1 / (norm1 + 1e-10)

--- a/mteb/models/model_implementations/rerankers_custom.py
+++ b/mteb/models/model_implementations/rerankers_custom.py
@@ -89,11 +89,13 @@ class BGEReranker(RerankerWrapper):
                 raise ValueError(
                     f"Expected {len(queries)} instructions, got {len(instructions)}"
                 )
-            queries = [f"{q} {i}".strip() for i, q in zip(instructions, queries)]
+            queries = [
+                f"{q} {i}".strip() for i, q in zip(instructions, queries, strict=True)
+            ]
 
         if len(queries) != len(passages):
             raise ValueError(f"Expected {len(queries)} passages, got {len(passages)}")
-        query_passage_tuples = list(zip(queries, passages))
+        query_passage_tuples = list(zip(queries, passages, strict=True))
         scores = self.model.compute_score(query_passage_tuples, normalize=True)
         if len(scores) != len(queries):
             raise ValueError(f"Expected {len(queries)} scores, got {len(scores)}")
@@ -143,13 +145,15 @@ class JinaReranker(RerankerWrapper):
         passages = [text for batch in inputs2 for text in batch["text"]]
 
         if instructions is not None and instructions[0] is not None:
-            queries = [f"{q} {i}".strip() for i, q in zip(instructions, queries)]
+            queries = [
+                f"{q} {i}".strip() for i, q in zip(instructions, queries, strict=True)
+            ]
 
         if self.first_print:
             logger.info(f"Using {queries[0]}")
             self.first_print = False
 
-        sentence_pairs = list(zip(queries, passages))
+        sentence_pairs = list(zip(queries, passages, strict=True))
         scores = self.model.predict(sentence_pairs, convert_to_tensor=True)
         return scores
 

--- a/mteb/models/model_implementations/rerankers_monot5_based.py
+++ b/mteb/models/model_implementations/rerankers_monot5_based.py
@@ -129,11 +129,13 @@ class MonoT5Reranker(RerankerWrapper):
         passages = [text for batch in inputs2 for text in batch["text"]]
 
         if instructions is not None and instructions[0] is not None:
-            queries = [f"{q} {i}".strip() for i, q in zip(instructions, queries)]
+            queries = [
+                f"{q} {i}".strip() for i, q in zip(instructions, queries, strict=True)
+            ]
 
         prompts = [
             self.prompt_template.format(query=query, text=text)
-            for (query, text) in zip(queries, passages)
+            for (query, text) in zip(queries, passages, strict=True)
         ]
 
         tokens = self.tokenizer(
@@ -237,12 +239,12 @@ Relevant: """
             # logger.info(f"Adding instructions to LLAMA queries")
             queries = [
                 self.query_instruct_template.format(instruction=i, query=q).strip()
-                for i, q in zip(instructions, queries)
+                for i, q in zip(instructions, queries, strict=True)
             ]
 
         prompts = [
             self.template.format(query=query, text=text)
-            for (query, text) in zip(queries, passages)
+            for (query, text) in zip(queries, passages, strict=True)
         ]
         if "{query}" in prompts[0]:
             raise ValueError("Query not replaced")

--- a/mteb/models/model_implementations/speecht5_models.py
+++ b/mteb/models/model_implementations/speecht5_models.py
@@ -67,7 +67,8 @@ class SpeechT5Audio(AbsEncoder):
                 if sr is None:
                     warnings.warn(
                         f"No sampling_rate provided for an audio sample. "
-                        f"Assuming {self.sampling_rate} Hz (model default)."
+                        f"Assuming {self.sampling_rate} Hz (model default).",
+                        stacklevel=2,
                     )
                     sr = self.sampling_rate
 

--- a/mteb/models/model_implementations/vggish_models.py
+++ b/mteb/models/model_implementations/vggish_models.py
@@ -129,7 +129,8 @@ def vggish_loader(*args, **kwargs):
                     if sr is None:
                         warnings.warn(
                             f"No sampling_rate provided for an audio sample. "
-                            f"Assuming {self.sampling_rate} Hz (model default)."
+                            f"Assuming {self.sampling_rate} Hz (model default).",
+                            stacklevel=2,
                         )
                         sr = self.sampling_rate
 

--- a/mteb/models/model_implementations/vlm2vec_models.py
+++ b/mteb/models/model_implementations/vlm2vec_models.py
@@ -223,7 +223,9 @@ class VLM2VecWrapper(AbsEncoder):
                     input_ids, pixel_values, image_sizes = [], [], []
                     batch_text = batch["text"]
                     batch_image = batch["image"]
-                    for item_image, item_text in zip(batch_image, batch_text):
+                    for item_image, item_text in zip(
+                        batch_image, batch_text, strict=True
+                    ):
                         inputs = self.processor(
                             f"<|image_1|> Represent the given image with the following question: {item_text}",
                             item_image,

--- a/mteb/models/model_implementations/voyage_v.py
+++ b/mteb/models/model_implementations/voyage_v.py
@@ -163,7 +163,8 @@ def voyage_v_loader(model_name, **kwargs):
                     ]
                     batch_texts = batch["text"]
                     interleaved_inputs = [
-                        [text, image] for image, text in zip(batch_images, batch_texts)
+                        [text, image]
+                        for image, text in zip(batch_images, batch_texts, strict=True)
                     ]
                     embeddings = self._multimodal_embed(
                         interleaved_inputs,

--- a/mteb/models/model_implementations/yamnet_models.py
+++ b/mteb/models/model_implementations/yamnet_models.py
@@ -134,7 +134,8 @@ def yamnet_loader(*args, **kwargs):
                     if sr is None:
                         warnings.warn(
                             f"No sampling_rate provided for an audio sample. "
-                            f"Assuming {self.sampling_rate} Hz (model default)."
+                            f"Assuming {self.sampling_rate} Hz (model default).",
+                            stacklevel=2,
                         )
                         sr = self.sampling_rate
 

--- a/mteb/models/model_meta.py
+++ b/mteb/models/model_meta.py
@@ -972,7 +972,8 @@ class ModelMeta(BaseModel):  # noqa: PLR0904
 
         if not _repo_exists(model_name):
             warnings.warn(
-                f"Could not find model {model_name} on HuggingFace Hub repository ({reference}). Metadata will be limited."
+                f"Could not find model {model_name} on HuggingFace Hub repository ({reference}). Metadata will be limited.",
+                stacklevel=2,
             )
             return cls.create_empty(
                 overwrites=dict(

--- a/mteb/models/openai_wrappers.py
+++ b/mteb/models/openai_wrappers.py
@@ -1008,7 +1008,7 @@ class OpenAIAPIRerankWrapper(OpenAIBaseWrapper):
                 doc_image,
                 _,
                 doc_video,
-            ) in zip(batch_queries, batch_docs):
+            ) in zip(batch_queries, batch_docs, strict=True):
                 query = self._to_score_input(
                     query_text, query_image, query_video, fps=self.fps
                 )
@@ -1288,7 +1288,7 @@ class OpenAIAPITokenEmbedWrapper(OpenAIBaseWrapper):
             batch_idx = text_indices[start : start + batch_size]
             batch_texts = [prompt + (items[i][0] or "") for i in batch_idx]
             batch_embeddings = self._encode_texts(batch_texts)
-            for idx, embedding in zip(batch_idx, batch_embeddings):
+            for idx, embedding in zip(batch_idx, batch_embeddings, strict=True):
                 embeddings_by_index[idx] = embedding
 
         for i in tqdm(
@@ -1393,7 +1393,7 @@ class OpenAIAPITokenEmbedWrapper(OpenAIBaseWrapper):
         doc_id_to_idx = {doc_id: idx for idx, doc_id in enumerate(self._corpus_ids)}
 
         results: RetrievalOutputType = {}
-        for query_id, query_embedding in zip(query_ids, query_embeddings):
+        for query_id, query_embedding in zip(query_ids, query_embeddings, strict=True):
             if top_ranked is not None:
                 candidate_ids = [
                     doc_id
@@ -1410,7 +1410,7 @@ class OpenAIAPITokenEmbedWrapper(OpenAIBaseWrapper):
             scores = _max_sim_scores(query_embedding, candidate_embeddings)
 
             top_items = heapq.nlargest(
-                top_k, zip(candidate_ids, scores), key=lambda item: item[1]
+                top_k, zip(candidate_ids, scores, strict=True), key=lambda item: item[1]
             )
             results[query_id] = dict(top_items)
 

--- a/mteb/models/search_encoder_index/search_indexes/faiss_search_index.py
+++ b/mteb/models/search_encoder_index/search_indexes/faiss_search_index.py
@@ -141,7 +141,7 @@ class FaissSearchIndex:
             if not ranked_ids:
                 msg = f"No top-ranked documents for query {query_id}"
                 logger.warning(msg)
-                warnings.warn(msg)
+                warnings.warn(msg, stacklevel=2)
                 scores_all.append([])
                 idxs_all.append([])
                 continue

--- a/mteb/models/search_wrappers.py
+++ b/mteb/models/search_wrappers.py
@@ -314,6 +314,7 @@ class SearchEncoderWrapper:
             for sub_corpus_id, score in zip(
                 cos_scores_top_k_idx[query_itr],
                 cos_scores_top_k_values[query_itr],
+                strict=True,
             ):
                 corpus_id = sub_corpus_ids[sub_corpus_id]
                 if len(result_heaps[query_id]) < top_k:
@@ -427,6 +428,7 @@ class SearchEncoderWrapper:
         for doc_idx, score in zip(
             scores_top_k_idx[0].tolist(),
             scores_top_k_values[0].tolist(),
+            strict=True,
         ):
             corpus_id = ranked_ids[doc_idx]
             heapq.heappush(result_heaps[query_id], (score, corpus_id))
@@ -583,7 +585,9 @@ class SearchCrossEncoderWrapper:
         )
 
         results: RetrievalOutputType = {qid: {} for qid in queries["id"]}
-        for (query_id, corpus_id), score in zip(doc_pairs_ids, predictions):
+        for (query_id, corpus_id), score in zip(
+            doc_pairs_ids, predictions, strict=True
+        ):
             results[query_id][corpus_id] = float(score)
 
         return results

--- a/mteb/models/sentence_transformer_wrapper.py
+++ b/mteb/models/sentence_transformer_wrapper.py
@@ -98,7 +98,8 @@ def _batch_to_modality_dicts(
     modality_batch = {k: v for k, v in batch.items() if k in supported_modalities}
     LogOnce(logger).info(f"Model will encode modalities {list(modality_batch.keys())}")
     return [
-        dict(zip(modality_batch, sample)) for sample in zip(*modality_batch.values())
+        dict(zip(modality_batch, sample, strict=True))
+        for sample in zip(*modality_batch.values(), strict=True)
     ]
 
 
@@ -174,7 +175,7 @@ class SentenceTransformerEncoderWrapper(AbsEncoder):
         elif model_prompts and built_in_prompts:
             msg = f"Model prompts specified, these will overwrite the default model prompts. Current prompts will be:\n {model_prompts}"
             logger.warning(msg)
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=2)
             self.model.prompts = model_prompts
 
         self.model_prompts, invalid_prompts = self.validate_task_to_prompt_name(
@@ -185,7 +186,7 @@ class SentenceTransformerEncoderWrapper(AbsEncoder):
             invalid_prompts = "\n".join(invalid_prompts)
             msg = f"Some prompts are not in the expected format and will be ignored. Problems:\n\n{invalid_prompts}"
             logger.warning(msg)
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=2)
 
         if (
             self.model_prompts
@@ -197,7 +198,7 @@ class SentenceTransformerEncoderWrapper(AbsEncoder):
         ):
             msg = f"SentenceTransformers that use prompts most often need to be configured with at least 'query' and 'document' prompts to ensure optimal performance. Received {self.model_prompts}"
             logger.warning(msg)
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=2)
 
         self.fps = fps
         self.max_frames = max_frames
@@ -457,7 +458,7 @@ class CrossEncoderWrapper:
         return cast(
             "Array",
             self.model.predict(
-                list(zip(queries, corpus)),
+                list(zip(queries, corpus, strict=True)),
                 **kwargs,
             ),
         )

--- a/mteb/results/benchmark_results.py
+++ b/mteb/results/benchmark_results.py
@@ -194,7 +194,7 @@ class BenchmarkResults(BaseModel):  # noqa: PLR0904
                 "The length of names and revisions must be the same or revisions must be None."
             )
 
-        for name, revision in zip(names, _revisions):
+        for name, revision in zip(names, _revisions, strict=True):
             if isinstance(name, ModelMeta):
                 if name.name is None:
                     raise ValueError("name in ModelMeta is None. It must be a string.")
@@ -360,7 +360,8 @@ class BenchmarkResults(BaseModel):  # noqa: PLR0904
                     )
                 except Exception as e:
                     warnings.warn(
-                        f"Couldn't get scores for {model_res.model_name}({model_res.model_revision}), due to: {e}"
+                        f"Couldn't get scores for {model_res.model_name}({model_res.model_revision}), due to: {e}",
+                        stacklevel=2,
                     )
         if format == "long":
             for model_res in self:
@@ -377,7 +378,8 @@ class BenchmarkResults(BaseModel):  # noqa: PLR0904
                     )
                 except Exception as e:
                     warnings.warn(
-                        f"Couldn't get scores for {model_res.model_name}({model_res.model_revision}), due to: {e}"
+                        f"Couldn't get scores for {model_res.model_name}({model_res.model_revision}), due to: {e}",
+                        stacklevel=2,
                     )
         return entries
 
@@ -423,7 +425,7 @@ class BenchmarkResults(BaseModel):  # noqa: PLR0904
         if df is None:
             msg = "No scores data available. Returning empty DataFrame."
             logger.warning(msg)
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=2)
             return pd.DataFrame()
 
         columns = ["model_name"]
@@ -523,7 +525,7 @@ class BenchmarkResults(BaseModel):  # noqa: PLR0904
         if training_sets:
             df["trained_on"] = [
                 tn in training_sets.get(mn, frozenset())
-                for mn, tn in zip(df["model_name"], df["task_name"])
+                for mn, tn in zip(df["model_name"], df["task_name"], strict=True)
             ]
         else:
             df["trained_on"] = False

--- a/mteb/results/model_result.py
+++ b/mteb/results/model_result.py
@@ -248,7 +248,8 @@ class ModelResult(BaseModel):
                         )
                 except Exception as e:
                     warnings.warn(
-                        f"Couldn't get scores for {res.task_name} due to {e}."
+                        f"Couldn't get scores for {res.task_name} due to {e}.",
+                        stacklevel=2,
                     )
             return scores
         if format == "long":
@@ -281,7 +282,8 @@ class ModelResult(BaseModel):
                     entries.append(entry)
                 except Exception as e:
                     warnings.warn(
-                        f"Couldn't get scores for {task_res.task_name} due to {e}."
+                        f"Couldn't get scores for {task_res.task_name} due to {e}.",
+                        stacklevel=2,
                     )
             return entries
 
@@ -346,7 +348,7 @@ class ModelResult(BaseModel):
         if not scores_data:
             msg = "No scores data available. Returning empty DataFrame."
             logger.warning(msg)
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=2)
             return pd.DataFrame()
 
         # Create DataFrame
@@ -519,7 +521,7 @@ class ModelResult(BaseModel):
 
             if benchmark_results is not None and benchmarks is not None:
                 for cur_benchmark, benchmark_result in zip(
-                    benchmarks, benchmark_results
+                    benchmarks, benchmark_results, strict=True
                 ):
                     if cur_benchmark.name is None:
                         raise ValueError(

--- a/mteb/similarity_functions.py
+++ b/mteb/similarity_functions.py
@@ -216,7 +216,7 @@ def pairwise_max_sim(
     scores = []
 
     for query_embedding, document_embedding in zip(
-        queries_embeddings, documents_embeddings
+        queries_embeddings, documents_embeddings, strict=True
     ):
         query_embedding = _convert_to_tensor(query_embedding)  # noqa: PLW2901
         document_embedding = _convert_to_tensor(document_embedding)  # noqa: PLW2901

--- a/mteb/tasks/classification/eng/toxic_chat_classification.py
+++ b/mteb/tasks/classification/eng/toxic_chat_classification.py
@@ -45,7 +45,7 @@ class ToxicChatClassification(AbsTaskClassification):
         num_proc: int | None = None,
     ):
         keep_cols = ["user_input", "toxicity"]
-        rename_dict = dict(zip(keep_cols, ["text", "label"]))
+        rename_dict = dict(zip(keep_cols, ["text", "label"], strict=True))
         remove_cols = [
             col
             for col in self.dataset[_EVAL_SPLITS[0]].column_names

--- a/mteb/tasks/classification/ind/indonesian_mongabay_conservation_classification.py
+++ b/mteb/tasks/classification/ind/indonesian_mongabay_conservation_classification.py
@@ -68,7 +68,9 @@ Purwarianti, Ayu},
         train_split = self.dataset["train"]
         train_docs: list = []
         train_labels: list = []
-        for text, label in zip(train_split["text"], train_split["softlabel"]):
+        for text, label in zip(
+            train_split["text"], train_split["softlabel"], strict=True
+        ):
             soft_label = ast.literal_eval(label)
             if len(soft_label) == len(class_labels):
                 train_docs.append(text)
@@ -87,7 +89,9 @@ Purwarianti, Ayu},
         # For evaluation
         for split in splits:
             ds_split = self.dataset[split]
-            for text, label in zip(ds_split["text"], ds_split["softlabel"]):
+            for text, label in zip(
+                ds_split["text"], ds_split["softlabel"], strict=True
+            ):
                 if label in class_labels:
                     documents.append(text)
                     labels.append(class_labels.index(label))

--- a/mteb/tasks/clustering/nob/snl_clustering.py
+++ b/mteb/tasks/clustering/nob/snl_clustering.py
@@ -83,9 +83,11 @@ class SNLClustering(AbsTaskClusteringLegacy):
                 raise ValueError(f"Expected {len(documents)} labels, got {len(labels)}")
 
             rng = random.Random(42)  # local only seed
-            pairs = list(zip(documents, labels))
+            pairs = list(zip(documents, labels, strict=True))
             rng.shuffle(pairs)
-            documents, labels = (list(collection) for collection in zip(*pairs))
+            documents, labels = (
+                list(collection) for collection in zip(*pairs, strict=True)
+            )
 
             # reduce size of dataset to not have too large datasets in the clustering task
             documents_batched = list(batched(documents, 512))[:4]

--- a/mteb/tasks/clustering/nob/vg_clustering.py
+++ b/mteb/tasks/clustering/nob/vg_clustering.py
@@ -87,9 +87,11 @@ class VGClustering(AbsTaskClusteringLegacy):
 
             rng = random.Random(1111)  # local only seed
             # resampling changes scores from 12.68, 11.30, 12.65 (sample model)
-            pairs = list(zip(documents, labels))
+            pairs = list(zip(documents, labels, strict=True))
             rng.shuffle(pairs)
-            documents, labels = (list(collection) for collection in zip(*pairs))
+            documents, labels = (
+                list(collection) for collection in zip(*pairs, strict=True)
+            )
 
             # reduce size of dataset to not have too large datasets in the clustering task
             documents_batched = list(batched(documents, 512))[:4]

--- a/mteb/tasks/image_text_pair_classification/eng/image_co_de.py
+++ b/mteb/tasks/image_text_pair_classification/eng/image_co_de.py
@@ -101,7 +101,9 @@ class ImageCoDe(AbsTaskImageTextPairClassification):
             correct_mask = np.array([cid == correct_id for cid in candidates])
             correct_idx = candidate_indices[np.argmax(correct_mask)]
             incorrect_indices = [
-                idx for idx, mask in zip(candidate_indices, ~correct_mask) if mask
+                idx
+                for idx, mask in zip(candidate_indices, ~correct_mask, strict=True)
+                if mask
             ]
             return {
                 "text": example["text"],

--- a/mteb/tasks/multichoice/eng/cv_bench.py
+++ b/mteb/tasks/multichoice/eng/cv_bench.py
@@ -74,7 +74,7 @@ def _load_data(
             corpus_ids = [corpus_id for _, corpus_id in corpus_to_id.items()]
             docs = [doc for doc, _ in corpus_to_id.items()]
         corpus_records = []
-        for corpus_id, doc in zip(corpus_ids, docs):
+        for corpus_id, doc in zip(corpus_ids, docs, strict=True):
             corpus_records.append({"id": corpus_id, "text": doc, "modality": "text"})
         corpus[split] = Dataset.from_list(corpus_records)
 

--- a/mteb/tasks/retrieval/code/code_rag.py
+++ b/mteb/tasks/retrieval/code/code_rag.py
@@ -80,7 +80,7 @@ class CodeRAGProgrammingSolutionsRetrieval(AbsTaskRetrieval):
 
         texts = ds["text"]
         meta = ds["meta"]
-        for text, mt in zip(texts, meta):
+        for text, mt in zip(texts, meta, strict=True):
             # in code-rag-bench,
             # text = query + "\n" + doc(code)
             query, doc = split_by_first_newline(text)
@@ -139,7 +139,7 @@ class CodeRAGOnlineTutorialsRetrieval(AbsTaskRetrieval):
         texts = ds["text"]
         parsed = ds["parsed"]
         id = 0
-        for title, text, _mt in zip(titles, texts, parsed):
+        for title, text, _mt in zip(titles, texts, parsed, strict=True):
             # in code-rag-bench,
             # query=doc(code)
             # text=query+doc(code)

--- a/mteb/tasks/retrieval/dan/dan_fever_retrieval.py
+++ b/mteb/tasks/retrieval/dan/dan_fever_retrieval.py
@@ -78,7 +78,9 @@ Derczynski, Leon},
             labels = ds["label"]
             class_labels = ds.features["label"].names
 
-            for claim, evidence, label_id in zip(claims, evidences, labels):
+            for claim, evidence, label_id in zip(
+                claims, evidences, labels, strict=True
+            ):
                 claim_is_supported = class_labels[label_id] == "Supported"
 
                 sim = (

--- a/mteb/tasks/retrieval/dan/tv2_nordretrieval.py
+++ b/mteb/tasks/retrieval/dan/tv2_nordretrieval.py
@@ -94,7 +94,7 @@ Piperidis, Stelios},
             article = ds["text"]
 
             n = 0
-            for summ, art in zip(summary, article):
+            for summ, art in zip(summary, article, strict=True):
                 self.queries[split][str(n)] = summ
                 q_n = n
                 n += 1

--- a/mteb/tasks/retrieval/ell/greek_civics_qa.py
+++ b/mteb/tasks/retrieval/ell/greek_civics_qa.py
@@ -44,7 +44,7 @@ class GreekCivicsQA(AbsTaskRetrieval):
 
         question_ids = {
             question: str(id)
-            for id, question in zip(data_raw["id"], data_raw["question"])
+            for id, question in zip(data_raw["id"], data_raw["question"], strict=True)
         }
 
         context_ids = {

--- a/mteb/tasks/retrieval/eng/bright_retrieval.py
+++ b/mteb/tasks/retrieval/eng/bright_retrieval.py
@@ -90,6 +90,7 @@ def load_data(self, num_proc: int | None = None, **kwargs) -> None:
     warnings.warn(
         "This task contains wrong prompts in the metadata. "
         "Please use BRIGHT(v1.1) benchmark instead.",
+        stacklevel=2,
         category=DeprecationWarning,
     )
 

--- a/mteb/tasks/retrieval/eng/browse_comp_plus_retrieval.py
+++ b/mteb/tasks/retrieval/eng/browse_comp_plus_retrieval.py
@@ -38,7 +38,7 @@ def _derive_key(password: str, length: int) -> bytes:
 def _decrypt_string(ciphertext_b64: str, password: str) -> str:
     encrypted = base64.b64decode(ciphertext_b64)
     key = _derive_key(password, len(encrypted))
-    return bytes(a ^ b for a, b in zip(encrypted, key)).decode("utf-8")
+    return bytes(a ^ b for a, b in zip(encrypted, key, strict=True)).decode("utf-8")
 
 
 class BrowseCompPlusRetrieval(AbsTaskRetrieval):

--- a/mteb/tasks/retrieval/eng/lit_search_retrieval.py
+++ b/mteb/tasks/retrieval/eng/lit_search_retrieval.py
@@ -47,6 +47,7 @@ class LitSearchRetrieval(AbsTaskRetrieval):
             zip(
                 [f"q{x + 1}" for x in range(len(query_ds["full"]))],
                 query_ds["full"]["query"],
+                strict=True,
             )
         )
 
@@ -58,11 +59,14 @@ class LitSearchRetrieval(AbsTaskRetrieval):
                 corpus_ds["full"]["corpusid"],
                 corpus_ds["full"]["title"],
                 corpus_ds["full"]["abstract"],
+                strict=True,
             )
         }
 
         self.relevant_docs["test"] = {
-            f"q{e + 1}": dict(zip([f"d{i}" for i in ids], range(1, len(ids) + 1)))
+            f"q{e + 1}": dict(
+                zip([f"d{i}" for i in ids], range(1, len(ids) + 1), strict=True)
+            )
             for e, ids in enumerate(query_ds["full"]["corpusids"])
         }
 

--- a/mteb/tasks/retrieval/eng/nano_argu_ana_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_argu_ana_retrieval.py
@@ -80,6 +80,7 @@ class NanoArguAnaRetrieval(AbsTaskRetrieval):
             for query_id, corpus_id in zip(
                 self.relevant_docs[split]["query-id"],
                 self.relevant_docs[split]["corpus-id"],
+                strict=True,
             ):
                 relevant_docs[split][query_id][corpus_id] = 1
         self.relevant_docs = relevant_docs

--- a/mteb/tasks/retrieval/eng/nano_climate_fever_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_climate_fever_retrieval.py
@@ -84,6 +84,7 @@ class NanoClimateFeverRetrieval(AbsTaskRetrieval):
             for query_id, corpus_id in zip(
                 self.relevant_docs[split]["query-id"],
                 self.relevant_docs[split]["corpus-id"],
+                strict=True,
             ):
                 relevant_docs[split][query_id][corpus_id] = 1
         self.relevant_docs = relevant_docs

--- a/mteb/tasks/retrieval/eng/nano_db_pedia_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_db_pedia_retrieval.py
@@ -82,6 +82,7 @@ class NanoDBPediaRetrieval(AbsTaskRetrieval):
             for query_id, corpus_id in zip(
                 self.relevant_docs[split]["query-id"],
                 self.relevant_docs[split]["corpus-id"],
+                strict=True,
             ):
                 relevant_docs[split][query_id][corpus_id] = 1
         self.relevant_docs = relevant_docs

--- a/mteb/tasks/retrieval/eng/nano_fever_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_fever_retrieval.py
@@ -97,6 +97,7 @@ Stent, Amanda},
             for query_id, corpus_id in zip(
                 self.relevant_docs[split]["query-id"],
                 self.relevant_docs[split]["corpus-id"],
+                strict=True,
             ):
                 relevant_docs[split][query_id][corpus_id] = 1
         self.relevant_docs = relevant_docs

--- a/mteb/tasks/retrieval/eng/nano_fi_qa2018_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_fi_qa2018_retrieval.py
@@ -83,6 +83,7 @@ class NanoFiQA2018Retrieval(AbsTaskRetrieval):
             for query_id, corpus_id in zip(
                 self.relevant_docs[split]["query-id"],
                 self.relevant_docs[split]["corpus-id"],
+                strict=True,
             ):
                 relevant_docs[split][query_id][corpus_id] = 1
         self.relevant_docs = relevant_docs

--- a/mteb/tasks/retrieval/eng/nano_hotpot_qa_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_hotpot_qa_retrieval.py
@@ -100,6 +100,7 @@ Tsujii, Jun{'}ichi},
             for query_id, corpus_id in zip(
                 self.relevant_docs[split]["query-id"],
                 self.relevant_docs[split]["corpus-id"],
+                strict=True,
             ):
                 relevant_docs[split][query_id][corpus_id] = 1
         self.relevant_docs = relevant_docs

--- a/mteb/tasks/retrieval/eng/nano_msmarco_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_msmarco_retrieval.py
@@ -95,6 +95,7 @@ Li Deng},
             for query_id, corpus_id in zip(
                 self.relevant_docs[split]["query-id"],
                 self.relevant_docs[split]["corpus-id"],
+                strict=True,
             ):
                 relevant_docs[split][query_id][corpus_id] = 1
         self.relevant_docs = relevant_docs

--- a/mteb/tasks/retrieval/eng/nano_nf_corpus_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_nf_corpus_retrieval.py
@@ -86,6 +86,7 @@ class NanoNFCorpusRetrieval(AbsTaskRetrieval):
             for query_id, corpus_id in zip(
                 self.relevant_docs[split]["query-id"],
                 self.relevant_docs[split]["corpus-id"],
+                strict=True,
             ):
                 relevant_docs[split][query_id][corpus_id] = 1
         self.relevant_docs = relevant_docs

--- a/mteb/tasks/retrieval/eng/nano_nq_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_nq_retrieval.py
@@ -86,6 +86,7 @@ Linguistics},
             for query_id, corpus_id in zip(
                 self.relevant_docs[split]["query-id"],
                 self.relevant_docs[split]["corpus-id"],
+                strict=True,
             ):
                 relevant_docs[split][query_id][corpus_id] = 1
         self.relevant_docs = relevant_docs

--- a/mteb/tasks/retrieval/eng/nano_quora_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_quora_retrieval.py
@@ -85,6 +85,7 @@ class NanoQuoraRetrieval(AbsTaskRetrieval):
             for query_id, corpus_id in zip(
                 self.relevant_docs[split]["query-id"],
                 self.relevant_docs[split]["corpus-id"],
+                strict=True,
             ):
                 relevant_docs[split][query_id][corpus_id] = 1
         self.relevant_docs = relevant_docs

--- a/mteb/tasks/retrieval/eng/nano_sci_fact_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_sci_fact_retrieval.py
@@ -82,6 +82,7 @@ class NanoSciFactRetrieval(AbsTaskRetrieval):
             for query_id, corpus_id in zip(
                 self.relevant_docs[split]["query-id"],
                 self.relevant_docs[split]["corpus-id"],
+                strict=True,
             ):
                 relevant_docs[split][query_id][corpus_id] = 1
         self.relevant_docs = relevant_docs

--- a/mteb/tasks/retrieval/eng/nano_scidocs_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_scidocs_retrieval.py
@@ -84,6 +84,7 @@ class NanoSCIDOCSRetrieval(AbsTaskRetrieval):
             for query_id, corpus_id in zip(
                 self.relevant_docs[split]["query-id"],
                 self.relevant_docs[split]["corpus-id"],
+                strict=True,
             ):
                 relevant_docs[split][query_id][corpus_id] = 1
         self.relevant_docs = relevant_docs

--- a/mteb/tasks/retrieval/eng/nano_touche2020_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_touche2020_retrieval.py
@@ -93,6 +93,7 @@ Questions}},
             for query_id, corpus_id in zip(
                 self.relevant_docs[split]["query-id"],
                 self.relevant_docs[split]["corpus-id"],
+                strict=True,
             ):
                 relevant_docs[split][query_id][corpus_id] = 1
         self.relevant_docs = relevant_docs

--- a/mteb/tasks/retrieval/eng/real_mm_rag_retrieval.py
+++ b/mteb/tasks/retrieval/eng/real_mm_rag_retrieval.py
@@ -76,7 +76,7 @@ def _load_data(
         )
         qrels = qrels.to_polars()
         relevant_docs = {
-            query_id[0]: dict(zip(group["corpus-id"], group["score"]))
+            query_id[0]: dict(zip(group["corpus-id"], group["score"], strict=True))
             for query_id, group in qrels.group_by("query-id", maintain_order=False)
         }
 

--- a/mteb/tasks/retrieval/hun/hun_sum2.py
+++ b/mteb/tasks/retrieval/hun/hun_sum2.py
@@ -48,7 +48,7 @@ class HunSum2AbstractiveRetrieval(AbsTaskRetrieval):
             return
         self.corpus, self.queries, self.relevant_docs = {}, {}, {}
         ds = load_dataset(**self.metadata.dataset, split=self.metadata.eval_splits)
-        ds = dict(zip(self.metadata.eval_splits, ds))
+        ds = dict(zip(self.metadata.eval_splits, ds, strict=True))
         for split_name, split in ds.items():
             self.corpus[split_name] = {}
             self.queries[split_name] = {}

--- a/mteb/tasks/retrieval/multilingual/x_qu_ad_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/x_qu_ad_retrieval.py
@@ -80,7 +80,8 @@ class XQuADRetrieval(AbsTaskRetrieval):
             data = data.filter(lambda x: x["answers"]["text"] != "")  # noqa: PLC1901
 
             question_ids = {
-                question: id for id, question in zip(data["id"], data["question"])
+                question: id
+                for id, question in zip(data["id"], data["question"], strict=True)
             }
             context_ids = {
                 context: sha256(context.encode("utf-8")).hexdigest()

--- a/mteb/tasks/retrieval/nob/norquad.py
+++ b/mteb/tasks/retrieval/nob/norquad.py
@@ -86,7 +86,7 @@ Fishel, Mark},
             answer = [a["text"][0] for a in ds["answers"]]
 
             n = 0
-            for q, cont, ans in zip(question, context, answer):
+            for q, cont, ans in zip(question, context, answer, strict=True):
                 self.queries[split][str(n)] = q
                 q_n = n
                 n += 1

--- a/mteb/tasks/retrieval/nob/snl_retrieval.py
+++ b/mteb/tasks/retrieval/nob/snl_retrieval.py
@@ -69,7 +69,7 @@ class SNLRetrieval(AbsTaskRetrieval):
             article = ds["article"]
 
             n = 0
-            for headl, art in zip(headline, article):
+            for headl, art in zip(headline, article, strict=True):
                 self.queries[split][str(n)] = headl
                 q_n = n
                 n += 1

--- a/mteb/tasks/retrieval/tur/tur_hist_quad.py
+++ b/mteb/tasks/retrieval/tur/tur_hist_quad.py
@@ -74,7 +74,7 @@ class TurHistQuadRetrieval(AbsTaskRetrieval):
             answer = [a["text"] for a in ds["answers"]]
 
             n = 0
-            for q, cont, ans in zip(question, context, answer):
+            for q, cont, ans in zip(question, context, answer, strict=True):
                 self.queries[split][str(n)] = q
                 q_n = n
                 n += 1

--- a/mteb/tasks/retrieval/vie/vie_qu_ad_retrieval.py
+++ b/mteb/tasks/retrieval/vie/vie_qu_ad_retrieval.py
@@ -88,7 +88,7 @@ Zong, Chengqing},
 
         text2id = {}
         n = 0
-        for t, q, cont, ans in zip(titles, questions, contexts, answers):
+        for t, q, cont, ans in zip(titles, questions, contexts, answers, strict=True):
             self.queries[split][str(n)] = q
             q_n = n
             n += 1

--- a/mteb/timing.py
+++ b/mteb/timing.py
@@ -145,7 +145,7 @@ class TimingStack:
         lines = []
         prev_group: tuple[str | None, str | None] = (None, None)
 
-        for phase, label in zip(self.phases, labels):
+        for phase, label in zip(self.phases, labels, strict=True):
             cur_group = (phase.get("split"), phase.get("subset"))
             if prev_group not in {cur_group, (None, None)}:
                 lines.append("")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -335,9 +335,6 @@ ignore = [
     "PLR0915",  # too many statements
     "PLW0717",  # too-many-statements-in-try-clause
     "ISC001",   # single-line implicit concat; conflicts with `ruff format`
-    # TODO: enable in a follow-up PR; each needs a per-site `strict=` / `stacklevel=` decision
-    "B905",     # zip-without-explicit-strict
-    "B028",     # no-explicit-stacklevel
 ]
 future-annotations = true  # For TC rules
 typing-modules = ["typing_extensions", "mteb.types", "collections.abc"]
@@ -583,6 +580,7 @@ extend-ignore-words-re = [
 extend-ignore-re = [
     "author.*",  # ignore authors in citations
     "editor.*",  # ignore authors in citations
+    "FIne-Grained Music retrievAl",  # stylised paper title (FIGMA)
 ]
 
 [tool.typos.files]

--- a/tests/test_benchmarks/test_benchmark_score.py
+++ b/tests/test_benchmarks/test_benchmark_score.py
@@ -305,7 +305,7 @@ def test_get_score_matches_summary_table_means(mock_mteb_cache: ResultCache):
     # Pair (get_score key, summary column) for each aggregation surfaced.
     parity_pairs: list[tuple[str, str]] = []
     for agg in bench.aggregations:
-        parity_pairs.extend(zip(agg.get_score_keys, agg.summary_columns))
+        parity_pairs.extend(zip(agg.get_score_keys, agg.summary_columns, strict=True))
     # TASK_TYPES is dynamic — match observed type names directly.
     if BenchmarkAggregation.TASK_TYPES in bench.aggregations:
         type_names = {t.metadata.type for t in bench.tasks}
@@ -406,7 +406,7 @@ def test_get_score_matches_summary_table_on_partial_split_coverage(
     # TASK_TYPES column/key to pair up alongside the fixed aggregation keys.
     parity_pairs: list[tuple[str, str]] = [("Classification", "Classification")]
     for agg in bench.aggregations:
-        parity_pairs.extend(zip(agg.get_score_keys, agg.summary_columns))
+        parity_pairs.extend(zip(agg.get_score_keys, agg.summary_columns, strict=True))
 
     _assert_score_parity(
         full,

--- a/tests/test_results/test_benchmark_results.py
+++ b/tests/test_results/test_benchmark_results.py
@@ -297,7 +297,7 @@ def test_generate_model_card_with_table_and_benchmarks(
 
     # Compare each data row
     for i, (output_row, golden_row) in enumerate(
-        zip(output_data_rows, golden_data_rows)
+        zip(output_data_rows, golden_data_rows, strict=True)
     ):
         assert output_row == golden_row, (
             f"Row {i} doesn't match.\nExpected: {golden_row}\nGot: {output_row}"

--- a/tests/test_search_index/test_search_index.py
+++ b/tests/test_search_index/test_search_index.py
@@ -68,7 +68,7 @@ def test_retrieval_backends(
         faiss_predictions = full_faiss_predictions["default"]["test"]
 
     for python_pred_key, faiss_pred_key in zip(
-        sorted(python_predictions.keys()), sorted(faiss_predictions.keys())
+        sorted(python_predictions.keys()), sorted(faiss_predictions.keys()), strict=True
     ):
         assert python_pred_key == faiss_pred_key
         assert python_predictions[python_pred_key] == pytest.approx(


### PR DESCRIPTION
Completes `B` (flake8-bugbear) from #2416 by enabling the two rules deferred in #5189. The ignore entries are removed, so `B` Ruff rules are fully enabled. 

| Rule | n | Pattern applied |
|---|---|---|
| `B905` zip-without-explicit-strict | 118 | `strict=True` at every site |
| `B028` no-explicit-stacklevel | 39 | `stacklevel=2` — points warnings at the caller, not at mteb internals |

### Why `strict=True` everywhere: They fall into a few families that are equal-length by construction:

- two columns of the same dataset or group — the largest family
- `zip(*pairs)` transposition (8 sites)
- parallel top-k index/value arrays from the same `topk` call
- embeddings zipped against the inputs they were computed from

Several already assert the invariant by hand - a `ValueError` on length mismatch immediately above the zip, a `titles` list padded to `[None] * len(texts)`, an XOR key derived to exactly `len(encrypted)` bytes. `strict=True` encodes what those guards already state.