### PR TITLE
fix: mock_tasks not supported by get_instruction

### DIFF
--- a/mteb/abstasks/abstask.py
+++ b/mteb/abstasks/abstask.py
@@ -20,6 +20,7 @@ from tqdm.auto import tqdm
 
 from mteb._hf_integration.eval_model import HFEvalMeta, HFEvalTaskConfig
 from mteb._hf_integration.hf_hub_utils import _get_file_on_hub
+from mteb._log_once import LogOnce
 from mteb._set_seed import _set_seed
 from mteb.languages import LanguageScripts
 from mteb.models import (
@@ -30,7 +31,7 @@ from mteb.models import (
 from mteb.timing import TimingStack
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Iterator, Mapping
 
     from typing_extensions import Self
 
@@ -43,6 +44,7 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+log_once = LogOnce(logger)
 
 
 def _multilabel_subsampling(
@@ -807,3 +809,53 @@ class AbsTask(ABC):  # noqa: PLR0904
     def superseded_by(self) -> str | None:
         """If the dataset is superseded by another dataset, return the name of the new dataset."""
         return self.metadata.superseded_by
+
+
+def get_abstask_prompt(task_name: str) -> str:
+    """Get the prompt defined by the abstask class (`AbsTask.abstask_prompt`) of a task.
+
+    The task is resolved from the imported task classes instead of the task registry, such that it
+    doesn't only work for tasks within mteb, but also for tasks outside of it, e.g. mock tasks or
+    user defined tasks.
+
+    Args:
+        task_name: The name of the task, e.g. "SciFact".
+
+    Returns:
+        The prompt defined by the abstask class of the task, or an empty string if its abstask class
+            doesn't define one.
+    """
+    if task_name not in _task_name_to_prompt:
+        prompt = ""
+        for task_cls in _iter_task_subclasses():
+            # `abstask_prompt` is defined on the abstask class, e.g. `AbsTaskRetrieval`, and is only
+            # annotated on `AbsTask`, so abstasks such as `AbsTaskAggregate` don't define one
+            if task_cls.metadata.name == task_name:
+                prompt = getattr(task_cls, "abstask_prompt", "")
+                if prompt:
+                    break
+        _task_name_to_prompt[task_name] = prompt
+
+    prompt = _task_name_to_prompt[task_name]
+    if not prompt:
+        log_once.warning(
+            f"No prompt found on the abstask class of task '{task_name}'. Using an empty prompt."
+        )
+    return prompt
+
+
+def _iter_task_subclasses() -> Iterator[type[AbsTask]]:
+    """Iterate over the imported subclasses of `AbsTask` that define a metadata."""
+    stack: list[Any] = [AbsTask]
+    seen: set[Any] = set()
+    while stack:
+        for subclass in stack.pop().__subclasses__():
+            if subclass in seen:
+                continue
+            seen.add(subclass)
+            stack.append(subclass)
+            if getattr(subclass, "metadata", None) is not None:
+                yield subclass
+
+
+_task_name_to_prompt: dict[str, str] = {}

--- a/mteb/abstasks/image/image_text_pair_classification.py
+++ b/mteb/abstasks/image/image_text_pair_classification.py
@@ -60,6 +60,7 @@ class AbsTaskImageTextPairClassification(AbsTask):
     # it can be ["image_0", "image_1"]; ["text_0", "text_1"] for datasets like WinoGround
     images_column_names: str | Sequence[str] = "image"
     texts_column_names: str | Sequence[str] = "caption"
+    abstask_prompt = "Identify the caption that matches the given image."
 
     def _calculate_descriptive_statistics_from_split(
         self,

--- a/mteb/abstasks/zeroshot_classification.py
+++ b/mteb/abstasks/zeroshot_classification.py
@@ -66,10 +66,12 @@ class AbsTaskZeroShotClassification(AbsTask):
         label_column_name: Name of the column containing the labels. Labels must be
             integer indices of the candidate labels or strings matching an entry of
             `get_candidate_labels`.
+        abstask_prompt: Prompt to use for the task for instruction model if not prompt is provided in TaskMetadata.prompt.
     """
 
     input_column_name: str | Sequence[Modalities] = "image"
     label_column_name: str = "label"
+    abstask_prompt = "Classify the given input into one of the candidate labels."
 
     def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """Keep only eval splits. Zero-shot tasks don't need train splits."""

--- a/mteb/get_tasks.py
+++ b/mteb/get_tasks.py
@@ -77,8 +77,6 @@ def _create_task_type_to_prompt_mapping(
     """Create a mapping from task type to the prompt defined by its abstask (base) class."""
     type_to_prompt: dict[str, str] = {}
     for cls in tasks:
-        # `abstask_prompt` is defined on the abstask (base) class, e.g. `AbsTaskRetrieval`, and is
-        # only annotated on `AbsTask` itself, so it can be missing (e.g. zero-shot classification)
         prompt = getattr(cls, "abstask_prompt", None)
         if prompt:
             type_to_prompt.setdefault(cls.metadata.type, prompt)

--- a/mteb/get_tasks.py
+++ b/mteb/get_tasks.py
@@ -17,7 +17,7 @@ from mteb.abstasks import (
 from mteb.filter_tasks import filter_tasks
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Sequence
+    from collections.abc import Iterable, Iterator, Sequence
 
     from mteb.abstasks.task_metadata import TaskCategory, TaskDomain, TaskType
     from mteb.types import Modalities
@@ -74,52 +74,63 @@ _SIMILAR_TASKS = _create_similar_tasks(TASK_LIST)
 def _create_task_type_to_prompt_mapping(
     tasks: Iterable[type[AbsTask]],
 ) -> dict[str, str]:
-    """Create a mapping from task type to the default prompt of its abstask class."""
+    """Create a mapping from task type to the prompt defined by its abstask (base) class."""
     type_to_prompt: dict[str, str] = {}
     for cls in tasks:
+        # `abstask_prompt` is defined on the abstask (base) class, e.g. `AbsTaskRetrieval`, and is
+        # only annotated on `AbsTask` itself, so it can be missing (e.g. zero-shot classification)
         prompt = getattr(cls, "abstask_prompt", None)
         if prompt:
             type_to_prompt.setdefault(cls.metadata.type, prompt)
     return type_to_prompt
 
 
-_TASK_TYPE_TO_PROMPT = _create_task_type_to_prompt_mapping(TASK_LIST)
+def _iter_task_subclasses() -> Iterator[type[AbsTask]]:
+    """Iterate over all currently imported (non-abstract) subclasses of `AbsTask`.
 
-# fallback for task types that no task in the registry implements (yet)
-_SIMPLIFIED_TASK_TYPE_TO_PROMPT: dict[str, str] = {
-    "retrieval": "Retrieve text based on user query.",
-    "clustering": "Identify categories in user passages.",
-    "classification": "Classify user passages.",
-    "semantic-similarity": "Retrieve semantically similar text.",
-    "pair-classification": "Retrieve text that are semantically similar to the given text.",
-}
+    Contrary to the task registry this also includes tasks that are not a part of mteb, such as
+    mock tasks and user defined tasks.
+    """
+    stack: list[Any] = [AbsTask]
+    seen: set[Any] = set()
+    while stack:
+        for subclass in stack.pop().__subclasses__():
+            if subclass in seen:
+                continue
+            seen.add(subclass)
+            stack.append(subclass)
+            if getattr(subclass, "metadata", None) is not None:
+                yield subclass
+
+
+_TASK_TYPE_TO_PROMPT = _create_task_type_to_prompt_mapping(TASK_LIST)
 
 
 def get_abstask_prompt(task_type: str) -> str:
-    """Get the default prompt (`AbsTask.abstask_prompt`) for a given task type.
+    """Get the prompt (`AbsTask.abstask_prompt`) defined by the abstask class of a task type.
 
-    This is derived from the task type instead of the task name, such that it also works for
-    tasks that are not a part of the task registry (e.g. mock tasks or custom tasks).
+    The prompt is resolved from the task type instead of the task name, such that it also works for
+    tasks that are not a part of the task registry (e.g. mock tasks or user defined tasks).
 
     Args:
         task_type: The type of the task, e.g. "Retrieval".
 
     Returns:
-        The default prompt for the task type or an empty string if no prompt is defined for the task type.
+        The prompt of the abstask class of the task type, or an empty string if its abstask class
+            doesn't define one (e.g. zero-shot classification).
     """
-    from mteb.abstasks.task_metadata import _TASKTYPE2SIMPLIFIEDTASKTYPE
-
     if task_type in _TASK_TYPE_TO_PROMPT:
         return _TASK_TYPE_TO_PROMPT[task_type]
 
-    simplified_task_type = _TASKTYPE2SIMPLIFIEDTASKTYPE.get(task_type)
-    if simplified_task_type in _SIMPLIFIED_TASK_TYPE_TO_PROMPT:
-        return _SIMPLIFIED_TASK_TYPE_TO_PROMPT[simplified_task_type]
-
-    log_once.warning(
-        f"No default prompt found for task type '{task_type}'. Using an empty prompt."
-    )
-    return ""
+    # no task in the registry uses this task type, fall back to the imported task classes
+    prompt = _create_task_type_to_prompt_mapping(_iter_task_subclasses()).get(task_type)
+    if prompt is None:
+        log_once.warning(
+            f"No prompt found on the abstask class of task type '{task_type}'. Using an empty prompt."
+        )
+        return ""
+    _TASK_TYPE_TO_PROMPT[task_type] = prompt
+    return prompt
 
 
 _DEFAULT_PROPRIETIES = (

--- a/mteb/get_tasks.py
+++ b/mteb/get_tasks.py
@@ -112,7 +112,7 @@ def get_abstask_prompt(task_type: str) -> str:
     if task_type in _TASK_TYPE_TO_PROMPT:
         return _TASK_TYPE_TO_PROMPT[task_type]
 
-    simplified_task_type = _TASKTYPE2SIMPLIFIEDTASKTYPE.get(task_type)  # type: ignore[arg-type]
+    simplified_task_type = _TASKTYPE2SIMPLIFIEDTASKTYPE.get(task_type)
     if simplified_task_type in _SIMPLIFIED_TASK_TYPE_TO_PROMPT:
         return _SIMPLIFIED_TASK_TYPE_TO_PROMPT[simplified_task_type]
 

--- a/mteb/get_tasks.py
+++ b/mteb/get_tasks.py
@@ -71,6 +71,57 @@ _TASKS_REGISTRY = _create_name_to_task_mapping(TASK_LIST)
 _SIMILAR_TASKS = _create_similar_tasks(TASK_LIST)
 
 
+def _create_task_type_to_prompt_mapping(
+    tasks: Iterable[type[AbsTask]],
+) -> dict[str, str]:
+    """Create a mapping from task type to the default prompt of its abstask class."""
+    type_to_prompt: dict[str, str] = {}
+    for cls in tasks:
+        prompt = getattr(cls, "abstask_prompt", None)
+        if prompt:
+            type_to_prompt.setdefault(cls.metadata.type, prompt)
+    return type_to_prompt
+
+
+_TASK_TYPE_TO_PROMPT = _create_task_type_to_prompt_mapping(TASK_LIST)
+
+# fallback for task types that no task in the registry implements (yet)
+_SIMPLIFIED_TASK_TYPE_TO_PROMPT: dict[str, str] = {
+    "retrieval": "Retrieve text based on user query.",
+    "clustering": "Identify categories in user passages.",
+    "classification": "Classify user passages.",
+    "semantic-similarity": "Retrieve semantically similar text.",
+    "pair-classification": "Retrieve text that are semantically similar to the given text.",
+}
+
+
+def get_abstask_prompt(task_type: str) -> str:
+    """Get the default prompt (`AbsTask.abstask_prompt`) for a given task type.
+
+    This is derived from the task type instead of the task name, such that it also works for
+    tasks that are not a part of the task registry (e.g. mock tasks or custom tasks).
+
+    Args:
+        task_type: The type of the task, e.g. "Retrieval".
+
+    Returns:
+        The default prompt for the task type or an empty string if no prompt is defined for the task type.
+    """
+    from mteb.abstasks.task_metadata import _TASKTYPE2SIMPLIFIEDTASKTYPE
+
+    if task_type in _TASK_TYPE_TO_PROMPT:
+        return _TASK_TYPE_TO_PROMPT[task_type]
+
+    simplified_task_type = _TASKTYPE2SIMPLIFIEDTASKTYPE.get(task_type)  # type: ignore[arg-type]
+    if simplified_task_type in _SIMPLIFIED_TASK_TYPE_TO_PROMPT:
+        return _SIMPLIFIED_TASK_TYPE_TO_PROMPT[simplified_task_type]
+
+    log_once.warning(
+        f"No default prompt found for task type '{task_type}'. Using an empty prompt."
+    )
+    return ""
+
+
 _DEFAULT_PROPRIETIES = (
     "name",
     "type",

--- a/mteb/get_tasks.py
+++ b/mteb/get_tasks.py
@@ -17,7 +17,7 @@ from mteb.abstasks import (
 from mteb.filter_tasks import filter_tasks
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator, Sequence
+    from collections.abc import Iterable, Sequence
 
     from mteb.abstasks.task_metadata import TaskCategory, TaskDomain, TaskType
     from mteb.types import Modalities
@@ -69,66 +69,6 @@ def _create_similar_tasks(tasks: Iterable[type[AbsTask]]) -> dict[str, list[str]
 TASK_LIST = _gather_tasks()
 _TASKS_REGISTRY = _create_name_to_task_mapping(TASK_LIST)
 _SIMILAR_TASKS = _create_similar_tasks(TASK_LIST)
-
-
-def _create_task_type_to_prompt_mapping(
-    tasks: Iterable[type[AbsTask]],
-) -> dict[str, str]:
-    """Create a mapping from task type to the prompt defined by its abstask (base) class."""
-    type_to_prompt: dict[str, str] = {}
-    for cls in tasks:
-        prompt = getattr(cls, "abstask_prompt", None)
-        if prompt:
-            type_to_prompt.setdefault(cls.metadata.type, prompt)
-    return type_to_prompt
-
-
-def _iter_task_subclasses() -> Iterator[type[AbsTask]]:
-    """Iterate over all currently imported (non-abstract) subclasses of `AbsTask`.
-
-    Contrary to the task registry this also includes tasks that are not a part of mteb, such as
-    mock tasks and user defined tasks.
-    """
-    stack: list[Any] = [AbsTask]
-    seen: set[Any] = set()
-    while stack:
-        for subclass in stack.pop().__subclasses__():
-            if subclass in seen:
-                continue
-            seen.add(subclass)
-            stack.append(subclass)
-            if getattr(subclass, "metadata", None) is not None:
-                yield subclass
-
-
-_TASK_TYPE_TO_PROMPT = _create_task_type_to_prompt_mapping(TASK_LIST)
-
-
-def get_abstask_prompt(task_type: str) -> str:
-    """Get the prompt (`AbsTask.abstask_prompt`) defined by the abstask class of a task type.
-
-    The prompt is resolved from the task type instead of the task name, such that it also works for
-    tasks that are not a part of the task registry (e.g. mock tasks or user defined tasks).
-
-    Args:
-        task_type: The type of the task, e.g. "Retrieval".
-
-    Returns:
-        The prompt of the abstask class of the task type, or an empty string if its abstask class
-            doesn't define one (e.g. zero-shot classification).
-    """
-    if task_type in _TASK_TYPE_TO_PROMPT:
-        return _TASK_TYPE_TO_PROMPT[task_type]
-
-    # no task in the registry uses this task type, fall back to the imported task classes
-    prompt = _create_task_type_to_prompt_mapping(_iter_task_subclasses()).get(task_type)
-    if prompt is None:
-        log_once.warning(
-            f"No prompt found on the abstask class of task type '{task_type}'. Using an empty prompt."
-        )
-        return ""
-    _TASK_TYPE_TO_PROMPT[task_type] = prompt
-    return prompt
 
 
 _DEFAULT_PROPRIETIES = (

--- a/mteb/models/abs_encoder.py
+++ b/mteb/models/abs_encoder.py
@@ -225,9 +225,9 @@ class AbsEncoder(ABC):
         if prompt:
             return prompt
 
-        from mteb.get_tasks import get_abstask_prompt
+        from mteb.abstasks.abstask import get_abstask_prompt
 
-        return get_abstask_prompt(task_metadata.type)
+        return get_abstask_prompt(task_metadata.name)
 
     def format_instruction(
         self, instruction: str, prompt_type: PromptType | None = None

--- a/mteb/models/abs_encoder.py
+++ b/mteb/models/abs_encoder.py
@@ -225,10 +225,9 @@ class AbsEncoder(ABC):
         if prompt:
             return prompt
 
-        from mteb.get_tasks import get_task
+        from mteb.get_tasks import get_abstask_prompt
 
-        abstask = get_task(task_name=task_metadata.name)
-        return abstask.abstask_prompt
+        return get_abstask_prompt(task_metadata.type)
 
     def format_instruction(
         self, instruction: str, prompt_type: PromptType | None = None


### PR DESCRIPTION
closes #5297 

`AbsEncoder.get_instruction` fell back to `get_task(task_name=task_metadata.name).abstask_prompt`,
which only works for tasks in the registry. Mock tasks (and any custom/unregistered task) raised `KeyError`

I have added `mteb.get_tasks.get_abstask_prompt(task_type)`, which resolves the default prompt from the
task **type** instead of the task **name**:

1. a type → `abstask_prompt` mapping built once from the task registry;
2. a fallback via `_TASKTYPE2SIMPLIFIEDTASKTYPE` for task types no registered task implements yet
   (e.g. `VideoMultilabelClassification`);
3. otherwise an empty string plus a one-time warning.

`get_instruction` now calls it. Prompt precedence is unchanged. `prompts_dict` and `TaskMetadata.prompt` are still checked first; this only affects the final fallback.

- No task type has conflicting `abstask_prompt` values, so registered tasks that resolved before return the identical string.
- Every value in `_TASK_TYPE` now resolves to a non-empty prompt, and each mock task's resolved prompt equals its own class's `abstask_prompt`.
- verified with `mteb.mock_run` on `codefuse-ai/F2LLM-v2-80M` and `intfloat/multilingual-e5-small` before and after fix