### PR TITLE
Update invalid links zensical setting 

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -150,4 +150,4 @@ extra:
       link: https://github.com/embeddings-benchmark/mteb
 
 validation:
-  unresolved_references: false
+  invalid_links: false


### PR DESCRIPTION
> Additionally, checking of autorefs is moved to the invalid_links setting. Please disable unresolved_references - it is not supported anymore

https://github.com/zensical/zensical/releases/tag/v0.0.56