### PR TITLE
ci: use minimal deps and fallback venv for dataset_loading workflow

### DIFF
--- a/.github/workflows/dataset_loading.yml
+++ b/.github/workflows/dataset_loading.yml
@@ -26,9 +26,19 @@ jobs:
         python-version: '3.10'
 
     - name: Install dependencies
-      timeout-minutes: 30
+      timeout-minutes: 5
+      id: sync
+      continue-on-error: true
       run: |
-        uv sync --extra image --group dev --frozen --verbose
+        uv sync --group test --frozen --verbose
+
+    - name: Create venv manually and sync (fallback)
+      if: steps.sync.outcome == 'failure'
+      timeout-minutes: 10
+      run: |
+        rm -rf .venv
+        $(uv python find) -m venv .venv
+        uv sync --group test --frozen --verbose
 
     - name: Run dataset loading tests
       env:


### PR DESCRIPTION
Reduces install footprint from `--extra image --group dev` to `--group test`.

Adds a fallback step: if `uv sync` hangs during venv creation (a known uv issue with uv-managed Python), the venv is created explicitly via `python -m venv` and sync is retried.

#5276