### PR TITLE
# fix: restore the EOS token for e5-mistral

### DIFF
--- a/mteb/models/model_implementations/e5_instruct.py
+++ b/mteb/models/model_implementations/e5_instruct.py
@@ -105,9 +105,19 @@ e5_mistral = ModelMeta(
         instruction_template=E5_INSTRUCTION,
         model_kwargs={"dtype": torch.float16},
         apply_instruction_to_passages=False,
+        # This model pools the last token, so its embedding is the hidden state of
+        # the trailing </s>. Its tokenizer_config.json sets add_eos_token, but its
+        # tokenizer.json post-processor only adds <s>; transformers <5 resolved that
+        # in favour of the config, transformers >=5 in favour of tokenizer.json, so
+        # the </s> silently disappeared and pooling started reading the last word.
+        # add_eos_token alone is not enough: it rebuilds the post-processor from
+        # add_bos_token, which defaults to False here, dropping the <s> instead.
+        add_eos_token=True,
+        tokenizer_kwargs={"add_bos_token": True},
     ),
     name="intfloat/e5-mistral-7b-instruct",
     model_type=["dense"],
+    output_dtypes="float16",
     languages=MISTRAL_LANGUAGES,
     open_weights=True,
     revision="07163b72af1488142a360786df853f237b1a3ca1",

--- a/mteb/models/model_implementations/e5_v.py
+++ b/mteb/models/model_implementations/e5_v.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 import torch
-from packaging import version
 from tqdm.auto import tqdm
 
 from mteb.models.abs_encoder import AbsEncoder
@@ -14,10 +13,6 @@ if TYPE_CHECKING:
 
     from mteb.abstasks.task_metadata import TaskMetadata
     from mteb.types import Array, BatchedInput, PromptType
-
-E5_V_TRANSFORMERS_VERSION = (
-    "4.44.2"  # Issue 1647: Only works with transformers==4.44.2.
-)
 
 E5_V_CITATION = """@article{jiang2024e5v,
       title={E5-V: Universal Embeddings with Multimodal Large Language Models},
@@ -39,15 +34,7 @@ class E5VModel(AbsEncoder):
         composed_prompt=None,
         **kwargs: Any,
     ):
-        import transformers
         from transformers import LlavaNextForConditionalGeneration, LlavaNextProcessor
-
-        if version.parse(transformers.__version__) > version.parse(
-            E5_V_TRANSFORMERS_VERSION
-        ):
-            raise ImportError(
-                f"This wrapper only works with transformers=={E5_V_TRANSFORMERS_VERSION}"
-            )
 
         self.model_name = model_name
         self.processor = LlavaNextProcessor.from_pretrained(
@@ -166,6 +153,7 @@ e5_v = ModelMeta(
     ),
     name="royokong/e5-v",
     model_type=["dense"],
+    extra_requirements_groups=["e5-v"],
     languages=["eng-Latn"],
     revision="0c1f22679417b3ae925d779442221c40cd1861ab",
     release_date="2024-07-17",

--- a/mteb/models/model_implementations/jina_models.py
+++ b/mteb/models/model_implementations/jina_models.py
@@ -28,8 +28,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-MIN_SENTENCE_TRANSFORMERS_VERSION = (3, 1, 0)
-
 multilingual_langs = [
     "afr-Latn",
     "ara-Arab",
@@ -338,17 +336,6 @@ class JinaWrapper(SentenceTransformerEncoderWrapper):
         model_prompts: dict[str, str] | None = None,
         **kwargs,
     ) -> None:
-        from sentence_transformers import __version__ as st_version
-
-        current_sentence_transformers_version = tuple(map(int, st_version.split(".")))
-
-        if current_sentence_transformers_version < MIN_SENTENCE_TRANSFORMERS_VERSION:
-            raise RuntimeError(
-                f"sentence_transformers version {st_version} is lower than the required version 3.1.0"
-            )
-        import einops  # noqa: F401
-        import flash_attn  # noqa: F401
-
         super().__init__(
             model, revision, device=device, model_prompts=model_prompts, **kwargs
         )

--- a/mteb/models/model_implementations/nomic_models.py
+++ b/mteb/models/model_implementations/nomic_models.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 import torch.nn.functional as F
-from packaging.version import Version
 
 from mteb.models.model_meta import ModelMeta, ScoringFunction
 from mteb.models.sentence_transformer_wrapper import SentenceTransformerEncoderWrapper
@@ -19,8 +18,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-MODERN_BERT_TRANSFORMERS_MIN_VERSION = "4.48.0"
-
 
 class NomicWrapper(SentenceTransformerEncoderWrapper):
     """following the hf model card documentation."""
@@ -33,17 +30,7 @@ class NomicWrapper(SentenceTransformerEncoderWrapper):
         model_prompts: dict[str, str] | None = None,
         **kwargs: Any,
     ):
-        import transformers
-
         self.model_name = model_name
-        if model_name == "nomic-ai/modernbert-embed-base" and (
-            Version(transformers.__version__).release
-            < Version(MODERN_BERT_TRANSFORMERS_MIN_VERSION).release
-        ):
-            raise RuntimeError(
-                f"Current transformers version is {transformers.__version__} is lower than the required version"
-                f" {MODERN_BERT_TRANSFORMERS_MIN_VERSION}"
-            )
         super().__init__(
             model_name, revision, device=device, model_prompts=model_prompts, **kwargs
         )
@@ -341,6 +328,7 @@ nomic_modern_bert_embed = ModelMeta(
         model_prompts=model_prompts,
     ),
     name="nomic-ai/modernbert-embed-base",
+    extra_requirements_groups=["modernbert"],
     model_type=["dense"],
     languages=["eng-Latn"],
     open_weights=True,

--- a/mteb/models/model_implementations/nvidia_models.py
+++ b/mteb/models/model_implementations/nvidia_models.py
@@ -5,10 +5,8 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 import torch.nn.functional as F
-from packaging.version import Version
 from tqdm.auto import tqdm
 from transformers import AutoModel, AutoTokenizer
-from transformers import __version__ as transformers_version
 
 from mteb.models import CrossEncoderWrapper, SentenceTransformerEncoderWrapper
 from mteb.models.abs_encoder import AbsEncoder
@@ -120,7 +118,7 @@ nvidia_training_datasets = {
 
 
 class _NVEmbedWrapper(InstructSentenceTransformerModel):
-    """Inherited, because nvembed requires `sbert==2`, but it doesn't have tokenizers kwargs"""
+    """Inherited, because nvembed requires `sbert==2`, but it doesn't have tokenizers kwargs."""
 
     def __init__(
         self,
@@ -138,20 +136,11 @@ class _NVEmbedWrapper(InstructSentenceTransformerModel):
     ):
         from sentence_transformers import __version__ as sbert_version
 
-        required_transformers_version = "4.42.4"
-        required_sbert_version = "2.7.0"
-
-        if Version(transformers_version) != Version(required_transformers_version):
-            raise RuntimeError(
-                f"transformers version {transformers_version} is not match with required "
-                f"install version {required_transformers_version} to run `nvidia/NV-Embed-v2`"
-            )
-
-        if Version(sbert_version) != Version(required_sbert_version):
-            raise RuntimeError(
-                f"sbert version {sbert_version} is not match with required "
-                f"install version {required_sbert_version} to run `nvidia/NV-Embed-v2`"
-            )
+        logger.warning(
+            f"{model_name} was previously required to run with sentence-transformers==2.7.0, "
+            f"but mteb requires sentence-transformers>=3.0.0, so it is now running on "
+            f"{sbert_version}. Results might not reproduce the previously reported scores."
+        )
 
         from sentence_transformers import SentenceTransformer
 
@@ -211,7 +200,7 @@ NV_embed_v2 = ModelMeta(
     public_training_code=None,
     public_training_data=None,
     citation=NV_RETRIEVER_CITATION,
-    extra_requirements_groups=["flash_attention"],
+    extra_requirements_groups=["flash_attention", "nvembed"],
 )
 
 NV_embed_v1 = ModelMeta(
@@ -244,7 +233,7 @@ NV_embed_v1 = ModelMeta(
     public_training_code=None,
     public_training_data=None,
     citation=NV_RETRIEVER_CITATION,
-    extra_requirements_groups=["flash_attention"],
+    extra_requirements_groups=["flash_attention", "nvembed"],
 )
 
 llama_embed_nemotron_evaluated_languages = [
@@ -424,13 +413,6 @@ class LlamaEmbedNemotron(AbsEncoder):
         revision: str,
         device: str | None = None,
     ) -> None:
-        required_transformers_version = "4.51.0"
-        if Version(transformers_version) != Version(required_transformers_version):
-            raise ImportError(
-                f"{model_name} requires transformers library version {required_transformers_version}, but it was not found in your environment. "
-                f"If you want to load {model_name} model, please run `pip install 'mteb[llama-embed-nemotron]'` to install the required package."
-            )
-
         self.model_name = model_name
         self.revision = revision
         self.max_seq_length = 4096
@@ -632,7 +614,7 @@ llama_embed_nemotron_8b = ModelMeta(
     public_training_data="https://huggingface.co/datasets/nvidia/embed-nemotron-dataset-v1",
     contacts=["ybabakhin"],
     citation=LlamaEmbedNemotron_CITATION,
-    extra_requirements_groups=["flash_attention"],
+    extra_requirements_groups=["flash_attention", "llama-embed-nemotron"],
 )
 
 
@@ -767,14 +749,6 @@ nemotron_3_embed_8b_bf16 = ModelMeta(
 
 
 def _nemotron_rerank_model(model: str, revision: str, **kwargs) -> CrossEncoderWrapper:
-    required_transformers_version = "4.47.1"
-
-    if Version(transformers_version) != Version(required_transformers_version):
-        raise RuntimeError(
-            f"transformers version {transformers_version} is not match with required "
-            f"install version {required_transformers_version} to run `nvidia/llama-nemotron-rerank-1b-v2`"
-        )
-
     return CrossEncoderWrapper(
         model=model,
         revision=revision,
@@ -791,6 +765,7 @@ nemotron_rerank_1b_v2 = ModelMeta(
         model_kwargs={"torch_dtype": torch.float32},
     ),
     name="nvidia/llama-nemotron-rerank-1b-v2",
+    extra_requirements_groups=["nemotron-rerank"],
     revision="78efcfdc23b53a753f6c73f2d78b18132a34ac4d",
     release_date="2025-10-16",
     languages=["eng-Latn"],

--- a/mteb/models/model_implementations/opensearch_neural_sparse_models.py
+++ b/mteb/models/model_implementations/opensearch_neural_sparse_models.py
@@ -51,12 +51,6 @@ class SparseEncoderWrapper(AbsEncoder):
         torch_dtype: torch.dtype = torch.float16,
         **kwargs,
     ):
-        import sentence_transformers
-
-        if sentence_transformers.__version__ < "5.0.0":
-            raise ImportError(
-                "sentence-transformers version must be >= 5.0.0 to load sparse encoder"
-            )
         from sentence_transformers.sparse_encoder import SparseEncoder
 
         self.model_name = model_name
@@ -134,6 +128,7 @@ class SparseEncoderWrapper(AbsEncoder):
 
 opensearch_neural_sparse_encoding_doc_v3_gte = ModelMeta(
     name="opensearch-project/opensearch-neural-sparse-encoding-doc-v3-gte",
+    extra_requirements_groups=["sparse-encoder"],
     model_type=["sparse"],
     languages=["eng-Latn"],
     open_weights=True,
@@ -161,6 +156,7 @@ opensearch_neural_sparse_encoding_doc_v3_gte = ModelMeta(
 
 opensearch_neural_sparse_encoding_doc_v3_distill = ModelMeta(
     name="opensearch-project/opensearch-neural-sparse-encoding-doc-v3-distill",
+    extra_requirements_groups=["sparse-encoder"],
     model_type=["sparse"],
     languages=["eng-Latn"],
     open_weights=True,
@@ -184,6 +180,7 @@ opensearch_neural_sparse_encoding_doc_v3_distill = ModelMeta(
 
 opensearch_neural_sparse_encoding_doc_v2_distill = ModelMeta(
     name="opensearch-project/opensearch-neural-sparse-encoding-doc-v2-distill",
+    extra_requirements_groups=["sparse-encoder"],
     model_type=["sparse"],
     languages=["eng-Latn"],
     open_weights=True,
@@ -208,6 +205,7 @@ opensearch_neural_sparse_encoding_doc_v2_distill = ModelMeta(
 
 opensearch_neural_sparse_encoding_doc_v2_mini = ModelMeta(
     name="opensearch-project/opensearch-neural-sparse-encoding-doc-v2-mini",
+    extra_requirements_groups=["sparse-encoder"],
     model_type=["sparse"],
     languages=["eng-Latn"],
     open_weights=True,
@@ -231,6 +229,7 @@ opensearch_neural_sparse_encoding_doc_v2_mini = ModelMeta(
 
 opensearch_neural_sparse_encoding_doc_v1 = ModelMeta(
     name="opensearch-project/opensearch-neural-sparse-encoding-doc-v1",
+    extra_requirements_groups=["sparse-encoder"],
     model_type=["sparse"],
     languages=["eng-Latn"],
     open_weights=True,

--- a/mteb/models/model_implementations/penguin_models.py
+++ b/mteb/models/model_implementations/penguin_models.py
@@ -117,7 +117,7 @@ penguin_encoder = ModelMeta(
     contacts=None,
     output_dtypes=None,
     extra_requirements_groups=[
-        "mctct",  # have rope init error with transformers v5
+        "transformers-v4",  # have rope init error with transformers v5
         "flash_attention",
     ],
 )

--- a/mteb/models/model_implementations/salesforce_models.py
+++ b/mteb/models/model_implementations/salesforce_models.py
@@ -85,6 +85,8 @@ SFR_Embedding_Code_2B_R = ModelMeta(
     ),
     name="Salesforce/SFR-Embedding-Code-2B_R",
     model_type=["dense"],
+    # its remote code imports transformers.cache_utils.HybridCache, removed in v5
+    extra_requirements_groups=["transformers-v4"],
     languages=["eng-Latn"],
     open_weights=True,
     revision="c73d8631a005876ed5abde34db514b1fb6566973",

--- a/mteb/models/model_implementations/webai_models.py
+++ b/mteb/models/model_implementations/webai_models.py
@@ -6,7 +6,6 @@ import torch
 from tqdm.auto import tqdm
 from transformers import AutoModel, AutoProcessor
 
-from mteb._requires_package import requires_image_dependencies
 from mteb.models.abs_encoder import AbsEncoder
 from mteb.models.model_meta import ModelMeta, ScoringFunction
 from mteb.types import OutputDType
@@ -35,7 +34,6 @@ class ColVec1Wrapper(AbsEncoder):
         torch_dtype: torch.dtype | None = torch.bfloat16,
         **kwargs,
     ):
-        requires_image_dependencies()
         self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
 
         self.model = AutoModel.from_pretrained(
@@ -157,7 +155,6 @@ class ColVec11Wrapper(ColVec1Wrapper):
         processor_kwargs: dict[str, Any] | None = None,
         **model_kwargs,
     ):
-        requires_image_dependencies()
         self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
         processor_kwargs = dict(processor_kwargs or {})
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ github = ["PyGithub>=1.60"]
 # model specific optional dependencies:
 peft = ["peft>=0.11.0"]
 flagembedding = ["FlagEmbedding==1.3.4"]
-jina = ["einops>=0.8.0"]
+jina = ["einops>=0.8.0", "sentence-transformers>=3.1.0"]
 jina-clip = ["peft>=0.15.2", "einops>=0.8.0", "transformers>=4.52.0,<5.0.0", "torchvision>=0.22.1", "timm>=1.0.15,<1.1.0"]
 jina-v4 = ["peft>=0.15.2", "transformers>=4.52.0,<5.0.0", "torchvision>=0.22.1"]
 flash_attention = ["flash-attn>=2.6.3"]
@@ -147,6 +147,13 @@ vllm = ["vllm>=0.11.1"]
 moca = ["transformers>=4.49.0,<4.53"]
 transformers-v4 = ["transformers<5"]
 transformers-v5 = ["transformers>=5"]
+e5-v = ["transformers<=4.44.2"] # https://github.com/embeddings-benchmark/mteb/issues/1647
+# NV-Embed previously needs sentence-transformers==2.7.0, which cannot be expressed here:
+# mteb itself requires sentence-transformers>=3.0.0, so the extra would be unsatisfiable.
+nvembed = ["transformers==4.42.4"]
+nemotron-rerank = ["transformers==4.47.1"]
+modernbert = ["transformers>=4.48.0"]
+sparse-encoder = ["sentence-transformers>=5.0.0"]
 cosmos-embed1 = ["transformers<5", "einops>=0.8.0", "torchvision>=0.16.0"]
 siglip = ["sentencepiece>=0.2.0","protobuf>=3.0.0"]
 tipsv2 = ["sentencepiece>=0.2.0", "protobuf>=3.0.0"]
@@ -500,6 +507,12 @@ conflicts = [
         { extra = "embeddinggemma" },
         # { extra = "ebind" },
         { extra = "visrag-ret" }, # conflicting version of timm with blip2
+        { extra = "e5-v" }, # conflicting versions of transformers
+        { extra = "nvembed" }, # conflicting versions of transformers
+        { extra = "flagembedding" }, # FlagEmbedding pins transformers>=4.44.2
+        { extra = "nemotron-rerank" }, # conflicting versions of transformers
+        { extra = "modernbert" }, # conflicting versions of transformers
+        { extra = "sparse-encoder" }, # conflicting version of sentence-transformers
     ],
 ]
 


### PR DESCRIPTION
Addresses #5230 (in code, we still need the results)

`intfloat/e5-mistral-7b-instruct` uses **last-token pooling** — the embedding is the hidden state of the EOS `</s>`. Under `transformers>=5` that `</s>` is no longer added, so we pool the last *content* token instead and the embeddings are wrong.

The model repo contradicts itself:

- `tokenizer_config.json` sets `"add_eos_token": true`
- `tokenizer.json`'s post-processor adds **only** `<s>`

`transformers<5` resolved that in favour of the config and rewrote the post-processor at load time; `transformers>=5` takes `tokenizer.json` as-is. Nothing warns.

```
transformers 4.57.6  post_processor: <s> + A + </s>
transformers 5.15.0  post_processor: <s> + A
```

Passing `add_eos_token=True` on its own is **not** a complete fix: on `transformers>=5` it rebuilds the post-processor from `add_bos_token`, which defaults to `False` for this repo, so you get the `</s>` back but lose the `<s>`. Both flags are needed.

## Results

`bBSARDNLRetrieval` (nDCG@10), `intfloat/e5-mistral-7b-instruct`, batch size 8, same GPU. The `before` / `add_eos_token only` / `after` rows are mteb 2.19.3 with the two tokenizer kwargs applied through a `loader_kwargs` override, which is exactly what this patch writes into the file:

| mteb | transformers | tokenizer | score |
| --- | --- | --- | --- |
| 2.18.1 | 4.57.6 | `<s> … </s>` | 0.37365 |
| 2.18.4 | 4.57.6 | `<s> … </s>` | 0.37365 |
| 2.18.7 | 4.57.6 | `<s> … </s>` | 0.37365 |
| 2.19.3 | 4.57.6 | `<s> … </s>` | 0.37365 |
| **before** | _5.15.0_ | `<s> …` | **0.06504** |
| `add_eos_token` only | _5.15.0_ | `… </s>` | 0.34506 | | **after** | _5.15.0_ | `<s> … </s>` | **0.37360** |

For reference the bBSARD paper reports **0.3770** for this model.

@tomaarsen I will just make you aware of this. I am not sure if it is something that we want to address upstream (if nothing else good to know that it exists).

**Re the GritLM → Sentence Transformers migration (#4085)** — the GritLM loader scores 0.05508
  on main today, it truncates at `max_length=512` and it prefixes documents with `"Instruct: \nQuery: "`. Fixing these give similar scores.

## Other models

I scanned to see if there were other cases of this, mostly it found cases of misspecified dependencies or missing. I have fixed those. The only other case was `Salesforce/SFR-Embedding-Code-2B_R`, but that doesn't work with never versions of ST and it is unclear if `BeastyZ/e5-R-mistral-7b` is intended to run with mean pooling (ships no `modules.json` or `1_Pooling`, so ST falls back to mean pooling)
