### PR TITLE
record the resolved BM25 search configuration in retrieval results

### DIFF
--- a/mteb/_evaluators/retrieval_metrics.py
+++ b/mteb/_evaluators/retrieval_metrics.py
@@ -428,7 +428,7 @@ def robustness_at_10(
     return sum(robustness_scores) / len(robustness_scores)
 
 
-def make_score_dict(
+def make_score_dict(  # noqa: PLR0913
     *,
     ndcg: dict[str, float],
     _map: dict[str, float],
@@ -440,6 +440,7 @@ def make_score_dict(
     hit_rate: dict[str, float],
     task_scores: dict[str, float],
     previous_results_model_meta: dict[str, Any] | None = None,
+    search_config: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     return {
         **{f"ndcg_at_{k.split('@')[1]}": v for (k, v) in ndcg.items()},
@@ -465,6 +466,7 @@ def make_score_dict(
             if previous_results_model_meta
             else {}
         ),
+        **({"search_config": search_config} if search_config else {}),
     }
 
 

--- a/mteb/abstasks/retrieval.py
+++ b/mteb/abstasks/retrieval.py
@@ -64,6 +64,18 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _resolved_search_config(search_model: Any) -> dict[str, Any] | None:
+    """Settings a search model resolved for this task, if it reports any.
+
+    Optional and duck-typed: a model that does not implement `resolved_config` is
+    unaffected, and `SearchProtocol` is unchanged.
+    """
+    fn = getattr(search_model, "resolved_config", None)
+    if not callable(fn):
+        return None
+    return fn() or None
+
+
 def _filter_queries_without_positives(
     relevant_docs: RelevantDocumentsType, queries: QueryDatasetType
 ) -> tuple[RelevantDocumentsType, QueryDatasetType]:
@@ -442,6 +454,7 @@ class AbsTaskRetrieval(AbsTask):
             hit_rate=hit_rate,
             task_scores=task_specific_scores,
             previous_results_model_meta=self._previous_results_model_meta,
+            search_config=_resolved_search_config(search_model),
         )
 
     def task_specific_scores(  # noqa: PLR6301

--- a/mteb/models/model_implementations/bm25.py
+++ b/mteb/models/model_implementations/bm25.py
@@ -9,6 +9,7 @@ from mteb.models.model_meta import ModelMeta
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from typing import Any
 
     from mteb.abstasks.task_metadata import TaskMetadata
     from mteb.models.models_protocols import SearchProtocol
@@ -163,6 +164,10 @@ class BM25Tokenizer:
             self._tok_arg = tokenizer if tokenizer is not None else detected_tok
 
         self.freq_threshold = freq_threshold
+        # Kept so the resolved settings can be reported alongside the scores;
+        # `stemmer_lang` is otherwise only a local and is lost after __init__.
+        self.stemmer_language = stemmer_lang
+        self.n_freq_stopwords: int | None = None
         self._raw_tok = None  # resolved callable (custom path only)
         self._combined_stops: frozenset[str] = frozenset()
         self._combined_list: list[str] | None = None  # bm25s path cache
@@ -211,6 +216,7 @@ class BM25Tokenizer:
             )
             self._combined_stops = named_stops
             self._combined_list = list(named_stops) if named_stops else None
+            self.n_freq_stopwords = 0
             return bm25s.tokenize(
                 corpus_texts, stopwords=self._combined_list, stemmer=self.stemmer
             )
@@ -233,6 +239,7 @@ class BM25Tokenizer:
 
         self._combined_stops = freq_stops
         self._combined_list = list(freq_stops) if freq_stops else None
+        self.n_freq_stopwords = len(freq_stops)
 
         stop_ids = frozenset(raw.vocab[t] for t in freq_stops if t in raw.vocab)
         filtered_ids = [
@@ -268,6 +275,7 @@ class BM25Tokenizer:
             _get_stopwords(self.stopwords_key) if self.stopwords_key else frozenset()
         )
         self._combined_stops = named_stops | freq_stops
+        self.n_freq_stopwords = len(freq_stops)
 
         filtered = [
             [t for t in toks if t not in self._combined_stops]
@@ -281,6 +289,23 @@ class BM25Tokenizer:
             for text in texts
         ]
         return self._to_tokenized(token_lists)
+
+    def resolved_config(self) -> dict[str, Any]:
+        """The settings this tokenizer actually resolved to, for the result file.
+
+        Defaults are language- and version-dependent, so `mteb_version` alone does not
+        identify them. `n_freq_stopwords` is None until `fit_transform` has run.
+        """
+        tok = self._tok_arg
+        return {
+            "stopwords_key": self.stopwords_key,
+            "stemmer_language": self.stemmer_language,
+            "tokenizer": tok
+            if isinstance(tok, str) or tok is None
+            else getattr(tok, "__name__", type(tok).__name__),
+            "freq_threshold": self.freq_threshold,
+            "n_freq_stopwords": self.n_freq_stopwords,
+        }
 
     @staticmethod
     def _named_tok(name: str) -> Callable[[str], list[str]]:
@@ -370,6 +395,11 @@ class BM25Search:
             ]
 
         return _tok
+
+    def resolved_config(self) -> dict[str, Any] | None:
+        """What the tokenizer resolved to, or None before `index` has run."""
+        tokenizer = getattr(self, "_tokenizer", None)
+        return tokenizer.resolved_config() if tokenizer is not None else None
 
     def index(
         self,


### PR DESCRIPTION
Follows up on #5157: published `mteb/baseline-bm25s` results can't be traced back to the
configuration that produced them.

`BM25Tokenizer` resolves stopwords, stemmer and tokenizer from the task's language at index
time, and those defaults have changed across releases, so `mteb_version` doesn't recover
them. The values already exist — computed in `__init__`, formatted into a log line no
result file keeps. This writes them into the result instead.

`AutoRAGRetrieval` on `mteb/baseline-bm25s`, `ndcg_at_10` unchanged at 0.65022:

```json
"search_config": {
  "stopwords_key": null, "stemmer_language": null, "tokenizer": "char",
  "freq_threshold": 0.9, "n_freq_stopwords": 7
}
```

`n_freq_stopwords` was previously only a log line: seven tokens dropped from corpus and
queries for appearing in ≥90% of documents.

One `mteb_version` covers many resolutions, since they follow the task's language:

| language | stopwords_key | stemmer_language | tokenizer |
|---|---|---|---|
| `eng` | `en` | `english` | — |
| `tur` | — | `turkish` | — |
| `kor` | — | — | `char` |
| `swa` | — | — | — |

`freq_threshold` only applies where `stopwords_key` is None (`bm25.py:206`, `:254`).

`SearchProtocol` is unchanged and `_resolved_search_config` is duck-typed, so a model
without `resolved_config` gets `None` and nothing is written. `search_config` is merged
only when present, exactly like `previous_results_model_meta`, and rides the existing
`**hf_scores` pass-through in `TaskResult.from_task_results` — no new `TaskResult` field,
and it lands per split and per subset, as it has to.

No score changes. `tests/test_models/test_bm25.py` passes, `ruff check` and
`ruff format --check` are clean, `mypy` reports nothing new.

Only BM25 is wired. If the shape is right the same three lines would let any search model
report what it resolved. Naming and shape are both guesses; happy to change either.