### PR TITLE
dataset: Add MUSE-VA A2I and I2A retrieval tasks

### DIFF
--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/MUSEVAA2IRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/MUSEVAA2IRetrieval.json
@@ -1,0 +1,44 @@
+{
+    "test": {
+        "num_samples": 1250,
+        "num_queries": 625,
+        "num_documents": 625,
+        "number_of_characters": 0,
+        "documents_text_statistics": null,
+        "documents_image_statistics": {
+            "min_image_width": 512,
+            "average_image_width": 512.0,
+            "max_image_width": 512,
+            "min_image_height": 512,
+            "average_image_height": 512.0,
+            "max_image_height": 512,
+            "unique_images": 625
+        },
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": null,
+        "queries_audio_statistics": {
+            "total_duration_seconds": 117830.5192063492,
+            "min_duration_seconds": 17.749115646258502,
+            "average_duration_seconds": 188.52883073015872,
+            "max_duration_seconds": 419.72,
+            "unique_audios": 625,
+            "average_sampling_rate": 44100.0,
+            "sampling_rates": {
+                "44100": 625
+            }
+        },
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 625,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 625,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/MUSEVAI2ARetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/MUSEVAI2ARetrieval.json
@@ -1,0 +1,44 @@
+{
+    "test": {
+        "num_samples": 1250,
+        "num_queries": 625,
+        "num_documents": 625,
+        "number_of_characters": 0,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": {
+            "total_duration_seconds": 117830.5192063492,
+            "min_duration_seconds": 17.749115646258502,
+            "average_duration_seconds": 188.52883073015872,
+            "max_duration_seconds": 419.72,
+            "unique_audios": 625,
+            "average_sampling_rate": 44100.0,
+            "sampling_rates": {
+                "44100": 625
+            }
+        },
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": {
+            "min_image_width": 512,
+            "average_image_width": 512.0,
+            "max_image_width": 512,
+            "min_image_height": 512,
+            "average_image_height": 512.0,
+            "max_image_height": 512,
+            "unique_images": 625
+        },
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 625,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 625,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -266,6 +266,7 @@ from .msr_vtt import (
 )
 from .msvd_t2v_retrieval import MSVDT2VRetrieval
 from .msvd_v2t_retrieval import MSVDV2TRetrieval
+from .muse_va_retrieval import MUSEVAA2IRetrieval, MUSEVAI2ARetrieval
 from .nano_argu_ana_retrieval import NanoArguAnaRetrieval
 from .nano_climate_fever_retrieval import NanoClimateFeverRetrieval
 from .nano_db_pedia_retrieval import NanoDBPediaRetrieval
@@ -703,6 +704,8 @@ __all__ = [
     "MSMARCOv2",
     "MSVDT2VRetrieval",
     "MSVDV2TRetrieval",
+    "MUSEVAA2IRetrieval",
+    "MUSEVAI2ARetrieval",
     "MarsVLPairsI2TRetrieval",
     "MarsVLPairsT2IRetrieval",
     "MedicalQARetrieval",

--- a/mteb/tasks/retrieval/eng/muse_va_retrieval.py
+++ b/mteb/tasks/retrieval/eng/muse_va_retrieval.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.task_metadata import TaskMetadata
+
+_REFERENCE = "https://huggingface.co/datasets/jiahaomei/MUSE-VA"
+_BIBTEX = r"""
+@misc{museva2026,
+  author = {Mei, Jiahao and others},
+  title = {MUSE-VA: Multimodal MUSic Emotion Dataset with Balanced Valence-Arousal},
+  howpublished = {Hugging Face dataset jiahaomei/MUSE-VA},
+  year = {2026},
+}
+"""
+_DESCRIPTION = (
+    "MUSE-VA (Multimodal MUSic Emotion Dataset with Balanced VA) pairs music clips "
+    "with emotion-aligned generated images. The test split contains 625 one-to-one "
+    "audio–image pairs spanning diverse genres and VA coordinates."
+)
+
+
+class MUSEVAA2IRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="MUSEVAA2IRetrieval",
+        description=_DESCRIPTION
+        + " Queries are music clips and the corpus contains paired images; the goal "
+        "is to retrieve the image that matches the music clip.",
+        reference=_REFERENCE,
+        dataset={
+            "path": "Wissam42/MUSE-VA-A2I",
+            "revision": "main",
+        },
+        type="Any2AnyRetrieval",
+        category="a2i",
+        modalities=["audio", "image"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2025-01-01", "2026-07-01"),
+        domains=["Music", "Web"],
+        task_subtypes=["Cross-Modal Retrieval"],
+        license="cc-by-nc-4.0",
+        annotations_creators="LM-generated and reviewed",
+        dialect=[],
+        sample_creation="created",
+        bibtex_citation=_BIBTEX,
+        prompt={
+            "query": "Retrieve the image that best matches the emotion and mood of this music clip."
+        },
+        is_beta=True,
+    )
+
+
+class MUSEVAI2ARetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="MUSEVAI2ARetrieval",
+        description=_DESCRIPTION
+        + " Queries are images and the corpus contains music clips; the goal is to "
+        "retrieve the music clip that matches the image.",
+        reference=_REFERENCE,
+        dataset={
+            "path": "Wissam42/MUSE-VA-I2A",
+            "revision": "main",
+        },
+        type="Any2AnyRetrieval",
+        category="i2a",
+        modalities=["image", "audio"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2025-01-01", "2026-07-01"),
+        domains=["Music", "Web"],
+        task_subtypes=["Cross-Modal Retrieval"],
+        license="cc-by-nc-4.0",
+        annotations_creators="LM-generated and reviewed",
+        dialect=[],
+        sample_creation="created",
+        bibtex_citation=_BIBTEX,
+        prompt={
+            "query": "Retrieve the music clip that best matches the emotion and mood of this image."
+        },
+        is_beta=True,
+    )

--- a/mteb/tasks/retrieval/eng/muse_va_retrieval.py
+++ b/mteb/tasks/retrieval/eng/muse_va_retrieval.py
@@ -28,7 +28,7 @@ class MUSEVAA2IRetrieval(AbsTaskRetrieval):
         reference=_REFERENCE,
         dataset={
             "path": "Wissam42/MUSE-VA-A2I",
-            "revision": "main",
+            "revision": "761cd11f21c1dad47a3fa82160ff5a77ee8cb705",
         },
         type="Any2AnyRetrieval",
         category="a2i",
@@ -60,7 +60,7 @@ class MUSEVAI2ARetrieval(AbsTaskRetrieval):
         reference=_REFERENCE,
         dataset={
             "path": "Wissam42/MUSE-VA-I2A",
-            "revision": "main",
+            "revision": "84ec3222e6fd1456db6599fcaf335b3f8c80f9d5",
         },
         type="Any2AnyRetrieval",
         category="i2a",

--- a/mteb/tasks/retrieval/eng/muse_va_retrieval.py
+++ b/mteb/tasks/retrieval/eng/muse_va_retrieval.py
@@ -27,8 +27,8 @@ class MUSEVAA2IRetrieval(AbsTaskRetrieval):
         "is to retrieve the image that matches the music clip.",
         reference=_REFERENCE,
         dataset={
-            "path": "Wissam42/MUSE-VA-A2I",
-            "revision": "761cd11f21c1dad47a3fa82160ff5a77ee8cb705",
+            "path": "mteb/MUSE-VA-A2I",
+            "revision": "0f35857db60c708e4b477981ed54c641bac97eca",
         },
         type="Any2AnyRetrieval",
         category="a2i",
@@ -59,8 +59,8 @@ class MUSEVAI2ARetrieval(AbsTaskRetrieval):
         "retrieve the music clip that matches the image.",
         reference=_REFERENCE,
         dataset={
-            "path": "Wissam42/MUSE-VA-I2A",
-            "revision": "84ec3222e6fd1456db6599fcaf335b3f8c80f9d5",
+            "path": "mteb/MUSE-VA-I2A",
+            "revision": "0cf8ca2cc4377959380ad0b27963345a50f76a5d",
         },
         type="Any2AnyRetrieval",
         category="i2a",

--- a/scripts/data/muse_va_retrieval/create_data.py
+++ b/scripts/data/muse_va_retrieval/create_data.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Package jiahaomei/MUSE-VA into MTEB audio↔image retrieval format.
+
+MUSE-VA pairs music clips with emotion-aligned generated images (~625 test pairs).
+Each audio clip has exactly one relevant image and vice versa.
+
+Builds two Hub datasets (corpus / queries / qrels configs, test split):
+  - {repo-prefix}-A2I  (audio query → image corpus)
+  - {repo-prefix}-I2A  (image query → audio corpus)
+
+Usage:
+  export HF_TOKEN=...
+  export HF_HUB_ENABLE_HF_TRANSFER=1   # optional
+  uv run python scripts/data/muse_va_retrieval/create_data.py \\
+      --repo-prefix Wissam42/MUSE-VA \\
+      --work-dir /tmp/muse_va_mteb \\
+      --push
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import os
+from pathlib import Path
+
+import pyarrow.parquet as pq
+from datasets import Audio, Dataset, DatasetDict, Image
+from huggingface_hub import create_repo, snapshot_download
+from PIL import Image as PILImage
+from tqdm import tqdm
+
+_SOURCE = "jiahaomei/MUSE-VA"
+
+
+def _push_retrieval_direction(
+    *,
+    repo_id: str,
+    queries: Dataset,
+    corpus: Dataset,
+    qrels: Dataset,
+    token: str | None,
+    out_dir: Path | None,
+) -> None:
+    if token:
+        create_repo(repo_id, repo_type="dataset", token=token, exist_ok=True)
+        DatasetDict({"test": corpus}).push_to_hub(repo_id, "corpus", token=token)
+        DatasetDict({"test": queries}).push_to_hub(repo_id, "queries", token=token)
+        DatasetDict({"test": qrels}).push_to_hub(repo_id, "qrels", token=token)
+        print(f"Pushed {repo_id}")
+        return
+
+    assert out_dir is not None
+    out = out_dir / repo_id.replace("/", "__")
+    out.mkdir(parents=True, exist_ok=True)
+    corpus.save_to_disk(out / "corpus")
+    queries.save_to_disk(out / "queries")
+    qrels.save_to_disk(out / "qrels")
+    print(f"Wrote {out}")
+
+
+def _audio_ext(path_hint: str | None) -> str:
+    if path_hint:
+        suf = Path(path_hint).suffix.lower()
+        if suf in {".wav", ".flac", ".mp3", ".ogg", ".opus", ".m4a"}:
+            return suf
+    return ".wav"
+
+
+def _save_resized_jpeg(raw: bytes, dst: Path, max_side: int) -> None:
+    if dst.exists():
+        return
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    with PILImage.open(io.BytesIO(raw)) as im:
+        im = im.convert("RGB")
+        w, h = im.size
+        scale = min(1.0, max_side / max(w, h))
+        if scale < 1.0:
+            im = im.resize(
+                (int(w * scale), int(h * scale)), PILImage.Resampling.LANCZOS
+            )
+        im.save(dst, format="JPEG", quality=90)
+
+
+def _extract_struct_bytes(cell) -> tuple[bytes, str | None]:
+    """Pull ``(bytes, path_hint)`` from a datasets/HF audio or image struct."""
+    if cell is None:
+        raise ValueError("empty media cell")
+    # pyarrow may return dict-like or object with as_py()
+    if hasattr(cell, "as_py"):
+        cell = cell.as_py()
+    if isinstance(cell, dict):
+        raw = cell.get("bytes")
+        path_hint = cell.get("path")
+        if raw is None and path_hint and Path(path_hint).is_file():
+            return Path(path_hint).read_bytes(), path_hint
+        if raw is None:
+            raise ValueError(f"media struct missing bytes: keys={list(cell)}")
+        return raw, path_hint
+    if isinstance(cell, (bytes, bytearray)):
+        return bytes(cell), None
+    raise TypeError(f"unsupported media cell type: {type(cell)!r}")
+
+
+def _extract_from_parquets(
+    parquet_files: list[Path],
+    *,
+    audio_dir: Path,
+    image_dir: Path,
+    max_side: int,
+) -> tuple[list[str], list[str], list[str], list[str]]:
+    audio_ids: list[str] = []
+    image_ids: list[str] = []
+    audio_paths: list[str] = []
+    image_paths: list[str] = []
+
+    audio_dir.mkdir(parents=True, exist_ok=True)
+    image_dir.mkdir(parents=True, exist_ok=True)
+
+    for pq_path in tqdm(parquet_files, desc="parquet shards"):
+        table = pq.read_table(pq_path, columns=["id", "audio", "image"])
+        ids = table.column("id")
+        audios = table.column("audio")
+        images = table.column("image")
+        for i in range(table.num_rows):
+            rid = ids[i].as_py()
+            aid = f"aud-{rid}"
+            iid = f"img-{rid}"
+
+            audio_bytes, audio_hint = _extract_struct_bytes(audios[i])
+            image_bytes, _ = _extract_struct_bytes(images[i])
+
+            ap = audio_dir / f"{aid}{_audio_ext(audio_hint)}"
+            ip = image_dir / f"{iid}.jpg"
+            if not ap.exists():
+                ap.write_bytes(audio_bytes)
+            _save_resized_jpeg(image_bytes, ip, max_side)
+
+            audio_ids.append(aid)
+            image_ids.append(iid)
+            audio_paths.append(str(ap))
+            image_paths.append(str(ip))
+
+        # Drop shard from RAM before opening the next one.
+        del table
+
+    return audio_ids, image_ids, audio_paths, image_paths
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-prefix", default="Wissam42/MUSE-VA")
+    parser.add_argument("--work-dir", type=Path, default=Path("/tmp/muse_va_mteb"))
+    parser.add_argument("--max-side", type=int, default=1024)
+    parser.add_argument(
+        "--skip-download",
+        action="store_true",
+        help="Reuse already-downloaded test shards under --work-dir/source",
+    )
+    parser.add_argument("--push", action="store_true")
+    args = parser.parse_args()
+
+    work: Path = args.work_dir
+    work.mkdir(parents=True, exist_ok=True)
+    source_dir = work / "source"
+    data_dir = source_dir / "data"
+
+    if not args.skip_download:
+        print(
+            f"Downloading {_SOURCE} *test* shards only "
+            f"(~21 GB across 106 files; train/valid ~185 GB are skipped)…"
+        )
+        snapshot_download(
+            _SOURCE,
+            repo_type="dataset",
+            local_dir=source_dir,
+            allow_patterns=["data/test-*", "README.md", ".gitattributes"],
+        )
+    elif not any(data_dir.glob("test-*.parquet")):
+        raise SystemExit(f"--skip-download set but no test shards under {data_dir}/")
+
+    parquet_files = sorted(data_dir.glob("test-*.parquet"))
+    if not parquet_files:
+        raise SystemExit(f"No test-*.parquet under {data_dir}")
+    print(f"Found {len(parquet_files)} test shards")
+
+    audio_ids, image_ids, audio_paths, image_paths = _extract_from_parquets(
+        parquet_files,
+        audio_dir=work / "media" / "audio",
+        image_dir=work / "media" / "image",
+        max_side=args.max_side,
+    )
+    n = len(audio_ids)
+    print(f"Extracted {n} pairs → {work / 'media'}")
+
+    a2i_corpus = Dataset.from_dict({"id": image_ids, "image": image_paths}).cast_column(
+        "image", Image()
+    )
+    a2i_queries = Dataset.from_dict(
+        {"id": audio_ids, "audio": audio_paths}
+    ).cast_column("audio", Audio())
+    a2i_qrels = Dataset.from_dict(
+        {
+            "query-id": audio_ids,
+            "corpus-id": image_ids,
+            "score": [1] * n,
+        }
+    )
+
+    i2a_corpus = Dataset.from_dict({"id": audio_ids, "audio": audio_paths}).cast_column(
+        "audio", Audio()
+    )
+    i2a_queries = Dataset.from_dict(
+        {"id": image_ids, "image": image_paths}
+    ).cast_column("image", Image())
+    i2a_qrels = Dataset.from_dict(
+        {
+            "query-id": image_ids,
+            "corpus-id": audio_ids,
+            "score": [1] * n,
+        }
+    )
+
+    print(
+        f"A2I corpus={len(a2i_corpus)} queries={len(a2i_queries)} "
+        f"qrels={len(a2i_qrels)}"
+    )
+    print(
+        f"I2A corpus={len(i2a_corpus)} queries={len(i2a_queries)} "
+        f"qrels={len(i2a_qrels)}"
+    )
+
+    token = os.environ.get("HF_TOKEN") if args.push else None
+    if args.push and not token:
+        raise SystemExit("Set HF_TOKEN to push")
+
+    out = None if args.push else work / "mteb_export"
+    _push_retrieval_direction(
+        repo_id=f"{args.repo_prefix}-A2I",
+        queries=a2i_queries,
+        corpus=a2i_corpus,
+        qrels=a2i_qrels,
+        token=token,
+        out_dir=out,
+    )
+    _push_retrieval_direction(
+        repo_id=f"{args.repo_prefix}-I2A",
+        queries=i2a_queries,
+        corpus=i2a_corpus,
+        qrels=i2a_qrels,
+        token=token,
+        out_dir=out,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- [x] I have outlined why this dataset is filling an existing gap in the MOEB benchmark
- [x] I have tested that the dataset runs with the `mteb` package.
- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
  - [x] `LCO-Embedding-Omni-3B`
  - [x] `mteb/baseline-random-encoder`
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [x] I have considered the size of the dataset and reduced it if it is too big (2048 examples is typically large enough for most tasks)

Results on MUSE-VA-A2I:
```
metric                 random LCO-Embedding-Omni-3B
ndcg_at_1             0.00000        0.02240
ndcg_at_5             0.00365        0.05676
ndcg_at_10            0.00569        0.07577
ndcg_at_20            0.01040        0.09928
ndcg_at_100           0.02946        0.17167
map_at_10             0.00355        0.05294
recall_at_1           0.00000        0.02240
recall_at_5           0.00640        0.09120
recall_at_10          0.01280        0.15200
recall_at_20          0.03200        0.24640
mrr_at_10             0.00355        0.05294
```

Results on MUSE-VA-I2A:
```
metric                 random LCO-Embedding-Omni-3B
ndcg_at_1             0.00160        0.02400
ndcg_at_5             0.00570        0.05861
ndcg_at_10            0.00662        0.07911
ndcg_at_20            0.00978        0.10377
ndcg_at_100           0.03156        0.19050
map_at_10             0.00472        0.05576
recall_at_1           0.00160        0.02400
recall_at_5           0.00960        0.09280
recall_at_10          0.01280        0.15680
recall_at_20          0.02560        0.25600
mrr_at_10             0.00472        0.05576
```