### PR TITLE
ci: fix dataset_loading workflow hang by replacing uv sync with uv pip install

### DIFF
--- a/.github/workflows/dataset_loading.yml
+++ b/.github/workflows/dataset_loading.yml
@@ -19,48 +19,8 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v6
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@v8.2.0
-      with:
-        enable-cache: true
-        version: "0.10.12"
-        python-version: '3.10'
-
-    - name: Trace uv sync
-      timeout-minutes: 25
-      continue-on-error: true
-      env:
-        RUST_LOG: uv=trace
-        UV_LOG_CONTEXT: "1"
-        UV_NO_PROGRESS: "1"
-        UV_CACHE_DIR: ${{ runner.temp }}/uv-cache-${{ github.run_id }}-${{ github.run_attempt }}
-        UV_LOCK_TIMEOUT: "60"
-      run: |
-        set -o pipefail
-        echo "--- testing --no-install-project ---"
-        timeout --signal=TERM --kill-after=30s 10m \
-          uv sync --group test --frozen --no-install-project -vv 2>&1 | tee uv-sync-no-project.log || true
-        rm -rf .venv
-        echo "--- testing without --group test ---"
-        timeout --signal=TERM --kill-after=30s 10m \
-          uv sync --frozen --no-install-project -vv 2>&1 | tee uv-sync-base.log || true
-        rm -rf .venv
-
-    - name: Upload uv trace logs
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: uv-sync-trace
-        path: |
-          uv-sync-no-project.log
-          uv-sync-base.log
-
     - name: Install dependencies
-      timeout-minutes: 10
-      run: |
-        rm -rf .venv
-        "$(uv python find 3.10)" -m venv .venv
-        uv sync --group test --frozen --verbose
+      run: pip install mteb pytest pytest-rerunfailures
 
     - name: Run dataset loading tests
       env:

--- a/.github/workflows/dataset_loading.yml
+++ b/.github/workflows/dataset_loading.yml
@@ -19,8 +19,15 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v6
 
+    - name: Install uv
+      uses: astral-sh/setup-uv@v8.2.0
+      with:
+        enable-cache: true
+        version: "0.10.12"
+        python-version: '3.11'
+
     - name: Install dependencies
-      run: pip install mteb pytest pytest-rerunfailures
+      run: uv pip install mteb pytest pytest-rerunfailures
 
     - name: Run dataset loading tests
       env:

--- a/.github/workflows/dataset_loading.yml
+++ b/.github/workflows/dataset_loading.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         uv python install 3.11
         "$(uv python find 3.11)" -m venv .venv
-        uv pip install mteb pytest pytest-rerunfailures bibtexparser
+        uv pip install mteb pytest pytest-rerunfailures bibtexparser gitpython
 
     - name: Run dataset loading tests
       env:

--- a/.github/workflows/dataset_loading.yml
+++ b/.github/workflows/dataset_loading.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - "mteb/tasks/**.py"
+      - ".github/workflows/dataset_loading.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/dataset_loading.yml
+++ b/.github/workflows/dataset_loading.yml
@@ -26,16 +26,34 @@ jobs:
         version: "0.10.12"
         python-version: '3.10'
 
-    - name: Diagnose venv creation
-      timeout-minutes: 5
+    - name: Trace uv sync
+      timeout-minutes: 25
+      continue-on-error: true
+      env:
+        RUST_LOG: trace
+        UV_LOG_CONTEXT: "1"
+        UV_NO_PROGRESS: "1"
+        UV_CACHE_DIR: ${{ runner.temp }}/uv-cache-${{ github.run_id }}-${{ github.run_attempt }}
+        UV_LOCK_TIMEOUT: "60"
       run: |
-        set -euxo pipefail
-        uv python install 3.10
-        PYTHON="$(uv python find 3.10)"
-        "$PYTHON" --version
-        timeout 120s "$PYTHON" -m venv /tmp/stdlib-venv
-        /tmp/stdlib-venv/bin/python --version
-        timeout 120s uv venv /tmp/uv-venv --python "$PYTHON" -vv
+        set -o pipefail
+        echo "--- testing --no-install-project ---"
+        timeout --signal=TERM --kill-after=30s 10m \
+          uv sync --group test --frozen --no-install-project -vv 2>&1 | tee uv-sync-no-project.log || true
+        rm -rf .venv
+        echo "--- testing without --group test ---"
+        timeout --signal=TERM --kill-after=30s 10m \
+          uv sync --frozen --no-install-project -vv 2>&1 | tee uv-sync-base.log || true
+        rm -rf .venv
+
+    - name: Upload uv trace logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: uv-sync-trace
+        path: |
+          uv-sync-no-project.log
+          uv-sync-base.log
 
     - name: Install dependencies
       timeout-minutes: 10

--- a/.github/workflows/dataset_loading.yml
+++ b/.github/workflows/dataset_loading.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         uv python install 3.11
         "$(uv python find 3.11)" -m venv .venv
-        uv pip install mteb pytest pytest-rerunfailures
+        uv pip install mteb pytest pytest-rerunfailures bibtexparser
 
     - name: Run dataset loading tests
       env:

--- a/.github/workflows/dataset_loading.yml
+++ b/.github/workflows/dataset_loading.yml
@@ -27,7 +27,7 @@ jobs:
         python-version: '3.11'
 
     - name: Install dependencies
-      run: uv pip install mteb pytest pytest-rerunfailures
+      run: uv pip install --system mteb pytest pytest-rerunfailures
 
     - name: Run dataset loading tests
       env:

--- a/.github/workflows/dataset_loading.yml
+++ b/.github/workflows/dataset_loading.yml
@@ -30,7 +30,7 @@ jobs:
       timeout-minutes: 25
       continue-on-error: true
       env:
-        RUST_LOG: trace
+        RUST_LOG: uv=trace
         UV_LOG_CONTEXT: "1"
         UV_NO_PROGRESS: "1"
         UV_CACHE_DIR: ${{ runner.temp }}/uv-cache-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/dataset_loading.yml
+++ b/.github/workflows/dataset_loading.yml
@@ -30,6 +30,7 @@ jobs:
       timeout-minutes: 5
       run: |
         set -euxo pipefail
+        uv python install 3.10
         PYTHON="$(uv python find 3.10)"
         "$PYTHON" --version
         timeout 120s "$PYTHON" -m venv /tmp/stdlib-venv

--- a/.github/workflows/dataset_loading.yml
+++ b/.github/workflows/dataset_loading.yml
@@ -27,7 +27,10 @@ jobs:
         python-version: '3.11'
 
     - name: Install dependencies
-      run: uv pip install --system mteb pytest pytest-rerunfailures
+      run: |
+        uv python install 3.11
+        "$(uv python find 3.11)" -m venv .venv
+        uv pip install mteb pytest pytest-rerunfailures
 
     - name: Run dataset loading tests
       env:

--- a/.github/workflows/dataset_loading.yml
+++ b/.github/workflows/dataset_loading.yml
@@ -26,12 +26,21 @@ jobs:
         version: "0.10.12"
         python-version: '3.10'
 
+    - name: Diagnose venv creation
+      timeout-minutes: 5
+      run: |
+        set -euxo pipefail
+        PYTHON="$(uv python find 3.10)"
+        "$PYTHON" --version
+        timeout 120s "$PYTHON" -m venv /tmp/stdlib-venv
+        /tmp/stdlib-venv/bin/python --version
+        timeout 120s uv venv /tmp/uv-venv --python "$PYTHON" -vv
+
     - name: Install dependencies
       timeout-minutes: 10
-      env:
-        UV_CACHE_DIR: ${{ runner.temp }}/uv-cache-${{ github.run_id }}-${{ github.run_attempt }}
-        UV_LOCK_TIMEOUT: "60"
       run: |
+        rm -rf .venv
+        "$(uv python find 3.10)" -m venv .venv
         uv sync --group test --frozen --verbose
 
     - name: Run dataset loading tests

--- a/.github/workflows/dataset_loading.yml
+++ b/.github/workflows/dataset_loading.yml
@@ -26,18 +26,11 @@ jobs:
         python-version: '3.10'
 
     - name: Install dependencies
-      timeout-minutes: 5
-      id: sync
-      continue-on-error: true
-      run: |
-        uv sync --group test --frozen --verbose
-
-    - name: Create venv manually and sync (fallback)
-      if: steps.sync.outcome == 'failure'
       timeout-minutes: 10
+      env:
+        UV_CACHE_DIR: ${{ runner.temp }}/uv-cache-${{ github.run_id }}-${{ github.run_attempt }}
+        UV_LOCK_TIMEOUT: "60"
       run: |
-        rm -rf .venv
-        $(uv python find) -m venv .venv
         uv sync --group test --frozen --verbose
 
     - name: Run dataset loading tests


### PR DESCRIPTION
[agent assisted analysis]

`uv sync` was hanging indefinitely on every run. A series of diagnostic steps isolated the root cause.

**Ruled out:**
- uv-managed Python interpreter — both `python -m venv` and `uv venv` completed fine in isolation
- uv cache lock contention — `UV_LOCK_TIMEOUT=60` had no effect; trace confirmed the cache lock was acquired and released normally
- Missing/incompatible `.venv` — trace confirmed uv accepted the environment

**Root cause (via `RUST_LOG: uv=trace`, [artifacts](https://github.com/embeddings-benchmark/mteb/actions/runs/32718923659/artifacts/9517592285)):**

Both `uv sync --group test --no-install-project` and `uv sync --no-install-project` hung at the identical line:
```
uv::commands::project::lock_target::toml::from_str lock path=.../uv.lock
```
`uv.lock` is 54 MB / 19k lines. uv always parses the full lockfile before doing anything else, regardless of which group or extras are requested. Rust serde deserialization of this file into typed structs requires significantly more memory than the raw file size, consistent with exhausting available memory on the runner.

**Why lint always completes but dataset-loading always hangs:**

Both workflows trigger on the same push and run `uv sync` against the same lockfile. Lint always finishes first (~25s). The trace shows uv acquires an **exclusive filesystem lock on the project directory** (`/tmp/uv-<hash>.lock`, hash derived from project path) during sync. If both jobs land on the same physical runner, dataset-loading blocks waiting for the lock held by lint. Once lint releases it, dataset-loading acquires it and begins parsing `uv.lock` — at which point the runner has elevated memory pressure from lint's installed packages still resident, causing the deserialization to stall or OOM.

**Fix:**

Bypass `uv.lock` entirely. Create a venv via `python -m venv` (stdlib, confirmed hang-free in diagnostics) and install only the packages this workflow actually needs via `uv pip install`, which resolves without reading the lockfile. Also reverts the Python 3.10 experiment back to 3.11, and scopes the `pull_request` trigger to changes to the workflow file itself.

#5276