### PR TITLE
dataset: use v2 GermanGovService retrieval data

### DIFF
--- a/mteb/tasks/retrieval/deu/german_gov_service_retrieval.py
+++ b/mteb/tasks/retrieval/deu/german_gov_service_retrieval.py
@@ -1,11 +1,5 @@
-import hashlib
-
-import datasets
-
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
-
-_EVAL_SPLIT = "test"
 
 
 class GermanGovServiceRetrieval(AbsTaskRetrieval):
@@ -14,13 +8,13 @@ class GermanGovServiceRetrieval(AbsTaskRetrieval):
         description="LHM-Dienstleistungen-QA is a German question answering dataset for government services of the Munich city administration. It associates questions with a textual context containing the answer",
         reference="https://huggingface.co/datasets/it-at-m/LHM-Dienstleistungen-QA",
         dataset={
-            "path": "it-at-m/LHM-Dienstleistungen-QA",
-            "revision": "ed40131b56ce86ce3666f2942953595dd9d29608",
+            "path": "mteb/GermanGovServiceRetrieval",
+            "revision": "a6cf81304bf8b82d5497a0f7ad9e08399b8f27d3",
         },
         type="Retrieval",
         category="t2t",
         modalities=["text"],
-        eval_splits=[_EVAL_SPLIT],
+        eval_splits=["test"],
         eval_langs=["deu-Latn"],
         main_score="ndcg_at_5",
         date=("2022-11-01", "2022-11-30"),
@@ -45,43 +39,3 @@ Lukas, Leon},
 """,
         sample_creation="found",
     )
-
-    @staticmethod
-    def get_hash(input_str) -> str:
-        return hashlib.md5(input_str.encode("utf-8"), usedforsecurity=False).hexdigest()
-
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
-        if self.data_loaded:
-            return
-
-        dataset = datasets.load_dataset(
-            path=self.metadata.dataset["path"],
-            split=_EVAL_SPLIT,
-            revision=self.metadata.dataset["revision"],
-        )
-        corpus = {}
-        queries = {}
-        relevant_docs = {}
-
-        for row in dataset:  # row: title, context, question, ...
-            # use hash values as IDs
-            d_id = "d_" + self.get_hash(row["title"] + row["context"])
-            q_id = "q_" + self.get_hash(row["question"])
-
-            corpus[d_id] = {
-                "_id": d_id,
-                "title": row["title"],
-                "text": row["context"],
-            }
-            queries[q_id] = row["question"]
-
-            if q_id not in relevant_docs:
-                relevant_docs[q_id] = {}
-
-            relevant_docs[q_id][d_id] = 1  # 1 = relevant
-
-        self.queries = {_EVAL_SPLIT: queries}
-        self.corpus = {_EVAL_SPLIT: corpus}
-        self.relevant_docs = {_EVAL_SPLIT: relevant_docs}
-
-        self.data_loaded = True


### PR DESCRIPTION
## Why
GermanGovServiceRetrieval is listed in #3424 as a retrieval task that still uses the old custom loading path. The dataset has already been re-uploaded under the MTEB organization with the standard corpus, queries, and qrels configs.

Refs #3424.

## What changed
- Point GermanGovServiceRetrieval to `mteb/GermanGovServiceRetrieval` at revision `a6cf81304bf8b82d5497a0f7ad9e08399b8f27d3`.
- Remove the custom hash-based `load_data()` implementation.
- Let the shared retrieval loader handle the v2 dataset layout.

## Validation
- Rebuilt the old-format IDs from `it-at-m/LHM-Dienstleistungen-QA@ed40131b56ce86ce3666f2942953595dd9d29608` and compared them with `mteb/GermanGovServiceRetrieval@a6cf81304bf8b82d5497a0f7ad9e08399b8f27d3`: corpus, queries, and qrels match exactly (105 corpus docs, 356 queries, 356 qrels).
- Loaded the v2 dataset through `RetrievalDatasetLoader`: 105 corpus docs, 356 queries, 356 qrels, no qrels pointing to missing query or corpus IDs.
- `python -m py_compile mteb\tasks\retrieval\deu\german_gov_service_retrieval.py`
- `.venv\Scripts\ruff.exe check mteb\tasks\retrieval\deu\german_gov_service_retrieval.py`
- `git diff --check`

## Risk / follow-up
Low. This changes only one German retrieval task to use the verified MTEB-hosted v2 dataset. Follow-up remains for other retrieval tasks in #3424.