### PR TITLE
ci: use Python 3.10 in dataset_loading workflow

### DIFF
--- a/.github/workflows/dataset_loading.yml
+++ b/.github/workflows/dataset_loading.yml
@@ -26,8 +26,9 @@ jobs:
         python-version: '3.10'
 
     - name: Install dependencies
+      timeout-minutes: 30
       run: |
-        uv sync --extra image --group dev --frozen
+        uv sync --extra image --group dev --frozen --verbose
 
     - name: Run dataset loading tests
       env:

--- a/.github/workflows/dataset_loading.yml
+++ b/.github/workflows/dataset_loading.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         enable-cache: true
         version: "0.10.12"
-        python-version: '3.11'
+        python-version: '3.10'
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Fixes #5276

Aligns `dataset_loading` with the other single-version workflows (lint, docs, etc.) so the uv package cache is shared, speeding up the install step. Also added verbosity to help debug future runs. 