### PR TITLE
dataset: add MovingFashion bidirectional image-video retrieval

### DIFF
--- a/mteb/abstasks/task_metadata.py
+++ b/mteb/abstasks/task_metadata.py
@@ -285,6 +285,7 @@ TaskCategory = Literal[
     "i2v",
     "i2va",
     "it2v",
+    "v2i",
 ]
 """The category of the task.
 
@@ -329,6 +330,7 @@ TaskCategory = Literal[
 39. i2v: image to video
 40. i2va: image to video+audio
 41. it2v: image+text to video
+42. v2i: video to image
 """
 
 _MODALITY_CODES: dict[str, str] = {

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/MovingFashionI2VRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/MovingFashionI2VRetrieval.json
@@ -1,0 +1,88 @@
+{
+    "test": {
+        "num_samples": 2668,
+        "num_queries": 1340,
+        "num_documents": 1328,
+        "number_of_characters": 0,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": {
+            "total_duration_seconds": 19003.636629089473,
+            "total_frames": 504064,
+            "min_width": 240,
+            "average_width": 678.4578313253012,
+            "max_width": 912,
+            "min_height": 400,
+            "average_height": 792.1807228915662,
+            "max_height": 960,
+            "min_duration_seconds": 0.26666666666666666,
+            "average_duration_seconds": 14.309967341181832,
+            "max_duration_seconds": 38.13333333333333,
+            "unique_videos": 1327,
+            "average_fps": 26.71460843373494,
+            "fps": {
+                "30": 456,
+                "25": 869,
+                "24": 3
+            },
+            "min_resolution": [
+                256,
+                400
+            ],
+            "average_resolution": [
+                678.4578313253012,
+                792.1807228915662
+            ],
+            "max_resolution": [
+                912,
+                960
+            ],
+            "resolutions": {
+                "320x640": 154,
+                "368x720": 78,
+                "336x640": 18,
+                "352x640": 5,
+                "272x544": 3,
+                "352x720": 20,
+                "368x640": 13,
+                "784x832": 1013,
+                "912x960": 1,
+                "320x784": 1,
+                "336x720": 1,
+                "288x576": 1,
+                "384x720": 1,
+                "320x624": 4,
+                "304x640": 3,
+                "288x640": 2,
+                "384x640": 1,
+                "368x656": 3,
+                "240x480": 2,
+                "416x720": 1,
+                "432x720": 1,
+                "288x544": 1,
+                "256x400": 1
+            }
+        },
+        "queries_text_statistics": null,
+        "queries_image_statistics": {
+            "min_image_width": 77,
+            "average_image_width": 762.694776119403,
+            "max_image_width": 920,
+            "min_image_height": 56,
+            "average_image_height": 1128.726119402985,
+            "max_image_height": 1696,
+            "unique_images": 1340
+        },
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 1341,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0007462686567163,
+            "max_relevant_docs_per_query": 2,
+            "unique_relevant_docs": 1328
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/MovingFashionV2IRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/MovingFashionV2IRetrieval.json
@@ -1,0 +1,88 @@
+{
+    "test": {
+        "num_samples": 2669,
+        "num_queries": 1328,
+        "num_documents": 1341,
+        "number_of_characters": 0,
+        "documents_text_statistics": null,
+        "documents_image_statistics": {
+            "min_image_width": 77,
+            "average_image_width": 762.324384787472,
+            "max_image_width": 920,
+            "min_image_height": 56,
+            "average_image_height": 1128.0954511558539,
+            "max_image_height": 1696,
+            "unique_images": 1341
+        },
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": {
+            "total_duration_seconds": 19003.636629089473,
+            "total_frames": 504064,
+            "min_width": 240,
+            "average_width": 678.4578313253012,
+            "max_width": 912,
+            "min_height": 400,
+            "average_height": 792.1807228915662,
+            "max_height": 960,
+            "min_duration_seconds": 0.26666666666666666,
+            "average_duration_seconds": 14.309967341181832,
+            "max_duration_seconds": 38.13333333333333,
+            "unique_videos": 1327,
+            "average_fps": 26.71460843373494,
+            "fps": {
+                "30": 456,
+                "25": 869,
+                "24": 3
+            },
+            "min_resolution": [
+                256,
+                400
+            ],
+            "average_resolution": [
+                678.4578313253012,
+                792.1807228915662
+            ],
+            "max_resolution": [
+                912,
+                960
+            ],
+            "resolutions": {
+                "320x640": 154,
+                "368x720": 78,
+                "336x640": 18,
+                "352x640": 5,
+                "272x544": 3,
+                "352x720": 20,
+                "368x640": 13,
+                "784x832": 1013,
+                "912x960": 1,
+                "320x784": 1,
+                "336x720": 1,
+                "288x576": 1,
+                "384x720": 1,
+                "320x624": 4,
+                "304x640": 3,
+                "288x640": 2,
+                "384x640": 1,
+                "368x656": 3,
+                "240x480": 2,
+                "416x720": 1,
+                "432x720": 1,
+                "288x544": 1,
+                "256x400": 1
+            }
+        },
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 1341,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.009789156626506,
+            "max_relevant_docs_per_query": 2,
+            "unique_relevant_docs": 1340
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/tasks/retrieval/zxx/__init__.py
+++ b/mteb/tasks/retrieval/zxx/__init__.py
@@ -1,4 +1,5 @@
 from .lp_music_caps import LPMusicCapsMTTA2TRetrieval, LPMusicCapsMTTT2ARetrieval
+from .moving_fashion_retrieval import MovingFashionV2IRetrieval
 from .music_caps import MusicCapsA2TRetrieval, MusicCapsT2ARetrieval
 from .song_describer import SongDescriberA2TRetrieval, SongDescriberT2ARetrieval
 from .sound_descs import SoundDescsA2TRetrieval, SoundDescsT2ARetrieval
@@ -10,6 +11,7 @@ from .vsc2022_retrieval import VSC2022Retrieval
 __all__ = [
     "LPMusicCapsMTTA2TRetrieval",
     "LPMusicCapsMTTT2ARetrieval",
+    "MovingFashionV2IRetrieval",
     "MusicCapsA2TRetrieval",
     "MusicCapsT2ARetrieval",
     "SongDescriberA2TRetrieval",

--- a/mteb/tasks/retrieval/zxx/__init__.py
+++ b/mteb/tasks/retrieval/zxx/__init__.py
@@ -1,5 +1,8 @@
 from .lp_music_caps import LPMusicCapsMTTA2TRetrieval, LPMusicCapsMTTT2ARetrieval
-from .moving_fashion_retrieval import MovingFashionV2IRetrieval
+from .moving_fashion_retrieval import (
+    MovingFashionI2VRetrieval,
+    MovingFashionV2IRetrieval,
+)
 from .music_caps import MusicCapsA2TRetrieval, MusicCapsT2ARetrieval
 from .song_describer import SongDescriberA2TRetrieval, SongDescriberT2ARetrieval
 from .sound_descs import SoundDescsA2TRetrieval, SoundDescsT2ARetrieval
@@ -11,6 +14,7 @@ from .vsc2022_retrieval import VSC2022Retrieval
 __all__ = [
     "LPMusicCapsMTTA2TRetrieval",
     "LPMusicCapsMTTT2ARetrieval",
+    "MovingFashionI2VRetrieval",
     "MovingFashionV2IRetrieval",
     "MusicCapsA2TRetrieval",
     "MusicCapsT2ARetrieval",

--- a/mteb/tasks/retrieval/zxx/moving_fashion_retrieval.py
+++ b/mteb/tasks/retrieval/zxx/moving_fashion_retrieval.py
@@ -4,6 +4,55 @@ from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
 
 
+class MovingFashionI2VRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="MovingFashionI2VRetrieval",
+        description=(
+            "Shop-image-to-video fashion retrieval obtained by reversing the "
+            "official MovingFashion test associations. The benchmark contains "
+            "1,340 available e-commerce product-image queries, a global corpus of "
+            "1,328 social videos, and 1,341 binary relevance judgments. Repeated "
+            "source media paths preserve one genuine multi-positive image query. "
+            "The official archive omits one annotated test video, so the shop image "
+            "whose only positive video is unavailable is excluded with that qrel."
+        ),
+        reference="https://arxiv.org/abs/2110.02627",
+        dataset={
+            "path": "pranitchawla/MovingFashionI2VRetrieval",
+            "revision": "29906095b736d5319f14ec1800640b40612b6e8d",
+        },
+        type="Any2AnyRetrieval",
+        category="i2v",
+        modalities=["image", "video"],
+        eval_splits=["test"],
+        eval_langs=["zxx-Zxxx"],
+        main_score="ndcg_at_10",
+        date=("2021-10-06", "2022-01-08"),
+        domains=["E-commerce", "Social"],
+        task_subtypes=["Cross-Modal Retrieval"],
+        license="cc-by-nc-sa-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=r"""
+@misc{godi2021movingfashion,
+  archiveprefix = {arXiv},
+  author = {Godi, Marco and Joppi, Christian and Skenderi, Geri and Cristani, Marco},
+  eprint = {2110.02627},
+  primaryclass = {cs.CV},
+  title = {MovingFashion: a Benchmark for the Video-to-Shop Challenge},
+  year = {2021},
+}
+""",
+        prompt={
+            "query": (
+                "Retrieve social videos showing the clothing item in this shop image."
+            )
+        },
+        is_beta=True,
+    )
+
+
 class MovingFashionV2IRetrieval(AbsTaskRetrieval):
     metadata = TaskMetadata(
         name="MovingFashionV2IRetrieval",

--- a/mteb/tasks/retrieval/zxx/moving_fashion_retrieval.py
+++ b/mteb/tasks/retrieval/zxx/moving_fashion_retrieval.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class MovingFashionV2IRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="MovingFashionV2IRetrieval",
+        description=(
+            "Video-to-shop-image fashion retrieval on the official MovingFashion "
+            "test split. The benchmark contains 1,328 available social-video queries, "
+            "a global corpus of 1,341 e-commerce product images, and 1,341 binary "
+            "relevance judgments. Repeated source media paths preserve 13 genuine "
+            "multi-positive video queries. The official archive omits one annotated "
+            "test video; that unavailable query and qrel are excluded while its "
+            "product image remains in the corpus as a distractor."
+        ),
+        reference="https://arxiv.org/abs/2110.02627",
+        dataset={
+            "path": "pranitchawla/MovingFashion",
+            "revision": "29c9813e2826ef2f4398455528881ab3e181311b",
+        },
+        type="Any2AnyRetrieval",
+        category="v2i",
+        modalities=["video", "image"],
+        eval_splits=["test"],
+        eval_langs=["zxx-Zxxx"],
+        main_score="ndcg_at_10",
+        date=("2021-10-06", "2022-01-08"),
+        domains=["E-commerce", "Social"],
+        task_subtypes=["Cross-Modal Retrieval"],
+        license="cc-by-nc-sa-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=r"""
+@misc{godi2021movingfashion,
+  archiveprefix = {arXiv},
+  author = {Godi, Marco and Joppi, Christian and Skenderi, Geri and Cristani, Marco},
+  eprint = {2110.02627},
+  primaryclass = {cs.CV},
+  title = {MovingFashion: a Benchmark for the Video-to-Shop Challenge},
+  year = {2021},
+}
+""",
+        prompt={
+            "query": (
+                "Retrieve the shop image of the clothing item worn in this video."
+            )
+        },
+        is_beta=True,
+    )

--- a/scripts/data/moving_fashion_retrieval/create_data.py
+++ b/scripts/data/moving_fashion_retrieval/create_data.py
@@ -1,0 +1,858 @@
+#!/usr/bin/env python3
+"""Build the native MovingFashion video-to-image retrieval benchmark for MTEB.
+
+The official archive contains train and test annotations plus the corresponding
+Instagram videos and Net-A-Porter shop images. MTEB uses every available query
+from the official test split: videos are queries, shop images form the corpus,
+and every usable annotated video/image association is a binary relevance
+judgment. Repeated media paths are collapsed by path, preserving the source's
+genuine multi-positive cases.
+
+The published Hugging Face dataset retains the source benchmark's video-to-shop
+image orientation.
+
+Examples:
+  # Download or resume the official source archive.
+  ./scripts/data/moving_fashion_retrieval/download_source.sh movingfashion.zip
+
+  # Audit annotations extracted from the archive (no media required).
+  uv run python scripts/data/moving_fashion_retrieval/create_data.py \
+      --annotation-dir /path/to/annotations
+
+  # Audit the complete archive, extract only test media, validate it, and save
+  # the standard MTEB retrieval configs locally.
+  uv run python scripts/data/moving_fashion_retrieval/create_data.py \
+      --archive /path/to/movingfashion.zip --save-to-disk
+
+  # Publish using the currently authenticated Hugging Face account.
+  uv run python scripts/data/moving_fashion_retrieval/create_data.py \
+      --archive /path/to/movingfashion.zip --push \
+      --repo-id pranitchawla/MovingFashion
+"""
+
+from __future__ import annotations
+
+import argparse
+import binascii
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import zipfile
+from collections import Counter, defaultdict
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import asdict, dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from datasets import Dataset, DatasetDict, Image, Value, Video
+from huggingface_hub import HfApi, create_repo, get_token
+from PIL import Image as PILImage
+
+_PROJECT_URL = "https://humaticslab.github.io/retrieval/movingfashion"
+_PAPER_URL = "https://arxiv.org/abs/2110.02627"
+_SOURCE_REPO_URL = "https://github.com/HumaticsLAB/SEAM-Match-RCNN"
+_SOURCE_REPO_REVISION = "4ca15d147ce87f0385c0c9779eac49e55c727ec8"
+_SOURCE_DOWNLOAD_URL = "https://bit.ly/4bTZGeS"
+_LICENSE = "cc-by-nc-sa-4.0"
+_EXPECTED_ARCHIVE_SHA256 = (
+    "20ae89a67a58d3dfc2304c2533d5a5c684eb6888aec9a7d7d3eda22b0a81f5f4"
+)
+
+
+@dataclass(frozen=True)
+class ExpectedSplit:
+    products: int
+    associations: int
+    unique_videos: int
+    unique_images: int
+    source_hard: int
+    source_regular: int
+    products_with_multiple_videos: int
+    max_videos_per_product: int
+
+
+_EXPECTED_SPLITS = {
+    "train": ExpectedSplit(
+        products=12648,
+        associations=13703,
+        unique_videos=13526,
+        unique_images=12630,
+        source_hard=3530,
+        source_regular=9118,
+        products_with_multiple_videos=573,
+        max_videos_per_product=24,
+    ),
+    "test": ExpectedSplit(
+        products=1342,
+        associations=1342,
+        unique_videos=1329,
+        unique_images=1341,
+        source_hard=328,
+        source_regular=1014,
+        products_with_multiple_videos=0,
+        max_videos_per_product=1,
+    ),
+}
+_EXPECTED_TEST_UNIQUE_PAIRS = 1342
+_EXPECTED_TEST_DUPLICATE_VIDEO_GROUPS = 13
+_EXPECTED_TEST_DUPLICATE_IMAGE_GROUPS = 1
+_EXPECTED_TOTAL_UNIQUE_VIDEOS = 14855
+_EXPECTED_MISSING_MEDIA = {
+    "train": {
+        "videos/0096903c8314b3870a7af2a425953536.mp4",
+        "videos/0476509b035f59bfc009827ac4d8bafc.mp4",
+        "videos/0580eb0b3128457511e09c4503391e64.mp4",
+        "videos/1242272_detail.mp4",
+        "videos/154532233c6ad4de20f01bd51b0fc1d0.mp4",
+        "videos/267e49a2051bbaedfe76d3ee2a20cd58.mp4",
+        "videos/3360fdc695014ce440aff4cb97afadbb.mp4",
+        "videos/47780e36140c63e91131555823fef909.mp4",
+        "videos/5330d0e23a7327d55685380893109692.mp4",
+        "videos/57893f18394ef329b66e35c345608694.mp4",
+        "videos/583c1c541b19369daa6ab457c9239455.mp4",
+        "videos/5f2fc22016a5e6935543dba09744032e.mp4",
+        "videos/784d4f0f64ddca7ff8d7c30b4d356e07.mp4",
+        "videos/7a8f7e95a14ed9d5f61875592ccc052b.mp4",
+        "videos/7ead8a1d0646890d2d509c91ce2e4872.mp4",
+        "videos/97210917e5c1423fb977e1ad54a3434b.mp4",
+        "videos/b2d1b95537f74557b78636c417a409ce.mp4",
+        "videos/b959460caa57d3a0144f097756485106.mp4",
+        "videos/c8ec36fdca477f3828313f91cbf2d370.mp4",
+        "videos/e1fa86dc926d29771ee89d8bc811487e.mp4",
+        "videos/e5e722166385f10fd462af377e3be7b5.mp4",
+        "videos/f386b23468d1ffda850fef2f8aa438cb.mp4",
+    },
+    "test": {"videos/bd6186ecf66d1a5c2d65ff3c891c7e44.mp4"},
+}
+
+
+@dataclass(frozen=True, order=True)
+class Association:
+    product_id: str
+    video_path: str
+    image_path: str
+    source: int
+
+
+def _validate_media_path(path: str, prefix: str) -> str:
+    pure_path = PurePosixPath(path)
+    if (
+        pure_path.is_absolute()
+        or ".." in pure_path.parts
+        or not pure_path.parts
+        or pure_path.parts[0] != prefix
+    ):
+        raise RuntimeError(f"Unexpected {prefix} path in annotations: {path!r}")
+    normalized = pure_path.as_posix()
+    if normalized != path:
+        raise RuntimeError(f"Non-canonical media path in annotations: {path!r}")
+    return normalized
+
+
+def _parse_annotations(
+    raw: Any, split: str
+) -> tuple[list[Association], Counter[int], Counter[str]]:
+    if not isinstance(raw, dict):
+        raise RuntimeError(f"{split}.json must contain a JSON object")
+
+    associations: list[Association] = []
+    source_counts: Counter[int] = Counter()
+    videos_per_product: Counter[str] = Counter()
+    for product_id, record in raw.items():
+        if not isinstance(product_id, str) or not product_id:
+            raise RuntimeError(f"Invalid product ID in {split}.json: {product_id!r}")
+        if not isinstance(record, dict):
+            raise RuntimeError(f"Invalid record for product {product_id}")
+
+        image_path = record.get("img_path")
+        video_paths = record.get("video_paths")
+        source = record.get("source")
+        if not isinstance(image_path, str):
+            raise RuntimeError(f"Invalid image path for product {product_id}")
+        image_path = _validate_media_path(image_path, "imgs")
+        if (
+            not isinstance(video_paths, list)
+            or not video_paths
+            or not all(isinstance(path, str) for path in video_paths)
+        ):
+            raise RuntimeError(f"Invalid video paths for product {product_id}")
+        if source not in {0, 1}:
+            raise RuntimeError(
+                f"Invalid source value for product {product_id}: {source!r}"
+            )
+        if len(video_paths) != len(set(video_paths)):
+            raise RuntimeError(f"Repeated video path within product {product_id}")
+
+        source_counts[source] += 1
+        videos_per_product[product_id] = len(video_paths)
+        associations.extend(
+            Association(
+                product_id=product_id,
+                video_path=_validate_media_path(video_path, "videos"),
+                image_path=image_path,
+                source=source,
+            )
+            for video_path in video_paths
+        )
+
+    if len(associations) != len(set(associations)):
+        raise RuntimeError(f"{split}.json contains duplicate association rows")
+    return associations, source_counts, videos_per_product
+
+
+def _load_json(path: Path) -> Any:
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _load_annotations_from_directory(
+    annotation_dir: Path,
+) -> dict[str, tuple[list[Association], Counter[int], Counter[str]]]:
+    output = {}
+    for split in _EXPECTED_SPLITS:
+        path = annotation_dir / f"{split}.json"
+        if not path.is_file():
+            raise RuntimeError(f"Missing annotation file: {path}")
+        output[split] = _parse_annotations(_load_json(path), split)
+    return output
+
+
+def _zip_member_map(archive: zipfile.ZipFile) -> dict[str, zipfile.ZipInfo]:
+    members: dict[str, zipfile.ZipInfo] = {}
+    for info in archive.infolist():
+        path = PurePosixPath(info.filename)
+        if path.is_absolute() or ".." in path.parts:
+            raise RuntimeError(f"Unsafe path in source archive: {info.filename!r}")
+        normalized = path.as_posix().removeprefix("./")
+        if normalized in members:
+            raise RuntimeError(f"Duplicate path in source archive: {normalized}")
+        members[normalized] = info
+    return members
+
+
+def _load_annotations_from_archive(
+    archive: zipfile.ZipFile, members: dict[str, zipfile.ZipInfo]
+) -> dict[str, tuple[list[Association], Counter[int], Counter[str]]]:
+    output = {}
+    for split in _EXPECTED_SPLITS:
+        filename = f"{split}.json"
+        if filename not in members:
+            raise RuntimeError(f"Missing {filename} in source archive")
+        with archive.open(members[filename]) as handle:
+            output[split] = _parse_annotations(json.load(handle), split)
+    return output
+
+
+def _split_summary(
+    associations: list[Association],
+    source_counts: Counter[int],
+    videos_per_product: Counter[str],
+) -> dict[str, Any]:
+    videos = {row.video_path for row in associations}
+    images = {row.image_path for row in associations}
+    return {
+        "products": len(videos_per_product),
+        "associations": len(associations),
+        "unique_videos": len(videos),
+        "unique_images": len(images),
+        "source_hard": source_counts[0],
+        "source_regular": source_counts[1],
+        "products_with_multiple_videos": sum(
+            count > 1 for count in videos_per_product.values()
+        ),
+        "max_videos_per_product": max(videos_per_product.values(), default=0),
+    }
+
+
+def _audit_annotations(
+    annotations: dict[str, tuple[list[Association], Counter[int], Counter[str]]],
+    *,
+    allow_source_changes: bool,
+) -> dict[str, Any]:
+    summary: dict[str, Any] = {
+        "source_repository": _SOURCE_REPO_URL,
+        "source_repository_revision": _SOURCE_REPO_REVISION,
+        "source_download": _SOURCE_DOWNLOAD_URL,
+        "license": _LICENSE,
+        "splits": {},
+    }
+    for split, expected in _EXPECTED_SPLITS.items():
+        actual = _split_summary(*annotations[split])
+        summary["splits"][split] = actual
+        if not allow_source_changes and actual != asdict(expected):
+            raise RuntimeError(
+                f"Unexpected {split} annotation statistics. Expected "
+                f"{asdict(expected)}, found {actual}. Review the source before rebuilding."
+            )
+
+    train_associations = annotations["train"][0]
+    test_associations = annotations["test"][0]
+    train_products = {row.product_id for row in train_associations}
+    train_videos = {row.video_path for row in train_associations}
+    train_images = {row.image_path for row in train_associations}
+    test_products = {row.product_id for row in test_associations}
+    test_videos = {row.video_path for row in test_associations}
+    test_images = {row.image_path for row in test_associations}
+    overlap = {
+        "products": sorted(train_products & test_products),
+        "videos": sorted(train_videos & test_videos),
+        "images": sorted(train_images & test_images),
+    }
+    if any(overlap.values()):
+        raise RuntimeError(f"Train/test leakage detected: {overlap}")
+
+    unique_pairs = {(row.video_path, row.image_path) for row in test_associations}
+    video_to_images: dict[str, set[str]] = defaultdict(set)
+    image_to_videos: dict[str, set[str]] = defaultdict(set)
+    for video_path, image_path in unique_pairs:
+        video_to_images[video_path].add(image_path)
+        image_to_videos[image_path].add(video_path)
+    duplicate_video_groups = {
+        video: sorted(images)
+        for video, images in video_to_images.items()
+        if len(images) > 1
+    }
+    duplicate_image_groups = {
+        image: sorted(videos)
+        for image, videos in image_to_videos.items()
+        if len(videos) > 1
+    }
+    retrieval = {
+        "v2i_queries": len(video_to_images),
+        "v2i_corpus": len(image_to_videos),
+        "v2i_qrels": len(unique_pairs),
+        "i2v_queries": len(image_to_videos),
+        "i2v_corpus": len(video_to_images),
+        "i2v_qrels": len(unique_pairs),
+        "video_queries_with_multiple_positives": len(duplicate_video_groups),
+        "image_queries_with_multiple_positives": len(duplicate_image_groups),
+        "duplicate_video_groups": duplicate_video_groups,
+        "duplicate_image_groups": duplicate_image_groups,
+    }
+    summary["annotated_retrieval"] = retrieval
+    summary["train_test_overlap"] = overlap
+    summary["total_unique_videos"] = len(train_videos | test_videos)
+
+    expected_retrieval = {
+        "v2i_queries": _EXPECTED_SPLITS["test"].unique_videos,
+        "v2i_corpus": _EXPECTED_SPLITS["test"].unique_images,
+        "v2i_qrels": _EXPECTED_TEST_UNIQUE_PAIRS,
+        "i2v_queries": _EXPECTED_SPLITS["test"].unique_images,
+        "i2v_corpus": _EXPECTED_SPLITS["test"].unique_videos,
+        "i2v_qrels": _EXPECTED_TEST_UNIQUE_PAIRS,
+        "video_queries_with_multiple_positives": (
+            _EXPECTED_TEST_DUPLICATE_VIDEO_GROUPS
+        ),
+        "image_queries_with_multiple_positives": (
+            _EXPECTED_TEST_DUPLICATE_IMAGE_GROUPS
+        ),
+    }
+    actual_retrieval = {key: retrieval[key] for key in expected_retrieval}
+    if not allow_source_changes and actual_retrieval != expected_retrieval:
+        raise RuntimeError(
+            "Unexpected test retrieval structure. Expected "
+            f"{expected_retrieval}, found {actual_retrieval}."
+        )
+    if (
+        not allow_source_changes
+        and summary["total_unique_videos"] != _EXPECTED_TOTAL_UNIQUE_VIDEOS
+    ):
+        raise RuntimeError(
+            f"Expected {_EXPECTED_TOTAL_UNIQUE_VIDEOS} unique videos, found "
+            f"{summary['total_unique_videos']}"
+        )
+    return summary
+
+
+def _sha256(path: Path, chunk_size: int = 16 * 1024 * 1024) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(chunk_size):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _crc32(path: Path, chunk_size: int = 8 * 1024 * 1024) -> int:
+    checksum = 0
+    with path.open("rb") as handle:
+        while chunk := handle.read(chunk_size):
+            checksum = binascii.crc32(chunk, checksum)
+    return checksum & 0xFFFFFFFF
+
+
+def _validate_archive_paths(
+    members: dict[str, zipfile.ZipInfo],
+    annotations: dict[str, tuple[Any, ...]],
+    *,
+    allow_source_changes: bool,
+) -> dict[str, Any]:
+    references_by_split = {
+        split: {
+            path
+            for row in split_annotations[0]
+            for path in (row.video_path, row.image_path)
+        }
+        for split, split_annotations in annotations.items()
+    }
+    referenced = set().union(*references_by_split.values())
+    missing_by_split = {
+        split: sorted(path for path in references if path not in members)
+        for split, references in references_by_split.items()
+    }
+    actual_missing = {split: set(paths) for split, paths in missing_by_split.items()}
+    if not allow_source_changes and actual_missing != _EXPECTED_MISSING_MEDIA:
+        raise RuntimeError(
+            "Unexpected source archive omissions. Expected "
+            f"{_EXPECTED_MISSING_MEDIA}, found {actual_missing}."
+        )
+    archive_media = {
+        path
+        for path, info in members.items()
+        if not info.is_dir() and path.startswith(("videos/", "imgs/"))
+    }
+    return {
+        "referenced_media": len(referenced),
+        "archive_media": len(archive_media),
+        "unreferenced_archive_media": len(archive_media - referenced),
+        "missing_referenced_media": missing_by_split,
+        "missing_referenced_media_count": sum(map(len, missing_by_split.values())),
+    }
+
+
+def _extract_member(
+    archive_path: Path,
+    info: zipfile.ZipInfo,
+    destination_root: Path,
+) -> Path:
+    destination = destination_root / PurePosixPath(info.filename)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if (
+        destination.is_file()
+        and destination.stat().st_size == info.file_size
+        and _crc32(destination) == info.CRC
+    ):
+        return destination
+
+    partial = destination.with_name(destination.name + ".part")
+    with zipfile.ZipFile(archive_path) as archive, archive.open(info) as source:
+        with partial.open("wb") as output:
+            shutil.copyfileobj(source, output, length=8 * 1024 * 1024)
+    if partial.stat().st_size != info.file_size or _crc32(partial) != info.CRC:
+        partial.unlink(missing_ok=True)
+        raise RuntimeError(f"Failed CRC/size validation for {info.filename}")
+    partial.replace(destination)
+    return destination
+
+
+def _extract_test_media(
+    archive_path: Path,
+    members: dict[str, zipfile.ZipInfo],
+    test_associations: list[Association],
+    media_dir: Path,
+    *,
+    workers: int,
+) -> tuple[list[str], list[str]]:
+    videos = sorted(
+        {row.video_path for row in test_associations if row.video_path in members}
+    )
+    images = sorted(
+        {row.image_path for row in test_associations if row.image_path in members}
+    )
+    paths = [*videos, *images]
+
+    def extract(path: str) -> Path:
+        return _extract_member(archive_path, members[path], media_dir)
+
+    with ThreadPoolExecutor(max_workers=max(1, workers)) as pool:
+        list(pool.map(extract, paths))
+    return videos, images
+
+
+def _image_is_decodable(path: Path) -> bool:
+    try:
+        with PILImage.open(path) as image:
+            image.verify()
+        return True
+    except Exception:
+        return False
+
+
+def _video_is_decodable(path: Path) -> bool:
+    ffprobe = shutil.which("ffprobe")
+    if ffprobe is None:
+        raise RuntimeError("ffprobe is required to validate MovingFashion videos")
+    result = subprocess.run(
+        [
+            ffprobe,
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=codec_name,width,height,duration",
+            "-of",
+            "json",
+            str(path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return False
+    try:
+        streams = json.loads(result.stdout).get("streams", [])
+    except json.JSONDecodeError:
+        return False
+    return bool(
+        streams
+        and streams[0].get("codec_name")
+        and streams[0].get("width", 0) > 0
+        and streams[0].get("height", 0) > 0
+    )
+
+
+def _validate_test_media(
+    media_dir: Path,
+    videos: list[str],
+    images: list[str],
+    *,
+    workers: int,
+) -> None:
+    with ThreadPoolExecutor(max_workers=max(1, workers)) as pool:
+        image_results = pool.map(
+            lambda path: _image_is_decodable(media_dir / path), images
+        )
+        bad_images = [
+            path for path, valid in zip(images, image_results, strict=True) if not valid
+        ]
+    with ThreadPoolExecutor(max_workers=max(1, workers)) as pool:
+        video_results = pool.map(
+            lambda path: _video_is_decodable(media_dir / path), videos
+        )
+        bad_videos = [
+            path for path, valid in zip(videos, video_results, strict=True) if not valid
+        ]
+    if bad_images or bad_videos:
+        raise RuntimeError(
+            f"Media validation failed: bad_images={bad_images}, bad_videos={bad_videos}"
+        )
+
+
+def _build_datasets(
+    test_associations: list[Association],
+    media_dir: Path,
+    videos: list[str],
+    images: list[str],
+) -> tuple[Dataset, Dataset, Dataset]:
+    video_ids = set(videos)
+    image_ids = set(images)
+    pairs = sorted(
+        {
+            (row.video_path, row.image_path)
+            for row in test_associations
+            if row.video_path in video_ids and row.image_path in image_ids
+        }
+    )
+    video_ids = sorted(video_ids)
+    image_ids = sorted(image_ids)
+    queries = Dataset.from_dict(
+        {
+            "id": video_ids,
+            "video": [str(media_dir / video_id) for video_id in video_ids],
+        }
+    ).cast_column("video", Video())
+    corpus = Dataset.from_dict(
+        {
+            "id": image_ids,
+            "image": [str(media_dir / image_id) for image_id in image_ids],
+        }
+    ).cast_column("image", Image())
+    qrels = Dataset.from_dict(
+        {
+            "query-id": [video_path for video_path, _ in pairs],
+            "corpus-id": [image_path for _, image_path in pairs],
+            "score": [1] * len(pairs),
+        }
+    ).cast_column("score", Value("int32"))
+    return corpus, queries, qrels
+
+
+def _published_retrieval_summary(
+    test_associations: list[Association], videos: list[str], images: list[str]
+) -> dict[str, Any]:
+    video_ids = set(videos)
+    image_ids = set(images)
+    pairs = {
+        (row.video_path, row.image_path)
+        for row in test_associations
+        if row.video_path in video_ids and row.image_path in image_ids
+    }
+    images_with_qrels = {image_path for _, image_path in pairs}
+    return {
+        "v2i_queries": len(video_ids),
+        "v2i_corpus": len(image_ids),
+        "v2i_qrels": len(pairs),
+        "corpus_images_without_qrels": sorted(image_ids - images_with_qrels),
+    }
+
+
+def _dataset_card(summary: dict[str, Any]) -> str:
+    retrieval = summary["published_retrieval"]
+    archive_sha256 = summary.get("archive_sha256", "not recorded")
+    return f"""---
+license: cc-by-nc-sa-4.0
+pretty_name: MovingFashion Retrieval
+tags:
+- mteb
+- moeb
+- video-to-image
+- cross-modal-retrieval
+configs:
+- config_name: corpus
+  data_files:
+  - split: test
+    path: corpus/test-*
+- config_name: qrels
+  data_files:
+  - split: test
+    path: qrels/test-*
+- config_name: queries
+  data_files:
+  - split: test
+    path: queries/test-*
+---
+
+# MovingFashion Retrieval
+
+Frozen MTEB/MOEB representation of the official MovingFashion test split for
+video-to-shop-image fashion retrieval.
+
+## Construction
+
+The dataset is derived from the [official MovingFashion release]({_PROJECT_URL})
+and its `test.json` associations. The MTEB construction script audits both
+official splits against the source code at revision
+[`{_SOURCE_REPO_REVISION}`]({_SOURCE_REPO_URL}/tree/{_SOURCE_REPO_REVISION}),
+checks that train and test share no product IDs or media paths, verifies every
+annotation reference against the archive, pins the known source omissions, and
+decodes all published test media. The source archive SHA-256 for this build is
+`{archive_sha256}`.
+
+Media paths are used as IDs. Repeated paths are collapsed without discarding
+associations, so the source's multi-positive relevance structure is preserved.
+The Hub configs use the standard MTEB representation: `queries` contains video
+queries, `corpus` contains shop images, and `qrels` contains binary relevance
+judgments.
+
+The official archive omits 22 train videos and one annotated test video. The
+missing test query and its unusable qrel are excluded; its available shop image
+remains in the corpus as a distractor. The construction script pins and reports
+all 23 source omissions rather than silently dropping them.
+
+## Evaluation contents
+
+- Video-to-image: {retrieval["v2i_queries"]} queries,
+  {retrieval["v2i_corpus"]} corpus images, and {retrieval["v2i_qrels"]} qrels.
+- Corpus images without a qrel: {len(retrieval["corpus_images_without_qrels"])}.
+- Source difficulty labels: `0` is hard and `1` is regular. They are audited
+  during construction but are not used to filter the benchmark.
+
+## Source protocol and baselines
+
+The source benchmark evaluates video-to-shop retrieval with top-k accuracy. The
+paper reports SEAM Match-RCNN top-1/5/10/20 accuracy of .49/.80/.89/.94 overall,
+.55/.86/.94/.97 on the regular subset, and .30/.62/.76/.87 on the hard subset.
+Those numbers use the original task-specific detector and are context rather
+than directly comparable guarantees for generic embedding models.
+
+## License, provenance, and limitations
+
+The official repository labels the work CC BY-NC-SA 4.0 and says the dataset is
+available for academic purposes. This derived release therefore retains
+CC BY-NC-SA 4.0, attribution, non-commercial, and share-alike requirements.
+Source videos originated on Instagram and shop images on Net-A-Porter; underlying
+media, privacy, publicity, trademark, and platform rights may remain with their
+respective owners. The paper states that faces were blurred. Users remain
+responsible for determining whether their use complies with the license,
+source-platform terms, and applicable law.
+
+## Citation
+
+```bibtex
+@misc{{godi2021movingfashion,
+  title = {{MovingFashion: a Benchmark for the Video-to-Shop Challenge}},
+  author = {{Godi, Marco and Joppi, Christian and Skenderi, Geri and Cristani, Marco}},
+  year = {{2021}},
+  eprint = {{2110.02627}},
+  archivePrefix = {{arXiv}},
+  primaryClass = {{cs.CV}},
+}}
+```
+
+See the [paper]({_PAPER_URL}) and [official code]({_SOURCE_REPO_URL}).
+"""
+
+
+def _save_datasets(
+    work_dir: Path, corpus: Dataset, queries: Dataset, qrels: Dataset
+) -> None:
+    export_dir = work_dir / "mteb_export"
+    export_dir.mkdir(parents=True, exist_ok=True)
+    DatasetDict({"test": corpus}).save_to_disk(export_dir / "corpus")
+    DatasetDict({"test": queries}).save_to_disk(export_dir / "queries")
+    DatasetDict({"test": qrels}).save_to_disk(export_dir / "qrels")
+    print(f"Wrote local dataset to {export_dir}")
+
+
+def _publish(
+    repo_id: str,
+    corpus: Dataset,
+    queries: Dataset,
+    qrels: Dataset,
+    summary: dict[str, Any],
+    work_dir: Path,
+) -> str:
+    token = get_token() or os.environ.get("HF_TOKEN")
+    if not token:
+        raise RuntimeError(
+            "No Hugging Face token found; run `hf auth login` before --push"
+        )
+    create_repo(repo_id, repo_type="dataset", token=token, exist_ok=True)
+    api = HfApi(token=token)
+    api.upload_file(
+        path_or_fileobj=_dataset_card(summary).encode(),
+        path_in_repo="README.md",
+        repo_id=repo_id,
+        repo_type="dataset",
+        commit_message="Add MovingFashion dataset card",
+    )
+    DatasetDict({"test": corpus}).push_to_hub(
+        repo_id,
+        "corpus",
+        token=token,
+        max_shard_size="500MB",
+        commit_message="Add MovingFashion image corpus",
+    )
+    DatasetDict({"test": queries}).push_to_hub(
+        repo_id,
+        "queries",
+        token=token,
+        max_shard_size="500MB",
+        commit_message="Add MovingFashion video queries",
+    )
+    DatasetDict({"test": qrels}).push_to_hub(
+        repo_id,
+        "qrels",
+        token=token,
+        commit_message="Add MovingFashion relevance judgments",
+    )
+    revision = api.dataset_info(repo_id).sha
+    (work_dir / "hub_revision.txt").write_text(f"{revision}\n", encoding="utf-8")
+    return revision
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument(
+        "--archive", type=Path, help="Path to the official movingfashion.zip"
+    )
+    source.add_argument(
+        "--annotation-dir",
+        type=Path,
+        help="Directory containing extracted train.json and test.json for audit only",
+    )
+    parser.add_argument(
+        "--work-dir", type=Path, default=Path("/tmp/moving_fashion_retrieval")
+    )
+    parser.add_argument("--repo-id", default="pranitchawla/MovingFashion")
+    parser.add_argument("--save-to-disk", action="store_true")
+    parser.add_argument("--push", action="store_true")
+    parser.add_argument(
+        "--allow-source-changes",
+        action="store_true",
+        help="Report rather than reject changes to the pinned annotation statistics",
+    )
+    parser.add_argument("--extract-workers", type=int, default=4)
+    parser.add_argument("--verify-workers", type=int, default=8)
+    args = parser.parse_args()
+
+    work_dir = args.work_dir.resolve()
+    work_dir.mkdir(parents=True, exist_ok=True)
+    archive: zipfile.ZipFile | None = None
+    members: dict[str, zipfile.ZipInfo] | None = None
+    if args.annotation_dir is not None:
+        if args.save_to_disk or args.push:
+            raise RuntimeError(
+                "--save-to-disk and --push require --archive so media can be included"
+            )
+        annotations = _load_annotations_from_directory(args.annotation_dir.resolve())
+    else:
+        archive_path = args.archive.resolve()
+        if not archive_path.is_file():
+            raise RuntimeError(f"Archive not found: {archive_path}")
+        archive = zipfile.ZipFile(archive_path)
+        members = _zip_member_map(archive)
+        annotations = _load_annotations_from_archive(archive, members)
+
+    summary = _audit_annotations(
+        annotations, allow_source_changes=args.allow_source_changes
+    )
+    corpus: Dataset | None = None
+    queries: Dataset | None = None
+    qrels: Dataset | None = None
+    if archive is not None and members is not None:
+        summary["archive"] = _validate_archive_paths(
+            members, annotations, allow_source_changes=args.allow_source_changes
+        )
+        archive.close()
+        summary["archive_sha256"] = _sha256(archive_path)
+        if (
+            not args.allow_source_changes
+            and summary["archive_sha256"] != _EXPECTED_ARCHIVE_SHA256
+        ):
+            raise RuntimeError(
+                "Unexpected source archive SHA-256. Expected "
+                f"{_EXPECTED_ARCHIVE_SHA256}, found {summary['archive_sha256']}."
+            )
+        media_dir = work_dir / "source" / "media"
+        videos, images = _extract_test_media(
+            archive_path,
+            members,
+            annotations["test"][0],
+            media_dir,
+            workers=args.extract_workers,
+        )
+        _validate_test_media(media_dir, videos, images, workers=args.verify_workers)
+        summary["validated_test_media"] = {
+            "videos": len(videos),
+            "images": len(images),
+        }
+        summary["published_retrieval"] = _published_retrieval_summary(
+            annotations["test"][0], videos, images
+        )
+        corpus, queries, qrels = _build_datasets(
+            annotations["test"][0], media_dir, videos, images
+        )
+
+    print(json.dumps(summary, indent=2, sort_keys=True))
+
+    summary_path = work_dir / "audit_summary.json"
+    summary_path.write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(f"Wrote audit summary to {summary_path}")
+
+    if args.save_to_disk:
+        assert corpus is not None and queries is not None and qrels is not None
+        _save_datasets(work_dir, corpus, queries, qrels)
+    if args.push:
+        assert corpus is not None and queries is not None and qrels is not None
+        revision = _publish(args.repo_id, corpus, queries, qrels, summary, work_dir)
+        print(f"Pushed {args.repo_id} at revision {revision}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/data/moving_fashion_retrieval/create_data.py
+++ b/scripts/data/moving_fashion_retrieval/create_data.py
@@ -1,15 +1,11 @@
 #!/usr/bin/env python3
-"""Build the native MovingFashion video-to-image retrieval benchmark for MTEB.
+"""Build the bidirectional MovingFashion image/video retrieval tasks for MTEB.
 
 The official archive contains train and test annotations plus the corresponding
-Instagram videos and Net-A-Porter shop images. MTEB uses every available query
-from the official test split: videos are queries, shop images form the corpus,
-and every usable annotated video/image association is a binary relevance
-judgment. Repeated media paths are collapsed by path, preserving the source's
-genuine multi-positive cases.
-
-The published Hugging Face dataset retains the source benchmark's video-to-shop
-image orientation.
+Instagram videos and Net-A-Porter shop images. MTEB uses every usable association
+from the official test split in both video-to-image and image-to-video directions.
+Repeated media paths are collapsed by path, preserving the source's genuine
+multi-positive cases.
 
 Examples:
   # Download or resume the official source archive.
@@ -24,10 +20,13 @@ Examples:
   uv run python scripts/data/moving_fashion_retrieval/create_data.py \
       --archive /path/to/movingfashion.zip --save-to-disk
 
-  # Publish using the currently authenticated Hugging Face account.
+  # Publish both directions using the authenticated Hugging Face account.
   uv run python scripts/data/moving_fashion_retrieval/create_data.py \
-      --archive /path/to/movingfashion.zip --push \
-      --repo-id pranitchawla/MovingFashion
+      --archive /path/to/movingfashion.zip --push --direction both
+
+  # Publish only the reverse image-to-video task.
+  uv run python scripts/data/moving_fashion_retrieval/create_data.py \
+      --archive /path/to/movingfashion.zip --push --direction i2v
 """
 
 from __future__ import annotations
@@ -44,7 +43,7 @@ from collections import Counter, defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
-from typing import Any
+from typing import Any, Literal
 
 from datasets import Dataset, DatasetDict, Image, Value, Video
 from huggingface_hub import HfApi, create_repo, get_token
@@ -59,6 +58,8 @@ _LICENSE = "cc-by-nc-sa-4.0"
 _EXPECTED_ARCHIVE_SHA256 = (
     "20ae89a67a58d3dfc2304c2533d5a5c684eb6888aec9a7d7d3eda22b0a81f5f4"
 )
+
+Direction = Literal["v2i", "i2v"]
 
 
 @dataclass(frozen=True)
@@ -540,23 +541,29 @@ def _validate_test_media(
         )
 
 
-def _build_datasets(
-    test_associations: list[Association],
-    media_dir: Path,
-    videos: list[str],
-    images: list[str],
-) -> tuple[Dataset, Dataset, Dataset]:
+def _available_pairs(
+    test_associations: list[Association], videos: list[str], images: list[str]
+) -> list[tuple[str, str]]:
     video_ids = set(videos)
     image_ids = set(images)
-    pairs = sorted(
+    return sorted(
         {
             (row.video_path, row.image_path)
             for row in test_associations
             if row.video_path in video_ids and row.image_path in image_ids
         }
     )
-    video_ids = sorted(video_ids)
-    image_ids = sorted(image_ids)
+
+
+def _build_v2i_datasets(
+    test_associations: list[Association],
+    media_dir: Path,
+    videos: list[str],
+    images: list[str],
+) -> tuple[Dataset, Dataset, Dataset]:
+    pairs = _available_pairs(test_associations, videos, images)
+    video_ids = sorted(videos)
+    image_ids = sorted(images)
     queries = Dataset.from_dict(
         {
             "id": video_ids,
@@ -579,35 +586,98 @@ def _build_datasets(
     return corpus, queries, qrels
 
 
+def _build_i2v_datasets(
+    test_associations: list[Association],
+    media_dir: Path,
+    videos: list[str],
+    images: list[str],
+) -> tuple[Dataset, Dataset, Dataset]:
+    pairs = _available_pairs(test_associations, videos, images)
+    image_query_ids = sorted({image_path for _, image_path in pairs})
+    video_corpus_ids = sorted(videos)
+    queries = Dataset.from_dict(
+        {
+            "id": image_query_ids,
+            "image": [str(media_dir / image_id) for image_id in image_query_ids],
+        }
+    ).cast_column("image", Image())
+    corpus = Dataset.from_dict(
+        {
+            "id": video_corpus_ids,
+            "video": [str(media_dir / video_id) for video_id in video_corpus_ids],
+        }
+    ).cast_column("video", Video())
+    qrels = Dataset.from_dict(
+        {
+            "query-id": [image_path for _, image_path in pairs],
+            "corpus-id": [video_path for video_path, _ in pairs],
+            "score": [1] * len(pairs),
+        }
+    ).cast_column("score", Value("int32"))
+    return corpus, queries, qrels
+
+
 def _published_retrieval_summary(
     test_associations: list[Association], videos: list[str], images: list[str]
 ) -> dict[str, Any]:
     video_ids = set(videos)
     image_ids = set(images)
-    pairs = {
-        (row.video_path, row.image_path)
-        for row in test_associations
-        if row.video_path in video_ids and row.image_path in image_ids
-    }
+    pairs = set(_available_pairs(test_associations, videos, images))
+    videos_with_qrels = {video_path for video_path, _ in pairs}
     images_with_qrels = {image_path for _, image_path in pairs}
     return {
-        "v2i_queries": len(video_ids),
-        "v2i_corpus": len(image_ids),
-        "v2i_qrels": len(pairs),
-        "corpus_images_without_qrels": sorted(image_ids - images_with_qrels),
+        "v2i": {
+            "queries": len(video_ids),
+            "corpus": len(image_ids),
+            "qrels": len(pairs),
+            "multi_positive_queries": sum(
+                count > 1 for count in Counter(video for video, _ in pairs).values()
+            ),
+            "corpus_items_without_qrels": sorted(image_ids - images_with_qrels),
+        },
+        "i2v": {
+            "queries": len(images_with_qrels),
+            "corpus": len(video_ids),
+            "qrels": len(pairs),
+            "multi_positive_queries": sum(
+                count > 1 for count in Counter(image for _, image in pairs).values()
+            ),
+            "excluded_queries_without_qrels": sorted(image_ids - images_with_qrels),
+            "corpus_items_without_qrels": sorted(video_ids - videos_with_qrels),
+        },
     }
 
 
-def _dataset_card(summary: dict[str, Any]) -> str:
-    retrieval = summary["published_retrieval"]
+def _dataset_card(summary: dict[str, Any], direction: Direction) -> str:
+    retrieval = summary["published_retrieval"][direction]
     archive_sha256 = summary.get("archive_sha256", "not recorded")
+    if direction == "v2i":
+        pretty_name = "MovingFashion Video-to-Image Retrieval"
+        direction_tag = "video-to-image"
+        direction_name = "video-to-shop-image"
+        query_description = "video queries"
+        corpus_description = "shop images"
+        omission_description = (
+            "The missing test video query and its unusable qrel are excluded; "
+            "its available shop image remains in the corpus as a distractor."
+        )
+    else:
+        pretty_name = "MovingFashion Image-to-Video Retrieval"
+        direction_tag = "image-to-video"
+        direction_name = "shop-image-to-video"
+        query_description = "shop-image queries"
+        corpus_description = "social videos"
+        omission_description = (
+            "The shop image whose only annotated video is missing is excluded "
+            "from the query set together with its unusable qrel."
+        )
     return f"""---
 license: cc-by-nc-sa-4.0
-pretty_name: MovingFashion Retrieval
+pretty_name: {pretty_name}
 tags:
 - mteb
 - moeb
-- video-to-image
+- {direction_tag}
 - cross-modal-retrieval
 configs:
 - config_name: corpus
@@ -624,10 +694,10 @@ configs:
     path: queries/test-*
 ---
 
-# MovingFashion Retrieval
+# {pretty_name}
 
 Frozen MTEB/MOEB representation of the official MovingFashion test split for
-video-to-shop-image fashion retrieval.
+{direction_name} fashion retrieval.
 
 ## Construction
 
@@ -642,20 +712,20 @@ decodes all published test media. The source archive SHA-256 for this build is
 
 Media paths are used as IDs. Repeated paths are collapsed without discarding
 associations, so the source's multi-positive relevance structure is preserved.
-The Hub configs use the standard MTEB representation: `queries` contains video
-queries, `corpus` contains shop images, and `qrels` contains binary relevance
-judgments.
+The Hub configs use the standard MTEB representation: `queries` contains
+{query_description}, `corpus` contains {corpus_description}, and `qrels`
+contains binary relevance judgments.
 
 The official archive omits 22 train videos and one annotated test video. The
-missing test query and its unusable qrel are excluded; its available shop image
-remains in the corpus as a distractor. The construction script pins and reports
-all 23 source omissions rather than silently dropping them.
+{omission_description} The construction script pins and reports all 23 source
+omissions rather than silently dropping them.
 
 ## Evaluation contents
 
-- Video-to-image: {retrieval["v2i_queries"]} queries,
-  {retrieval["v2i_corpus"]} corpus images, and {retrieval["v2i_qrels"]} qrels.
-- Corpus images without a qrel: {len(retrieval["corpus_images_without_qrels"])}.
+- {direction_name}: {retrieval["queries"]} queries,
+  {retrieval["corpus"]} corpus items, and {retrieval["qrels"]} qrels.
+- Queries with multiple positives: {retrieval["multi_positive_queries"]}.
+- Corpus items without a qrel: {len(retrieval["corpus_items_without_qrels"])}.
 - Source difficulty labels: `0` is hard and `1` is regular. They are audited
   during construction but are not used to filter the benchmark.
 
@@ -696,9 +766,13 @@ See the [paper]({_PAPER_URL}) and [official code]({_SOURCE_REPO_URL}).
 
 
 def _save_datasets(
-    work_dir: Path, corpus: Dataset, queries: Dataset, qrels: Dataset
+    work_dir: Path,
+    direction: Direction,
+    corpus: Dataset,
+    queries: Dataset,
+    qrels: Dataset,
 ) -> None:
-    export_dir = work_dir / "mteb_export"
+    export_dir = work_dir / "mteb_export" / direction
     export_dir.mkdir(parents=True, exist_ok=True)
     DatasetDict({"test": corpus}).save_to_disk(export_dir / "corpus")
     DatasetDict({"test": queries}).save_to_disk(export_dir / "queries")
@@ -708,6 +782,7 @@ def _save_datasets(
 
 def _publish(
     repo_id: str,
+    direction: Direction,
     corpus: Dataset,
     queries: Dataset,
     qrels: Dataset,
@@ -722,25 +797,25 @@ def _publish(
     create_repo(repo_id, repo_type="dataset", token=token, exist_ok=True)
     api = HfApi(token=token)
     api.upload_file(
-        path_or_fileobj=_dataset_card(summary).encode(),
+        path_or_fileobj=_dataset_card(summary, direction).encode(),
         path_in_repo="README.md",
         repo_id=repo_id,
         repo_type="dataset",
-        commit_message="Add MovingFashion dataset card",
+        commit_message=f"Add MovingFashion {direction} dataset card",
     )
     DatasetDict({"test": corpus}).push_to_hub(
         repo_id,
         "corpus",
         token=token,
         max_shard_size="500MB",
-        commit_message="Add MovingFashion image corpus",
+        commit_message=f"Add MovingFashion {direction} corpus",
     )
     DatasetDict({"test": queries}).push_to_hub(
         repo_id,
         "queries",
         token=token,
         max_shard_size="500MB",
-        commit_message="Add MovingFashion video queries",
+        commit_message=f"Add MovingFashion {direction} queries",
     )
     DatasetDict({"test": qrels}).push_to_hub(
         repo_id,
@@ -749,7 +824,9 @@ def _publish(
         commit_message="Add MovingFashion relevance judgments",
     )
     revision = api.dataset_info(repo_id).sha
-    (work_dir / "hub_revision.txt").write_text(f"{revision}\n", encoding="utf-8")
+    (work_dir / f"hub_revision_{direction}.txt").write_text(
+        f"{revision}\n", encoding="utf-8"
+    )
     return revision
 
 
@@ -767,7 +844,17 @@ def main() -> None:
     parser.add_argument(
         "--work-dir", type=Path, default=Path("/tmp/moving_fashion_retrieval")
     )
-    parser.add_argument("--repo-id", default="pranitchawla/MovingFashion")
+    parser.add_argument(
+        "--repo-id",
+        default="pranitchawla/MovingFashion",
+        help="Hugging Face repository for video-to-image retrieval",
+    )
+    parser.add_argument(
+        "--i2v-repo-id",
+        default="pranitchawla/MovingFashionI2VRetrieval",
+        help="Hugging Face repository for image-to-video retrieval",
+    )
+    parser.add_argument("--direction", choices=("v2i", "i2v", "both"), default="both")
     parser.add_argument("--save-to-disk", action="store_true")
     parser.add_argument("--push", action="store_true")
     parser.add_argument(
@@ -800,9 +887,7 @@ def main() -> None:
     summary = _audit_annotations(
         annotations, allow_source_changes=args.allow_source_changes
     )
-    corpus: Dataset | None = None
-    queries: Dataset | None = None
-    qrels: Dataset | None = None
+    datasets_by_direction: dict[Direction, tuple[Dataset, Dataset, Dataset]] = {}
     if archive is not None and members is not None:
         summary["archive"] = _validate_archive_paths(
             members, annotations, allow_source_changes=args.allow_source_changes
@@ -833,7 +918,10 @@ def main() -> None:
         summary["published_retrieval"] = _published_retrieval_summary(
             annotations["test"][0], videos, images
         )
-        corpus, queries, qrels = _build_datasets(
+        datasets_by_direction["v2i"] = _build_v2i_datasets(
+            annotations["test"][0], media_dir, videos, images
+        )
+        datasets_by_direction["i2v"] = _build_i2v_datasets(
             annotations["test"][0], media_dir, videos, images
         )
 
@@ -845,13 +933,25 @@ def main() -> None:
     )
     print(f"Wrote audit summary to {summary_path}")
 
+    directions: tuple[Direction, ...]
+    if args.direction == "both":
+        directions = ("v2i", "i2v")
+    else:
+        directions = (args.direction,)
+    repo_ids = {"v2i": args.repo_id, "i2v": args.i2v_repo_id}
+
     if args.save_to_disk:
-        assert corpus is not None and queries is not None and qrels is not None
-        _save_datasets(work_dir, corpus, queries, qrels)
+        for direction in directions:
+            corpus, queries, qrels = datasets_by_direction[direction]
+            _save_datasets(work_dir, direction, corpus, queries, qrels)
     if args.push:
-        assert corpus is not None and queries is not None and qrels is not None
-        revision = _publish(args.repo_id, corpus, queries, qrels, summary, work_dir)
-        print(f"Pushed {args.repo_id} at revision {revision}")
+        for direction in directions:
+            corpus, queries, qrels = datasets_by_direction[direction]
+            repo_id = repo_ids[direction]
+            revision = _publish(
+                repo_id, direction, corpus, queries, qrels, summary, work_dir
+            )
+            print(f"Pushed {repo_id} at revision {revision}")
 
 
 if __name__ == "__main__":

--- a/scripts/data/moving_fashion_retrieval/download_source.sh
+++ b/scripts/data/moving_fashion_retrieval/download_source.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Download the official MovingFashion archive with byte-range resume support.
+#
+# Usage:
+#   ./scripts/data/moving_fashion_retrieval/download_source.sh [OUTPUT] [PARTIAL]
+#
+# OUTPUT defaults to ./movingfashion.zip. PARTIAL defaults to OUTPUT.part. To
+# continue a browser download, pass its .crdownload path as PARTIAL after the
+# browser has stopped writing to it. The partial file is preserved on errors
+# and atomically renamed to OUTPUT only after its exact size is verified.
+
+readonly SOURCE_URL="https://bit.ly/4bTZGeS"
+readonly LAST_KNOWN_SHARE_URL="https://gofile-334e684f37.fr1.quickconnect.to/sharing/qZYHiHJpf"
+readonly DOWNLOAD_FILENAME="movingfashion.zip"
+readonly EXPECTED_BYTES="25925189869"
+readonly MAX_ATTEMPTS="50"
+
+output_path="${1:-movingfashion.zip}"
+partial_path="${2:-${output_path}.part}"
+
+if [[ "${output_path}" == "${partial_path}" ]]; then
+    echo "OUTPUT and PARTIAL must be different paths." >&2
+    exit 2
+fi
+
+mkdir -p "$(dirname "${output_path}")" "$(dirname "${partial_path}")"
+
+cookie_jar="$(mktemp "${TMPDIR:-/tmp}/movingfashion-cookies.XXXXXX")"
+cleanup() {
+    rm -f "${cookie_jar}"
+}
+trap cleanup EXIT INT TERM
+
+if [[ -f "${output_path}" ]]; then
+    output_bytes="$(wc -c < "${output_path}" | tr -d ' ')"
+    if [[ "${output_bytes}" == "${EXPECTED_BYTES}" ]]; then
+        echo "MovingFashion archive is already complete: ${output_path}"
+        exit 0
+    fi
+    echo "Existing OUTPUT has an unexpected size: ${output_bytes} bytes" >&2
+    echo "Move it aside or pass a different OUTPUT path." >&2
+    exit 2
+fi
+
+if [[ -f "${partial_path}" ]]; then
+    before_bytes="$(wc -c < "${partial_path}" | tr -d ' ')"
+    sleep 2
+    after_bytes="$(wc -c < "${partial_path}" | tr -d ' ')"
+    if [[ "${before_bytes}" != "${after_bytes}" ]]; then
+        echo "PARTIAL is still being written by another downloader:" >&2
+        echo "  ${partial_path}" >&2
+        echo "Pause or stop the browser download before running this script." >&2
+        exit 2
+    fi
+    if (( after_bytes > EXPECTED_BYTES )); then
+        echo "PARTIAL is larger than the official archive." >&2
+        exit 2
+    fi
+    echo "Resuming at ${after_bytes} of ${EXPECTED_BYTES} bytes."
+else
+    echo "Starting a new MovingFashion download."
+fi
+
+# Follow the official source URL on every run because Synology may change the
+# QuickConnect relay hostname. Some gofile.me responses perform their final
+# redirect in JavaScript, which curl cannot execute; retain the verified relay
+# as a fallback in that case.
+share_url="$(curl \
+    --fail \
+    --location \
+    --connect-timeout 30 \
+    --retry 5 \
+    --retry-all-errors \
+    --output /dev/null \
+    --write-out '%{url_effective}' \
+    "${SOURCE_URL}")"
+share_url="${share_url%%\?*}"
+share_url="${share_url%/}"
+if [[ "${share_url}" != */sharing/* ]]; then
+    echo "Official redirect uses JavaScript; using the verified Synology relay."
+    share_url="${LAST_KNOWN_SHARE_URL}"
+fi
+relay_base="${share_url%%/sharing/*}"
+sharing_id="${share_url##*/sharing/}"
+download_url="${relay_base}/fsdownload/${sharing_id}/${DOWNLOAD_FILENAME}"
+
+# Synology binds the anonymous sharing cookie to the connection route. Visit the
+# share and start the file transfer as two operations in one curl process so its
+# connection can be reused. `--continue-at -` derives the Range start from the
+# existing PARTIAL size and leaves those bytes intact if the network drops.
+# Restart the whole two-request sequence after a failure so each retry gets a
+# fresh cookie and recomputes the resume offset from the current file size.
+attempt=1
+while (( attempt <= MAX_ATTEMPTS )); do
+    echo "Download attempt ${attempt}/${MAX_ATTEMPTS}."
+    if curl \
+        --fail \
+        --location \
+        --connect-timeout 30 \
+        --retry 5 \
+        --retry-delay 5 \
+        --retry-all-errors \
+        --cookie-jar "${cookie_jar}" \
+        --cookie "${cookie_jar}" \
+        --output /dev/null \
+        "${share_url}" \
+        --next \
+        --fail \
+        --location \
+        --connect-timeout 30 \
+        --retry 0 \
+        --speed-limit 1024 \
+        --speed-time 120 \
+        --cookie-jar "${cookie_jar}" \
+        --cookie "${cookie_jar}" \
+        --continue-at - \
+        --output "${partial_path}" \
+        "${download_url}"
+    then
+        break
+    else
+        curl_status="$?"
+        current_bytes="$(wc -c < "${partial_path}" | tr -d ' ')"
+        if [[ "${current_bytes}" == "${EXPECTED_BYTES}" ]]; then
+            break
+        fi
+        if (( attempt == MAX_ATTEMPTS )); then
+            echo "Download failed after ${MAX_ATTEMPTS} attempts." >&2
+            exit "${curl_status}"
+        fi
+        echo "Transfer interrupted at ${current_bytes}/${EXPECTED_BYTES} bytes; reconnecting in 10 seconds." >&2
+        sleep 10
+        ((attempt += 1))
+    fi
+done
+
+actual_bytes="$(wc -c < "${partial_path}" | tr -d ' ')"
+if [[ "${actual_bytes}" != "${EXPECTED_BYTES}" ]]; then
+    echo "Download remains incomplete: ${actual_bytes}/${EXPECTED_BYTES} bytes." >&2
+    echo "Rerun this script to continue." >&2
+    exit 1
+fi
+
+mv "${partial_path}" "${output_path}"
+echo "MovingFashion download complete: ${output_path}"


### PR DESCRIPTION
Closes #5141.

## Summary

Adds bidirectional MovingFashion retrieval between social videos and shop images. Both tasks use the official held-out test partition, rank its full available gallery, and preserve genuine multi-positive associations.

Frozen datasets:

- [V2I](https://huggingface.co/datasets/pranitchawla/MovingFashion) at `29c9813e2826ef2f4398455528881ab3e181311b`
- [I2V](https://huggingface.co/datasets/pranitchawla/MovingFashionI2VRetrieval) at `29906095b736d5319f14ec1800640b40612b6e8d`

**Dataset scope:** The complete MovingFashion release contains 14,855 unique annotated video paths across its 90/10 train/test split: 13,526 train and 1,329 test. This PR audits both partitions for source integrity, missing media, and train/test leakage, but materializes only the official test partition for MTEB evaluation. One annotated test video is missing from the source archive, leaving 1,328 available evaluation videos.

The builder and resumable downloader pin the 25.9 GB archive checksum and audit missing media.

## Evaluation data (official test split)

| Task | Queries | Candidates | Qrels | Multi-positive queries |
| --- | ---: | ---: | ---: | ---: |
| V2I | 1,328 videos | 1,341 images | 1,341 | 13 |
| I2V | 1,340 images | 1,328 videos | 1,341 | 1 |

Videos total 19,003.64 seconds (14.31 seconds average); 1,327 contents are unique across 1,328 IDs. All 1,341 V2I images are unique. One annotated test video is missing: its qrel is dropped, its image remains a V2I distractor, and it is excluded as an I2V query.

## Results

| Model | V2I nDCG@10 | I2V nDCG@10 | V2I R@10 | I2V R@10 |
| --- | ---: | ---: | ---: | ---: |
| Random encoder | .00154 | .00309 | .00377 | .00597 |
| CLIP ViT-B/32, 8-frame mean | .19613 | .27579 | .31739 | .38134 |

The paper describes the complete 14,855-video collection, but defines a 90/10 train/test split and evaluates held-out test samples. Its Table 2 results use repeated 800-sample test pools and Top-K accuracy. This MTEB conversion instead ranks the full available official-test gallery and reports standard retrieval metrics, so the scores are not directly comparable.

## Checklist

- [x] Fills the image-video retrieval gap in MTEB
- [x] Both tasks load and run end-to-end
- [x] Random and compatible CLIP baselines evaluated
- [x] Performance is above random and below saturation
- [x] Retains the official evaluation-scale test associations
- [x] Descriptive statistics and paper context included
- [x] Ruff, repository hooks, and 1,842 metadata tests pass
