### PR TITLE
ci: use --frozen flag in dataset_loading and lint install steps

### DIFF
--- a/.github/workflows/dataset_loading.yml
+++ b/.github/workflows/dataset_loading.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        make install
+        uv sync --extra image --group dev --frozen
 
     - name: Run dataset loading tests
       env:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/configure-pages@v6
 
       - name: Install dependencies
-        run: uv sync --group docs
+        run: uv sync --group docs --frozen
 
       - name: Build docs
         run: make build-docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          make install
+          uv sync --extra image --group dev --frozen
 
       - name: Lint
         id: lint


### PR DESCRIPTION
Fixes #5276

Adds `--frozen` to the `uv sync` install step in `dataset_loading.yml`, `lint.yml`, and `documentation.yml`, bypassing dependency resolution in CI and using the lockfile as-is. This speeds up the install step for these workflows.