### PR TITLE
fix: skip R_cap division when a query has no relevant docs

### DIFF
--- a/mteb/_evaluators/retrieval_metrics.py
+++ b/mteb/_evaluators/retrieval_metrics.py
@@ -78,6 +78,7 @@ def recall_cap(
             denominator = min(len(query_relevant_docs), k)
             if denominator == 0:
                 capped_recall[f"R_cap_at_{k}"].append(None)
+                continue
             capped_recall[f"R_cap_at_{k}"].append(len(retrieved_docs) / denominator)
     return capped_recall
 

--- a/tests/test_evaluators/test_evaluation_metrics.py
+++ b/tests/test_evaluators/test_evaluation_metrics.py
@@ -1,6 +1,24 @@
 import pytrec_eval
 
-from mteb._evaluators.retrieval_metrics import calculate_pmrr, mrr
+from mteb._evaluators.retrieval_metrics import calculate_pmrr, mrr, recall_cap
+
+
+def test_recall_cap_no_relevant_docs_yields_none():
+    # a query whose qrels hold only non-relevant (relevance 0) judgments has an empty
+    # relevant set, so the R_cap denominator is 0. The zero guard should record None and
+    # skip the division; without the skip it fell through and raised ZeroDivisionError.
+    qrels = {"q1": {"d1": 0, "d2": 0}}
+    results = {"q1": {"d1": 0.9, "d2": 0.1}}
+
+    assert recall_cap(qrels, results, [10]) == {"R_cap_at_10": [None]}
+
+
+def test_recall_cap_counts_capped_relevant_hits():
+    # normal path stays intact: 2 relevant docs retrieved, capped at min(#relevant, k).
+    qrels = {"q1": {"d1": 1, "d2": 1, "d3": 0}}
+    results = {"q1": {"d1": 0.9, "d2": 0.8, "d3": 0.1}}
+
+    assert recall_cap(qrels, results, [10]) == {"R_cap_at_10": [1.0]}
 
 
 def test_mrr_tiebreak_independent_of_insertion_order():


### PR DESCRIPTION
`recall_cap` guards against a zero denominator, but the guard doesn't actually short-circuit: it appends `None` and then falls through to `len(retrieved_docs) / denominator`, so a query whose qrels contain only non-relevant (relevance 0) judgments hits `ZeroDivisionError` instead of yielding `None`.

```python
qrels   = {"q1": {"d1": 0, "d2": 0}}
results = {"q1": {"d1": 0.9, "d2": 0.1}}
recall_cap(qrels, results, [10])  # ZeroDivisionError
```

The intended contract is clearly "record `None` and skip" — the LMEB tasks that consume this (`task_specific_scores` → `_average_optional`) already filter `None` out before averaging. Added the missing `continue`, which also stops the double append that happened for that `k` when the guard fired. Added a test for the no-relevant-docs case (raises on current main) plus one for the normal capped path. `ruff` clean, metric tests green.
