### PR TITLE
fix: support current Qwen2-VL GME layout

### DIFF
--- a/mteb/models/model_implementations/gme_v_models.py
+++ b/mteb/models/model_implementations/gme_v_models.py
@@ -63,7 +63,7 @@ class Encoder(torch.nn.Module):
         **kwargs,
     ) -> torch.Tensor:
         if inputs_embeds is None:
-            inputs_embeds = self.base.model.embed_tokens(input_ids)
+            inputs_embeds = self.base.get_input_embeddings()(input_ids)
             if pixel_values is not None:
                 pixel_values = pixel_values.type(self.base.visual.get_dtype())
                 image_embeds = self.base.visual(
@@ -79,7 +79,8 @@ class Encoder(torch.nn.Module):
             if attention_mask is not None:
                 attention_mask = attention_mask.to(inputs_embeds.device)
 
-        outputs = self.base.model(
+        language_model = getattr(self.base.model, "language_model", self.base.model)
+        outputs = language_model(
             input_ids=None,
             position_ids=position_ids,
             attention_mask=attention_mask,
@@ -193,7 +194,7 @@ class GmeQwen2VL(AbsEncoder):
         self.model = self.model.to(self.device)
         all_embeddings = []
         for batch in tqdm(inputs, disable=not show_progress_bar, desc="Fused Encoding"):
-            batch_size = len(batch["text"]) or len(batch["image"])
+            batch_size = len(batch["text"]) if "text" in batch else len(batch["image"])
             if "text" in batch:
                 text_batch = batch["text"]
             else:

--- a/tests/test_models/test_gme_v_models.py
+++ b/tests/test_models/test_gme_v_models.py
@@ -1,0 +1,57 @@
+from types import SimpleNamespace
+
+import torch
+
+from mteb.models.model_implementations.gme_v_models import Encoder, GmeQwen2VL
+
+
+class _LanguageModel(torch.nn.Module):
+    def forward(self, *, inputs_embeds, **kwargs):
+        return SimpleNamespace(last_hidden_state=inputs_embeds)
+
+
+class _ImageOnlyEncoder(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.embedded_batches: list[tuple[list[None], list[object]]] = []
+
+    def embed(self, *, texts, images, **kwargs):
+        self.embedded_batches.append((texts, images))
+        return torch.ones(len(images), 2)
+
+
+def test_encoder_supports_qwen2vl_language_model_layout():
+    embedding = torch.nn.Embedding(10, 3)
+    language_model = _LanguageModel()
+    base = SimpleNamespace(
+        model=SimpleNamespace(language_model=language_model),
+        get_input_embeddings=lambda: embedding,
+    )
+    encoder = Encoder(base, processor=SimpleNamespace(tokenizer=SimpleNamespace()))
+
+    embeddings = encoder(
+        input_ids=torch.tensor([[1, 2]]),
+        attention_mask=torch.tensor([[1, 1]]),
+    )
+
+    expected = torch.nn.functional.normalize(embedding(torch.tensor([[1, 2]]))[:, -1])
+    torch.testing.assert_close(embeddings, expected)
+
+
+def test_gme_encodes_image_only_batches():
+    model = object.__new__(GmeQwen2VL)
+    model.model = _ImageOnlyEncoder()
+    model.device = "cpu"
+    model.get_instruction = lambda *args: None
+    images = [object(), object()]
+
+    embeddings = model.encode(
+        [{"image": images}],
+        task_metadata=SimpleNamespace(),
+        hf_split="test",
+        hf_subset="default",
+        show_progress_bar=False,
+    )
+
+    assert model.model.embedded_batches == [([None, None], images)]
+    torch.testing.assert_close(embeddings, torch.ones(2, 2))


### PR DESCRIPTION
## Summary
- use the public input-embedding accessor and current Qwen2-VL language-model path in the GME wrapper