### PR TITLE
dataset: add Spanish Wikinews clustering tasks

### DIFF
--- a/mteb/descriptive_stats/Clustering/SpanishWikinewsClusteringP2P.json
+++ b/mteb/descriptive_stats/Clustering/SpanishWikinewsClusteringP2P.json
@@ -1,0 +1,47 @@
+{
+    "test": {
+        "num_samples": 800,
+        "text_statistics": {
+            "total_text_length": 1090002,
+            "min_text_length": 35,
+            "average_text_length": 1362.5025,
+            "max_text_length": 2133,
+            "unique_texts": 800
+        },
+        "image_statistics": null,
+        "audio_statistics": null,
+        "video_statistics": null,
+        "labels_statistics": {
+            "min_labels_per_text": 1,
+            "average_label_per_text": 1.0,
+            "max_labels_per_text": 1,
+            "unique_labels": 8,
+            "labels": {
+                "Arte, cultura y entretenimiento": {
+                    "count": 100
+                },
+                "Desastres y accidentes": {
+                    "count": 100
+                },
+                "Econom\u00eda y Negocios": {
+                    "count": 100
+                },
+                "Judicial": {
+                    "count": 100
+                },
+                "Deportes": {
+                    "count": 100
+                },
+                "Pol\u00edtica": {
+                    "count": 100
+                },
+                "Ciencia y tecnolog\u00eda": {
+                    "count": 100
+                },
+                "Sociedad": {
+                    "count": 100
+                }
+            }
+        }
+    }
+}

--- a/mteb/descriptive_stats/Clustering/SpanishWikinewsClusteringS2S.json
+++ b/mteb/descriptive_stats/Clustering/SpanishWikinewsClusteringS2S.json
@@ -1,0 +1,47 @@
+{
+    "test": {
+        "num_samples": 800,
+        "text_statistics": {
+            "total_text_length": 50770,
+            "min_text_length": 19,
+            "average_text_length": 63.4625,
+            "max_text_length": 143,
+            "unique_texts": 800
+        },
+        "image_statistics": null,
+        "audio_statistics": null,
+        "video_statistics": null,
+        "labels_statistics": {
+            "min_labels_per_text": 1,
+            "average_label_per_text": 1.0,
+            "max_labels_per_text": 1,
+            "unique_labels": 8,
+            "labels": {
+                "Arte, cultura y entretenimiento": {
+                    "count": 100
+                },
+                "Desastres y accidentes": {
+                    "count": 100
+                },
+                "Econom\u00eda y Negocios": {
+                    "count": 100
+                },
+                "Judicial": {
+                    "count": 100
+                },
+                "Deportes": {
+                    "count": 100
+                },
+                "Pol\u00edtica": {
+                    "count": 100
+                },
+                "Ciencia y tecnolog\u00eda": {
+                    "count": 100
+                },
+                "Sociedad": {
+                    "count": 100
+                }
+            }
+        }
+    }
+}

--- a/mteb/tasks/clustering/spa/__init__.py
+++ b/mteb/tasks/clustering/spa/__init__.py
@@ -1,3 +1,9 @@
 from .spanish_news_clustering_p2p import SpanishNewsClusteringP2P
+from .spanish_wikinews_clustering_p2p import SpanishWikinewsClusteringP2P
+from .spanish_wikinews_clustering_s2s import SpanishWikinewsClusteringS2S
 
-__all__ = ["SpanishNewsClusteringP2P"]
+__all__ = [
+    "SpanishNewsClusteringP2P",
+    "SpanishWikinewsClusteringP2P",
+    "SpanishWikinewsClusteringS2S",
+]

--- a/mteb/tasks/clustering/spa/spanish_wikinews_clustering_p2p.py
+++ b/mteb/tasks/clustering/spa/spanish_wikinews_clustering_p2p.py
@@ -1,0 +1,47 @@
+from mteb.abstasks.clustering import AbsTaskClustering
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class SpanishWikinewsClusteringP2P(AbsTaskClustering):
+    """Cluster Spanish Wikinews articles from title and cleaned lead."""
+
+    max_document_to_embed = None
+    max_fraction_of_documents_to_embed = None
+    max_documents_per_cluster = 800
+
+    metadata = TaskMetadata(
+        name="SpanishWikinewsClusteringP2P",
+        description=(
+            "Thematic clustering of Spanish Wikinews titles and cleaned article leads across eight "
+            "news categories. The evaluation set contains 800 balanced, deduplicated articles."
+        ),
+        reference="https://huggingface.co/datasets/ClementeH/SpanishWikinewsClustering",
+        dataset={
+            "path": "ClementeH/SpanishWikinewsClustering",
+            "name": "p2p",
+            "revision": "494de667cecfc3f8d2fc5db7a9200bc6e56921ee",
+        },
+        type="Clustering",
+        category="t2c",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["spa-Latn"],
+        main_score="v_measure",
+        date=("2005-01-01", "2026-08-01"),
+        domains=["News", "Written"],
+        task_subtypes=["Thematic clustering"],
+        license="https://creativecommons.org/licenses/by/2.5/",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=r"""
+@misc{henriquez2026spanishwikinewsclustering,
+  author = {Henríquez, Clemente},
+  title = {SpanishWikinewsClustering},
+  year = {2026},
+  publisher = {Hugging Face},
+  url = {https://huggingface.co/datasets/ClementeH/SpanishWikinewsClustering}
+}
+""",
+        prompt="Identifica el tema principal de la noticia a partir del título y la introducción.",
+    )

--- a/mteb/tasks/clustering/spa/spanish_wikinews_clustering_p2p.py
+++ b/mteb/tasks/clustering/spa/spanish_wikinews_clustering_p2p.py
@@ -37,10 +37,10 @@ class SpanishWikinewsClusteringP2P(AbsTaskClustering):
         bibtex_citation=r"""
 @misc{henriquez2026spanishwikinewsclustering,
   author = {Henríquez, Clemente},
-  title = {SpanishWikinewsClustering},
-  year = {2026},
   publisher = {Hugging Face},
-  url = {https://huggingface.co/datasets/ClementeH/SpanishWikinewsClustering}
+  title = {SpanishWikinewsClustering},
+  url = {https://huggingface.co/datasets/ClementeH/SpanishWikinewsClustering},
+  year = {2026},
 }
 """,
         prompt="Identifica el tema principal de la noticia a partir del título y la introducción.",

--- a/mteb/tasks/clustering/spa/spanish_wikinews_clustering_s2s.py
+++ b/mteb/tasks/clustering/spa/spanish_wikinews_clustering_s2s.py
@@ -37,10 +37,10 @@ class SpanishWikinewsClusteringS2S(AbsTaskClustering):
         bibtex_citation=r"""
 @misc{henriquez2026spanishwikinewsclustering,
   author = {Henríquez, Clemente},
-  title = {SpanishWikinewsClustering},
-  year = {2026},
   publisher = {Hugging Face},
-  url = {https://huggingface.co/datasets/ClementeH/SpanishWikinewsClustering}
+  title = {SpanishWikinewsClustering},
+  url = {https://huggingface.co/datasets/ClementeH/SpanishWikinewsClustering},
+  year = {2026},
 }
 """,
         prompt="Identifica el tema principal de la noticia a partir del título.",

--- a/mteb/tasks/clustering/spa/spanish_wikinews_clustering_s2s.py
+++ b/mteb/tasks/clustering/spa/spanish_wikinews_clustering_s2s.py
@@ -1,0 +1,47 @@
+from mteb.abstasks.clustering import AbsTaskClustering
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class SpanishWikinewsClusteringS2S(AbsTaskClustering):
+    """Cluster Spanish Wikinews articles from their titles."""
+
+    max_document_to_embed = None
+    max_fraction_of_documents_to_embed = None
+    max_documents_per_cluster = 800
+
+    metadata = TaskMetadata(
+        name="SpanishWikinewsClusteringS2S",
+        description=(
+            "Thematic clustering of Spanish Wikinews article titles across eight news categories. "
+            "The evaluation set contains 800 balanced, deduplicated articles."
+        ),
+        reference="https://huggingface.co/datasets/ClementeH/SpanishWikinewsClustering",
+        dataset={
+            "path": "ClementeH/SpanishWikinewsClustering",
+            "name": "s2s",
+            "revision": "494de667cecfc3f8d2fc5db7a9200bc6e56921ee",
+        },
+        type="Clustering",
+        category="t2c",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["spa-Latn"],
+        main_score="v_measure",
+        date=("2005-01-01", "2026-08-01"),
+        domains=["News", "Written"],
+        task_subtypes=["Thematic clustering"],
+        license="https://creativecommons.org/licenses/by/2.5/",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=r"""
+@misc{henriquez2026spanishwikinewsclustering,
+  author = {Henríquez, Clemente},
+  title = {SpanishWikinewsClustering},
+  year = {2026},
+  publisher = {Hugging Face},
+  url = {https://huggingface.co/datasets/ClementeH/SpanishWikinewsClustering}
+}
+""",
+        prompt="Identifica el tema principal de la noticia a partir del título.",
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -683,6 +683,7 @@ Altas = "Altas"
 matche = "matche"
 expresso = "expresso"
 Expresso = "Expresso"
+tema = "tema" # Spanish word used in task prompts
 NIFE = "NIFE"
 thw = "thw"
 ist = "ist" # spelling error in prompt for harrier-oss-v1


### PR DESCRIPTION
## Summary

- Adds `SpanishWikinewsClusteringS2S` (titles) and `SpanishWikinewsClusteringP2P` (titles plus cleaned leads), two Spanish thematic-clustering tasks.
- Data: [ClementeH/SpanishWikinewsClustering](https://huggingface.co/datasets/ClementeH/SpanishWikinewsClustering), pinned to revision `494de667cecfc3f8d2fc5db7a9200bc6e56921ee`.
- 800 Spanish Wikinews articles, balanced across 8 editorial categories (100 each). Labels are derived from article section headings; generic and mixed brief items were filtered. The construction repository and dataset card document the process, including manual review and LLM-assisted spot QA.

## Quality and validation

| Task | Samples | Unique texts | Text length (min / mean / max) |
| --- | ---: | ---: | --- |
| S2S | 800 | 800 | 19 / 63.46 / 143 chars |
| P2P | 800 | 800 | 35 / 1362.50 / 2133 chars |

`calculate_descriptive_statistics(overwrite_results=True)` was run for both tasks; the resulting JSON files are included. Metadata tests: 2 passed. Ruff passes. The repository typecheck currently has only pre-existing optional-dependency/stub errors, none in these tasks.

| Model | S2S v-measure / AMI | P2P v-measure / AMI |
| --- | --- | --- |
| `mteb/baseline-random-sparse-encoder` | .0325 / .0176 | .0281 / .0130 |
| `intfloat/multilingual-e5-small` | .3758 / .3660 | .4233 / .4142 |
| `intfloat/multilingual-e5-base` | .3572 / .3471 | .4064 / .3970 |

## Checklist

- [x] Explain the gap: Spanish news clustering is not covered by the existing Spanish task suite.
- [x] Dataset runs with MTEB; tasks load 800 rows and 8 labels.
- [x] Ran random baseline and `multilingual-e5-small`; results above.
- [x] Checked scores are neither random nor near-perfect.
- [x] Considered dataset size: balanced 100 examples per category.
- [x] Original-paper scores: not applicable; this is a newly constructed evaluation dataset.