### PR TITLE
dataset: add IntPhys2 video zero-shot task

### DIFF
--- a/mteb/abstasks/task_metadata.py
+++ b/mteb/abstasks/task_metadata.py
@@ -76,6 +76,7 @@ TaskSubtype = Literal[
     "Emotion recognition",
     "Textures recognition",
     "Activity recognition",
+    "Physical plausibility classification",
     "Tumor detection",
     "Duplicate Detection",
     "Rendered semantic textual similarity",
@@ -903,6 +904,7 @@ class TaskMetadata(BaseModel):
             "Emotion recognition": ["sentiment-scoring"],
             "Textures recognition": [],
             "Activity recognition": [],
+            "Physical plausibility classification": [],
             "Tumor detection": [],
             "Duplicate Detection": [],
             "Rendered semantic textual similarity": [
@@ -992,6 +994,7 @@ class TaskMetadata(BaseModel):
             "AudioPairClassification": ["audio-classification"],
             # video
             "VideoCentricQA": ["visual-question-answering"],
+            "VideoZeroshotClassification": ["video-classification"],
         }
         if self.type == "ZeroShotClassification":
             if self.modalities == ["image"]:

--- a/mteb/descriptive_stats/VideoZeroshotClassification/IntPhys2VideoZeroShot.json
+++ b/mteb/descriptive_stats/VideoZeroshotClassification/IntPhys2VideoZeroShot.json
@@ -1,0 +1,62 @@
+{
+    "test": {
+        "num_samples": 1012,
+        "text_statistics": null,
+        "image_statistics": null,
+        "audio_statistics": null,
+        "video_statistics": {
+            "total_duration_seconds": 10902.3,
+            "total_frames": 654138,
+            "min_width": 512,
+            "average_width": 512.0,
+            "max_width": 512,
+            "min_height": 512,
+            "average_height": 512.0,
+            "max_height": 512,
+            "min_duration_seconds": 10.583333333333332,
+            "average_duration_seconds": 10.77302371541502,
+            "max_duration_seconds": 15.633333333333333,
+            "unique_videos": 1012,
+            "average_fps": 60.0,
+            "fps": {
+                "60": 1012
+            },
+            "min_resolution": [
+                512,
+                512
+            ],
+            "average_resolution": [
+                512.0,
+                512.0
+            ],
+            "max_resolution": [
+                512,
+                512
+            ],
+            "resolutions": {
+                "512x512": 1012
+            }
+        },
+        "label_statistics": {
+            "min_labels_per_text": 1,
+            "average_label_per_text": 1.0,
+            "max_labels_per_text": 1,
+            "unique_labels": 2,
+            "labels": {
+                "1": {
+                    "count": 506
+                },
+                "0": {
+                    "count": 506
+                }
+            }
+        },
+        "candidates_labels_text_statistics": {
+            "total_text_length": 142,
+            "min_text_length": 70,
+            "average_text_length": 71.0,
+            "max_text_length": 72,
+            "unique_texts": 2
+        }
+    }
+}

--- a/mteb/tasks/zeroshot_classification/eng/__init__.py
+++ b/mteb/tasks/zeroshot_classification/eng/__init__.py
@@ -24,6 +24,7 @@ from .human_animal_cartoon import (
     HumanAnimalCartoonZeroShotClassification,
 )
 from .imagenet1k import Imagenet1kZeroShotClassification
+from .intphys2 import IntPhys2VideoZeroShot
 from .kinetics400 import (
     Kinetics400VAZeroShotClassification,
     Kinetics400ZeroShotClassification,
@@ -99,6 +100,7 @@ __all__ = [
     "HumanAnimalCartoonVAZeroShotClassification",
     "HumanAnimalCartoonZeroShotClassification",
     "Imagenet1kZeroShotClassification",
+    "IntPhys2VideoZeroShot",
     "Kinetics400VAZeroShotClassification",
     "Kinetics400ZeroShotClassification",
     "Kinetics600VAZeroShotClassification",

--- a/mteb/tasks/zeroshot_classification/eng/intphys2.py
+++ b/mteb/tasks/zeroshot_classification/eng/intphys2.py
@@ -1,0 +1,53 @@
+from mteb.abstasks.task_metadata import TaskMetadata
+from mteb.abstasks.zeroshot_classification import AbsTaskZeroShotClassification
+
+_DATASET_PATH = "artist/IntPhys2VideoZeroShot"
+_DATASET_REVISION = "9ceb62a8a1fdf1b9f0c276430f72e3eb30426bbe"
+_LABEL_NAMES = [
+    "object behavior is inconsistent with Earth's physical laws",
+    "object behavior is consistent with Earth's physical laws",
+]
+
+
+class IntPhys2VideoZeroShot(AbsTaskZeroShotClassification):
+    metadata = TaskMetadata(
+        name="IntPhys2VideoZeroShot",
+        description=(
+            "Classify synthetic videos as physically possible or impossible across "
+            "permanence, immutability, continuity, and solidity conditions."
+        ),
+        reference="https://arxiv.org/abs/2506.09849",
+        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        type="VideoZeroshotClassification",
+        category="v2t",
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="accuracy",
+        prompt="Represent the input for physical plausibility classification.",
+        date=("2025-06-11", "2025-06-11"),
+        domains=["Constructed"],
+        task_subtypes=["Physical plausibility classification"],
+        license="cc-by-nc-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        modalities=["video", "text"],
+        sample_creation="created",
+        bibtex_citation=r"""
+@misc{bordes2025intphys2benchmarkingintuitive,
+  archiveprefix = {arXiv},
+  author = {Florian Bordes and Quentin Garrido and Justine T Kao and Adina Williams and Michael Rabbat and Emmanuel Dupoux},
+  eprint = {2506.09849},
+  primaryclass = {cs.CV},
+  title = {IntPhys 2: Benchmarking Intuitive Physics Understanding In Complex Synthetic Environments},
+  url = {https://arxiv.org/abs/2506.09849},
+  year = {2025},
+}
+""",
+        is_beta=True,
+    )
+
+    input_column_name = "video"
+    label_column_name = "label"
+
+    def get_candidate_labels(self) -> list[str]:  # noqa: PLR6301
+        return [f"a video where {label}" for label in _LABEL_NAMES]

--- a/mteb/tasks/zeroshot_classification/eng/intphys2.py
+++ b/mteb/tasks/zeroshot_classification/eng/intphys2.py
@@ -1,15 +1,15 @@
 from mteb.abstasks.task_metadata import TaskMetadata
 from mteb.abstasks.zeroshot_classification import AbsTaskZeroShotClassification
 
-_DATASET_PATH = "artist/IntPhys2VideoZeroShot"
-_DATASET_REVISION = "9ceb62a8a1fdf1b9f0c276430f72e3eb30426bbe"
-_LABEL_NAMES = [
-    "object behavior is inconsistent with Earth's physical laws",
-    "object behavior is consistent with Earth's physical laws",
-]
-
 
 class IntPhys2VideoZeroShot(AbsTaskZeroShotClassification):
+    _DATASET_PATH = "artist/IntPhys2VideoZeroShot"
+    _DATASET_REVISION = "9ceb62a8a1fdf1b9f0c276430f72e3eb30426bbe"
+    _LABEL_NAMES = (
+        "object behavior is inconsistent with Earth's physical laws",
+        "object behavior is consistent with Earth's physical laws",
+    )
+
     metadata = TaskMetadata(
         name="IntPhys2VideoZeroShot",
         description=(
@@ -49,5 +49,5 @@ class IntPhys2VideoZeroShot(AbsTaskZeroShotClassification):
     input_column_name = "video"
     label_column_name = "label"
 
-    def get_candidate_labels(self) -> list[str]:  # noqa: PLR6301
-        return [f"a video where {label}" for label in _LABEL_NAMES]
+    def get_candidate_labels(self) -> list[str]:
+        return [f"a video where {label}" for label in self._LABEL_NAMES]

--- a/mteb/tasks/zeroshot_classification/eng/intphys2.py
+++ b/mteb/tasks/zeroshot_classification/eng/intphys2.py
@@ -3,8 +3,8 @@ from mteb.abstasks.zeroshot_classification import AbsTaskZeroShotClassification
 
 
 class IntPhys2VideoZeroShot(AbsTaskZeroShotClassification):
-    _DATASET_PATH = "artist/IntPhys2VideoZeroShot"
-    _DATASET_REVISION = "9ceb62a8a1fdf1b9f0c276430f72e3eb30426bbe"
+    _DATASET_PATH = "mteb/IntPhys2VideoZeroShot"
+    _DATASET_REVISION = "503c0a2f8e624472ff3e44cdc6065ec68c9df2ed"
     _LABEL_NAMES = (
         "object behavior is inconsistent with Earth's physical laws",
         "object behavior is consistent with Earth's physical laws",

--- a/scripts/data/intphys2/create_data.py
+++ b/scripts/data/intphys2/create_data.py
@@ -1,0 +1,171 @@
+"""Build the MTEB IntPhys2 dataset from the official labeled Main split.
+
+Example:
+    uv run python scripts/data/intphys2/create_data.py \
+        --download --source-dir /path/to/source --output-dir /path/to/output
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import re
+from collections import Counter
+from pathlib import Path
+
+from datasets import ClassLabel, Dataset, DatasetDict, Features, Value, Video
+from huggingface_hub import snapshot_download
+
+SOURCE_REPO = "facebook/IntPhys2"
+SOURCE_REVISION = "a077a2f94e25889016fc6e5983cf21e2ddc25fb2"
+SOURCE_METADATA_SHA256 = (
+    "0db123911e595e263e88dde19ac52bc2684d23d19d7c1f2dc49c67c916075422"
+)
+EXPECTED_ROWS = 1_012
+EXPECTED_SCENES = 253
+EXPECTED_VARIANTS = {
+    "1_Possible",
+    "1_Impossible",
+    "2_Possible",
+    "2_Impossible",
+}
+TYPE_TO_LABEL = {
+    "1_Impossible": 0,
+    "2_Impossible": 0,
+    "1_Possible": 1,
+    "2_Possible": 1,
+}
+LABEL_NAMES = [
+    "object behavior is inconsistent with Earth's physical laws",
+    "object behavior is consistent with Earth's physical laws",
+]
+CANDIDATE_LABELS = [f"a video where {label}" for label in LABEL_NAMES]
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def download_source(source_dir: Path) -> None:
+    snapshot_download(
+        repo_id=SOURCE_REPO,
+        repo_type="dataset",
+        revision=SOURCE_REVISION,
+        allow_patterns=["Main/**", "README.md"],
+        local_dir=source_dir,
+    )
+
+
+def load_source(source_dir: Path) -> tuple[list[Path], list[int]]:
+    main_dir = source_dir / "Main"
+    metadata_path = main_dir / "metadata.csv"
+    if sha256(metadata_path) != SOURCE_METADATA_SHA256:
+        raise ValueError("IntPhys2 metadata does not match the pinned source revision")
+
+    with metadata_path.open(newline="", encoding="utf-8") as file:
+        rows = list(csv.DictReader(file))
+    if len(rows) != EXPECTED_ROWS:
+        raise ValueError(f"Expected {EXPECTED_ROWS} rows, found {len(rows)}")
+
+    required_columns = {"SceneIndex", "name", "file_name", "type"}
+    if not rows or not required_columns.issubset(rows[0]):
+        raise ValueError("Unexpected IntPhys2 metadata schema")
+
+    sample_ids: set[str] = set()
+    variants_by_scene: dict[str, set[str]] = {}
+    video_paths: list[Path] = []
+    labels: list[int] = []
+    for row in rows:
+        sample_id = row["name"]
+        if sample_id in sample_ids or not re.fullmatch(r"[0-9a-f]{64}", sample_id):
+            raise ValueError(f"Invalid or duplicate sample id: {sample_id}")
+        sample_ids.add(sample_id)
+
+        variant = row["type"]
+        if variant not in EXPECTED_VARIANTS:
+            raise ValueError(f"Unexpected variant: {variant}")
+        variants_by_scene.setdefault(row["SceneIndex"], set()).add(variant)
+
+        relative_path = Path(row["file_name"])
+        if relative_path.parts != ("Videos", f"{sample_id}.mp4"):
+            raise ValueError(f"Unexpected video path: {relative_path}")
+        video_path = main_dir / relative_path
+        if not video_path.is_file():
+            raise FileNotFoundError(video_path)
+
+        video_paths.append(video_path)
+        labels.append(TYPE_TO_LABEL[variant])
+
+    if len(variants_by_scene) != EXPECTED_SCENES or any(
+        variants != EXPECTED_VARIANTS for variants in variants_by_scene.values()
+    ):
+        raise ValueError("Unexpected scene/variant structure")
+    if Counter(labels) != {0: 506, 1: 506}:
+        raise ValueError(f"Unexpected label counts: {Counter(labels)}")
+    return video_paths, labels
+
+
+def build_dataset(source_dir: Path) -> tuple[DatasetDict, Dataset]:
+    video_paths, labels = load_source(source_dir)
+    default = DatasetDict(
+        {
+            "test": Dataset.from_dict(
+                {
+                    "video": [str(path) for path in video_paths],
+                    "label": labels,
+                },
+                features=Features(
+                    {
+                        "video": Video(),
+                        "label": ClassLabel(names=LABEL_NAMES),
+                    }
+                ),
+            )
+        }
+    )
+    candidates = Dataset.from_dict(
+        {"labels": CANDIDATE_LABELS},
+        features=Features({"labels": Value("string")}),
+    )
+    return default, candidates
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-dir", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--download", action="store_true")
+    parser.add_argument("--push", action="store_true")
+    parser.add_argument("--repo-id")
+    args = parser.parse_args()
+    if args.push and not args.repo_id:
+        parser.error("--repo-id is required with --push")
+
+    if args.download:
+        download_source(args.source_dir)
+    default, candidates = build_dataset(args.source_dir)
+
+    if args.output_dir.exists():
+        raise FileExistsError(args.output_dir)
+    default.save_to_disk(args.output_dir / "default")
+    DatasetDict({"train": candidates}).save_to_disk(args.output_dir / "labels")
+
+    if args.push:
+        default.push_to_hub(args.repo_id)
+        candidates.push_to_hub(args.repo_id, config_name="labels", split="train")
+
+    counts = Counter(default["test"]["label"])
+    print(
+        f"Built {len(default['test'])} videos "
+        f"({counts[0]} impossible, {counts[1]} possible) and "
+        f"{len(candidates)} candidate labels."
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #2814.

Adds IntPhys2 video zero-shot classification on the official 1,012-video Main split.

| Model | Accuracy |
|---|---:|
| Random baseline | 0.5168 |
| Qwen3-VL-Embedding-2B | 0.5020 |
| Qwen3-VL-Embedding-8B | 0.4931 |
| omni-embed-nemotron-3b | 0.4980 |

The paper reports 52.27% for Qwen2.5-VL and 57.51% for V-JEPA 2 using different evaluation protocols.

- [x] Fills an existing MTEB video task gap
- [x] Runs with MTEB
- [x] Evaluated with random and three video embedding models
- [x] Checked performance; current embedding baselines remain near random, consistent with the paper
- [x] Retains the full balanced Main split after size review
- [x] Compared with paper results; protocols differ
