### PR TITLE
dataset: add MMEdit audio editing retrieval

### DIFF
--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/MMEditAT2ARetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/MMEditAT2ARetrieval.json
@@ -1,0 +1,51 @@
+{
+    "test": {
+        "num_samples": 6634,
+        "num_queries": 3317,
+        "num_documents": 3317,
+        "number_of_characters": 205312,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": {
+            "total_duration_seconds": 30013.9630625,
+            "min_duration_seconds": 2.3985,
+            "average_duration_seconds": 9.048526699577932,
+            "max_duration_seconds": 10.0,
+            "unique_audios": 3307,
+            "average_sampling_rate": 23655.11003919204,
+            "sampling_rates": {
+                "24000": 3174,
+                "16000": 143
+            }
+        },
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 205312,
+            "min_text_length": 14,
+            "average_text_length": 61.896894784443774,
+            "max_text_length": 190,
+            "unique_texts": 3302
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": {
+            "total_duration_seconds": 30013.963625,
+            "min_duration_seconds": 2.3985,
+            "average_duration_seconds": 9.048526869158879,
+            "max_duration_seconds": 10.0,
+            "unique_audios": 3312,
+            "average_sampling_rate": 24000.0,
+            "sampling_rates": {
+                "24000": 3317
+            }
+        },
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 3337,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.00602954476937,
+            "max_relevant_docs_per_query": 2,
+            "unique_relevant_docs": 3317
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -246,6 +246,7 @@ from .ml_questions import MLQuestionsRetrieval
 from .mm_long_bench_doc_retrieval import MMLongBenchDocRetrieval
 from .mmdocir_t2i_retrieval import MMDocIRT2IRetrieval
 from .mmdocir_t2it_retrieval import MMDocIRT2ITRetrieval
+from .mmedit_retrieval import MMEditAT2ARetrieval
 from .moment_seeker import MomentSeekerTI2VRetrieval, MomentSeekerTV2VRetrieval
 from .mscoco_i2t_retrieval import MSCOCOI2TRetrieval
 from .mscoco_t2i_retrieval import MSCOCOT2IRetrieval
@@ -690,6 +691,7 @@ __all__ = [
     "MLQuestionsRetrieval",
     "MMDocIRT2IRetrieval",
     "MMDocIRT2ITRetrieval",
+    "MMEditAT2ARetrieval",
     "MMLongBenchDocRetrieval",
     "MSCOCOI2TRetrieval",
     "MSCOCOT2IRetrieval",

--- a/mteb/tasks/retrieval/eng/mmedit_retrieval.py
+++ b/mteb/tasks/retrieval/eng/mmedit_retrieval.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class MMEditAT2ARetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="MMEditAT2ARetrieval",
+        description=(
+            "Composed audio retrieval derived from the MMEdit test set. Each query "
+            "combines an unedited source recording with a natural-language editing "
+            "instruction, and the goal is to retrieve the corresponding edited "
+            "recording from a global corpus of 3,317 candidates. Byte-identical "
+            "target recordings are all marked relevant. Because edited recordings "
+            "usually preserve most of their source audio, source-only matching is a "
+            "strong shortcut on this task; results should therefore be interpreted "
+            "together with an audio-only diagnostic."
+        ),
+        reference="https://arxiv.org/abs/2512.20339",
+        dataset={
+            "path": "pranitchawla/MMEdit-AT2A",
+            "revision": "ab1ce44e7fc3dc31292c025b6e002915538d4feb",
+        },
+        type="Any2AnyRetrieval",
+        category="at2a",
+        modalities=["audio", "text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2019-01-01", "2025-12-23"),
+        domains=["AudioScene"],
+        task_subtypes=["Environment Sound Retrieval"],
+        license="apache-2.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="created",
+        bibtex_citation=r"""
+@article{tao2025mmedit,
+  author = {Tao, Ye and Xu, Xuenan and Wu, Wen and Wang, Shuai and Wu, Mengyue and Zhang, Chao},
+  journal = {arXiv preprint arXiv:2512.20339},
+  title = {MMEDIT: A Unified Framework for Multi-Type Audio Editing via Audio Language Model},
+  url = {https://arxiv.org/abs/2512.20339},
+  year = {2025},
+}
+""",
+        prompt={
+            "query": "Given the source audio and an editing instruction, retrieve the corresponding edited audio."
+        },
+        is_beta=True,
+    )

--- a/scripts/data/mmedit_retrieval/create_data.py
+++ b/scripts/data/mmedit_retrieval/create_data.py
@@ -1,0 +1,951 @@
+#!/usr/bin/env python3
+"""Audit the public MMEdit-TestSet source data for an MTEB retrieval task.
+
+The default mode is intentionally audit-only. Dataset construction and remote
+upload require explicit flags.
+
+Usage:
+  uv run python scripts/data/mmedit_retrieval/create_data.py
+
+  # Keep the Hugging Face cache at a specific location outside this repository.
+  uv run python scripts/data/mmedit_retrieval/create_data.py \
+      --cache-dir /path/to/huggingface-cache
+
+  # Re-audit an already-downloaded snapshot without network access.
+  uv run python scripts/data/mmedit_retrieval/create_data.py \
+      --source-dir /path/to/MMEdit-TestSet --offline
+
+  # Construct and inspect the MTEB dataset locally, without uploading.
+  uv run python scripts/data/mmedit_retrieval/create_data.py \
+      --source-dir /path/to/MMEdit-TestSet \
+      --build --output-dir /tmp/mmedit-mteb
+
+  # Upload only after local validation. HF_TOKEN is read from the environment.
+  HF_TOKEN=... uv run python scripts/data/mmedit_retrieval/create_data.py \
+      --source-dir /path/to/MMEdit-TestSet --build --push
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+from collections import Counter, defaultdict
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+from wave import Error as WaveError
+from wave import open as wave_open
+
+from datasets import Audio, Dataset, DatasetDict, Features, Value
+from huggingface_hub import HfApi, create_repo, dataset_info, snapshot_download
+from tqdm import tqdm
+
+SOURCE_REPO_ID = "CocoBro/MMEdit-TestSet"
+SOURCE_REVISION = "ae4f9a772180a2a3c77c2e865b398e7d6f60bcee"
+DEFAULT_OUTPUT_REPO_ID = "pranitchawla/MMEdit-AT2A"
+EXPECTED_TRIPLETS = 3_317
+EXPECTED_QRELS = 3_337
+EXPECTED_SAMPLE_RATE = 24_000
+EXPECTED_CHANNELS = 1
+EXPECTED_DURATION_SECONDS = 10.0
+_DURATION_TOLERANCE_SECONDS = 0.05
+_AUDIO_ID_RE = re.compile(r"^(?P<family>.+)_(?P<number>\d+)$")
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_DATASET_CARD = """---
+license: apache-2.0
+language:
+- en
+task_categories:
+- audio-to-audio
+tags:
+- mteb
+- audio-retrieval
+- composed-retrieval
+configs:
+- config_name: queries
+  data_files:
+  - split: test
+    path: queries/test-*
+- config_name: corpus
+  data_files:
+  - split: test
+    path: corpus/test-*
+- config_name: qrels
+  data_files:
+  - split: test
+    path: qrels/test-*
+---
+
+# MMEdit-AT2A
+
+MMEdit-AT2A is an MTEB-formatted composed audio retrieval adaptation of
+[`CocoBro/MMEdit-TestSet`](https://huggingface.co/datasets/CocoBro/MMEdit-TestSet).
+Each query combines an unedited source recording with a natural-language edit
+instruction, and the corpus contains the corresponding edited recordings.
+
+## Schema
+
+- `queries`: `id`, `audio` (unedited source), and `text` (edit instruction)
+- `corpus`: `id` and `audio` (edited target)
+- `qrels`: `query-id`, `corpus-id`, and binary `score`
+
+The test split contains 3,317 queries and 3,317 corpus items. Exact
+byte-identical target duplicates are all marked relevant, producing 3,337 qrels.
+
+## Construction
+
+The source is pinned to commit
+`ae4f9a772180a2a3c77c2e865b398e7d6f60bcee`. Triplets are joined by `audio_id`.
+The construction preserves the original WAV payloads without padding,
+resampling, or loudness normalization. IDs are deterministic:
+`q-{audio_id}` for queries and `t-{audio_id}` for corpus items.
+
+## Known source-format discrepancies
+
+Although the source card describes all clips as 24 kHz, mono, and ten seconds:
+
+- 1,394 source files and 1,394 target files differ from ten seconds by more
+  than 0.05 seconds (minimum observed duration: 2.3985 seconds).
+- 143 targets (`replace_one` and `replace_time`) are 16 kHz, 32-bit PCM rather
+  than 24 kHz, 16-bit PCM.
+- All 6,634 WAV files are mono.
+
+These properties are retained so this derivative stays faithful to the source.
+
+## Benchmark limitation: source-only leakage
+
+The native global candidate pool has a substantial shortcut: a model can often
+identify the edited target from source audio alone without using the instruction.
+A deterministic, non-neural 64-bin log-mel fingerprint baseline obtained the
+following full-pool results:
+
+| Diagnostic | Recall@1 | mAP@10 | nDCG@10 |
+|---|---:|---:|---:|
+| Random expectation | 0.0003 | 0.0009 | 0.0014 |
+| Source-only spectral fingerprint | 0.5849 | 0.6094 | 0.6216 |
+| Source duration + spectral fingerprint | 0.8113 | 0.8376 | 0.8495 |
+
+Consequently, scores on this benchmark must not be interpreted as measuring
+instruction use alone. Results should be accompanied by an audio-only ablation
+where possible. The native 3,317-pair design is intentionally preserved rather
+than introducing synthetic edits or reviewer-unapproved hard negatives.
+
+## Source reuse and duplicate handling
+
+The audit found five byte-identical source groups, four of which have multiple
+distinct edited targets. It also found ten byte-identical target groups. The
+corpus retains every native item, while qrels mark every byte-identical copy of
+a query's target as relevant.
+
+## License and citation
+
+The source dataset is published under Apache-2.0. Please also cite the original
+MMEdit work:
+
+```bibtex
+@article{tao2025mmedit,
+  author = {Tao, Ye and Xu, Xuenan and Wu, Wen and Wang, Shuai and Wu, Mengyue and Zhang, Chao},
+  journal = {arXiv preprint arXiv:2512.20339},
+  title = {MMEDIT: A Unified Framework for Multi-Type Audio Editing via Audio Language Model},
+  url = {https://arxiv.org/abs/2512.20339},
+  year = {2025},
+}
+```
+"""
+
+
+@dataclass(frozen=True)
+class AudioInfo:
+    """Header and content-hash information for one WAV file."""
+
+    audio_id: str
+    path: Path
+    size_bytes: int
+    sha256: str
+    sample_rate: int
+    channels: int
+    sample_width_bytes: int
+    frames: int
+    duration_seconds: float
+
+
+@dataclass
+class AuditResult:
+    """Machine-readable output from a complete source audit."""
+
+    source_repo_id: str
+    source_revision: str
+    source_dir: str
+    valid: bool
+    errors: list[str]
+    warnings: list[str]
+    counts: dict[str, int]
+    edit_families: dict[str, int]
+    audio_summary: dict[str, Any]
+    duplicate_summary: dict[str, Any]
+    source_reuse_summary: dict[str, Any]
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _require_external_directory(path: Path, *, description: str) -> Path:
+    resolved = path.expanduser().resolve()
+    if _is_relative_to(resolved, _REPO_ROOT):
+        raise SystemExit(
+            f"{description} must be outside the Git repository ({_REPO_ROOT}): "
+            f"{resolved}"
+        )
+    return resolved
+
+
+def _download_source(cache_dir: Path | None, *, offline: bool) -> Path:
+    kwargs: dict[str, Any] = {
+        "repo_id": SOURCE_REPO_ID,
+        "repo_type": "dataset",
+        "revision": SOURCE_REVISION,
+        "allow_patterns": ["README.md", "content.jsonl", "raw/*.wav", "target/*.wav"],
+        "local_files_only": offline,
+    }
+    if cache_dir is not None:
+        kwargs["cache_dir"] = str(cache_dir)
+    print(f"Source: {SOURCE_REPO_ID}@{SOURCE_REVISION}")
+    print("Resolving pinned source snapshot...")
+    return Path(snapshot_download(**kwargs)).resolve()
+
+
+def _load_instructions(
+    metadata_path: Path,
+) -> tuple[dict[str, str], list[str], list[str]]:
+    instructions: dict[str, str] = {}
+    duplicate_ids: list[str] = []
+    malformed_rows: list[str] = []
+
+    with metadata_path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as error:
+                malformed_rows.append(f"line {line_number}: invalid JSON ({error})")
+                continue
+
+            audio_id = row.get("audio_id")
+            caption = row.get("caption")
+            if not isinstance(audio_id, str) or not audio_id.strip():
+                malformed_rows.append(f"line {line_number}: missing string audio_id")
+                continue
+            if not isinstance(caption, str) or not caption.strip():
+                malformed_rows.append(
+                    f"line {line_number}: {audio_id!r} has an empty caption"
+                )
+                continue
+            if audio_id in instructions:
+                duplicate_ids.append(audio_id)
+                continue
+            instructions[audio_id] = caption.strip()
+
+    return instructions, duplicate_ids, malformed_rows
+
+
+def _index_wavs(directory: Path) -> tuple[dict[str, Path], list[str]]:
+    wavs: dict[str, Path] = {}
+    duplicate_ids: list[str] = []
+    for path in sorted(directory.glob("*.wav")):
+        if path.stem in wavs:
+            duplicate_ids.append(path.stem)
+        else:
+            wavs[path.stem] = path
+    return wavs, duplicate_ids
+
+
+def _inspect_wav(item: tuple[str, Path]) -> AudioInfo:
+    audio_id, path = item
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+
+    try:
+        with wave_open(str(path), "rb") as wav:
+            channels = wav.getnchannels()
+            sample_width = wav.getsampwidth()
+            sample_rate = wav.getframerate()
+            frames = wav.getnframes()
+    except (EOFError, WaveError) as error:
+        raise ValueError(f"{path}: cannot decode WAV header ({error})") from error
+
+    if sample_rate <= 0:
+        raise ValueError(f"{path}: invalid sample rate {sample_rate}")
+    return AudioInfo(
+        audio_id=audio_id,
+        path=path,
+        size_bytes=path.stat().st_size,
+        sha256=digest.hexdigest(),
+        sample_rate=sample_rate,
+        channels=channels,
+        sample_width_bytes=sample_width,
+        frames=frames,
+        duration_seconds=frames / sample_rate,
+    )
+
+
+def _inspect_all_wavs(
+    wavs: dict[str, Path], *, workers: int, description: str
+) -> tuple[dict[str, AudioInfo], list[str]]:
+    infos: dict[str, AudioInfo] = {}
+    errors: list[str] = []
+
+    def inspect(item: tuple[str, Path]) -> tuple[str, AudioInfo | None, str | None]:
+        audio_id, _ = item
+        try:
+            return audio_id, _inspect_wav(item), None
+        except (OSError, ValueError) as error:
+            return audio_id, None, str(error)
+
+    items = sorted(wavs.items())
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        results = executor.map(inspect, items)
+        for audio_id, info, error in tqdm(
+            results, total=len(items), desc=description, unit="file"
+        ):
+            if error is not None:
+                errors.append(error)
+            elif info is not None:
+                infos[audio_id] = info
+    return infos, errors
+
+
+def _group_by_hash(infos: dict[str, AudioInfo]) -> dict[str, list[str]]:
+    groups: dict[str, list[str]] = defaultdict(list)
+    for audio_id, info in infos.items():
+        groups[info.sha256].append(audio_id)
+    return {digest: sorted(ids) for digest, ids in groups.items()}
+
+
+def _duplicate_groups(groups: dict[str, list[str]]) -> list[list[str]]:
+    return sorted(
+        (ids for ids in groups.values() if len(ids) > 1),
+        key=lambda ids: (-len(ids), ids),
+    )
+
+
+def _preview(values: list[str], limit: int = 8) -> str:
+    shown = ", ".join(values[:limit])
+    remaining = len(values) - limit
+    return f"{shown}{f', +{remaining} more' if remaining > 0 else ''}"
+
+
+def _validate_audio_properties(infos: dict[str, AudioInfo], *, label: str) -> list[str]:
+    errors: list[str] = []
+    bad_sample_rates = sorted(
+        audio_id
+        for audio_id, info in infos.items()
+        if info.sample_rate != EXPECTED_SAMPLE_RATE
+    )
+    bad_channels = sorted(
+        audio_id
+        for audio_id, info in infos.items()
+        if info.channels != EXPECTED_CHANNELS
+    )
+    bad_durations = sorted(
+        audio_id
+        for audio_id, info in infos.items()
+        if abs(info.duration_seconds - EXPECTED_DURATION_SECONDS)
+        > _DURATION_TOLERANCE_SECONDS
+    )
+    if bad_sample_rates:
+        errors.append(
+            f"{label}: {len(bad_sample_rates)} files are not "
+            f"{EXPECTED_SAMPLE_RATE} Hz ({_preview(bad_sample_rates)})"
+        )
+    if bad_channels:
+        errors.append(
+            f"{label}: {len(bad_channels)} files are not mono "
+            f"({_preview(bad_channels)})"
+        )
+    if bad_durations:
+        errors.append(
+            f"{label}: {len(bad_durations)} files differ from "
+            f"{EXPECTED_DURATION_SECONDS:.1f}s by more than "
+            f"{_DURATION_TOLERANCE_SECONDS:.2f}s ({_preview(bad_durations)})"
+        )
+    return errors
+
+
+def audit_source(source_dir: Path, *, workers: int) -> AuditResult:
+    """Run all structural, audio-format, hash, and reuse checks."""
+    errors: list[str] = []
+    warnings: list[str] = []
+    metadata_path = source_dir / "content.jsonl"
+    raw_dir = source_dir / "raw"
+    target_dir = source_dir / "target"
+
+    for required in (metadata_path, raw_dir, target_dir):
+        if not required.exists():
+            errors.append(f"Missing required source path: {required}")
+    if errors:
+        return AuditResult(
+            source_repo_id=SOURCE_REPO_ID,
+            source_revision=SOURCE_REVISION,
+            source_dir=str(source_dir),
+            valid=False,
+            errors=errors,
+            warnings=warnings,
+            counts={},
+            edit_families={},
+            audio_summary={},
+            duplicate_summary={},
+            source_reuse_summary={},
+        )
+
+    instructions, duplicate_instruction_ids, malformed_rows = _load_instructions(
+        metadata_path
+    )
+    raw_wavs, duplicate_raw_ids = _index_wavs(raw_dir)
+    target_wavs, duplicate_target_ids = _index_wavs(target_dir)
+
+    if malformed_rows:
+        errors.extend(malformed_rows)
+    if duplicate_instruction_ids:
+        errors.append(
+            f"Duplicate instruction IDs: {_preview(sorted(duplicate_instruction_ids))}"
+        )
+    if duplicate_raw_ids:
+        errors.append(f"Duplicate raw IDs: {_preview(sorted(duplicate_raw_ids))}")
+    if duplicate_target_ids:
+        errors.append(f"Duplicate target IDs: {_preview(sorted(duplicate_target_ids))}")
+
+    instruction_ids = set(instructions)
+    raw_ids = set(raw_wavs)
+    target_ids = set(target_wavs)
+    all_ids = instruction_ids | raw_ids | target_ids
+    complete_ids = instruction_ids & raw_ids & target_ids
+    missing_sources = sorted((instruction_ids | target_ids) - raw_ids)
+    missing_targets = sorted((instruction_ids | raw_ids) - target_ids)
+    missing_instructions = sorted((raw_ids | target_ids) - instruction_ids)
+
+    for label, values in (
+        ("Missing sources", missing_sources),
+        ("Missing targets", missing_targets),
+        ("Missing instructions", missing_instructions),
+    ):
+        if values:
+            errors.append(f"{label}: {_preview(values)}")
+
+    expected_counts = {
+        "instructions": len(instructions),
+        "raw_wavs": len(raw_wavs),
+        "target_wavs": len(target_wavs),
+        "complete_triplets": len(complete_ids),
+    }
+    for label, count in expected_counts.items():
+        if count != EXPECTED_TRIPLETS:
+            errors.append(f"Expected {EXPECTED_TRIPLETS} {label}, found {count}")
+
+    family_counts: Counter[str] = Counter()
+    invalid_family_ids: list[str] = []
+    for audio_id in sorted(all_ids):
+        match = _AUDIO_ID_RE.fullmatch(audio_id)
+        if match is None:
+            invalid_family_ids.append(audio_id)
+        else:
+            family_counts[match.group("family")] += 1
+    if invalid_family_ids:
+        errors.append(
+            "IDs without a '<family>_<number>' structure: "
+            f"{_preview(invalid_family_ids)}"
+        )
+
+    raw_infos, raw_decode_errors = _inspect_all_wavs(
+        raw_wavs, workers=workers, description="Audit raw audio"
+    )
+    target_infos, target_decode_errors = _inspect_all_wavs(
+        target_wavs, workers=workers, description="Audit target audio"
+    )
+    errors.extend(raw_decode_errors)
+    errors.extend(target_decode_errors)
+    # The source card's format claims do not match every file, but the audio is
+    # decodable and usable. Preserve these discrepancies as prominent warnings;
+    # structural failures and undecodable files remain blocking errors.
+    warnings.extend(_validate_audio_properties(raw_infos, label="raw"))
+    warnings.extend(_validate_audio_properties(target_infos, label="target"))
+
+    raw_hash_groups = _group_by_hash(raw_infos)
+    target_hash_groups = _group_by_hash(target_infos)
+    raw_duplicate_groups = _duplicate_groups(raw_hash_groups)
+    target_duplicate_groups = _duplicate_groups(target_hash_groups)
+    shared_hashes = set(raw_hash_groups) & set(target_hash_groups)
+    identical_pairs = sorted(
+        audio_id
+        for audio_id in complete_ids
+        if audio_id in raw_infos
+        and audio_id in target_infos
+        and raw_infos[audio_id].sha256 == target_infos[audio_id].sha256
+    )
+    if identical_pairs:
+        errors.append(
+            f"{len(identical_pairs)} triplets have byte-identical source and target "
+            f"audio ({_preview(identical_pairs)})"
+        )
+    if raw_duplicate_groups:
+        warnings.append(
+            f"Raw audio has {len(raw_duplicate_groups)} byte-identical duplicate "
+            "groups; inspect source reuse before defining qrels"
+        )
+    if target_duplicate_groups:
+        warnings.append(
+            f"Target audio has {len(target_duplicate_groups)} byte-identical duplicate "
+            "groups; relevant duplicates may need additional qrels"
+        )
+
+    reused_sources: list[dict[str, Any]] = []
+    for digest, ids in raw_hash_groups.items():
+        if len(ids) < 2:
+            continue
+        captions = {
+            instructions[audio_id] for audio_id in ids if audio_id in instructions
+        }
+        target_hashes = {
+            target_infos[audio_id].sha256
+            for audio_id in ids
+            if audio_id in target_infos
+        }
+        reused_sources.append(
+            {
+                "sha256": digest,
+                "audio_ids": ids,
+                "instruction_count": len(captions),
+                "target_count": len(target_hashes),
+            }
+        )
+    reused_sources.sort(
+        key=lambda group: (-len(group["audio_ids"]), group["audio_ids"])
+    )
+
+    durations = [
+        info.duration_seconds for info in [*raw_infos.values(), *target_infos.values()]
+    ]
+    sampling_rates = Counter(
+        info.sample_rate for info in [*raw_infos.values(), *target_infos.values()]
+    )
+    channels = Counter(
+        info.channels for info in [*raw_infos.values(), *target_infos.values()]
+    )
+    sample_widths = Counter(
+        info.sample_width_bytes
+        for info in [*raw_infos.values(), *target_infos.values()]
+    )
+    total_size_bytes = sum(
+        info.size_bytes for info in [*raw_infos.values(), *target_infos.values()]
+    )
+
+    duplicate_summary = {
+        "raw_unique_hashes": len(raw_hash_groups),
+        "target_unique_hashes": len(target_hash_groups),
+        "raw_duplicate_groups": len(raw_duplicate_groups),
+        "raw_duplicate_files": sum(len(ids) for ids in raw_duplicate_groups),
+        "target_duplicate_groups": len(target_duplicate_groups),
+        "target_duplicate_files": sum(len(ids) for ids in target_duplicate_groups),
+        "source_target_shared_hashes": len(shared_hashes),
+        "identical_source_target_pairs": len(identical_pairs),
+        "raw_duplicate_examples": raw_duplicate_groups[:10],
+        "target_duplicate_examples": target_duplicate_groups[:10],
+    }
+    source_reuse_summary = {
+        "reused_source_groups": len(reused_sources),
+        "groups_with_multiple_instructions": sum(
+            group["instruction_count"] > 1 for group in reused_sources
+        ),
+        "groups_with_multiple_targets": sum(
+            group["target_count"] > 1 for group in reused_sources
+        ),
+        "examples": reused_sources[:10],
+    }
+    audio_summary = {
+        "decoded_files": len(raw_infos) + len(target_infos),
+        "total_size_bytes": total_size_bytes,
+        "duration_seconds": {
+            "minimum": min(durations) if durations else None,
+            "average": sum(durations) / len(durations) if durations else None,
+            "maximum": max(durations) if durations else None,
+        },
+        "sampling_rates": dict(sorted(sampling_rates.items())),
+        "channels": dict(sorted(channels.items())),
+        "sample_width_bytes": dict(sorted(sample_widths.items())),
+    }
+    counts = {
+        **expected_counts,
+        "all_ids": len(all_ids),
+        "edit_families": len(family_counts),
+    }
+
+    return AuditResult(
+        source_repo_id=SOURCE_REPO_ID,
+        source_revision=SOURCE_REVISION,
+        source_dir=str(source_dir),
+        valid=not errors,
+        errors=errors,
+        warnings=warnings,
+        counts=counts,
+        edit_families=dict(sorted(family_counts.items())),
+        audio_summary=audio_summary,
+        duplicate_summary=duplicate_summary,
+        source_reuse_summary=source_reuse_summary,
+    )
+
+
+def _build_retrieval_data(
+    source_dir: Path, *, workers: int
+) -> tuple[dict[str, DatasetDict], dict[str, Any]]:
+    """Construct deterministic MTEB queries, corpus, and duplicate-aware qrels."""
+    instructions, duplicate_ids, malformed_rows = _load_instructions(
+        source_dir / "content.jsonl"
+    )
+    raw_wavs, duplicate_raw_ids = _index_wavs(source_dir / "raw")
+    target_wavs, duplicate_target_ids = _index_wavs(source_dir / "target")
+    if duplicate_ids or malformed_rows or duplicate_raw_ids or duplicate_target_ids:
+        raise ValueError("Source metadata changed after audit; refusing to build")
+
+    complete_ids = sorted(set(instructions) & set(raw_wavs) & set(target_wavs))
+    if len(complete_ids) != EXPECTED_TRIPLETS:
+        raise ValueError(
+            f"Expected {EXPECTED_TRIPLETS:,} complete triplets, "
+            f"found {len(complete_ids):,}"
+        )
+
+    target_infos, decode_errors = _inspect_all_wavs(
+        target_wavs,
+        workers=workers,
+        description="Hash target audio for qrels",
+    )
+    if decode_errors or len(target_infos) != EXPECTED_TRIPLETS:
+        raise ValueError(
+            "Target audio changed after audit; refusing to build: "
+            f"{_preview(decode_errors)}"
+        )
+    target_hash_groups = _group_by_hash(target_infos)
+
+    query_rows = {
+        "id": [f"q-{audio_id}" for audio_id in complete_ids],
+        "audio": [str(raw_wavs[audio_id]) for audio_id in complete_ids],
+        "text": [instructions[audio_id] for audio_id in complete_ids],
+    }
+    corpus_rows = {
+        "id": [f"t-{audio_id}" for audio_id in complete_ids],
+        "audio": [str(target_wavs[audio_id]) for audio_id in complete_ids],
+    }
+    qrel_rows: dict[str, list[Any]] = {
+        "query-id": [],
+        "corpus-id": [],
+        "score": [],
+    }
+    for audio_id in complete_ids:
+        relevant_ids = target_hash_groups[target_infos[audio_id].sha256]
+        for relevant_id in relevant_ids:
+            qrel_rows["query-id"].append(f"q-{audio_id}")
+            qrel_rows["corpus-id"].append(f"t-{relevant_id}")
+            qrel_rows["score"].append(1)
+
+    query_ids = set(query_rows["id"])
+    corpus_ids = set(corpus_rows["id"])
+    qrel_query_ids = set(qrel_rows["query-id"])
+    qrel_corpus_ids = set(qrel_rows["corpus-id"])
+    if len(query_ids) != len(query_rows["id"]):
+        raise ValueError("Constructed duplicate query IDs")
+    if len(corpus_ids) != len(corpus_rows["id"]):
+        raise ValueError("Constructed duplicate corpus IDs")
+    if qrel_query_ids != query_ids:
+        raise ValueError("Not every query has at least one positive qrel")
+    if not qrel_corpus_ids <= corpus_ids:
+        raise ValueError("A qrel references a missing corpus ID")
+    if len(qrel_rows["query-id"]) != EXPECTED_QRELS:
+        raise ValueError(
+            f"Expected {EXPECTED_QRELS:,} duplicate-aware qrels, "
+            f"constructed {len(qrel_rows['query-id']):,}"
+        )
+
+    # Cast after constructing the Arrow table. ``datasets>=5`` otherwise tries
+    # to re-encode every WAV through the optional torchcodec dependency even
+    # though these rows already point to valid source files.
+    queries = Dataset.from_dict(query_rows).cast_column("audio", Audio())
+    corpus = Dataset.from_dict(corpus_rows).cast_column("audio", Audio())
+    qrels = Dataset.from_dict(
+        qrel_rows,
+        features=Features(
+            {
+                "query-id": Value("string"),
+                "corpus-id": Value("string"),
+                "score": Value("int32"),
+            }
+        ),
+    )
+    datasets = {
+        "queries": DatasetDict({"test": queries}),
+        "corpus": DatasetDict({"test": corpus}),
+        "qrels": DatasetDict({"test": qrels}),
+    }
+    manifest = {
+        "source_repo_id": SOURCE_REPO_ID,
+        "source_revision": SOURCE_REVISION,
+        "counts": {
+            "queries": len(queries),
+            "corpus": len(corpus),
+            "qrels": len(qrels),
+        },
+        "id_format": {
+            "query": "q-{audio_id}",
+            "corpus": "t-{audio_id}",
+        },
+        "duplicate_qrels_policy": (
+            "Every corpus item with a byte-identical target WAV is relevant."
+        ),
+        "target_duplicate_groups": _duplicate_groups(target_hash_groups),
+        "audio_transformation": "none",
+        "source_only_diagnostic": {
+            "method": "64-bin log-mel distribution fingerprint",
+            "spectral_fingerprint": {
+                "recall_at_1": 0.5848658426288815,
+                "map_at_10": 0.6094354001272904,
+                "ndcg_at_10": 0.6215856571177805,
+            },
+            "duration_then_fingerprint": {
+                "recall_at_1": 0.8112752487187217,
+                "map_at_10": 0.8376390743213172,
+                "ndcg_at_10": 0.8495169772023567,
+            },
+            "random_expected": {
+                "recall_at_1": 0.0003032950089747874,
+                "map_at_10": 0.0008830211369784203,
+                "ndcg_at_10": 0.0013716487209221259,
+            },
+        },
+    }
+    return datasets, manifest
+
+
+def _write_local_dataset(
+    datasets: dict[str, DatasetDict], manifest: dict[str, Any], output_dir: Path
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    occupied = [
+        name
+        for name in (*datasets, "README.md", "manifest.json")
+        if (output_dir / name).exists()
+    ]
+    if occupied:
+        raise ValueError(
+            f"Output directory is not empty ({_preview(occupied)}); "
+            "choose a new --output-dir"
+        )
+    for config_name, dataset in datasets.items():
+        dataset.save_to_disk(output_dir / config_name)
+    (output_dir / "README.md").write_text(_DATASET_CARD, encoding="utf-8")
+    (output_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(f"Wrote local MTEB dataset: {output_dir}")
+
+
+def _push_dataset(datasets: dict[str, DatasetDict], *, repo_id: str, token: str) -> str:
+    create_repo(repo_id, repo_type="dataset", token=token, exist_ok=True)
+    for config_name in ("queries", "corpus", "qrels"):
+        print(f"Pushing {config_name} configuration to {repo_id}...")
+        datasets[config_name].push_to_hub(
+            repo_id,
+            config_name=config_name,
+            token=token,
+            max_shard_size="500MB",
+        )
+    HfApi(token=token).upload_file(
+        path_or_fileobj=_DATASET_CARD.encode(),
+        path_in_repo="README.md",
+        repo_id=repo_id,
+        repo_type="dataset",
+        commit_message="Document MMEdit-AT2A construction and limitations",
+    )
+    revision = dataset_info(repo_id, token=token).sha
+    print(f"Pushed {repo_id}@{revision}")
+    return revision
+
+
+def _print_summary(result: AuditResult) -> None:
+    print("\nMMEdit source audit")
+    print(f"  Revision:          {result.source_revision}")
+    print(f"  Snapshot:          {result.source_dir}")
+    if result.counts:
+        print(f"  Complete triplets: {result.counts['complete_triplets']:,}")
+        print(f"  Edit families:     {result.counts['edit_families']}")
+    if result.audio_summary:
+        duration = result.audio_summary["duration_seconds"]
+        total_gib = result.audio_summary["total_size_bytes"] / 1024**3
+        print(f"  Decoded WAVs:      {result.audio_summary['decoded_files']:,}")
+        print(f"  Audio size:        {total_gib:.2f} GiB")
+        if duration["minimum"] is not None and duration["maximum"] is not None:
+            print(
+                "  Duration range:    "
+                f"{duration['minimum']:.3f}s–{duration['maximum']:.3f}s"
+            )
+    if result.duplicate_summary:
+        duplicates = result.duplicate_summary
+        print(
+            "  Duplicate groups:  "
+            f"raw={duplicates['raw_duplicate_groups']}, "
+            f"target={duplicates['target_duplicate_groups']}"
+        )
+        print(
+            "  Shared hashes:     "
+            f"{duplicates['source_target_shared_hashes']} source↔target"
+        )
+        print(f"  Identical pairs:   {duplicates['identical_source_target_pairs']}")
+    if result.source_reuse_summary:
+        reuse = result.source_reuse_summary
+        print(
+            "  Reused sources:    "
+            f"{reuse['reused_source_groups']} groups "
+            f"({reuse['groups_with_multiple_targets']} with multiple targets)"
+        )
+    if result.edit_families:
+        families = ", ".join(
+            f"{family}={count}" for family, count in result.edit_families.items()
+        )
+        print(f"  Family counts:     {families}")
+    for warning in result.warnings:
+        print(f"WARNING: {warning}", file=sys.stderr)
+    for error in result.errors:
+        print(f"ERROR: {error}", file=sys.stderr)
+    print(f"  Result:            {'PASS' if result.valid else 'FAIL'}")
+
+
+def _json_ready(result: AuditResult) -> dict[str, Any]:
+    data = asdict(result)
+    return data
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--source-dir",
+        type=Path,
+        help="Audit an existing snapshot instead of downloading it.",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        help="Hugging Face cache directory; must be outside this Git repository.",
+    )
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="Use cached/local files only; never access the network.",
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=min(16, max(1, (os.cpu_count() or 1) * 2)),
+        help="Threads used for WAV inspection and hashing.",
+    )
+    parser.add_argument(
+        "--json-report",
+        type=Path,
+        help="Optionally write the complete audit report as JSON.",
+    )
+    parser.add_argument(
+        "--build",
+        action="store_true",
+        help="Construct the deterministic MTEB queries/corpus/qrels after auditing.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Write a local dataset export here; must be outside this repository.",
+    )
+    parser.add_argument(
+        "--repo-id",
+        default=DEFAULT_OUTPUT_REPO_ID,
+        help=f"Hugging Face output repository (default: {DEFAULT_OUTPUT_REPO_ID}).",
+    )
+    parser.add_argument(
+        "--push",
+        action="store_true",
+        help="Upload all three configurations. Requires --build and HF_TOKEN.",
+    )
+    args = parser.parse_args()
+
+    if args.workers < 1:
+        parser.error("--workers must be at least 1")
+    if args.source_dir is not None and args.cache_dir is not None:
+        parser.error("--source-dir and --cache-dir cannot be used together")
+    if args.output_dir is not None and not args.build:
+        parser.error("--output-dir requires --build")
+    if args.push and not args.build:
+        parser.error("--push requires --build")
+
+    cache_dir = None
+    if args.cache_dir is not None:
+        cache_dir = _require_external_directory(
+            args.cache_dir, description="Cache directory"
+        )
+        cache_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.source_dir is not None:
+        source_dir = _require_external_directory(
+            args.source_dir, description="Source directory"
+        )
+    else:
+        source_dir = _download_source(cache_dir, offline=args.offline)
+
+    result = audit_source(source_dir, workers=args.workers)
+    _print_summary(result)
+
+    if args.json_report is not None:
+        report_path = args.json_report.expanduser().resolve()
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(
+            json.dumps(_json_ready(result), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        print(f"Wrote JSON report: {report_path}")
+
+    if not result.valid:
+        raise SystemExit(1)
+    if not args.build:
+        return
+
+    try:
+        datasets, manifest = _build_retrieval_data(source_dir, workers=args.workers)
+        if args.output_dir is not None:
+            output_dir = _require_external_directory(
+                args.output_dir, description="Output directory"
+            )
+            _write_local_dataset(datasets, manifest, output_dir)
+        if args.push:
+            token = os.environ.get("HF_TOKEN")
+            if not token:
+                raise ValueError("Set HF_TOKEN in the environment before using --push")
+            revision = _push_dataset(datasets, repo_id=args.repo_id, token=token)
+            if args.output_dir is not None:
+                (output_dir / "hub_revision.txt").write_text(
+                    revision + "\n", encoding="utf-8"
+                )
+        elif args.output_dir is None:
+            print(
+                "Build validated in memory; use --output-dir to save or --push to upload."
+            )
+    except ValueError as error:
+        parser.error(str(error))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/data/mmedit_retrieval/diagnose_source_only.py
+++ b/scripts/data/mmedit_retrieval/diagnose_source_only.py
@@ -1,0 +1,556 @@
+#!/usr/bin/env python3
+"""Measure how well MMEdit targets can be retrieved without the edit instruction.
+
+This diagnostic intentionally ignores the text instruction. It embeds each source
+and target WAV with a lightweight, order-insensitive log-mel fingerprint and ranks
+targets by cosine similarity. The fingerprint is not intended as a competitive
+audio model; it is a cheap lower-bound check for source-content leakage that runs
+on CPU without downloading model weights.
+
+Run a deterministic, stratified subset first:
+
+  uv run python scripts/data/mmedit_retrieval/diagnose_source_only.py \
+      --source-dir /path/to/MMEdit-TestSet --limit 512
+
+Use ``--limit 0`` only after reviewing the subset result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import re
+from collections import Counter, defaultdict
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+from wave import open as wave_open
+
+import numpy as np
+from scipy.signal import resample_poly, spectrogram
+from tqdm import tqdm
+
+SOURCE_REPO_ID = "CocoBro/MMEdit-TestSet"
+SOURCE_REVISION = "ae4f9a772180a2a3c77c2e865b398e7d6f60bcee"
+EXPECTED_TRIPLETS = 3_317
+TARGET_SAMPLE_RATE = 16_000
+N_MELS = 64
+_AUDIO_ID_RE = re.compile(r"^(?P<family>.+)_(?P<number>\d+)$")
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+@dataclass(frozen=True)
+class RetrievalMetrics:
+    """Retrieval metrics for binary qrels at a fixed cutoff of ten."""
+
+    recall_at_1: float
+    map_at_10: float
+    ndcg_at_10: float
+
+
+@dataclass
+class DiagnosticResult:
+    """Machine-readable result from the source-only diagnostic."""
+
+    source_repo_id: str
+    source_revision: str
+    source_dir: str
+    method: str
+    seed: int
+    requested_limit: int
+    query_count: int
+    corpus_count: int
+    family_counts: dict[str, int]
+    metrics: RetrievalMetrics
+    duration_then_fingerprint_metrics: RetrievalMetrics
+    random_expected: RetrievalMetrics
+    recall_at_1_by_family: dict[str, float]
+    top_false_positives: list[dict[str, Any]]
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _external_source_dir(path: Path) -> Path:
+    resolved = path.expanduser().resolve()
+    if _is_relative_to(resolved, _REPO_ROOT):
+        raise SystemExit(
+            f"--source-dir must be outside the Git repository ({_REPO_ROOT}): "
+            f"{resolved}"
+        )
+    for required in ("content.jsonl", "raw", "target"):
+        if not (resolved / required).exists():
+            raise SystemExit(f"Missing required source path: {resolved / required}")
+    return resolved
+
+
+def _load_complete_ids(source_dir: Path) -> list[str]:
+    metadata_ids: list[str] = []
+    with (source_dir / "content.jsonl").open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            row = json.loads(line)
+            audio_id = row.get("audio_id")
+            if not isinstance(audio_id, str) or not audio_id:
+                raise SystemExit(f"Invalid audio_id on metadata line {line_number}")
+            metadata_ids.append(audio_id)
+
+    if len(metadata_ids) != len(set(metadata_ids)):
+        raise SystemExit("content.jsonl contains duplicate audio_id values")
+    complete_ids = [
+        audio_id
+        for audio_id in metadata_ids
+        if (source_dir / "raw" / f"{audio_id}.wav").is_file()
+        and (source_dir / "target" / f"{audio_id}.wav").is_file()
+    ]
+    if len(complete_ids) != EXPECTED_TRIPLETS:
+        raise SystemExit(
+            f"Expected {EXPECTED_TRIPLETS:,} complete triplets, "
+            f"found {len(complete_ids):,}; run create_data.py first"
+        )
+    return sorted(complete_ids)
+
+
+def _family(audio_id: str) -> str:
+    match = _AUDIO_ID_RE.fullmatch(audio_id)
+    if match is None:
+        raise ValueError(f"Invalid MMEdit audio_id: {audio_id!r}")
+    return match.group("family")
+
+
+def _stable_order(audio_ids: list[str], seed: int) -> list[str]:
+    return sorted(
+        audio_ids,
+        key=lambda audio_id: hashlib.sha256(f"{seed}:{audio_id}".encode()).digest(),
+    )
+
+
+def _stratified_subset(audio_ids: list[str], limit: int, seed: int) -> list[str]:
+    """Select a proportional subset while retaining every edit family."""
+    if limit == 0 or limit >= len(audio_ids):
+        return sorted(audio_ids)
+
+    by_family: dict[str, list[str]] = defaultdict(list)
+    for audio_id in audio_ids:
+        by_family[_family(audio_id)].append(audio_id)
+    if limit < len(by_family):
+        raise ValueError(
+            f"--limit must be 0 or at least the {len(by_family)} edit families"
+        )
+
+    family_sizes = {family: len(ids) for family, ids in by_family.items()}
+    quotas = {family: 1 for family in by_family}
+    remaining = limit - len(quotas)
+    total_after_minimum = sum(size - 1 for size in family_sizes.values())
+    fractional: list[tuple[float, str]] = []
+    assigned = 0
+    for family, size in family_sizes.items():
+        exact = remaining * (size - 1) / total_after_minimum
+        addition = math.floor(exact)
+        quotas[family] += addition
+        assigned += addition
+        fractional.append((exact - addition, family))
+    for _, family in sorted(fractional, key=lambda item: (-item[0], item[1]))[
+        : remaining - assigned
+    ]:
+        quotas[family] += 1
+
+    selected = []
+    for family in sorted(by_family):
+        selected.extend(_stable_order(by_family[family], seed)[: quotas[family]])
+    return sorted(selected)
+
+
+def _read_pcm_mono(path: Path) -> tuple[np.ndarray, int]:
+    with wave_open(str(path), "rb") as wav:
+        channels = wav.getnchannels()
+        sample_width = wav.getsampwidth()
+        sample_rate = wav.getframerate()
+        frames = wav.getnframes()
+        compression = wav.getcomptype()
+        payload = wav.readframes(frames)
+
+    if compression != "NONE":
+        raise ValueError(f"Unsupported compressed WAV {path}: {compression}")
+    dtype_and_scale = {
+        1: (np.dtype("u1"), 128.0),
+        2: (np.dtype("<i2"), 32768.0),
+        4: (np.dtype("<i4"), 2147483648.0),
+    }
+    if sample_width not in dtype_and_scale:
+        raise ValueError(f"Unsupported {sample_width}-byte PCM WAV: {path}")
+    dtype, scale = dtype_and_scale[sample_width]
+    audio = np.frombuffer(payload, dtype=dtype).astype(np.float32)
+    if sample_width == 1:
+        audio -= 128.0
+    audio /= scale
+    if channels > 1:
+        audio = audio.reshape(-1, channels).mean(axis=1)
+    if sample_rate != TARGET_SAMPLE_RATE:
+        divisor = math.gcd(sample_rate, TARGET_SAMPLE_RATE)
+        audio = resample_poly(
+            audio,
+            TARGET_SAMPLE_RATE // divisor,
+            sample_rate // divisor,
+        ).astype(np.float32)
+    return audio, TARGET_SAMPLE_RATE
+
+
+def _hz_to_mel(frequency: np.ndarray | float) -> np.ndarray:
+    return 2595.0 * np.log10(1.0 + np.asarray(frequency) / 700.0)
+
+
+def _mel_to_hz(mel: np.ndarray) -> np.ndarray:
+    return 700.0 * (10 ** (mel / 2595.0) - 1.0)
+
+
+def _mel_filterbank(sample_rate: int, n_fft: int, n_mels: int) -> np.ndarray:
+    frequencies = np.linspace(0.0, sample_rate / 2, n_fft // 2 + 1)
+    mel_points = np.linspace(_hz_to_mel(50.0), _hz_to_mel(sample_rate / 2), n_mels + 2)
+    hz_points = _mel_to_hz(mel_points)
+    filters = np.zeros((n_mels, len(frequencies)), dtype=np.float32)
+    for index in range(n_mels):
+        left, center, right = hz_points[index : index + 3]
+        filters[index] = np.maximum(
+            0.0,
+            np.minimum(
+                (frequencies - left) / (center - left),
+                (right - frequencies) / (right - center),
+            ),
+        )
+    return filters
+
+
+_MEL_FILTERS = _mel_filterbank(TARGET_SAMPLE_RATE, n_fft=512, n_mels=N_MELS)
+
+
+def _spectral_fingerprint(path: Path) -> np.ndarray:
+    audio, sample_rate = _read_pcm_mono(path)
+    if len(audio) == 0:
+        raise ValueError(f"Empty WAV: {path}")
+
+    # Remove gain as an easy cue so that the diagnostic primarily measures
+    # shared acoustic content, including for MMEdit's loudness operations.
+    audio = audio - np.mean(audio)
+    rms = float(np.sqrt(np.mean(np.square(audio))))
+    if rms > 1e-8:
+        audio = audio / rms
+
+    _, _, power = spectrogram(
+        audio,
+        fs=sample_rate,
+        window="hann",
+        nperseg=400,
+        noverlap=240,
+        nfft=512,
+        detrend=False,
+        scaling="spectrum",
+        mode="psd",
+    )
+    mel_power = _MEL_FILTERS @ power
+    mel_power /= np.maximum(mel_power.sum(axis=0, keepdims=True), 1e-12)
+    log_mel = np.log(np.maximum(mel_power, 1e-10))
+    temporal_change = np.abs(np.diff(log_mel, axis=1)).mean(axis=1)
+    fingerprint = np.concatenate(
+        [
+            log_mel.mean(axis=1),
+            log_mel.std(axis=1),
+            np.quantile(log_mel, 0.25, axis=1),
+            np.quantile(log_mel, 0.50, axis=1),
+            np.quantile(log_mel, 0.75, axis=1),
+            temporal_change,
+        ]
+    )
+    return fingerprint.astype(np.float32)
+
+
+def _embed(paths: list[Path], *, description: str) -> np.ndarray:
+    embeddings = [
+        _spectral_fingerprint(path)
+        for path in tqdm(paths, desc=description, unit="file")
+    ]
+    return np.vstack(embeddings)
+
+
+def _normalize_embeddings(
+    source_embeddings: np.ndarray, target_embeddings: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """Fit unsupervised feature scaling on sources, then L2-normalize both sets."""
+    center = source_embeddings.mean(axis=0, keepdims=True)
+    scale = source_embeddings.std(axis=0, keepdims=True)
+    scale[scale < 1e-6] = 1.0
+    source_embeddings = (source_embeddings - center) / scale
+    target_embeddings = (target_embeddings - center) / scale
+    source_embeddings /= np.maximum(
+        np.linalg.norm(source_embeddings, axis=1, keepdims=True), 1e-12
+    )
+    target_embeddings /= np.maximum(
+        np.linalg.norm(target_embeddings, axis=1, keepdims=True), 1e-12
+    )
+    return source_embeddings, target_embeddings
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _duration_seconds(path: Path) -> float:
+    with wave_open(str(path), "rb") as wav:
+        return wav.getnframes() / wav.getframerate()
+
+
+def _relevant_indices(target_paths: list[Path]) -> list[set[int]]:
+    """Treat byte-identical target candidates as equally relevant."""
+    hashes = [_sha256(path) for path in target_paths]
+    by_hash: dict[str, set[int]] = defaultdict(set)
+    for index, digest in enumerate(hashes):
+        by_hash[digest].add(index)
+    return [by_hash[digest] for digest in hashes]
+
+
+def _metrics_from_order(
+    order: np.ndarray, relevant: list[set[int]], *, cutoff: int = 10
+) -> tuple[RetrievalMetrics, np.ndarray]:
+    recalls = []
+    average_precisions = []
+    ndcgs = []
+    first_relevant_ranks = []
+    for ranking, positives in zip(order, relevant):
+        first_rank = next(
+            rank
+            for rank, candidate in enumerate(ranking, start=1)
+            if candidate in positives
+        )
+        first_relevant_ranks.append(first_rank)
+        recalls.append(float(first_rank == 1))
+
+        hits = 0
+        precision_sum = 0.0
+        dcg = 0.0
+        for rank, candidate in enumerate(ranking[:cutoff], start=1):
+            if candidate not in positives:
+                continue
+            hits += 1
+            precision_sum += hits / rank
+            dcg += 1.0 / math.log2(rank + 1)
+        average_precisions.append(precision_sum / min(len(positives), cutoff))
+        ideal_dcg = sum(
+            1.0 / math.log2(rank + 1)
+            for rank in range(1, min(len(positives), cutoff) + 1)
+        )
+        ndcgs.append(dcg / ideal_dcg)
+
+    return (
+        RetrievalMetrics(
+            recall_at_1=float(np.mean(recalls)),
+            map_at_10=float(np.mean(average_precisions)),
+            ndcg_at_10=float(np.mean(ndcgs)),
+        ),
+        np.asarray(first_relevant_ranks),
+    )
+
+
+def _random_expected(relevant: list[set[int]], corpus_size: int) -> RetrievalMetrics:
+    """Compute exact expected metrics for a uniformly random candidate ordering."""
+    recall_values = []
+    ap_values = []
+    ndcg_values = []
+    cutoff = min(10, corpus_size)
+    for positives in relevant:
+        relevant_count = len(positives)
+        recall_values.append(relevant_count / corpus_size)
+
+        # At rank r, a relevant item occurs with probability R/N. Conditional on
+        # that hit, expected relevant hits through r is 1 + (r-1)(R-1)/(N-1).
+        expected_precision_sum = 0.0
+        expected_dcg = 0.0
+        for rank in range(1, cutoff + 1):
+            hit_probability = relevant_count / corpus_size
+            earlier_hits = (
+                (rank - 1) * (relevant_count - 1) / (corpus_size - 1)
+                if corpus_size > 1
+                else 0.0
+            )
+            expected_precision_sum += hit_probability * (1 + earlier_hits) / rank
+            expected_dcg += hit_probability / math.log2(rank + 1)
+        ap_values.append(expected_precision_sum / min(relevant_count, cutoff))
+        ideal_dcg = sum(
+            1.0 / math.log2(rank + 1)
+            for rank in range(1, min(relevant_count, cutoff) + 1)
+        )
+        ndcg_values.append(expected_dcg / ideal_dcg)
+
+    return RetrievalMetrics(
+        recall_at_1=float(np.mean(recall_values)),
+        map_at_10=float(np.mean(ap_values)),
+        ndcg_at_10=float(np.mean(ndcg_values)),
+    )
+
+
+def diagnose(source_dir: Path, *, limit: int, seed: int) -> DiagnosticResult:
+    all_ids = _load_complete_ids(source_dir)
+    selected_ids = _stratified_subset(all_ids, limit=limit, seed=seed)
+    source_paths = [source_dir / "raw" / f"{audio_id}.wav" for audio_id in selected_ids]
+    target_paths = [
+        source_dir / "target" / f"{audio_id}.wav" for audio_id in selected_ids
+    ]
+
+    source_embeddings = _embed(source_paths, description="Embed source audio")
+    target_embeddings = _embed(target_paths, description="Embed target audio")
+    source_embeddings, target_embeddings = _normalize_embeddings(
+        source_embeddings, target_embeddings
+    )
+    scores = source_embeddings @ target_embeddings.T
+    order = np.argsort(-scores, axis=1, kind="stable")
+    relevant = _relevant_indices(target_paths)
+    metrics, first_relevant_ranks = _metrics_from_order(order, relevant)
+
+    # MMEdit's source and target have exactly matching lengths, while 1,394 pairs
+    # violate the advertised ten-second duration. Measure that additional leakage
+    # explicitly: duration distance is the primary key and the spectral score only
+    # resolves clips with the same duration.
+    source_durations = np.asarray([_duration_seconds(path) for path in source_paths])
+    target_durations = np.asarray([_duration_seconds(path) for path in target_paths])
+    duration_distances = np.abs(
+        source_durations[:, np.newaxis] - target_durations[np.newaxis, :]
+    )
+    duration_then_fingerprint_order = np.vstack(
+        [
+            np.lexsort((-scores[index], duration_distances[index]))
+            for index in range(len(selected_ids))
+        ]
+    )
+    duration_then_fingerprint_metrics, _ = _metrics_from_order(
+        duration_then_fingerprint_order, relevant
+    )
+
+    family_counts = Counter(_family(audio_id) for audio_id in selected_ids)
+    recall_by_family = {}
+    for family in sorted(family_counts):
+        family_hits = [
+            first_relevant_ranks[index] == 1
+            for index, audio_id in enumerate(selected_ids)
+            if _family(audio_id) == family
+        ]
+        recall_by_family[family] = float(np.mean(family_hits))
+
+    false_positives = []
+    for query_index, rank in enumerate(first_relevant_ranks):
+        if rank == 1:
+            continue
+        predicted_index = int(order[query_index, 0])
+        false_positives.append(
+            {
+                "query_id": selected_ids[query_index],
+                "query_family": _family(selected_ids[query_index]),
+                "predicted_target_id": selected_ids[predicted_index],
+                "predicted_target_family": _family(selected_ids[predicted_index]),
+                "positive_rank": int(rank),
+                "predicted_score": float(scores[query_index, predicted_index]),
+                "positive_score": float(scores[query_index, query_index]),
+            }
+        )
+    false_positives.sort(
+        key=lambda row: (row["positive_rank"], row["query_id"]), reverse=True
+    )
+
+    return DiagnosticResult(
+        source_repo_id=SOURCE_REPO_ID,
+        source_revision=SOURCE_REVISION,
+        source_dir=str(source_dir),
+        method=(
+            "source-only order-invariant 64-bin log-mel distribution fingerprint; "
+            "cosine similarity"
+        ),
+        seed=seed,
+        requested_limit=limit,
+        query_count=len(selected_ids),
+        corpus_count=len(selected_ids),
+        family_counts=dict(sorted(family_counts.items())),
+        metrics=metrics,
+        duration_then_fingerprint_metrics=duration_then_fingerprint_metrics,
+        random_expected=_random_expected(relevant, len(selected_ids)),
+        recall_at_1_by_family=recall_by_family,
+        top_false_positives=false_positives[:20],
+    )
+
+
+def _print_metrics(label: str, metrics: RetrievalMetrics) -> None:
+    print(
+        f"  {label:<20} "
+        f"R@1={metrics.recall_at_1:.4f}  "
+        f"mAP@10={metrics.map_at_10:.4f}  "
+        f"nDCG@10={metrics.ndcg_at_10:.4f}"
+    )
+
+
+def _print_result(result: DiagnosticResult) -> None:
+    print("\nMMEdit source-only retrieval diagnostic")
+    print(f"  Revision:            {result.source_revision}")
+    print(f"  Queries/corpus:      {result.query_count:,}/{result.corpus_count:,}")
+    print(f"  Deterministic seed:  {result.seed}")
+    _print_metrics("Spectral fingerprint", result.metrics)
+    _print_metrics("Duration + spectral", result.duration_then_fingerprint_metrics)
+    _print_metrics("Random expectation", result.random_expected)
+    family_scores = ", ".join(
+        f"{family}={score:.2f}"
+        for family, score in result.recall_at_1_by_family.items()
+    )
+    print(f"  R@1 by family:       {family_scores}")
+    if result.top_false_positives:
+        print("  Highest-rank misses:")
+        for row in result.top_false_positives[:8]:
+            print(
+                f"    {row['query_id']} -> {row['predicted_target_id']} "
+                f"(positive rank {row['positive_rank']})"
+            )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-dir", type=Path, required=True)
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=512,
+        help="Number of stratified triplets to evaluate; 0 uses all 3,317.",
+    )
+    parser.add_argument(
+        "--seed", type=int, default=5140, help="Deterministic subset selection seed."
+    )
+    parser.add_argument(
+        "--json-report", type=Path, help="Optionally write the result as JSON."
+    )
+    args = parser.parse_args()
+
+    if args.limit < 0:
+        parser.error("--limit cannot be negative")
+    source_dir = _external_source_dir(args.source_dir)
+    try:
+        result = diagnose(source_dir, limit=args.limit, seed=args.seed)
+    except ValueError as error:
+        parser.error(str(error))
+    _print_result(result)
+
+    if args.json_report is not None:
+        report_path = args.json_report.expanduser().resolve()
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(
+            json.dumps(asdict(result), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        print(f"Wrote JSON report: {report_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds `MMEditAT2ARetrieval`, an audio+text-to-audio retrieval task derived from MMEdit. A query combines a source recording with an editing instruction and retrieves the edited recording from a global pool of 3,317 candidates.

This adds coverage for composed audio retrieval, where models must represent both the source and requested edit. Closes #5140.

## Dataset

- [Hugging Face dataset](https://huggingface.co/datasets/pranitchawla/MMEdit-AT2A), pinned at `ab1ce44e7fc3dc31292c025b6e002915538d4feb`
- 3,317 queries, 3,317 candidates, and 3,337 qrels
- Byte-identical targets are all relevant, avoiding false negatives
- Includes construction/diagnostic scripts and descriptive statistics

Important caveat: edited recordings preserve much of the source audio, creating a strong source-only shortcut. This is documented in the task metadata and quantified by the included diagnostic.

| Baseline | nDCG@10 | mAP@10 | R@1 |
| --- | ---: | ---: | ---: |
| Random | .00098 | .00048 | .00000 |
| CLAP HTSAT fused | .50619 | .47491 | .41694 |
| Source spectral | .62159 | .60944 | .58487 |
| Source duration+spectral | .84952 | .83764 | .81128 |

Validation: Ruff/formatting, task discovery, 1,842 metadata/quality tests, and full random/CLAP evaluations passed.

## Checklist

- [x] Fills a composed-audio retrieval gap
- [x] Runs with MTEB; random and CLAP results included
- [x] Performance is above random and below perfect; shortcut disclosed
- [x] Retains all pairs because the global pool defines the task
- [x] Paper retrieval scores are N/A; this task is derived from its editing test set
