### PR TITLE
fix: set explicit query prefix for ColPali wrappers

### DIFF
--- a/mteb/models/model_implementations/colpali_models.py
+++ b/mteb/models/model_implementations/colpali_models.py
@@ -34,6 +34,7 @@ class ColPaliEngineWrapper(AbsEncoder):
         processor_class: type,
         revision: str | None = None,
         device: str | None = None,
+        query_prefix: str | None = None,
         **kwargs,
     ):
         self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
@@ -49,6 +50,8 @@ class ColPaliEngineWrapper(AbsEncoder):
 
         # Load processor
         self.processor = processor_class.from_pretrained(model_name)
+        if query_prefix is not None:
+            self.processor.query_prefix = query_prefix
 
     def encode(
         self,
@@ -165,6 +168,7 @@ class ColPaliWrapper(ColPaliEngineWrapper):
         model_name: str = "vidore/colpali-v1.3",
         revision: str | None = None,
         device: str | None = None,
+        query_prefix: str = "Query: ",
         **kwargs,
     ):
         from colpali_engine.models import ColPali, ColPaliProcessor
@@ -175,6 +179,7 @@ class ColPaliWrapper(ColPaliEngineWrapper):
             processor_class=ColPaliProcessor,
             revision=revision,
             device=device,
+            query_prefix=query_prefix,
             **kwargs,
         )
 

--- a/mteb/models/model_implementations/colqwen_models.py
+++ b/mteb/models/model_implementations/colqwen_models.py
@@ -33,6 +33,7 @@ class ColQwen2Wrapper(ColPaliEngineWrapper):
         model_name: str = "vidore/colqwen2-v1.0",
         revision: str | None = None,
         device: str | None = None,
+        query_prefix: str = "Query: ",
         **kwargs,
     ):
         from colpali_engine.models import ColQwen2, ColQwen2Processor
@@ -43,6 +44,7 @@ class ColQwen2Wrapper(ColPaliEngineWrapper):
             processor_class=ColQwen2Processor,
             revision=revision,
             device=device,
+            query_prefix=query_prefix,
             **kwargs,
         )
 
@@ -56,6 +58,7 @@ class ColQwen2_5Wrapper(ColPaliEngineWrapper):  # noqa: N801
         revision: str | None = None,
         device: str | None = None,
         attn_implementation: str | None = None,
+        query_prefix: str = "Query: ",
         **kwargs,
     ):
         from colpali_engine.models import ColQwen2_5, ColQwen2_5_Processor
@@ -72,6 +75,7 @@ class ColQwen2_5Wrapper(ColPaliEngineWrapper):  # noqa: N801
             processor_class=ColQwen2_5_Processor,
             revision=revision,
             device=device,
+            query_prefix=query_prefix,
             **kwargs,
         )
 

--- a/mteb/models/model_implementations/colsmol_models.py
+++ b/mteb/models/model_implementations/colsmol_models.py
@@ -22,6 +22,7 @@ class ColSmolWrapper(ColPaliEngineWrapper):
         revision: str | None = None,
         device: str | None = None,
         attn_implementation: str | None = None,
+        query_prefix: str = "Query: ",
         **kwargs,
     ):
         from colpali_engine.models import ColIdefics3, ColIdefics3Processor
@@ -38,6 +39,7 @@ class ColSmolWrapper(ColPaliEngineWrapper):
             processor_class=ColIdefics3Processor,
             revision=revision,
             device=device,
+            query_prefix=query_prefix,
             **kwargs,
         )
 


### PR DESCRIPTION
Closes #5166

## Summary

`colpali-engine` 0.3.13 changed the default query prefix from `"Query: "` to an empty string. This changes the query embeddings produced for models previously evaluated with the old processor behavior.

This PR makes the query prefix explicit in the affected MTEB wrappers instead of restoring it globally.

## Changes

- Add an optional `query_prefix` argument to `ColPaliEngineWrapper`.
- Apply the prefix after loading the processor.
- Explicitly default the affected ColPali, ColQwen2, ColQwen2.5, and ColSmol wrappers to `"Query: "`.
- Preserve the defaults of other processor families that may intentionally use an empty prefix.