### PR TITLE
dataset: add FSDKaggle2018

### DIFF
--- a/mteb/descriptive_stats/AudioClassification/FSDKaggle2018Classification.json
+++ b/mteb/descriptive_stats/AudioClassification/FSDKaggle2018Classification.json
@@ -1,0 +1,300 @@
+{
+    "test": {
+        "num_samples": 1600,
+        "samples_in_train": 0,
+        "text_statistics": null,
+        "image_statistics": null,
+        "audio_statistics": {
+            "total_duration_seconds": 8325.92,
+            "min_duration_seconds": 0.3,
+            "average_duration_seconds": 5.2037,
+            "max_duration_seconds": 29.74,
+            "unique_audios": 1600,
+            "average_sampling_rate": 44100.0,
+            "sampling_rates": {
+                "44100": 1600
+            }
+        },
+        "video_statistics": null,
+        "label_statistics": {
+            "min_labels_per_text": 1,
+            "average_label_per_text": 1.0,
+            "max_labels_per_text": 1,
+            "unique_labels": 41,
+            "labels": {
+                "29": {
+                    "count": 42
+                },
+                "3": {
+                    "count": 28
+                },
+                "30": {
+                    "count": 110
+                },
+                "7": {
+                    "count": 29
+                },
+                "14": {
+                    "count": 32
+                },
+                "32": {
+                    "count": 29
+                },
+                "2": {
+                    "count": 28
+                },
+                "0": {
+                    "count": 45
+                },
+                "31": {
+                    "count": 25
+                },
+                "12": {
+                    "count": 40
+                },
+                "25": {
+                    "count": 39
+                },
+                "37": {
+                    "count": 48
+                },
+                "39": {
+                    "count": 108
+                },
+                "21": {
+                    "count": 63
+                },
+                "4": {
+                    "count": 32
+                },
+                "8": {
+                    "count": 56
+                },
+                "9": {
+                    "count": 26
+                },
+                "18": {
+                    "count": 55
+                },
+                "6": {
+                    "count": 54
+                },
+                "35": {
+                    "count": 40
+                },
+                "13": {
+                    "count": 29
+                },
+                "33": {
+                    "count": 34
+                },
+                "15": {
+                    "count": 30
+                },
+                "27": {
+                    "count": 29
+                },
+                "38": {
+                    "count": 37
+                },
+                "17": {
+                    "count": 32
+                },
+                "5": {
+                    "count": 25
+                },
+                "24": {
+                    "count": 28
+                },
+                "1": {
+                    "count": 32
+                },
+                "22": {
+                    "count": 33
+                },
+                "10": {
+                    "count": 30
+                },
+                "20": {
+                    "count": 37
+                },
+                "19": {
+                    "count": 29
+                },
+                "36": {
+                    "count": 27
+                },
+                "40": {
+                    "count": 29
+                },
+                "34": {
+                    "count": 29
+                },
+                "28": {
+                    "count": 29
+                },
+                "26": {
+                    "count": 38
+                },
+                "16": {
+                    "count": 33
+                },
+                "23": {
+                    "count": 39
+                },
+                "11": {
+                    "count": 42
+                }
+            }
+        }
+    },
+    "train": {
+        "num_samples": 3710,
+        "samples_in_train": null,
+        "text_statistics": null,
+        "image_statistics": null,
+        "audio_statistics": {
+            "total_duration_seconds": 19566.34,
+            "min_duration_seconds": 0.32,
+            "average_duration_seconds": 5.273946091644205,
+            "max_duration_seconds": 30.0,
+            "unique_audios": 3710,
+            "average_sampling_rate": 44100.0,
+            "sampling_rates": {
+                "44100": 3710
+            }
+        },
+        "video_statistics": null,
+        "label_statistics": {
+            "min_labels_per_text": 1,
+            "average_label_per_text": 1.0,
+            "max_labels_per_text": 1,
+            "unique_labels": 41,
+            "labels": {
+                "30": {
+                    "count": 256
+                },
+                "19": {
+                    "count": 70
+                },
+                "6": {
+                    "count": 125
+                },
+                "25": {
+                    "count": 90
+                },
+                "21": {
+                    "count": 145
+                },
+                "23": {
+                    "count": 89
+                },
+                "26": {
+                    "count": 88
+                },
+                "18": {
+                    "count": 128
+                },
+                "37": {
+                    "count": 112
+                },
+                "2": {
+                    "count": 67
+                },
+                "31": {
+                    "count": 59
+                },
+                "20": {
+                    "count": 85
+                },
+                "28": {
+                    "count": 67
+                },
+                "32": {
+                    "count": 67
+                },
+                "22": {
+                    "count": 88
+                },
+                "3": {
+                    "count": 67
+                },
+                "29": {
+                    "count": 99
+                },
+                "5": {
+                    "count": 59
+                },
+                "35": {
+                    "count": 92
+                },
+                "24": {
+                    "count": 66
+                },
+                "14": {
+                    "count": 74
+                },
+                "8": {
+                    "count": 130
+                },
+                "17": {
+                    "count": 75
+                },
+                "27": {
+                    "count": 69
+                },
+                "12": {
+                    "count": 92
+                },
+                "10": {
+                    "count": 69
+                },
+                "0": {
+                    "count": 105
+                },
+                "39": {
+                    "count": 250
+                },
+                "33": {
+                    "count": 70
+                },
+                "34": {
+                    "count": 69
+                },
+                "16": {
+                    "count": 77
+                },
+                "40": {
+                    "count": 67
+                },
+                "38": {
+                    "count": 86
+                },
+                "13": {
+                    "count": 67
+                },
+                "11": {
+                    "count": 96
+                },
+                "36": {
+                    "count": 62
+                },
+                "15": {
+                    "count": 71
+                },
+                "7": {
+                    "count": 66
+                },
+                "4": {
+                    "count": 75
+                },
+                "9": {
+                    "count": 60
+                },
+                "1": {
+                    "count": 61
+                }
+            }
+        }
+    }
+}

--- a/mteb/tasks/classification/zxx/__init__.py
+++ b/mteb/tasks/classification/zxx/__init__.py
@@ -3,6 +3,7 @@ from .beijing_opera import BeijingOpera
 from .bird_clef import BirdCLEFClassification
 from .diving48_classification import Diving48ClassificationV1, Diving48ClassificationV2
 from .esc50 import ESC50Classification
+from .fsdkaggle2018 import FSDKaggle2018Classification
 from .gtzan_genre import GTZANGenre
 from .gunshot_triangulation import GunshotTriangulation
 from .inat_sounds import INatSoundsClassification
@@ -20,6 +21,7 @@ __all__ = [
     "Diving48ClassificationV1",
     "Diving48ClassificationV2",
     "ESC50Classification",
+    "FSDKaggle2018Classification",
     "GTZANGenre",
     "GunshotTriangulation",
     "INatSoundsClassification",

--- a/mteb/tasks/classification/zxx/fsdkaggle2018.py
+++ b/mteb/tasks/classification/zxx/fsdkaggle2018.py
@@ -1,0 +1,49 @@
+from mteb.abstasks.classification import AbsTaskClassification
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class FSDKaggle2018Classification(AbsTaskClassification):
+    """Classify verified FSDKaggle2018 audio clips."""
+
+    metadata = TaskMetadata(
+        name="FSDKaggle2018Classification",
+        description=(
+            "Classify manually verified Freesound clips into 41 AudioSet "
+            "sound-event classes."
+        ),
+        reference="https://arxiv.org/abs/1807.09902",
+        dataset={
+            "path": "artist/FSDKaggle2018",
+            "revision": "f1fa466b5a226463d5b6ba1f8ecbe05f2f74262f",
+        },
+        type="AudioClassification",
+        category="a2c",
+        eval_splits=["test"],
+        eval_langs=["zxx-Zxxx"],
+        main_score="accuracy",
+        date=("2018-03-30", "2018-07-31"),
+        domains=["AudioScene"],
+        task_subtypes=["Environment Sound Classification"],
+        # The curated dataset is CC BY 4.0, while each embedded Freesound clip
+        # retains its own CC license. Use the authoritative mixed-license notice.
+        license="https://zenodo.org/records/2552860",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["audio"],
+        sample_creation="found",
+        bibtex_citation=r"""
+@inproceedings{Fonseca2018_DCASE,
+  author = {Fonseca, Eduardo and Plakal, Manoj and Font, Frederic and Ellis, Daniel P. W. and Favory, Xavier and Pons, Jordi and Serra, Xavier},
+  booktitle = {Proceedings of the Detection and Classification of Acoustic Scenes and Events 2018 Workshop},
+  month = {November},
+  pages = {69--73},
+  title = {General-purpose Tagging of Freesound Audio with AudioSet Labels: Task Description, Dataset, and Baseline},
+  url = {https://arxiv.org/abs/1807.09902},
+  year = {2018},
+}
+""",
+        is_beta=True,
+    )
+
+    input_column_name = "audio"
+    label_column_name = "label"

--- a/scripts/data/fsdkaggle2018/create_data.py
+++ b/scripts/data/fsdkaggle2018/create_data.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import zipfile
+from collections import Counter
+from pathlib import Path
+
+from datasets import Audio, ClassLabel, Dataset, DatasetDict, Features, Value
+
+ARCHIVES = {
+    "FSDKaggle2018.audio_test.zip": "f85c8665c3fc39311ea1b748e194a81d",
+    "FSDKaggle2018.audio_train.zip": "a8b47ff4b52022c178f88fa5c6f080d0",
+    "FSDKaggle2018.doc.zip": "4f2d1ac88f33a62f9db3108b269ee1b7",
+    "FSDKaggle2018.meta.zip": "f16828ac8be0e5285b9175a12f90d784",
+}
+
+EXPECTED_TRAIN_ROWS = 9_473
+EXPECTED_VERIFIED_TRAIN_ROWS = 3_710
+EXPECTED_TEST_ROWS = 1_600
+EXPECTED_LABELS = 41
+EXPECTED_SOURCE_LICENSES = {
+    "Attribution",
+    "Attribution Noncommercial",
+    "Creative Commons 0",
+}
+ARTIFACT_MANIFEST_FILENAME = "fsdkaggle2018_artifact_manifest.json"
+ZENODO_RECORD_ID = 2_552_860
+
+
+def _md5(path: Path) -> str:
+    digest = hashlib.md5()  # noqa: S324 - verifies published archive checksums
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _validate_and_extract(source_dir: Path, extracted_dir: Path) -> None:
+    extracted_dir.mkdir(parents=True, exist_ok=True)
+    for filename, expected_md5 in ARCHIVES.items():
+        archive = source_dir / filename
+        if not archive.is_file():
+            raise FileNotFoundError(f"Missing source archive: {archive}")
+        actual_md5 = _md5(archive)
+        if actual_md5 != expected_md5:
+            raise ValueError(
+                f"Checksum mismatch for {archive}: {actual_md5} != {expected_md5}"
+            )
+        with zipfile.ZipFile(archive) as zip_file:
+            extraction_root = extracted_dir.resolve()
+            for member in zip_file.infolist():
+                destination = (extracted_dir / member.filename).resolve()
+                if not destination.is_relative_to(extraction_root):
+                    raise ValueError(f"Unsafe archive member: {member.filename}")
+            zip_file.extractall(extracted_dir)
+
+
+def _read_metadata(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as file:
+        return list(csv.DictReader(file))
+
+
+def _validate_metadata_rows(
+    train_rows: list[dict[str, str]], test_rows: list[dict[str, str]]
+) -> tuple[list[dict[str, str]], list[str]]:
+    train_columns = {"fname", "label", "manually_verified", "freesound_id", "license"}
+    test_columns = {"fname", "label", "usage", "freesound_id", "license"}
+    if not train_rows or set(train_rows[0]) != train_columns:
+        raise ValueError("Unexpected FSDKaggle2018 training metadata schema")
+    if not test_rows or set(test_rows[0]) != test_columns:
+        raise ValueError("Unexpected FSDKaggle2018 test metadata schema")
+
+    verified_train_rows = [row for row in train_rows if row["manually_verified"] == "1"]
+    label_names = sorted({row["label"] for row in train_rows + test_rows})
+    selected_rows = verified_train_rows + test_rows
+    selected_filenames = [row["fname"] for row in selected_rows]
+
+    if (
+        len(train_rows) != EXPECTED_TRAIN_ROWS
+        or len(verified_train_rows) != EXPECTED_VERIFIED_TRAIN_ROWS
+    ):
+        raise ValueError("Unexpected FSDKaggle2018 training metadata counts")
+    if len(test_rows) != EXPECTED_TEST_ROWS or len(label_names) != EXPECTED_LABELS:
+        raise ValueError("Unexpected FSDKaggle2018 test or label counts")
+    if len(selected_filenames) != len(set(selected_filenames)):
+        raise ValueError("Selected FSDKaggle2018 filenames must be unique")
+    if {row["license"] for row in selected_rows} != EXPECTED_SOURCE_LICENSES:
+        raise ValueError("Unexpected FSDKaggle2018 source-license values")
+    if any(not row["freesound_id"].isdigit() for row in selected_rows):
+        raise ValueError("FSDKaggle2018 Freesound IDs must be numeric")
+    return verified_train_rows, label_names
+
+
+def _build_split(
+    rows: list[dict[str, str]],
+    audio_dir: Path,
+    label_names: list[str],
+) -> Dataset:
+    audio_paths = [audio_dir / row["fname"] for row in rows]
+    missing_audio = [path for path in audio_paths if not path.is_file()]
+    if missing_audio:
+        raise FileNotFoundError(f"Missing audio file: {missing_audio[0]}")
+
+    features = Features(
+        {
+            "id": Value("string"),
+            "audio": Audio(),
+            "label": ClassLabel(names=label_names),
+            "freesound_id": Value("string"),
+            "source_url": Value("string"),
+            "source_license": Value("string"),
+        }
+    )
+    dataset = Dataset.from_dict(
+        {
+            "id": [row["fname"].removesuffix(".wav") for row in rows],
+            "audio": [str(path) for path in audio_paths],
+            "label": [label_names.index(row["label"]) for row in rows],
+            "freesound_id": [row["freesound_id"] for row in rows],
+            "source_url": [
+                f"https://freesound.org/s/{row['freesound_id']}/" for row in rows
+            ],
+            "source_license": [row["license"] for row in rows],
+        },
+        features=features,
+    )
+    fingerprint = hashlib.sha256(
+        json.dumps(
+            {"archives": ARCHIVES, "labels": label_names, "rows": rows},
+            sort_keys=True,
+        ).encode()
+    ).hexdigest()
+    return dataset.select(range(len(dataset)), new_fingerprint=fingerprint)
+
+
+def _write_artifact_manifest(
+    output_dir: Path,
+    source_dir: Path,
+    rows_by_split: dict[str, list[dict[str, str]]],
+    audio_dirs: dict[str, Path],
+    label_names: list[str],
+) -> None:
+    files = {}
+    for split, rows in rows_by_split.items():
+        for row in rows:
+            sample_id = row["fname"].removesuffix(".wav")
+            audio_path = audio_dirs[split] / row["fname"]
+            files[sample_id] = {
+                "split": split,
+                "source_filename": row["fname"],
+                "label": row["label"],
+                "freesound_id": row["freesound_id"],
+                "source_url": f"https://freesound.org/s/{row['freesound_id']}/",
+                "source_license": row["license"],
+                "sha256": _sha256(audio_path),
+            }
+
+    manifest = {
+        "schema_version": 1,
+        "zenodo_record_id": ZENODO_RECORD_ID,
+        "selection": "manually verified training clips and all scored test clips",
+        "archives": {
+            filename: {
+                "md5": expected_md5,
+                "size": (source_dir / filename).stat().st_size,
+            }
+            for filename, expected_md5 in sorted(ARCHIVES.items())
+        },
+        "splits": {split: len(rows) for split, rows in rows_by_split.items()},
+        "labels": label_names,
+        "source_license_counts": {
+            split: dict(sorted(Counter(row["license"] for row in rows).items()))
+            for split, rows in rows_by_split.items()
+        },
+        "files": dict(sorted(files.items())),
+    }
+    manifest_path = output_dir / ARTIFACT_MANIFEST_FILENAME
+    temporary_path = manifest_path.with_suffix(".json.part")
+    with temporary_path.open("w", encoding="utf-8") as file:
+        json.dump(manifest, file, indent=2, sort_keys=True)
+        file.write("\n")
+    temporary_path.replace(manifest_path)
+
+
+def create_dataset(source_dir: Path, work_dir: Path, output_dir: Path) -> None:
+    if output_dir.exists():
+        raise FileExistsError(
+            f"Output directory already exists; choose a new path: {output_dir}"
+        )
+
+    extracted_dir = work_dir / "extracted"
+    _validate_and_extract(source_dir, extracted_dir)
+
+    metadata_dir = extracted_dir / "FSDKaggle2018.meta"
+    train_rows = _read_metadata(metadata_dir / "train_post_competition.csv")
+    test_rows = _read_metadata(metadata_dir / "test_post_competition_scoring_clips.csv")
+    verified_train_rows, label_names = _validate_metadata_rows(train_rows, test_rows)
+
+    audio_dirs = {
+        "train": extracted_dir / "FSDKaggle2018.audio_train",
+        "test": extracted_dir / "FSDKaggle2018.audio_test",
+    }
+    rows_by_split = {"train": verified_train_rows, "test": test_rows}
+    dataset = DatasetDict(
+        {
+            "train": _build_split(
+                verified_train_rows,
+                audio_dirs["train"],
+                label_names,
+            ),
+            "test": _build_split(
+                test_rows,
+                audio_dirs["test"],
+                label_names,
+            ),
+        }
+    )
+    dataset.save_to_disk(output_dir)
+    _write_artifact_manifest(
+        output_dir,
+        source_dir,
+        rows_by_split,
+        audio_dirs,
+        label_names,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Build the manually verified FSDKaggle2018 MTEB dataset."
+    )
+    parser.add_argument(
+        "--source-dir",
+        type=Path,
+        required=True,
+        help="Directory containing the four official Zenodo zip archives.",
+    )
+    parser.add_argument(
+        "--work-dir",
+        type=Path,
+        required=True,
+        help="Directory used for checksum-verified archive extraction.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="New directory where the DatasetDict is saved.",
+    )
+    args = parser.parse_args()
+    create_dataset(args.source_dir, args.work_dir, args.output_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds FSDKaggle2018, the 41-class audio tagging task from DCASE 2018, as an MTEB audio classification benchmark. It uses the official train/test split: 3,710 / 1,600 clips.

## Results

- Random encoder: 2.60% accuracy (2.44% chance)
- LAION-CLAP: 93.46% accuracy
- Original DCASE baseline: 69.43% private / 70.49% public mAP@3

The original baseline uses a different metric, so it is included only for context.

## Checklist

- [x] Adds an established general-purpose audio benchmark
- [x] Runs end-to-end with `mteb`
- [x] Random encoder and LAION-CLAP evaluated
- [x] Dataset size and performance checked
- [x] Original baseline included for reference
