### PR TITLE
Create speech edit acoustic AT2A dataset

### DIFF
--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/SpeechEditAcousticRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/SpeechEditAcousticRetrieval.json
@@ -1,0 +1,54 @@
+{
+    "test": {
+        "num_samples": 1000,
+        "num_queries": 500,
+        "num_documents": 500,
+        "number_of_characters": 12125,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": {
+            "total_duration_seconds": 4340.775529761905,
+            "min_duration_seconds": 5.0,
+            "average_duration_seconds": 8.68155105952381,
+            "max_duration_seconds": 26.73,
+            "unique_audios": 500,
+            "average_sampling_rate": 34050.0,
+            "sampling_rates": {
+                "24000": 250,
+                "44100": 250
+            }
+        },
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 12125,
+            "min_text_length": 7,
+            "average_text_length": 24.25,
+            "max_text_length": 43,
+            "unique_texts": 16
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": {
+            "total_duration_seconds": 4340.775529761905,
+            "min_duration_seconds": 5.0,
+            "average_duration_seconds": 8.68155105952381,
+            "max_duration_seconds": 26.73,
+            "unique_audios": 500,
+            "average_sampling_rate": 34050.0,
+            "sampling_rates": {
+                "24000": 250,
+                "44100": 250
+            }
+        },
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 500,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 500,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -249,7 +249,6 @@ from .mm_long_bench_doc_retrieval import MMLongBenchDocRetrieval
 from .mmdocir_t2i_retrieval import MMDocIRT2IRetrieval
 from .mmdocir_t2it_retrieval import MMDocIRT2ITRetrieval
 from .mmedit_retrieval import MMEditAT2ARetrieval
-from .speech_edit_acoustic import SpeechEditAcousticRetrieval
 from .moment_seeker import MomentSeekerTI2VRetrieval, MomentSeekerTV2VRetrieval
 from .mscoco_i2t_retrieval import MSCOCOI2TRetrieval
 from .mscoco_t2i_retrieval import MSCOCOT2IRetrieval
@@ -364,6 +363,7 @@ from .sop_i2i_retrieval import SOPI2IRetrieval
 from .sounding_earth import SoundingEarthA2IRetrieval, SoundingEarthI2ARetrieval
 from .spart_qa_retrieval import SpartQA
 from .speech_coco import SpeechCocoA2IRetrieval, SpeechCocoI2ARetrieval
+from .speech_edit_acoustic import SpeechEditAcousticRetrieval
 from .spoken_coco_retrieval import SpokenCOCOA2IRetrieval, SpokenCOCOI2ARetrieval
 from .spoken_s_qu_ad import SpokenSQuADT2ARetrieval
 from .ssw60 import SSW60A2IRetrieval, SSW60I2ARetrieval

--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -249,6 +249,7 @@ from .mm_long_bench_doc_retrieval import MMLongBenchDocRetrieval
 from .mmdocir_t2i_retrieval import MMDocIRT2IRetrieval
 from .mmdocir_t2it_retrieval import MMDocIRT2ITRetrieval
 from .mmedit_retrieval import MMEditAT2ARetrieval
+from .speech_edit_acoustic import SpeechEditAcousticRetrieval
 from .moment_seeker import MomentSeekerTI2VRetrieval, MomentSeekerTV2VRetrieval
 from .mscoco_i2t_retrieval import MSCOCOI2TRetrieval
 from .mscoco_t2i_retrieval import MSCOCOT2IRetrieval
@@ -797,6 +798,7 @@ __all__ = [
     "SpartQA",
     "SpeechCocoA2IRetrieval",
     "SpeechCocoI2ARetrieval",
+    "SpeechEditAcousticRetrieval",
     "SpokenCOCOA2IRetrieval",
     "SpokenCOCOI2ARetrieval",
     "SpokenSQuADT2ARetrieval",

--- a/mteb/tasks/retrieval/eng/speech_edit_acoustic.py
+++ b/mteb/tasks/retrieval/eng/speech_edit_acoustic.py
@@ -32,10 +32,10 @@ class SpeechEditAcousticRetrieval(AbsTaskRetrieval):
         sample_creation="created",
         bibtex_citation=r"""
 @article{zhang2026speecheditbench,
-  title={SpeechEditBench: A Bilingual Multi-Attribute Benchmark for Instruction-Guided Speech Editing},
-  author={Zhang, Hanlin and Tan, Daxin and Tao, Dehua and Chen, Xiao and Tan, Haochen and Song, Linqi},
-  journal={arXiv preprint arXiv:2606.01804},
-  year={2026}
+  author = {Zhang, Hanlin and Tan, Daxin and Tao, Dehua and Chen, Xiao and Tan, Haochen and Song, Linqi},
+  journal = {arXiv preprint arXiv:2606.01804},
+  title = {SpeechEditBench: A Bilingual Multi-Attribute Benchmark for Instruction-Guided Speech Editing},
+  year = {2026},
 }
 """,
         prompt={

--- a/mteb/tasks/retrieval/eng/speech_edit_acoustic.py
+++ b/mteb/tasks/retrieval/eng/speech_edit_acoustic.py
@@ -22,7 +22,7 @@ class SpeechEditAcousticRetrieval(AbsTaskRetrieval):
         modalities=["audio", "text"],
         eval_splits=["test"],
         eval_langs=["eng-Latn"],
-        main_score="ndcg_at_10",
+        main_score="hit_rate_at_1",
         date=("2024-01-01", "2026-08-23"),
         domains=["Spoken"],
         task_subtypes=["Speech Retrieval"],

--- a/mteb/tasks/retrieval/eng/speech_edit_acoustic.py
+++ b/mteb/tasks/retrieval/eng/speech_edit_acoustic.py
@@ -12,7 +12,7 @@ class SpeechEditAcousticRetrieval(AbsTaskRetrieval):
             "Each query combines an original speech recording with a natural-language editing instruction, "
             "and the goal is to retrieve the corresponding edited target recording."
         ),
-        reference="https://huggingface.co/datasets/DiscreteSpeech/SpeechEditBench",
+        reference="https://arxiv.org/abs/2606.01804",
         dataset={
             "path": "deep9539/speech_edit_acoustic",
             "revision": "27955b1e1dfc1b433602a26f697a9d19de710d36",

--- a/mteb/tasks/retrieval/eng/speech_edit_acoustic.py
+++ b/mteb/tasks/retrieval/eng/speech_edit_acoustic.py
@@ -26,7 +26,7 @@ class SpeechEditAcousticRetrieval(AbsTaskRetrieval):
         date=("2024-01-01", "2026-08-23"),
         domains=["Spoken"],
         task_subtypes=["Speech Retrieval"],
-        license="cc-by-4.0",
+        license="apache-2.0",
         annotations_creators="derived",
         dialect=[],
         sample_creation="created",

--- a/mteb/tasks/retrieval/eng/speech_edit_acoustic.py
+++ b/mteb/tasks/retrieval/eng/speech_edit_acoustic.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class SpeechEditAcousticRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="SpeechEditAcousticRetrieval",
+        description=(
+            "Composed audio retrieval task based on the acoustic_editing subset of DiscreteSpeech/SpeechEditBench. "
+            "Each query combines an original speech recording with a natural-language editing instruction, "
+            "and the goal is to retrieve the corresponding edited target recording."
+        ),
+        reference="https://huggingface.co/datasets/DiscreteSpeech/SpeechEditBench",
+        dataset={
+            "path": "deep9539/speech_edit_acoustic",
+            "revision": "27955b1e1dfc1b433602a26f697a9d19de710d36",
+        },
+        type="Any2AnyRetrieval",
+        category="at2a",
+        modalities=["audio", "text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2024-01-01", "2026-08-23"),
+        domains=["Spoken"],
+        task_subtypes=["Speech Retrieval"],
+        license="cc-by-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="created",
+        bibtex_citation=r"""
+@misc{speecheditbench2024,
+  title={SpeechEditBench: A Benchmark for Speech Editing},
+  author={DiscreteSpeech},
+  year={2024},
+  url={https://huggingface.co/datasets/DiscreteSpeech/SpeechEditBench}
+}
+""",
+        prompt={
+            "query": "Given the source audio and an editing instruction, retrieve the corresponding edited audio."
+        },
+    )

--- a/mteb/tasks/retrieval/eng/speech_edit_acoustic.py
+++ b/mteb/tasks/retrieval/eng/speech_edit_acoustic.py
@@ -31,11 +31,11 @@ class SpeechEditAcousticRetrieval(AbsTaskRetrieval):
         dialect=[],
         sample_creation="created",
         bibtex_citation=r"""
-@misc{speecheditbench2024,
-  title={SpeechEditBench: A Benchmark for Speech Editing},
-  author={DiscreteSpeech},
-  year={2024},
-  url={https://huggingface.co/datasets/DiscreteSpeech/SpeechEditBench}
+@article{zhang2026speecheditbench,
+  title={SpeechEditBench: A Bilingual Multi-Attribute Benchmark for Instruction-Guided Speech Editing},
+  author={Zhang, Hanlin and Tan, Daxin and Tao, Dehua and Chen, Xiao and Tan, Haochen and Song, Linqi},
+  journal={arXiv preprint arXiv:2606.01804},
+  year={2026}
 }
 """,
         prompt={

--- a/scripts/speech_edit_acoustic/data_prep.py
+++ b/scripts/speech_edit_acoustic/data_prep.py
@@ -134,7 +134,7 @@ def process_and_upload(
             )
 
         readme_content = f"""---
-license: cc-by-4.0
+license: apache-2.0
 language:
 - en
 task_categories:

--- a/scripts/speech_edit_acoustic/data_prep.py
+++ b/scripts/speech_edit_acoustic/data_prep.py
@@ -94,7 +94,9 @@ def process_and_upload(
         qrel_rows["corpus-id"].append(corpus_id)
         qrel_rows["score"].append(1)
 
-    print(f"Constructed {len(query_rows['id'])} queries and {len(corpus_rows['id'])} corpus items.")
+    print(
+        f"Constructed {len(query_rows['id'])} queries and {len(corpus_rows['id'])} corpus items."
+    )
 
     # 4. Create Hugging Face Datasets
     print("Casting columns to Arrow schemas and Audio features...")
@@ -120,7 +122,9 @@ def process_and_upload(
     # 5. Output / Upload
     if push:
         if not token:
-            raise ValueError("Hugging Face Hub token (token or HF_TOKEN env var) must be provided to push.")
+            raise ValueError(
+                "Hugging Face Hub token (token or HF_TOKEN env var) must be provided to push."
+            )
         print(f"Creating repository {repo_id} (or checking existence)...")
         create_repo(repo_id, repo_type="dataset", token=token, exist_ok=True)
 
@@ -171,6 +175,7 @@ Each query combines an original/source speech recording with a natural-language 
 - **qrels**: `query-id` (string), `corpus-id` (string), and binary `score` (int32)
 """
         from huggingface_hub import HfApi
+
         HfApi(token=token).upload_file(
             path_or_fileobj=readme_content.encode("utf-8"),
             path_in_repo="README.md",
@@ -180,7 +185,9 @@ Each query combines an original/source speech recording with a natural-language 
         )
 
         sha = dataset_info(repo_id, token=token).sha
-        print(f"\nSuccessfully pushed dataset to Hub!\nRepo ID: {repo_id}\nRevision (SHA): {sha}\n")
+        print(
+            f"\nSuccessfully pushed dataset to Hub!\nRepo ID: {repo_id}\nRevision (SHA): {sha}\n"
+        )
     else:
         if output_dir:
             output_dir.mkdir(parents=True, exist_ok=True)
@@ -188,15 +195,31 @@ Each query combines an original/source speech recording with a natural-language 
                 dataset_dict.save_to_disk(output_dir / config_name)
             print(f"Saved dataset locally to {output_dir}")
         else:
-            print("No action taken. Pass --push or --output-dir to save the constructed dataset.")
+            print(
+                "No action taken. Pass --push or --output-dir to save the constructed dataset."
+            )
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Prepare SpeechEditBench acoustic retrieval task.")
-    parser.add_argument("--repo-id", type=str, default="deep9539/speech_edit_acoustic", help="Hugging Face repository ID")
-    parser.add_argument("--token", type=str, default=os.environ.get("HF_TOKEN"), help="Hugging Face write token")
+    parser = argparse.ArgumentParser(
+        description="Prepare SpeechEditBench acoustic retrieval task."
+    )
+    parser.add_argument(
+        "--repo-id",
+        type=str,
+        default="deep9539/speech_edit_acoustic",
+        help="Hugging Face repository ID",
+    )
+    parser.add_argument(
+        "--token",
+        type=str,
+        default=os.environ.get("HF_TOKEN"),
+        help="Hugging Face write token",
+    )
     parser.add_argument("--push", action="store_true", help="Push dataset to HF Hub")
-    parser.add_argument("--output-dir", type=Path, help="Local directory to save processed datasets")
+    parser.add_argument(
+        "--output-dir", type=Path, help="Local directory to save processed datasets"
+    )
     args = parser.parse_args()
 
     process_and_upload(

--- a/scripts/speech_edit_acoustic/data_prep.py
+++ b/scripts/speech_edit_acoustic/data_prep.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""
+Data preparation script for the SpeechEditBench Acoustic Editing retrieval task.
+Downloads the SpeechEditBench dataset, processes the acoustic_editing subset,
+creates MTEB retrieval splits (queries, corpus, qrels), and uploads to Hugging Face.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from datasets import Audio, Dataset, DatasetDict, Features, Value
+from huggingface_hub import create_repo, dataset_info, snapshot_download
+
+
+def process_and_upload(
+    repo_id: str,
+    token: str | None,
+    push: bool,
+    output_dir: Path | None,
+) -> None:
+    # 1. Download SpeechEditBench snapshot (acoustic_editing folder)
+    print("Downloading SpeechEditBench acoustic editing files from HF Hub...")
+    snapshot_path_str = snapshot_download(
+        repo_id="DiscreteSpeech/SpeechEditBench",
+        repo_type="dataset",
+        allow_patterns="data/acoustic_editing/**",
+        token=token,
+    )
+    snapshot_path = Path(snapshot_path_str)
+    print(f"Snapshot downloaded to {snapshot_path}")
+
+    # 2. Read samples.jsonl
+    samples_file = snapshot_path / "data" / "acoustic_editing" / "samples.jsonl"
+    if not samples_file.exists():
+        raise FileNotFoundError(f"Could not find samples.jsonl at {samples_file}")
+
+    print("Loading samples.jsonl...")
+    samples = []
+    with open(samples_file, "r", encoding="utf-8") as f:
+        for line in f:
+            if line.strip():
+                samples.append(json.loads(line))
+
+    print(f"Loaded {len(samples)} samples from SpeechEditBench acoustic_editing.")
+
+    # 3. Construct retrieval rows
+    query_rows: dict[str, list[Any]] = {
+        "id": [],
+        "audio": [],
+        "text": [],
+    }
+    corpus_rows: dict[str, list[Any]] = {
+        "id": [],
+        "audio": [],
+    }
+    qrel_rows: dict[str, list[Any]] = {
+        "query-id": [],
+        "corpus-id": [],
+        "score": [],
+    }
+
+    for s in samples:
+        sample_id = s["sample_id"]
+        instruction = s["instruction"]
+        source_rel_path = s["audio_path"]
+        target_rel_path = s["anchor"]["target_reference_path"]
+
+        source_abs_path = snapshot_path / source_rel_path
+        target_abs_path = snapshot_path / target_rel_path
+
+        if not source_abs_path.exists():
+            print(f"Warning: Source audio file not found: {source_abs_path}")
+            continue
+        if not target_abs_path.exists():
+            print(f"Warning: Target audio file not found: {target_abs_path}")
+            continue
+
+        query_id = f"q-{sample_id}"
+        corpus_id = f"t-{sample_id}"
+
+        query_rows["id"].append(query_id)
+        query_rows["audio"].append(str(source_abs_path))
+        query_rows["text"].append(instruction)
+
+        corpus_rows["id"].append(corpus_id)
+        corpus_rows["audio"].append(str(target_abs_path))
+
+        qrel_rows["query-id"].append(query_id)
+        qrel_rows["corpus-id"].append(corpus_id)
+        qrel_rows["score"].append(1)
+
+    print(f"Constructed {len(query_rows['id'])} queries and {len(corpus_rows['id'])} corpus items.")
+
+    # 4. Create Hugging Face Datasets
+    print("Casting columns to Arrow schemas and Audio features...")
+    queries_ds = Dataset.from_dict(query_rows).cast_column("audio", Audio())
+    corpus_ds = Dataset.from_dict(corpus_rows).cast_column("audio", Audio())
+    qrels_ds = Dataset.from_dict(
+        qrel_rows,
+        features=Features(
+            {
+                "query-id": Value("string"),
+                "corpus-id": Value("string"),
+                "score": Value("int32"),
+            }
+        ),
+    )
+
+    datasets = {
+        "queries": DatasetDict({"test": queries_ds}),
+        "corpus": DatasetDict({"test": corpus_ds}),
+        "qrels": DatasetDict({"test": qrels_ds}),
+    }
+
+    # 5. Output / Upload
+    if push:
+        if not token:
+            raise ValueError("Hugging Face Hub token (token or HF_TOKEN env var) must be provided to push.")
+        print(f"Creating repository {repo_id} (or checking existence)...")
+        create_repo(repo_id, repo_type="dataset", token=token, exist_ok=True)
+
+        for config_name, dataset_dict in datasets.items():
+            print(f"Pushing {config_name} configuration to {repo_id}...")
+            dataset_dict.push_to_hub(
+                repo_id,
+                config_name=config_name,
+                token=token,
+                max_shard_size="500MB",
+            )
+
+        readme_content = f"""---
+license: cc-by-4.0
+language:
+- en
+task_categories:
+- audio-to-audio
+tags:
+- mteb
+- audio-retrieval
+- composed-retrieval
+configs:
+- config_name: queries
+  data_files:
+  - split: test
+    path: queries/test-*
+- config_name: corpus
+  data_files:
+  - split: test
+    path: corpus/test-*
+- config_name: qrels
+  data_files:
+  - split: test
+    path: qrels/test-*
+---
+
+# SpeechEdit Acoustic Retrieval Dataset
+
+This dataset is an MTEB-formatted Any-to-Any (AT2A) composed audio retrieval adaptation of the `acoustic_editing` subset of [`DiscreteSpeech/SpeechEditBench`](https://huggingface.co/datasets/DiscreteSpeech/SpeechEditBench).
+
+Each query combines an original/source speech recording with a natural-language editing instruction, and the corpus contains the corresponding edited target speech recordings.
+
+## Schema
+
+- **queries**: `id` (string), `audio` (source audio), and `text` (edit instruction)
+- **corpus**: `id` (string) and `audio` (edited target)
+- **qrels**: `query-id` (string), `corpus-id` (string), and binary `score` (int32)
+"""
+        from huggingface_hub import HfApi
+        HfApi(token=token).upload_file(
+            path_or_fileobj=readme_content.encode("utf-8"),
+            path_in_repo="README.md",
+            repo_id=repo_id,
+            repo_type="dataset",
+            commit_message="Add MTEB SpeechEdit Acoustic metadata and README",
+        )
+
+        sha = dataset_info(repo_id, token=token).sha
+        print(f"\nSuccessfully pushed dataset to Hub!\nRepo ID: {repo_id}\nRevision (SHA): {sha}\n")
+    else:
+        if output_dir:
+            output_dir.mkdir(parents=True, exist_ok=True)
+            for config_name, dataset_dict in datasets.items():
+                dataset_dict.save_to_disk(output_dir / config_name)
+            print(f"Saved dataset locally to {output_dir}")
+        else:
+            print("No action taken. Pass --push or --output-dir to save the constructed dataset.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Prepare SpeechEditBench acoustic retrieval task.")
+    parser.add_argument("--repo-id", type=str, default="deep9539/speech_edit_acoustic", help="Hugging Face repository ID")
+    parser.add_argument("--token", type=str, default=os.environ.get("HF_TOKEN"), help="Hugging Face write token")
+    parser.add_argument("--push", action="store_true", help="Push dataset to HF Hub")
+    parser.add_argument("--output-dir", type=Path, help="Local directory to save processed datasets")
+    args = parser.parse_args()
+
+    process_and_upload(
+        repo_id=args.repo_id,
+        token=args.token,
+        push=args.push,
+        output_dir=args.output_dir,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_tasks/test_load_data.py
+++ b/tests/test_tasks/test_load_data.py
@@ -33,7 +33,6 @@ def test_multilingual_load_data(task):
     "task",
     [
         mteb.get_task("MIRACLRetrievalHardNegatives", languages=["eng"]),
-        mteb.get_task("SpeechEditAcousticRetrieval"),
     ],
 )
 def test_multilingual_retrieval_load_data(task):

--- a/tests/test_tasks/test_load_data.py
+++ b/tests/test_tasks/test_load_data.py
@@ -33,6 +33,7 @@ def test_multilingual_load_data(task):
     "task",
     [
         mteb.get_task("MIRACLRetrievalHardNegatives", languages=["eng"]),
+        mteb.get_task("SpeechEditAcousticRetrieval"),
     ],
 )
 def test_multilingual_retrieval_load_data(task):

--- a/tests/test_tasks/test_task_quality.py
+++ b/tests/test_tasks/test_task_quality.py
@@ -609,6 +609,7 @@ KNOWN_ISSUES: dict[str, list[str]] = {
         "SpanishPassageRetrievalS2P",
         "SpanishPassageRetrievalS2S",
         "SpartQA",
+        "SpeechEditAcousticRetrieval",  # repeated instruction for speech edit
         "SpokenSQuADT2ARetrieval",
         "StackExchangeClustering",
         "StackExchangeClustering-VN",
@@ -878,7 +879,6 @@ KNOWN_ISSUES: dict[str, list[str]] = {
         "SpeechCommands",  # many repeated recordings of the same short command word
         "SpeechCommandsZeroshotv0.01",
         "SpeechCommandsZeroshotv0.02",
-        "SpeechEditAcousticRetrieval",  # repeated instruction for speech edit
         "StanfordI2VRetrieval",  # official manifest contains repeated video+audio clips
         "WorldSenseAudioVideoClassification",  # multiple QA rows share the same underlying video/audio
         "WorldSenseAudioVideoZeroShot",

--- a/tests/test_tasks/test_task_quality.py
+++ b/tests/test_tasks/test_task_quality.py
@@ -878,6 +878,7 @@ KNOWN_ISSUES: dict[str, list[str]] = {
         "SpeechCommands",  # many repeated recordings of the same short command word
         "SpeechCommandsZeroshotv0.01",
         "SpeechCommandsZeroshotv0.02",
+        "SpeechEditAcousticRetrieval", # repeated instruction for speech edit
         "StanfordI2VRetrieval",  # official manifest contains repeated video+audio clips
         "WorldSenseAudioVideoClassification",  # multiple QA rows share the same underlying video/audio
         "WorldSenseAudioVideoZeroShot",

--- a/tests/test_tasks/test_task_quality.py
+++ b/tests/test_tasks/test_task_quality.py
@@ -878,7 +878,7 @@ KNOWN_ISSUES: dict[str, list[str]] = {
         "SpeechCommands",  # many repeated recordings of the same short command word
         "SpeechCommandsZeroshotv0.01",
         "SpeechCommandsZeroshotv0.02",
-        "SpeechEditAcousticRetrieval", # repeated instruction for speech edit
+        "SpeechEditAcousticRetrieval",  # repeated instruction for speech edit
         "StanfordI2VRetrieval",  # official manifest contains repeated video+audio clips
         "WorldSenseAudioVideoClassification",  # multiple QA rows share the same underlying video/audio
         "WorldSenseAudioVideoZeroShot",


### PR DESCRIPTION
Implements SpeedEdit for acoustic edits as covered [here](https://huggingface.co/datasets/DiscreteSpeech/SpeechEditBench/tree/main/data/acoustic_editing).

- [x] I have outlined why this dataset is filling an existing gap in `mteb`
- [x] I have tested that the dataset runs with the `mteb` package.
- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb run -m {model_name} -t {task_name}` command.
- [x] I have checked that the performance is neither trivial (close to perfect scores) nor random.
- [x] I have considered the size of the dataset and reduced it if it is too big (e.g. 2048 examples for binary classification)
- [NA] I reproduced scores from the original paper (if applicable) and added them to the PR description for reference.

| Model | Task | Hit Rate @ 1 |
| :--- | :--- | :--- |
| Haon-Chen/e5-omni-7B | SpeechEditAcousticRetrieval | 0.604 |
| LCO-Embedding/LCO-Embedding-Omni-7B | SpeechEditAcousticRetrieval | 0.584 |
| LCO-Embedding/LCO-Embedding-Omni-3B-2605 | SpeechEditAcousticRetrieval | 0.512 |
| nvidia/omni-embed-nemotron-3b | SpeechEditAcousticRetrieval | 0.502 |
| nvidia/audio-flamingo-3-hf | SpeechEditAcousticRetrieval | 0.314 |
| laion/larger_clap_general | SpeechEditAcousticRetrieval | 0.022 |
| Qwen/Qwen3-Omni-30B-A3B-Thinking | SpeechEditAcousticRetrieval | 0.004 |
| mteb/baseline-random-encoder | SpeechEditAcousticRetrieval | 0.002 |

Co-authored by: @nehal309 