### PR TITLE
fix: break p-MRR rank ties by doc id to match the other retrieval metrics

### DIFF
--- a/mteb/_evaluators/retrieval_metrics.py
+++ b/mteb/_evaluators/retrieval_metrics.py
@@ -141,7 +141,12 @@ def get_rank_from_dict(
     dict_of_results: dict[str, float], doc_id: str
 ) -> tuple[int, float]:
     tuple_of_id_score = dict_of_results.items()
-    sorted_by_score = sorted(tuple_of_id_score, key=lambda x: x[1], reverse=True)
+    # tie-break by doc id descending, matching the other rank computations in this module
+    # (#5092); a score-only sort is stable, so a tied doc's rank followed dict insertion
+    # order and leaked into p-MRR, which weights rank as 1/rank
+    sorted_by_score = sorted(
+        tuple_of_id_score, key=lambda x: (x[1], x[0]), reverse=True
+    )
     for i, (id, score) in enumerate(sorted_by_score):
         if id == doc_id:
             return i + 1, score

--- a/tests/test_evaluators/test_evaluation_metrics.py
+++ b/tests/test_evaluators/test_evaluation_metrics.py
@@ -29,6 +29,22 @@ def test_mrr_tiebreak_matches_pytrec_eval():
     assert got == expected == 1 / 3
 
 
+def test_p_mrr_tiebreak_independent_of_insertion_order():
+    # regression for the same #5092 tie-break bug in get_rank_from_dict: p-MRR ranks a
+    # doc with a score-only stable sort, so on tied scores its rank followed dict
+    # insertion order. Here both runs carry identical scores, so p-MRR must be 0 — but
+    # the reversed insertion order moves the changed doc from rank 1 to rank 3 without
+    # the fix, producing a spurious non-zero change.
+    changed_qrels = {"a": ["0"]}
+    tied = {"0": 0.5, "1": 0.5, "2": 0.5}
+
+    original_run = {"a-og": tied}
+    new_run = {"a-changed": dict(reversed(tied.items()))}
+
+    score = calculate_pmrr(original_run, new_run, changed_qrels)
+    assert score == 0.0
+
+
 def test_p_mrr():
     changed_qrels = {
         "a": ["0"],


### PR DESCRIPTION
Follow-up to #5136. That PR made `mrr`, `recall_cap`, `hole` and `top_k_accuracy` break score ties by doc id, but `get_rank_from_dict` — the ranking behind p-MRR (the main score for the FollowIR / instruction-reranking tasks: Robust04, Core17, News21, m_follow_ir) — still sorts by score alone.

Since that sort is stable, a doc tied with others keeps its dict insertion order, so its rank depends on how the results dict happens to be built rather than on the scores. p-MRR weights rank as `1/rank` and compares the original vs changed run, so a tie can shift a doc between rank 1 and rank N and produce a non-zero change even when the two runs carry identical scores.

Switched the sort to the same `(score, doc_id)` descending key the rest of the module already uses, so every rank in the file breaks ties the same way. Runs with distinct scores are unaffected. Added a regression test where both runs have identical tied scores in reversed insertion order — p-MRR is now 0 as it should be, whereas the score-only sort reported a spurious change.
