### PR TITLE
fix: drop unlabelled documents at a level instead of scoring them

### DIFF
--- a/mteb/abstasks/clustering.py
+++ b/mteb/abstasks/clustering.py
@@ -46,7 +46,7 @@ def _evaluate_clustering_bootstrapped(
     max_depth: int | None,
     rng_state: random.Random,
     seed: int,
-    drop_unlabelled_documents: bool = True,
+    drop_unlabelled_documents: bool = False,
 ) -> tuple[dict[str, dict[str, list[float]]], dict[str, list[list[int]]]]:
     """Bootstrapped evaluation of clustering performance.
 
@@ -86,9 +86,8 @@ def _evaluate_clustering_bootstrapped(
             if not valid_idx.all():
                 logger.warning(
                     "Level %d: dropping %d of %d documents that have no label at "
-                    "this level. Set drop_unlabelled_documents=False on the task to "
-                    "score them as one shared class instead, which is the older "
-                    "behaviour.",
+                    "this level, because drop_unlabelled_documents is set on this task. "
+                    "The older behaviour scores them as one shared class.",
                     i_level,
                     len(labels) - int(valid_idx.sum()),
                     len(labels),
@@ -167,10 +166,11 @@ class AbsTaskClustering(AbsTask):
         drop_unlabelled_documents: For a hierarchical task, whether a document whose label
             path is shorter than the level being scored is dropped at that level rather than
             scored. Those documents have nothing in common except a missing label, so keeping
-            them asks the model to find a class that is not really there. Defaults to True.
-            The hierarchical tasks that existed before this option was added set it to False
-            so their published scores stay reproducible. A task whose label paths all reach
-            the same depth is unaffected either way, since no document is ever dropped.
+            them asks the model to find a class that is not really there. Defaults to False,
+            which is the behaviour every published hierarchical score was produced under.
+            New tasks that want the corrected behaviour set it to True; the .v2 hierarchical
+            tasks do. A task whose label paths all reach the same depth is unaffected either
+            way, since no document is ever dropped.
         input_column_name: Name of the column(s) containing the input sentences or data points. Default is "sentences".
             Can be a string for single-column tasks or a list of strings for multimodal tasks (e.g. ["video", "audio"]).
             When specified as a list, values must be the default column names as defined in the encoder I/O types
@@ -185,7 +185,7 @@ class AbsTaskClustering(AbsTask):
     n_clusters: int = 10
     k_mean_batch_size: int = 512
     max_depth = None
-    drop_unlabelled_documents: bool = True
+    drop_unlabelled_documents: bool = False
     abstask_prompt = "Identify categories in user passages."
     input_column_name: str | Sequence[Modalities] = "sentences"
     label_column_name: str = "labels"

--- a/mteb/abstasks/clustering.py
+++ b/mteb/abstasks/clustering.py
@@ -46,11 +46,17 @@ def _evaluate_clustering_bootstrapped(
     max_depth: int | None,
     rng_state: random.Random,
     seed: int,
+    drop_unlabelled_documents: bool = True,
 ) -> tuple[dict[str, dict[str, list[float]]], dict[str, list[list[int]]]]:
     """Bootstrapped evaluation of clustering performance.
 
     The bootstrapping is done by sampling N samples from the corpus and clustering them. It is done without replacement to get a diverse set of
     samples.
+
+    `drop_unlabelled_documents` decides what happens at a given level to the documents
+    whose label path is shorter than that level: drop them, or keep them under the
+    sentinel gold label -1, which is the older behaviour. See
+    `AbsTaskClustering.drop_unlabelled_documents`.
 
     Returns:
         A tuple containing:
@@ -72,15 +78,45 @@ def _evaluate_clustering_bootstrapped(
         max_depth = max(map(len, labels))
     # Evaluate on each level til max depth
     for i_level in range(max_depth):
-        # Drop the documents whose label path does not reach this level, rather
-        # than give them a sentinel gold label and filter on it afterwards. An
-        # earlier version appended -1 for those documents, but np.array() on a
-        # mixed list of str and int returns a string array, so the sentinel
-        # became the string "-1" and the filter kept every document.
-        valid_idx = np.array([len(label) > i_level for label in labels])
-        np_level_labels = np.array(
-            [label[i_level] for label in labels if len(label) > i_level]
-        )
+        if drop_unlabelled_documents:
+            # Drop the documents whose label path does not reach this level,
+            # rather than give them a sentinel gold label and filter on it
+            # afterwards.
+            valid_idx = np.array([len(label) > i_level for label in labels])
+            if not valid_idx.all():
+                logger.warning(
+                    "Level %d: dropping %d of %d documents that have no label at "
+                    "this level. Set drop_unlabelled_documents=False on the task to "
+                    "score them as one shared class instead, which is the older "
+                    "behaviour.",
+                    i_level,
+                    len(labels) - int(valid_idx.sum()),
+                    len(labels),
+                )
+            np_level_labels = np.array(
+                [label[i_level] for label in labels if len(label) > i_level]
+            )
+        else:
+            # The older behaviour, kept so that published results stay
+            # reproducible. Note that it is not one consistent rule: np.array()
+            # on a mixed list of str and int returns a string array, so for
+            # string labels the sentinel becomes "-1", the filter below never
+            # matches, and every document is kept and scored as one shared
+            # class. For integer labels the filter does fire and they are
+            # dropped. Which of the two happens is decided by the dataset's
+            # label dtype.
+            level_labels: list[str | int] = []
+            # Assign -1 to gold label if the level is not there
+            for label in labels:
+                if len(label) > i_level:
+                    level_labels.append(label[i_level])
+                else:
+                    level_labels.append(-1)
+            np_level_labels = np.array(level_labels)
+            valid_idx = np.array(
+                [level_label != -1 for level_label in np_level_labels]
+            )  # Could be level_labels != -1 but fails with FutureWarning: elementwise comparison failed
+            np_level_labels = np_level_labels[valid_idx]
         level_embeddings = embeddings[valid_idx]
         clustering_model = MiniBatchKMeans(
             n_clusters=np.unique(np_level_labels).size,
@@ -128,6 +164,13 @@ class AbsTaskClustering(AbsTask):
         n_clusters: Number of clustering experiments to run.
         k_mean_batch_size: Batch size to use for k-means clustering.
         max_depth: Maximum depth to evaluate clustering. If None, evaluates all levels.
+        drop_unlabelled_documents: For a hierarchical task, whether a document whose label
+            path is shorter than the level being scored is dropped at that level rather than
+            scored. Those documents have nothing in common except a missing label, so keeping
+            them asks the model to find a class that is not really there. Defaults to True.
+            The hierarchical tasks that existed before this option was added set it to False
+            so their published scores stay reproducible. A task whose label paths all reach
+            the same depth is unaffected either way, since no document is ever dropped.
         input_column_name: Name of the column(s) containing the input sentences or data points. Default is "sentences".
             Can be a string for single-column tasks or a list of strings for multimodal tasks (e.g. ["video", "audio"]).
             When specified as a list, values must be the default column names as defined in the encoder I/O types
@@ -142,6 +185,7 @@ class AbsTaskClustering(AbsTask):
     n_clusters: int = 10
     k_mean_batch_size: int = 512
     max_depth = None
+    drop_unlabelled_documents: bool = True
     abstask_prompt = "Identify categories in user passages."
     input_column_name: str | Sequence[Modalities] = "sentences"
     label_column_name: str = "labels"
@@ -250,6 +294,7 @@ class AbsTaskClustering(AbsTask):
                 max_depth=self.max_depth,
                 rng_state=self.rng_state,
                 seed=self.seed,
+                drop_unlabelled_documents=self.drop_unlabelled_documents,
             )
 
         if prediction_folder:

--- a/mteb/abstasks/clustering.py
+++ b/mteb/abstasks/clustering.py
@@ -72,18 +72,15 @@ def _evaluate_clustering_bootstrapped(
         max_depth = max(map(len, labels))
     # Evaluate on each level til max depth
     for i_level in range(max_depth):
-        level_labels: list[str | int] = []
-        # Assign -1 to gold label if the level is not there
-        for label in labels:
-            if len(label) > i_level:
-                level_labels.append(label[i_level])
-            else:
-                level_labels.append(-1)
-        np_level_labels = np.array(level_labels)
-        valid_idx = np.array(
-            [level_label != -1 for level_label in np_level_labels]
-        )  # Could be level_labels != -1 but fails with FutureWarning: elementwise comparison failed
-        np_level_labels = np_level_labels[valid_idx]
+        # Drop the documents whose label path does not reach this level, rather
+        # than give them a sentinel gold label and filter on it afterwards. An
+        # earlier version appended -1 for those documents, but np.array() on a
+        # mixed list of str and int returns a string array, so the sentinel
+        # became the string "-1" and the filter kept every document.
+        valid_idx = np.array([len(label) > i_level for label in labels])
+        np_level_labels = np.array(
+            [label[i_level] for label in labels if len(label) > i_level]
+        )
         level_embeddings = embeddings[valid_idx]
         clustering_model = MiniBatchKMeans(
             n_clusters=np.unique(np_level_labels).size,

--- a/mteb/tasks/clustering/eng/__init__.py
+++ b/mteb/tasks/clustering/eng/__init__.py
@@ -3,7 +3,9 @@ from .arxiv_clustering_p2p import ArxivClusteringP2P, ArxivClusteringP2PFast
 from .arxiv_clustering_s2s import ArxivClusteringS2S
 from .arxiv_hierarchical_clustering import (
     ArXivHierarchicalClusteringP2P,
+    ArXivHierarchicalClusteringP2PV2,
     ArXivHierarchicalClusteringS2S,
+    ArXivHierarchicalClusteringS2SV2,
 )
 from .ave_dataset_clustering import (
     AVEDatasetAudioVideoClustering,
@@ -71,7 +73,9 @@ __all__ = [
     "AVEDatasetVideoClustering",
     "AmbientAcousticContextClustering",
     "ArXivHierarchicalClusteringP2P",
+    "ArXivHierarchicalClusteringP2PV2",
     "ArXivHierarchicalClusteringS2S",
+    "ArXivHierarchicalClusteringS2SV2",
     "ArxivClusteringP2P",
     "ArxivClusteringP2PFast",
     "ArxivClusteringS2S",

--- a/mteb/tasks/clustering/eng/arxiv_hierarchical_clustering.py
+++ b/mteb/tasks/clustering/eng/arxiv_hierarchical_clustering.py
@@ -14,12 +14,9 @@ def split_labels(record: dict) -> dict:
 
 
 class ArXivHierarchicalClusteringP2P(AbsTaskClustering):
-    # Pinned to the behaviour these scores were published under. New
-    # hierarchical tasks should leave this at the default.
-    drop_unlabelled_documents = False
-
     metadata = TaskMetadata(
         name="ArXivHierarchicalClusteringP2P",
+        superseded_by="ArXivHierarchicalClusteringP2P.v2",
         description="Clustering of titles+abstract from arxiv. Clustering of 30 sets, either on the main or secondary category",
         reference="https://www.kaggle.com/Cornell-University/arxiv",
         dataset={
@@ -61,12 +58,9 @@ class ArXivHierarchicalClusteringP2P(AbsTaskClustering):
 
 
 class ArXivHierarchicalClusteringS2S(AbsTaskClustering):
-    # Pinned to the behaviour these scores were published under. New
-    # hierarchical tasks should leave this at the default.
-    drop_unlabelled_documents = False
-
     metadata = TaskMetadata(
         name="ArXivHierarchicalClusteringS2S",
+        superseded_by="ArXivHierarchicalClusteringS2S.v2",
         description="Clustering of titles from arxiv. Clustering of 30 sets, either on the main or secondary category",
         reference="https://www.kaggle.com/Cornell-University/arxiv",
         dataset={
@@ -105,3 +99,45 @@ class ArXivHierarchicalClusteringS2S(AbsTaskClustering):
         self.dataset["test"] = self.dataset["test"].train_test_split(
             test_size=N_SAMPLES, seed=self.seed
         )["test"]
+
+
+class ArXivHierarchicalClusteringP2PV2(ArXivHierarchicalClusteringP2P):
+    """ArXivHierarchicalClusteringP2P with documents that have no label at the level being scored dropped.
+
+    Same data and same revision as ArXivHierarchicalClusteringP2P. The only difference is that a
+    document whose label path stops above the level being scored is left out of that
+    level rather than gathered into one group under a sentinel label. Those documents
+    have nothing in common except a missing label, so scoring them asks the model to
+    find a class that is not really there.
+
+    Scores are not comparable with ArXivHierarchicalClusteringP2P. On the SNL tasks the difference is
+    about +0.13 v_measure, and it tracks the share of documents that have no label at
+    each level.
+    """
+
+    drop_unlabelled_documents = True
+
+    metadata = ArXivHierarchicalClusteringP2P.metadata.model_copy(
+        update={"name": "ArXivHierarchicalClusteringP2P.v2", "superseded_by": None},
+    )
+
+
+class ArXivHierarchicalClusteringS2SV2(ArXivHierarchicalClusteringS2S):
+    """ArXivHierarchicalClusteringS2S with documents that have no label at the level being scored dropped.
+
+    Same data and same revision as ArXivHierarchicalClusteringS2S. The only difference is that a
+    document whose label path stops above the level being scored is left out of that
+    level rather than gathered into one group under a sentinel label. Those documents
+    have nothing in common except a missing label, so scoring them asks the model to
+    find a class that is not really there.
+
+    Scores are not comparable with ArXivHierarchicalClusteringS2S. On the SNL tasks the difference is
+    about +0.13 v_measure, and it tracks the share of documents that have no label at
+    each level.
+    """
+
+    drop_unlabelled_documents = True
+
+    metadata = ArXivHierarchicalClusteringS2S.metadata.model_copy(
+        update={"name": "ArXivHierarchicalClusteringS2S.v2", "superseded_by": None},
+    )

--- a/mteb/tasks/clustering/eng/arxiv_hierarchical_clustering.py
+++ b/mteb/tasks/clustering/eng/arxiv_hierarchical_clustering.py
@@ -14,6 +14,10 @@ def split_labels(record: dict) -> dict:
 
 
 class ArXivHierarchicalClusteringP2P(AbsTaskClustering):
+    # Pinned to the behaviour these scores were published under. New
+    # hierarchical tasks should leave this at the default.
+    drop_unlabelled_documents = False
+
     metadata = TaskMetadata(
         name="ArXivHierarchicalClusteringP2P",
         description="Clustering of titles+abstract from arxiv. Clustering of 30 sets, either on the main or secondary category",
@@ -57,6 +61,10 @@ class ArXivHierarchicalClusteringP2P(AbsTaskClustering):
 
 
 class ArXivHierarchicalClusteringS2S(AbsTaskClustering):
+    # Pinned to the behaviour these scores were published under. New
+    # hierarchical tasks should leave this at the default.
+    drop_unlabelled_documents = False
+
     metadata = TaskMetadata(
         name="ArXivHierarchicalClusteringS2S",
         description="Clustering of titles from arxiv. Clustering of 30 sets, either on the main or secondary category",

--- a/mteb/tasks/clustering/nob/__init__.py
+++ b/mteb/tasks/clustering/nob/__init__.py
@@ -1,19 +1,27 @@
 from .snl_clustering import SNLClustering
 from .snl_hierarchical_clustering import (
     SNLHierarchicalClusteringP2P,
+    SNLHierarchicalClusteringP2PV2,
     SNLHierarchicalClusteringS2S,
+    SNLHierarchicalClusteringS2SV2,
 )
 from .vg_clustering import VGClustering
 from .vg_hierarchical_clustering import (
     VGHierarchicalClusteringP2P,
+    VGHierarchicalClusteringP2PV2,
     VGHierarchicalClusteringS2S,
+    VGHierarchicalClusteringS2SV2,
 )
 
 __all__ = [
     "SNLClustering",
     "SNLHierarchicalClusteringP2P",
+    "SNLHierarchicalClusteringP2PV2",
     "SNLHierarchicalClusteringS2S",
+    "SNLHierarchicalClusteringS2SV2",
     "VGClustering",
     "VGHierarchicalClusteringP2P",
+    "VGHierarchicalClusteringP2PV2",
     "VGHierarchicalClusteringS2S",
+    "VGHierarchicalClusteringS2SV2",
 ]

--- a/mteb/tasks/clustering/nob/snl_hierarchical_clustering.py
+++ b/mteb/tasks/clustering/nob/snl_hierarchical_clustering.py
@@ -10,14 +10,12 @@ def split_labels(record: dict) -> dict:
 
 
 class SNLHierarchicalClusteringP2P(AbsTaskClustering):
-    # Pinned to the behaviour these scores were published under. New
-    # hierarchical tasks should leave this at the default.
-    drop_unlabelled_documents = False
     max_document_to_embed = 1300
     max_fraction_of_documents_to_embed = None
 
     metadata = TaskMetadata(
         name="SNLHierarchicalClusteringP2P",
+        superseded_by="SNLHierarchicalClusteringP2P.v2",
         dataset={
             "path": "mteb/SNLHierarchicalClusteringP2P",
             "revision": "693a321c42fb13ffe76bb9043f8d2aaa8f0a9499",
@@ -51,14 +49,12 @@ class SNLHierarchicalClusteringP2P(AbsTaskClustering):
 
 
 class SNLHierarchicalClusteringS2S(AbsTaskClustering):
-    # Pinned to the behaviour these scores were published under. New
-    # hierarchical tasks should leave this at the default.
-    drop_unlabelled_documents = False
     max_document_to_embed = 1300
     max_fraction_of_documents_to_embed = None
 
     metadata = TaskMetadata(
         name="SNLHierarchicalClusteringS2S",
+        superseded_by="SNLHierarchicalClusteringS2S.v2",
         dataset={
             "path": "mteb/SNLHierarchicalClusteringS2S",
             "revision": "b505e4ce65f255228e49dd07b6f8148731c5dc64",
@@ -89,3 +85,45 @@ class SNLHierarchicalClusteringS2S(AbsTaskClustering):
         prompt="Identify categories in a Norwegian lexicon",
     )
     max_depth = 5
+
+
+class SNLHierarchicalClusteringP2PV2(SNLHierarchicalClusteringP2P):
+    """SNLHierarchicalClusteringP2P with documents that have no label at the level being scored dropped.
+
+    Same data and same revision as SNLHierarchicalClusteringP2P. The only difference is that a
+    document whose label path stops above the level being scored is left out of that
+    level rather than gathered into one group under a sentinel label. Those documents
+    have nothing in common except a missing label, so scoring them asks the model to
+    find a class that is not really there.
+
+    Scores are not comparable with SNLHierarchicalClusteringP2P. On the SNL tasks the difference is
+    about +0.13 v_measure, and it tracks the share of documents that have no label at
+    each level.
+    """
+
+    drop_unlabelled_documents = True
+
+    metadata = SNLHierarchicalClusteringP2P.metadata.model_copy(
+        update={"name": "SNLHierarchicalClusteringP2P.v2", "superseded_by": None},
+    )
+
+
+class SNLHierarchicalClusteringS2SV2(SNLHierarchicalClusteringS2S):
+    """SNLHierarchicalClusteringS2S with documents that have no label at the level being scored dropped.
+
+    Same data and same revision as SNLHierarchicalClusteringS2S. The only difference is that a
+    document whose label path stops above the level being scored is left out of that
+    level rather than gathered into one group under a sentinel label. Those documents
+    have nothing in common except a missing label, so scoring them asks the model to
+    find a class that is not really there.
+
+    Scores are not comparable with SNLHierarchicalClusteringS2S. On the SNL tasks the difference is
+    about +0.13 v_measure, and it tracks the share of documents that have no label at
+    each level.
+    """
+
+    drop_unlabelled_documents = True
+
+    metadata = SNLHierarchicalClusteringS2S.metadata.model_copy(
+        update={"name": "SNLHierarchicalClusteringS2S.v2", "superseded_by": None},
+    )

--- a/mteb/tasks/clustering/nob/snl_hierarchical_clustering.py
+++ b/mteb/tasks/clustering/nob/snl_hierarchical_clustering.py
@@ -10,6 +10,9 @@ def split_labels(record: dict) -> dict:
 
 
 class SNLHierarchicalClusteringP2P(AbsTaskClustering):
+    # Pinned to the behaviour these scores were published under. New
+    # hierarchical tasks should leave this at the default.
+    drop_unlabelled_documents = False
     max_document_to_embed = 1300
     max_fraction_of_documents_to_embed = None
 
@@ -48,6 +51,9 @@ class SNLHierarchicalClusteringP2P(AbsTaskClustering):
 
 
 class SNLHierarchicalClusteringS2S(AbsTaskClustering):
+    # Pinned to the behaviour these scores were published under. New
+    # hierarchical tasks should leave this at the default.
+    drop_unlabelled_documents = False
     max_document_to_embed = 1300
     max_fraction_of_documents_to_embed = None
 

--- a/mteb/tasks/clustering/nob/vg_hierarchical_clustering.py
+++ b/mteb/tasks/clustering/nob/vg_hierarchical_clustering.py
@@ -10,6 +10,9 @@ def split_labels(record: dict) -> dict:
 
 
 class VGHierarchicalClusteringP2P(AbsTaskClustering):
+    # Pinned to the behaviour these scores were published under. New
+    # hierarchical tasks should leave this at the default.
+    drop_unlabelled_documents = False
     max_document_to_embed = N_SAMPLES
     max_fraction_of_documents_to_embed = None
 
@@ -57,6 +60,9 @@ class VGHierarchicalClusteringP2P(AbsTaskClustering):
 
 
 class VGHierarchicalClusteringS2S(AbsTaskClustering):
+    # Pinned to the behaviour these scores were published under. New
+    # hierarchical tasks should leave this at the default.
+    drop_unlabelled_documents = False
     max_document_to_embed = N_SAMPLES
     max_fraction_of_documents_to_embed = None
 

--- a/mteb/tasks/clustering/nob/vg_hierarchical_clustering.py
+++ b/mteb/tasks/clustering/nob/vg_hierarchical_clustering.py
@@ -10,14 +10,12 @@ def split_labels(record: dict) -> dict:
 
 
 class VGHierarchicalClusteringP2P(AbsTaskClustering):
-    # Pinned to the behaviour these scores were published under. New
-    # hierarchical tasks should leave this at the default.
-    drop_unlabelled_documents = False
     max_document_to_embed = N_SAMPLES
     max_fraction_of_documents_to_embed = None
 
     metadata = TaskMetadata(
         name="VGHierarchicalClusteringP2P",
+        superseded_by="VGHierarchicalClusteringP2P.v2",
         dataset={
             "path": "navjordj/VG_summarization",
             "revision": "d4c5a8ba10ae71224752c727094ac4c46947fa29",
@@ -60,14 +58,12 @@ class VGHierarchicalClusteringP2P(AbsTaskClustering):
 
 
 class VGHierarchicalClusteringS2S(AbsTaskClustering):
-    # Pinned to the behaviour these scores were published under. New
-    # hierarchical tasks should leave this at the default.
-    drop_unlabelled_documents = False
     max_document_to_embed = N_SAMPLES
     max_fraction_of_documents_to_embed = None
 
     metadata = TaskMetadata(
         name="VGHierarchicalClusteringS2S",
+        superseded_by="VGHierarchicalClusteringS2S.v2",
         dataset={
             "path": "navjordj/VG_summarization",
             "revision": "d4c5a8ba10ae71224752c727094ac4c46947fa29",
@@ -107,3 +103,45 @@ class VGHierarchicalClusteringS2S(AbsTaskClustering):
         self.dataset["test"] = self.dataset["test"].train_test_split(
             test_size=N_SAMPLES, seed=self.seed
         )["test"]
+
+
+class VGHierarchicalClusteringP2PV2(VGHierarchicalClusteringP2P):
+    """VGHierarchicalClusteringP2P with documents that have no label at the level being scored dropped.
+
+    Same data and same revision as VGHierarchicalClusteringP2P. The only difference is that a
+    document whose label path stops above the level being scored is left out of that
+    level rather than gathered into one group under a sentinel label. Those documents
+    have nothing in common except a missing label, so scoring them asks the model to
+    find a class that is not really there.
+
+    Scores are not comparable with VGHierarchicalClusteringP2P. On the SNL tasks the difference is
+    about +0.13 v_measure, and it tracks the share of documents that have no label at
+    each level.
+    """
+
+    drop_unlabelled_documents = True
+
+    metadata = VGHierarchicalClusteringP2P.metadata.model_copy(
+        update={"name": "VGHierarchicalClusteringP2P.v2", "superseded_by": None},
+    )
+
+
+class VGHierarchicalClusteringS2SV2(VGHierarchicalClusteringS2S):
+    """VGHierarchicalClusteringS2S with documents that have no label at the level being scored dropped.
+
+    Same data and same revision as VGHierarchicalClusteringS2S. The only difference is that a
+    document whose label path stops above the level being scored is left out of that
+    level rather than gathered into one group under a sentinel label. Those documents
+    have nothing in common except a missing label, so scoring them asks the model to
+    find a class that is not really there.
+
+    Scores are not comparable with VGHierarchicalClusteringS2S. On the SNL tasks the difference is
+    about +0.13 v_measure, and it tracks the share of documents that have no label at
+    each level.
+    """
+
+    drop_unlabelled_documents = True
+
+    metadata = VGHierarchicalClusteringS2S.metadata.model_copy(
+        update={"name": "VGHierarchicalClusteringS2S.v2", "superseded_by": None},
+    )

--- a/tests/test_abstasks/test_clustering_metrics.py
+++ b/tests/test_abstasks/test_clustering_metrics.py
@@ -126,3 +126,85 @@ def test_level_cluster_count_excludes_documents_without_a_label():
     # Level 0 is reached by every document, so it is unaffected.
     for assignment in assignments["Level 0"]:
         assert len(set(assignment)) == 1
+
+
+def _run_with(embeddings, labels, *, drop_unlabelled_documents):
+    return _evaluate_clustering_bootstrapped(
+        embeddings,
+        labels,
+        n_clusters=2,
+        cluster_size=len(embeddings),
+        kmean_batch_size=64,
+        max_depth=None,
+        rng_state=random.Random(0),
+        seed=0,
+        drop_unlabelled_documents=drop_unlabelled_documents,
+    )
+
+
+def test_flag_off_keeps_the_documents_and_scores_them_as_one_class():
+    # The older behaviour, kept for reproducibility: the documents whose label
+    # stops at level 0 are given the sentinel and, because these labels are
+    # strings, survive the filter and are scored as a third gold class.
+    embeddings, labels = _ragged_dataset()
+    scores, assignments = _run_with(embeddings, labels, drop_unlabelled_documents=False)
+
+    for assignment in assignments["Level 1"]:
+        assert len(set(assignment)) == 3
+    assert max(scores["v_measure"]["Level 1"]) < 1.0
+
+
+def test_flag_off_with_integer_labels_drops_them_instead():
+    # The same flag value, the opposite outcome. np.array() on a mixed list of
+    # int and int stays an integer array, so the sentinel really is -1 and the
+    # filter does fire. Which of the two happens is decided by the dataset's
+    # label dtype, not by the option, which is why the option exists.
+    embeddings, string_labels = _ragged_dataset()
+    labels = [
+        [int(part[-1]) if part != "Top" else 9 for part in label]
+        for label in string_labels
+    ]
+
+    _, assignments = _run_with(embeddings, labels, drop_unlabelled_documents=False)
+
+    for assignment in assignments["Level 1"]:
+        assert len(set(assignment)) == 2
+
+
+def test_flag_makes_no_difference_when_every_label_reaches_every_level():
+    # A task whose label paths all reach the same depth selects the same
+    # documents under both settings, so the option cannot move its score. This
+    # is why only the hierarchical tasks are affected.
+    embeddings, labels = _well_separated_dataset(n_clusters=3, points_per_cluster=20)
+
+    dropped, dropped_assignments = _run_with(
+        embeddings, labels, drop_unlabelled_documents=True
+    )
+    kept, kept_assignments = _run_with(
+        embeddings, labels, drop_unlabelled_documents=False
+    )
+
+    assert dropped == kept
+    assert dropped_assignments == kept_assignments
+
+
+def test_default_is_to_drop():
+    from mteb.abstasks.clustering import AbsTaskClustering
+
+    assert AbsTaskClustering.drop_unlabelled_documents is True
+
+
+def test_existing_hierarchical_tasks_stay_on_the_published_behaviour():
+    # These six were scored before the option existed. Flipping any of them
+    # changes numbers that are already published.
+    pinned = [
+        "ArXivHierarchicalClusteringP2P",
+        "ArXivHierarchicalClusteringS2S",
+        "SNLHierarchicalClusteringP2P",
+        "SNLHierarchicalClusteringS2S",
+        "VGHierarchicalClusteringP2P",
+        "VGHierarchicalClusteringS2S",
+    ]
+    for name in pinned:
+        task = mteb.get_task(name)
+        assert task.drop_unlabelled_documents is False, name

--- a/tests/test_abstasks/test_clustering_metrics.py
+++ b/tests/test_abstasks/test_clustering_metrics.py
@@ -67,3 +67,62 @@ def test_end_to_end_result_dict_contains_both_metrics():
     assert isinstance(scores["ami"], float)
     assert isinstance(scores["v_measures"], dict)
     assert isinstance(scores["ami_scores"], dict)
+
+
+def _ragged_dataset(dim: int = 8, seed: int = 0):
+    """Two gold classes at level 1, plus documents whose label stops at level 0.
+
+    The documents that stop at level 0 are placed on top of the two level-1
+    classes, so they cannot be recovered as a group of their own. If they are
+    scored at level 1 they drag the score down; if they are excluded, the two
+    level-1 classes are perfectly separable.
+    """
+    rng = np.random.default_rng(seed)
+    centers = rng.normal(scale=10.0, size=(2, dim))
+    embeddings: list[np.ndarray] = []
+    labels: list[list[str]] = []
+    for cluster_idx, center in enumerate(centers):
+        for _ in range(12):
+            embeddings.append(center + rng.normal(scale=0.01, size=dim))
+            labels.append(["Top", f"Sub{cluster_idx}"])
+    # Documents with no level-1 label, sitting on the same two centers.
+    for center in centers:
+        for _ in range(6):
+            embeddings.append(center + rng.normal(scale=0.01, size=dim))
+            labels.append(["Top"])
+    return np.asarray(embeddings), labels
+
+
+def _run(embeddings, labels):
+    return _evaluate_clustering_bootstrapped(
+        embeddings,
+        labels,
+        n_clusters=2,
+        cluster_size=len(embeddings),
+        kmean_batch_size=64,
+        max_depth=None,
+        rng_state=random.Random(0),
+        seed=0,
+    )
+
+
+def test_documents_without_a_label_at_this_level_are_excluded():
+    # The two level-1 classes are perfectly separable once the documents whose
+    # label stops at level 0 are excluded, so v_measure at level 1 is 1.0.
+    embeddings, labels = _ragged_dataset()
+    scores, _ = _run(embeddings, labels)
+
+    assert min(scores["v_measure"]["Level 1"]) == 1.0
+
+
+def test_level_cluster_count_excludes_documents_without_a_label():
+    # Two gold classes reach level 1, so k is 2. Counting the excluded
+    # documents as a gold class of their own would make it 3.
+    embeddings, labels = _ragged_dataset()
+    _, assignments = _run(embeddings, labels)
+
+    for assignment in assignments["Level 1"]:
+        assert len(set(assignment)) == 2
+    # Level 0 is reached by every document, so it is unaffected.
+    for assignment in assignments["Level 0"]:
+        assert len(set(assignment)) == 1

--- a/tests/test_abstasks/test_clustering_metrics.py
+++ b/tests/test_abstasks/test_clustering_metrics.py
@@ -9,6 +9,15 @@ from mteb.abstasks.clustering import _evaluate_clustering_bootstrapped
 from mteb.mocks.mock_tasks import LegacyMockClusteringFastTask
 from tests.mock_models import MockSentenceTransformer
 
+HIERARCHICAL_TASKS = [
+    "ArXivHierarchicalClusteringP2P",
+    "ArXivHierarchicalClusteringS2S",
+    "SNLHierarchicalClusteringP2P",
+    "SNLHierarchicalClusteringS2S",
+    "VGHierarchicalClusteringP2P",
+    "VGHierarchicalClusteringS2S",
+]
+
 
 def _well_separated_dataset(
     n_clusters: int = 3, points_per_cluster: int = 12, dim: int = 8, seed: int = 0
@@ -94,6 +103,9 @@ def _ragged_dataset(dim: int = 8, seed: int = 0):
 
 
 def _run(embeddings, labels):
+    # These two tests are about what dropping does, so they ask for it. The
+    # parameter defaults to False, which is the behaviour published scores were
+    # produced under.
     return _evaluate_clustering_bootstrapped(
         embeddings,
         labels,
@@ -103,6 +115,7 @@ def _run(embeddings, labels):
         max_depth=None,
         rng_state=random.Random(0),
         seed=0,
+        drop_unlabelled_documents=True,
     )
 
 
@@ -188,23 +201,37 @@ def test_flag_makes_no_difference_when_every_label_reaches_every_level():
     assert dropped_assignments == kept_assignments
 
 
-def test_default_is_to_drop():
+def test_default_keeps_the_published_behaviour():
+    # Default False, so a task that predates the option is unaffected by it.
     from mteb.abstasks.clustering import AbsTaskClustering
 
-    assert AbsTaskClustering.drop_unlabelled_documents is True
+    assert AbsTaskClustering.drop_unlabelled_documents is False
 
 
-def test_existing_hierarchical_tasks_stay_on_the_published_behaviour():
-    # These six were scored before the option existed. Flipping any of them
-    # changes numbers that are already published.
-    pinned = [
-        "ArXivHierarchicalClusteringP2P",
-        "ArXivHierarchicalClusteringS2S",
-        "SNLHierarchicalClusteringP2P",
-        "SNLHierarchicalClusteringS2S",
-        "VGHierarchicalClusteringP2P",
-        "VGHierarchicalClusteringS2S",
-    ]
-    for name in pinned:
+def test_existing_hierarchical_tasks_are_untouched_and_superseded():
+    # These six were scored before the option existed. They keep their behaviour
+    # and point at the .v2 that has the fix.
+    for name in HIERARCHICAL_TASKS:
         task = mteb.get_task(name)
         assert task.drop_unlabelled_documents is False, name
+        assert task.metadata.superseded_by == f"{name}.v2", name
+
+
+def test_v2_hierarchical_tasks_drop_unlabelled_documents():
+    # The new version is where the corrected behaviour lives.
+    for name in HIERARCHICAL_TASKS:
+        task = mteb.get_task(f"{name}.v2")
+        assert task.drop_unlabelled_documents is True, name
+
+
+def test_v2_keeps_the_same_data_as_the_task_it_supersedes():
+    # A v2 is a scoring change, not a data change: same path and same revision,
+    # so a difference in score cannot be blamed on the dataset moving.
+    for name in HIERARCHICAL_TASKS:
+        old_task = mteb.get_task(name)
+        new_task = mteb.get_task(f"{name}.v2")
+        assert new_task.metadata.dataset["path"] == old_task.metadata.dataset["path"]
+        assert (
+            new_task.metadata.dataset["revision"]
+            == old_task.metadata.dataset["revision"]
+        )


### PR DESCRIPTION
## What changed

In `_evaluate_clustering_bootstrapped`, documents whose label path does not reach the level being scored get the sentinel `-1`, and the next lines try to filter them out. The filter never removes anything.

Labels are strings, so `np.array(['Fysikk', -1])` gives a `<U21` array and the sentinel becomes the string `'-1'`. The comparison is then `np.str_('-1') != -1`, always `True`. The in-code comment records that the vectorised form raised a `FutureWarning`; rewriting it as a loop silenced the warning but not the cause.

So those documents stay in with `'-1'` as their gold class. `n_clusters=np.unique(...).size` is one larger than the number of real classes, and `v_measure`/`ami` are scored against a gold partition holding a class that means "no label at this level".

The fix builds the mask from the same condition that produced the sentinel, so the sentinel is never created.

## Why it matters

Measured on the test splits at the pinned revisions, both `SNLHierarchicalClusteringP2P` and `...S2S` (1300 docs, `max_depth=5`):

| Level | 1 | 2 | 3 | 4 |
|---|---|---|---|---|
| documents given the sentinel | 0% | 5% | 26% | **73%** |

`_evaluate_subset` averages across levels before reporting `v_measure`, so level 4 reaches the reported number.

I did not measure `ArXivHierarchicalClustering` or the VG tasks, so I make no claim about those.

## Scope

Only datasets whose label paths vary in depth are affected. I ran both versions over a depth-1 dataset and the score dictionaries are identical. Scores for the hierarchical tasks will change, so existing numbers for them were produced under the old behaviour. I have not touched anything about published results.

## Tests

Two added to `tests/test_abstasks/test_clustering_metrics.py`, both failing on `main`: `v_measure` is 1.0 here and 0.3632 on main, and `k` is 2 here and 3 on main. `pytest tests/test_abstasks`: 166 passed, 46 skipped (all unrelated optional media deps).
