### PR TITLE
fix: add GME dependencies and support image-only batches

### DIFF
--- a/mteb/models/model_implementations/gme_v_models.py
+++ b/mteb/models/model_implementations/gme_v_models.py
@@ -193,7 +193,7 @@ class GmeQwen2VL(AbsEncoder):
         self.model = self.model.to(self.device)
         all_embeddings = []
         for batch in tqdm(inputs, disable=not show_progress_bar, desc="Fused Encoding"):
-            batch_size = len(batch["text"]) or len(batch["image"])
+            batch_size = len(batch["text"]) if "text" in batch else len(batch["image"])
             if "text" in batch:
                 text_batch = batch["text"]
             else:
@@ -365,6 +365,7 @@ gme_qwen2vl_2b = ModelMeta(
     public_training_data=None,
     training_datasets=training_data,
     citation=GME_CITATION,
+    extra_requirements_groups=["gme"],
 )
 
 gme_qwen2vl_7b = ModelMeta(
@@ -390,4 +391,5 @@ gme_qwen2vl_7b = ModelMeta(
     public_training_data=None,
     training_datasets=training_data,
     citation=GME_CITATION,
+    extra_requirements_groups=["gme"],
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,7 @@ qwen-vl = ["transformers>=4.57.0", "qwen-vl-utils>=0.0.14"]
 qwen_omni_utils = ["qwen_omni_utils"]
 embeddinggemma = ["transformers>=4.56.0"]
 # ebind = ["ebind @ git+https://github.com/encord-team/ebind@7909701e9372353ca678b9515f9f61cf87c83c71", "soundfile>=0.13.1", "transformers>=4.57.1,!=5.0.0"]
+gme = ["transformers<4.52.0"]
 
 [dependency-groups]
 lint = [
@@ -512,6 +513,7 @@ conflicts = [
         { extra = "nemotron-rerank" }, # conflicting versions of transformers
         { extra = "modernbert" }, # conflicting versions of transformers
         { extra = "sparse-encoder" }, # conflicting version of sentence-transformers
+        { extra = "gme" }, # requires transformers<4.52.0
     ],
 ]
 


### PR DESCRIPTION
## Summary

-  adding a dedicated `gme` extra pinned to the compatible Transformers version
- supporting image-only batches.

## Description

While evaluating `gme-Qwen2-VL-2B-Instruct`, I encountered two issues in the current GME wrapper:

1. With `transformers==4.57.6`, encoding fails because `self.base.model.embed_tokens` no longer exists in the newer Qwen2-VL implementation:

```text
AttributeError: 'Qwen2VLModel' object has no attribute 'embed_tokens'
```

Pinning `transformers<4.52.0` allows the evaluation to proceed. The wrapper may need an explicit Transformers version constraint or support for the newer Qwen2-VL structure.

2. Corpus encoding fails for image-only batches at:

```python
batch_size = len(batch["text"]) or len(batch["image"])
```

with:

```text
KeyError: 'text'
```

Some multimodal retrieval tasks provide image-text queries while their corpus entries contain only images. This is handled by determining the batch size from the modality present in the batch:

```python
batch_size = (
    len(batch["text"]) if "text" in batch else len(batch["image"])
)
```

After applying these changes, the GME evaluation proceeds successfully.