### PR TITLE
Update SugarCrepe task description to reflect word order

### DIFF
--- a/mteb/tasks/image_text_pair_classification/eng/sugar_crepe.py
+++ b/mteb/tasks/image_text_pair_classification/eng/sugar_crepe.py
@@ -12,7 +12,15 @@ class SugarCrepe(AbsTaskImageTextPairClassification):
 
     metadata = TaskMetadata(
         name="SugarCrepe",
-        description="Compositionality Evaluation of images to their captions.",
+        description=(
+            "Compositionality Evaluation of images to their captions. "
+            "Note that 572 of the 7511 pairs (7.6%) have a caption and "
+            "negative_caption that are the same words in a different order "
+            "(the swap_obj and swap_att subsets of the source benchmark). A "
+            "model whose text representation is order-insensitive scores "
+            "chance on those pairs by construction, capping its text_acc at "
+            "0.962."
+        ),
         reference="https://proceedings.neurips.cc/paper_files/paper/2023/hash/63461de0b4cb760fc498e85b18a7fe81-Abstract-Datasets_and_Benchmarks.html",
         dataset={
             "path": "mteb/SUGARCREPE_fmt",


### PR DESCRIPTION

## What I found

I was using this task to check whether a linear read-out on a frozen LLM
represents word order, and found a property of the data that changes how the
score reads.

Counting on `mteb/SUGARCREPE_fmt` directly, 572 of the 7511 pairs have a
`caption` and `negative_caption` that are the same multiset of words:

| source subset | n | same words, different order |
|---|---|---|
| swap_obj | 245 | 164 (66.9%) |
| swap_att | 666 | 408 (61.3%) |
| replace_att / replace_obj / replace_rel | 3846 | 0 |
| add_att / add_obj | 2754 | 0 |
| **total** | **7511** | **572 (7.6%)** |

Example:

```
caption:          A cat sits on its hind legs, and swats at the plant.
negative_caption: A cat sits on the plant, and swats at its hind legs.
```

## Why it is worth stating

For those pairs, a model whose text representation ignores word order scores
both captions identically and is at chance by construction. It has nothing to
do with how well the model represents content. That puts a hard ceiling on
`text_acc` of 0.9619 for any such model, so the remaining points above it are
unreachable and not merely difficult.

Without this, a result in the low 0.9s reads as a near-ceiling score when it
may be an exact ceiling score for that model class.

## The change

Description only, no behaviour change. I kept it to the counted facts and the
implied ceiling.

## Reproducing

Counts only, no model involved:

```python
import collections, re
import pyarrow.parquet as pq
from huggingface_hub import hf_hub_download

def bag(s):
    return collections.Counter(re.findall(r"[a-z0-9']+", s.lower()))

n = sym = 0
for i in range(8):
    p = hf_hub_download("mteb/SUGARCREPE_fmt",
                        f"data/train-0000{i}-of-00008.parquet",
                        repo_type="dataset")
    t = pq.read_table(p, columns=["caption", "negative_caption"])
    for c, g in zip(t.column("caption").to_pylist(),
                    t.column("negative_caption").to_pylist()):
        n += 1
        sym += bag(c) == bag(g)

print(n, sym, sym / n)                  # 7511 572 0.0762
print((n - sym) / n + 0.5 * sym / n)    # 0.9619, the ceiling
```

Script and JSON output are also at
https://huggingface.co/datasets/RiverRider/srt-depth-probe-artifacts
(`scripts/sugarcrepe_symmetry_audit.py`).

## Scope

Scope note: this is a property of the data alone. No model was run to produce
any number here, the counts are identical to the source benchmark at
RAIVNLab/sugar-crepe, and it is not a defect, since the swap subsets exist
precisely to probe word order. I also raised it upstream at
https://github.com/RAIVNLab/sugar-crepe/issues/10.

Happy to shorten the wording or move it to a comment if the description field
is meant to stay to one line.
