### PR TITLE
[MOEB] Add Reflectra I2A retrieval task

### DIFF
--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/ReflectraI2ARetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/ReflectraI2ARetrieval.json
@@ -1,0 +1,45 @@
+{
+    "test": {
+        "num_samples": 1399,
+        "num_queries": 653,
+        "num_documents": 746,
+        "number_of_characters": 0,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": {
+            "total_duration_seconds": 11190.0,
+            "min_duration_seconds": 15.0,
+            "average_duration_seconds": 15.0,
+            "max_duration_seconds": 15.0,
+            "unique_audios": 547,
+            "average_sampling_rate": 44262.06434316354,
+            "sampling_rates": {
+                "44100": 715,
+                "48000": 31
+            }
+        },
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": {
+            "min_image_width": 200,
+            "average_image_width": 461.1500765696784,
+            "max_image_width": 500,
+            "min_image_height": 198,
+            "average_image_height": 394.6217457886677,
+            "max_image_height": 500,
+            "unique_images": 653
+        },
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 1258,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.9264931087289434,
+            "max_relevant_docs_per_query": 5,
+            "unique_relevant_docs": 511,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/ReflectraI2ARetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/ReflectraI2ARetrieval.json
@@ -1,21 +1,21 @@
 {
     "test": {
-        "num_samples": 1399,
+        "num_samples": 1200,
         "num_queries": 653,
-        "num_documents": 746,
+        "num_documents": 547,
         "number_of_characters": 0,
         "documents_text_statistics": null,
         "documents_image_statistics": null,
         "documents_audio_statistics": {
-            "total_duration_seconds": 11190.0,
+            "total_duration_seconds": 8205.0,
             "min_duration_seconds": 15.0,
             "average_duration_seconds": 15.0,
             "max_duration_seconds": 15.0,
             "unique_audios": 547,
-            "average_sampling_rate": 44262.06434316354,
+            "average_sampling_rate": 44235.46617915905,
             "sampling_rates": {
-                "44100": 715,
-                "48000": 31
+                "44100": 528,
+                "48000": 19
             }
         },
         "documents_video_statistics": null,
@@ -32,11 +32,11 @@
         "queries_audio_statistics": null,
         "queries_video_statistics": null,
         "relevant_docs_statistics": {
-            "num_relevant_docs": 1258,
+            "num_relevant_docs": 1256,
             "min_relevant_docs_per_query": 1,
-            "average_relevant_docs_per_query": 1.9264931087289434,
+            "average_relevant_docs_per_query": 1.9234303215926494,
             "max_relevant_docs_per_query": 5,
-            "unique_relevant_docs": 511,
+            "unique_relevant_docs": 413,
             "num_missing_query_ids": 0,
             "num_missing_corpus_ids": 0
         },

--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -336,6 +336,7 @@ from .real_mm_rag_retrieval import (
     RealMMRAGTechReportRetrieval,
     RealMMRAGTechSlidesRetrieval,
 )
+from .reflectra_retrieval import ReflectraI2ARetrieval
 from .rp2k_i2i_retrieval import RP2kI2IRetrieval
 from .rt1_retrieval import RT1T2VRetrieval, RT1V2TRetrieval
 from .sci_fact_retrieval import SciFact
@@ -774,6 +775,7 @@ __all__ = [
     "RealMMRAGFinSlidesRetrieval",
     "RealMMRAGTechReportRetrieval",
     "RealMMRAGTechSlidesRetrieval",
+    "ReflectraI2ARetrieval",
     "SHS100KA2ARetrieval",
     "SOPI2IRetrieval",
     "SSW60A2IRetrieval",

--- a/mteb/tasks/retrieval/eng/reflectra_retrieval.py
+++ b/mteb/tasks/retrieval/eng/reflectra_retrieval.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class ReflectraI2ARetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="ReflectraI2ARetrieval",
+        description=(
+            "Reflectra evaluates image-to-audio emotion matching. "
+            "One thousand images are each rated against six candidate music clips on a 0–10 scale; "
+            "scores >= 7 are treated as relevant. "
+            "Queries are images and the corpus contains music clips; "
+            "the goal is to retrieve music that emotionally matches the image."
+        ),
+        reference="https://huggingface.co/datasets/AraNge/reflectra-benchmark",
+        dataset={
+            "path": "Wissam42/Reflectra-I2A",
+            "revision": "26d44f3452f3d1be242fa9e6c4d9f8ebfa840af1",
+        },
+        type="Any2AnyRetrieval",
+        category="i2a",
+        modalities=["image", "audio"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2025-01-01", "2025-12-01"),
+        domains=["Music", "Web"],
+        task_subtypes=["Cross-Modal Retrieval", "Emotion classification"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=r"""
+@misc{reflectra2025,
+  author = {AraNge},
+  title = {Reflectra Benchmark: Image-to-Audio Emotion Matching},
+  howpublished = {Hugging Face dataset AraNge/reflectra-benchmark},
+  year = {2025},
+}
+""",
+        prompt={"query": "Retrieve music clips that emotionally match this image."},
+        is_beta=True,
+    )

--- a/mteb/tasks/retrieval/eng/reflectra_retrieval.py
+++ b/mteb/tasks/retrieval/eng/reflectra_retrieval.py
@@ -17,7 +17,7 @@ class ReflectraI2ARetrieval(AbsTaskRetrieval):
         reference="https://huggingface.co/datasets/AraNge/reflectra-benchmark",
         dataset={
             "path": "Wissam42/Reflectra-I2A",
-            "revision": "26d44f3452f3d1be242fa9e6c4d9f8ebfa840af1",
+            "revision": "73167e920e77c3aeea687ac82daa7e6909e8b2db",
         },
         type="Any2AnyRetrieval",
         category="i2a",

--- a/mteb/tasks/retrieval/eng/reflectra_retrieval.py
+++ b/mteb/tasks/retrieval/eng/reflectra_retrieval.py
@@ -16,8 +16,8 @@ class ReflectraI2ARetrieval(AbsTaskRetrieval):
         ),
         reference="https://huggingface.co/datasets/AraNge/reflectra-benchmark",
         dataset={
-            "path": "Wissam42/Reflectra-I2A",
-            "revision": "73167e920e77c3aeea687ac82daa7e6909e8b2db",
+            "path": "mteb/Reflectra-I2A",
+            "revision": "e39ae8a364e093cab5278f26b52d9333084383b7",
         },
         type="Any2AnyRetrieval",
         category="i2a",

--- a/scripts/data/reflectra_retrieval/create_data.py
+++ b/scripts/data/reflectra_retrieval/create_data.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Package AraNge/reflectra-benchmark into MTEB image→audio retrieval.
+
+Reflectra contains 1,000 images each rated against six candidate music clips on a
+0–10 scale. We treat scores >= 7 as relevant for binary qrels (image query →
+audio corpus).
+
+Usage:
+  export HF_TOKEN=...
+  uv run python scripts/data/reflectra_retrieval/create_data.py \\
+      --repo-id Wissam42/Reflectra-I2A \\
+      --work-dir /tmp/reflectra_mteb \\
+      --score-threshold 7 \\
+      --push
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+import pyarrow.parquet as pq
+from datasets import Audio, Dataset, DatasetDict, Image
+from huggingface_hub import create_repo, hf_hub_download
+
+_SOURCE = "AraNge/reflectra-benchmark"
+
+
+def _push_retrieval_direction(
+    *,
+    repo_id: str,
+    queries: Dataset,
+    corpus: Dataset,
+    qrels: Dataset,
+    token: str | None,
+    out_dir: Path | None,
+) -> None:
+    if token:
+        create_repo(repo_id, repo_type="dataset", token=token, exist_ok=True)
+        DatasetDict({"test": corpus}).push_to_hub(repo_id, "corpus", token=token)
+        DatasetDict({"test": queries}).push_to_hub(repo_id, "queries", token=token)
+        DatasetDict({"test": qrels}).push_to_hub(repo_id, "qrels", token=token)
+        print(f"Pushed {repo_id}")
+        return
+
+    assert out_dir is not None
+    out = out_dir / repo_id.replace("/", "__")
+    out.mkdir(parents=True, exist_ok=True)
+    corpus.save_to_disk(out / "corpus")
+    queries.save_to_disk(out / "queries")
+    qrels.save_to_disk(out / "qrels")
+    print(f"Wrote {out}")
+
+
+def _download(filename: str) -> str:
+    # Without repo_type="dataset", hf_hub_download looks under models/ and 404s.
+    return hf_hub_download(_SOURCE, filename, repo_type="dataset")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-id", default="Wissam42/Reflectra-I2A")
+    parser.add_argument("--work-dir", type=Path, default=Path("/tmp/reflectra_mteb"))
+    parser.add_argument("--score-threshold", type=int, default=7)
+    parser.add_argument("--push", action="store_true")
+    args = parser.parse_args()
+
+    work = args.work_dir
+    work.mkdir(parents=True, exist_ok=True)
+
+    scores_path = _download("image_audio_scores.parquet")
+    image_path = _download("image_table.parquet")
+    audio_path = _download("audio_table.parquet")
+
+    scores = pq.read_table(scores_path).to_pydict()
+    images = pq.read_table(image_path).to_pydict()
+    audios = pq.read_table(audio_path).to_pydict()
+
+    i2a_queries = Dataset.from_dict(
+        {"id": images["image_id"], "image": images["image"]},
+    ).cast_column("image", Image())
+
+    corpus_ids = audios["audio_id"]
+    i2a_corpus = Dataset.from_dict(
+        {"id": corpus_ids, "audio": audios["audio"]},
+    ).cast_column("audio", Audio())
+
+    audio_by_id = set(audios["audio_id"])
+    qrels = {"query-id": [], "corpus-id": [], "score": []}
+    skipped_queries = 0
+    for qid, audio_ids, score_list in zip(
+        scores["image_id"],
+        scores["audio_ids"],
+        scores["scores"],
+        strict=True,
+    ):
+        added = False
+        for aid, score in zip(audio_ids, score_list, strict=True):
+            if score >= args.score_threshold and aid in audio_by_id:
+                qrels["query-id"].append(qid)
+                qrels["corpus-id"].append(aid)
+                qrels["score"].append(1)
+                added = True
+        if not added:
+            skipped_queries += 1
+
+    if skipped_queries:
+        print(f"Warning: {skipped_queries} queries have no positives at threshold")
+    print(
+        f"I2A corpus={len(i2a_corpus)} queries={len(i2a_queries)} "
+        f"qrels={len(qrels['query-id'])} threshold>={args.score_threshold}"
+    )
+
+    token = os.environ.get("HF_TOKEN") if args.push else None
+    if args.push and not token:
+        raise SystemExit("Set HF_TOKEN to push")
+
+    out = None if args.push else work / "mteb_export"
+    _push_retrieval_direction(
+        repo_id=args.repo_id,
+        queries=i2a_queries,
+        corpus=i2a_corpus,
+        qrels=Dataset.from_dict(qrels),
+        token=token,
+        out_dir=out,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/data/reflectra_retrieval/create_data.py
+++ b/scripts/data/reflectra_retrieval/create_data.py
@@ -5,6 +5,10 @@ Reflectra contains 1,000 images each rated against six candidate music clips on 
 0–10 scale. We treat scores >= 7 as relevant for binary qrels (image query →
 audio corpus).
 
+The upstream audio table reuses identical clips under different audio_ids; the
+corpus is therefore deduplicated by content hash and qrels are remapped to the
+canonical ids.
+
 Usage:
   export HF_TOKEN=...
   uv run python scripts/data/reflectra_retrieval/create_data.py \\
@@ -17,6 +21,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import os
 from pathlib import Path
 
@@ -58,6 +63,53 @@ def _download(filename: str) -> str:
     return hf_hub_download(_SOURCE, filename, repo_type="dataset")
 
 
+def _media_bytes(cell) -> bytes | None:
+    if cell is None:
+        return None
+    if isinstance(cell, (bytes, bytearray)):
+        return bytes(cell)
+    if isinstance(cell, dict):
+        raw = cell.get("bytes")
+        if raw:
+            return bytes(raw)
+        path = cell.get("path")
+        if path and Path(path).is_file():
+            return Path(path).read_bytes()
+    return None
+
+
+def _media_hash(cell) -> str | None:
+    raw = _media_bytes(cell)
+    if not raw:
+        return None
+    return hashlib.md5(raw, usedforsecurity=False).hexdigest()
+
+
+def _dedupe_audios(
+    audio_ids: list,
+    audios: list,
+) -> tuple[list, list, dict]:
+    """Keep one corpus row per unique audio content; map aliases → canonical id."""
+    hash_to_id: dict[str, object] = {}
+    id_remap: dict[object, object] = {}
+    canonical_ids: list = []
+    canonical_audios: list = []
+
+    for audio_id, audio in zip(audio_ids, audios, strict=True):
+        media_hash = _media_hash(audio)
+        if media_hash is None:
+            continue
+        canonical_id = hash_to_id.get(media_hash)
+        if canonical_id is None:
+            hash_to_id[media_hash] = audio_id
+            canonical_id = audio_id
+            canonical_ids.append(audio_id)
+            canonical_audios.append(audio)
+        id_remap[audio_id] = canonical_id
+
+    return canonical_ids, canonical_audios, id_remap
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--repo-id", default="Wissam42/Reflectra-I2A")
@@ -81,13 +133,24 @@ def main() -> None:
         {"id": images["image_id"], "image": images["image"]},
     ).cast_column("image", Image())
 
-    corpus_ids = audios["audio_id"]
+    corpus_ids, corpus_audios, audio_id_remap = _dedupe_audios(
+        audios["audio_id"],
+        audios["audio"],
+    )
+    dropped = len(audios["audio_id"]) - len(corpus_ids)
+    if dropped:
+        print(
+            f"Deduped corpus audios: {len(audios['audio_id'])} → {len(corpus_ids)} "
+            f"({dropped} duplicate contents removed)"
+        )
+
     i2a_corpus = Dataset.from_dict(
-        {"id": corpus_ids, "audio": audios["audio"]},
+        {"id": corpus_ids, "audio": corpus_audios},
     ).cast_column("audio", Audio())
 
-    audio_by_id = set(audios["audio_id"])
+    canonical_ids = set(corpus_ids)
     qrels = {"query-id": [], "corpus-id": [], "score": []}
+    seen_pairs: set[tuple[object, object]] = set()
     skipped_queries = 0
     for qid, audio_ids, score_list in zip(
         scores["image_id"],
@@ -97,11 +160,19 @@ def main() -> None:
     ):
         added = False
         for aid, score in zip(audio_ids, score_list, strict=True):
-            if score >= args.score_threshold and aid in audio_by_id:
-                qrels["query-id"].append(qid)
-                qrels["corpus-id"].append(aid)
-                qrels["score"].append(1)
-                added = True
+            if score < args.score_threshold:
+                continue
+            canonical_aid = audio_id_remap.get(aid)
+            if canonical_aid is None or canonical_aid not in canonical_ids:
+                continue
+            pair = (qid, canonical_aid)
+            if pair in seen_pairs:
+                continue
+            seen_pairs.add(pair)
+            qrels["query-id"].append(qid)
+            qrels["corpus-id"].append(canonical_aid)
+            qrels["score"].append(1)
+            added = True
         if not added:
             skipped_queries += 1
 


### PR DESCRIPTION
- [ ] I have outlined why this dataset is filling an existing gap in the MOEB benchmark
- [ ] I have tested that the dataset runs with the `mteb` package.
- [ ] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
  - [ ] ...
  - [ ] `mteb/baseline-random-encoder`
- [ ] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [ ] I have considered the size of the dataset and reduced it if it is too big (2048 examples is typically large enough for most tasks)