### PR TITLE
Enable `A` (flake8-builtins) ruff rule

### DIFF
--- a/docs/overview/create_available_models.py
+++ b/docs/overview/create_available_models.py
@@ -139,9 +139,9 @@ def format_model_entry(meta: ModelMeta) -> str:
     revision = meta.revision or "not specified"
     raw_license = meta.license or "not specified"
     if raw_license.startswith(("http://", "https://")):
-        license = f"[custom]({raw_license})"
+        license_str = f"[custom]({raw_license})"
     else:
-        license = raw_license
+        license_str = raw_license
     max_tokens = (
         human_readable_number(meta.max_tokens)
         if meta.max_tokens is not None
@@ -168,7 +168,7 @@ def format_model_entry(meta: ModelMeta) -> str:
         model_name=meta.name,
         learn_more=learn_more,
         revision=revision,
-        license=license,
+        license=license_str,
         max_tokens=max_tokens,
         embed_dim=embed_dim,
         n_parameters=n_parameters,

--- a/docs/overview/create_available_tasks.py
+++ b/docs/overview/create_available_tasks.py
@@ -104,9 +104,9 @@ def format_task_entry(task: mteb.AbsTask) -> str:  # noqa: PLR0914
         description += f" Contributed by {task.metadata.contributed_by}."
     raw_license = task.metadata.license or "not specified"
     if raw_license.startswith(("http://", "https://")):
-        license = f"[custom]({raw_license})"
+        license_str = f"[custom]({raw_license})"
     else:
-        license = raw_license
+        license_str = raw_license
     reference = task.metadata.reference
     dataset_name = task.metadata.dataset["path"]
     if not reference and not isinstance(task, AbsTaskAggregate):
@@ -135,10 +135,10 @@ def format_task_entry(task: mteb.AbsTask) -> str:  # noqa: PLR0914
     if not isinstance(task, AbsTaskAggregate):
         dataset_line = (
             f"**Dataset:** [`{dataset_name}`](https://huggingface.co/datasets/{dataset_name}) "
-            f"• **License:** {license}{learn_more}"
+            f"• **License:** {license_str}{learn_more}"
         )
     else:
-        dataset_line = f"**License:** {license}{learn_more}"
+        dataset_line = f"**License:** {license_str}{learn_more}"
 
     entry = task_entry.format(
         task_name=task.metadata.name,

--- a/mteb/_evaluators/retrieval_metrics.py
+++ b/mteb/_evaluators/retrieval_metrics.py
@@ -148,8 +148,8 @@ def get_rank_from_dict(
     sorted_by_score = sorted(
         tuple_of_id_score, key=lambda x: (x[1], x[0]), reverse=True
     )
-    for i, (id, score) in enumerate(sorted_by_score):
-        if id == doc_id:
+    for i, (cur_doc_id, score) in enumerate(sorted_by_score):
+        if cur_doc_id == doc_id:
             return i + 1, score
 
     return len(sorted_by_score) + 1, 0

--- a/mteb/get_tasks.py
+++ b/mteb/get_tasks.py
@@ -90,11 +90,11 @@ class MTEBTasks(tuple[AbsTask]):
         return "MTEBTasks" + super().__repr__()
 
     @staticmethod
-    def _extract_property_from_task(task: AbsTask, property: str) -> Any:
-        if hasattr(task.metadata, property):
-            return getattr(task.metadata, property)
-        elif hasattr(task, property):
-            return getattr(task, property)
+    def _extract_property_from_task(task: AbsTask, property_name: str) -> Any:
+        if hasattr(task.metadata, property_name):
+            return getattr(task.metadata, property_name)
+        elif hasattr(task, property_name):
+            return getattr(task, property_name)
         else:
             raise KeyError("Property neither in Task attribute or in task metadata.")
 

--- a/mteb/leaderboard/event_logger/logger.py
+++ b/mteb/leaderboard/event_logger/logger.py
@@ -253,7 +253,7 @@ class EventLogger:
         self,
         session_id: str,
         benchmark: str | None = None,
-        format: str = "csv",
+        file_format: str = "csv",
         row_count: int | None = None,
         **kwargs,
     ):
@@ -262,14 +262,14 @@ class EventLogger:
         Args:
             session_id: Session ID
             benchmark: Current benchmark
-            format: Download format (e.g., csv, json)
+            file_format: Download format (e.g., csv, json)
             row_count: Number of rows downloaded
             **kwargs (Any): Additional context.
         """
         event = TableDownloadEvent.create(
             session_id=session_id,
             benchmark=benchmark,
-            format=format,
+            file_format=file_format,
             row_count=row_count,
             **kwargs,
         )

--- a/mteb/leaderboard/event_logger/models/events.py
+++ b/mteb/leaderboard/event_logger/models/events.py
@@ -160,13 +160,13 @@ class TableDownloadEvent(BaseEvent):
         cls,
         session_id: str,
         benchmark: str | None = None,
-        format: str = "csv",
+        file_format: str = "csv",
         row_count: int | None = None,
         properties: dict[str, Any] | None = None,
         **kwargs,
     ) -> TableDownloadEvent:
         """Convenience creation method"""
-        merged = {"format": format}
+        merged = {"format": file_format}
         if row_count is not None:
             merged["row_count"] = row_count
         if properties:

--- a/mteb/models/model_implementations/seed_1_6_embedding_models.py
+++ b/mteb/models/model_implementations/seed_1_6_embedding_models.py
@@ -30,9 +30,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def pil_to_base64(image, format="jpeg"):
+def pil_to_base64(image, image_format="jpeg"):
     buffer = BytesIO()
-    image.save(buffer, format=format)
+    image.save(buffer, format=image_format)
     img_bytes = buffer.getvalue()
     encoded_bytes = base64.b64encode(img_bytes)
     return encoded_bytes.decode("utf-8")

--- a/mteb/models/model_implementations/seed_1_6_embedding_models_1215.py
+++ b/mteb/models/model_implementations/seed_1_6_embedding_models_1215.py
@@ -60,11 +60,11 @@ class Seed16EmbeddingWrapper(AbsEncoder):
         self._embed_dim = embed_dim
         self._available_embed_dims = [2048, 1024]
 
-    def pil_to_base64(self, image, format="jpeg"):  # noqa: PLR6301
+    def pil_to_base64(self, image, image_format="jpeg"):  # noqa: PLR6301
         if image is None:
             return None
         buffer = BytesIO()
-        image.save(buffer, format=format)
+        image.save(buffer, format=image_format)
         img_bytes = buffer.getvalue()
         encoded_bytes = base64.b64encode(img_bytes)
         return encoded_bytes.decode("utf-8")

--- a/mteb/models/model_implementations/vlm2vec_models.py
+++ b/mteb/models/model_implementations/vlm2vec_models.py
@@ -94,10 +94,10 @@ class VLM2VecWrapper(AbsEncoder):
             num_crops=4,
         )
 
-    def encode_input(self, input):
-        hidden_states = self.mdl(**input, return_dict=True, output_hidden_states=True)
+    def encode_input(self, inputs):
+        hidden_states = self.mdl(**inputs, return_dict=True, output_hidden_states=True)
         hidden_states = hidden_states.hidden_states[-1]
-        pooled_output = self._pooling(hidden_states, input["attention_mask"])
+        pooled_output = self._pooling(hidden_states, inputs["attention_mask"])
         return pooled_output
 
     def _pooling(self, last_hidden_state, attention_mask):

--- a/mteb/results/benchmark_results.py
+++ b/mteb/results/benchmark_results.py
@@ -337,10 +337,10 @@ class BenchmarkResults(BaseModel):  # noqa: PLR0904
         scripts: list[ISOLanguageScript] | None = None,
         getter: Callable[[ScoresDict], Score] | None = None,
         aggregation: Callable[[list[Score]], Any] | None = None,
-        format: Literal["wide", "long"] = "wide",
+        output_format: Literal["wide", "long"] = "wide",
     ) -> list[dict[str, Any]]:
         entries: list[dict[str, Any]] = []
-        if format == "wide":
+        if output_format == "wide":
             for model_res in self:
                 try:
                     model_scores = model_res._get_scores(
@@ -349,7 +349,7 @@ class BenchmarkResults(BaseModel):  # noqa: PLR0904
                         scripts=scripts,
                         getter=getter,
                         aggregation=aggregation,
-                        format="wide",
+                        output_format="wide",
                     )
                     entries.append(
                         {
@@ -363,7 +363,7 @@ class BenchmarkResults(BaseModel):  # noqa: PLR0904
                         f"Couldn't get scores for {model_res.model_name}({model_res.model_revision}), due to: {e}",
                         stacklevel=2,
                     )
-        if format == "long":
+        if output_format == "long":
             for model_res in self:
                 try:
                     entries.extend(
@@ -373,7 +373,7 @@ class BenchmarkResults(BaseModel):  # noqa: PLR0904
                             scripts=scripts,
                             getter=getter,
                             aggregation=aggregation,
-                            format="long",
+                            output_format="long",
                         )
                     )
                 except Exception as e:
@@ -388,7 +388,7 @@ class BenchmarkResults(BaseModel):  # noqa: PLR0904
         aggregation_level: Literal["subset", "split", "task", "language"] = "task",
         aggregation_fn: Callable[[list[Score]], Any] | None = None,
         include_model_revision: bool = False,
-        format: Literal["wide", "long"] = "wide",
+        format: Literal["wide", "long"] = "wide",  # noqa: A002  # public API, renaming would break callers
     ) -> pd.DataFrame:
         """Get a DataFrame with the scores for all models and tasks.
 
@@ -437,7 +437,7 @@ class BenchmarkResults(BaseModel):  # noqa: PLR0904
             columns=columns,
             aggregation_level=aggregation_level,
             aggregation_fn=aggregation_fn,
-            format=format,
+            output_format=format,
         )
         # Cast categorical columns back to object so downstream string ops don't
         # raise "can only concatenate str (not Categorical) to str".

--- a/mteb/results/model_result.py
+++ b/mteb/results/model_result.py
@@ -47,7 +47,7 @@ def _aggregate_and_pivot(
     df: pd.DataFrame,
     columns: list[str],
     aggregation_level: Literal["subset", "split", "task", "language"],
-    format: Literal["wide", "long"],
+    output_format: Literal["wide", "long"],
     aggregation_fn: Callable[[list[Score]], Any] | str | None,
 ) -> pd.DataFrame:
     if aggregation_level == "subset":
@@ -70,7 +70,7 @@ def _aggregate_and_pivot(
     # Pass "mean" string rather than np.mean to avoid a pandas FutureWarning:
     aggregation_fn_pandas = "mean" if aggregation_fn is None else aggregation_fn
 
-    if format == "wide":
+    if output_format == "wide":
         return df.pivot_table(
             index=index_columns,
             columns=columns,
@@ -78,7 +78,7 @@ def _aggregate_and_pivot(
             aggfunc=aggregation_fn_pandas,  # type: ignore[arg-type]
             observed=True,
         ).reset_index()
-    elif format == "long":
+    elif output_format == "long":
         return (
             df.groupby(columns + index_columns, observed=True)
             .agg(score=("score", aggregation_fn_pandas))
@@ -193,7 +193,7 @@ class ModelResult(BaseModel):
         scripts: list[ISOLanguageScript] | None = None,
         getter: Callable[[ScoresDict], Score] | None = None,
         aggregation: Callable[[list[Score]], Any] | None = None,
-        format: Literal["wide"] = "wide",
+        output_format: Literal["wide"] = "wide",
     ) -> dict[str, float]: ...
 
     @overload
@@ -205,7 +205,7 @@ class ModelResult(BaseModel):
         scripts: list[ISOLanguageScript] | None = None,
         getter: Callable[[ScoresDict], Score] | None = None,
         aggregation: Callable[[list[Score]], Any] | None = None,
-        format: Literal["long"] = "long",
+        output_format: Literal["long"] = "long",
     ) -> list[dict[str, str | float | None]]: ...
 
     def _get_scores(
@@ -216,7 +216,7 @@ class ModelResult(BaseModel):
         scripts: list[ISOLanguageScript] | None = None,
         getter: Callable[[ScoresDict], Score] | None = None,
         aggregation: Callable[[list[Score]], Any] | None = None,
-        format: Literal["wide", "long"] = "wide",
+        output_format: Literal["wide", "long"] = "wide",
     ) -> dict[str, float] | list[dict[str, str | float | None]]:
         if (getter is not None) or (aggregation is not None) or (scripts is not None):
             use_fast = False
@@ -229,7 +229,7 @@ class ModelResult(BaseModel):
         aggregation = cast("Callable[[list[Score]], Any]", aggregation)
         getter = cast("Callable[[ScoresDict], Score]", getter)
 
-        if format == "wide":
+        if output_format == "wide":
             scores = {}
             for res in self.task_results:
                 try:
@@ -252,7 +252,7 @@ class ModelResult(BaseModel):
                         stacklevel=2,
                     )
             return scores
-        if format == "long":
+        if output_format == "long":
             entries = []
             for task_res in self.task_results:
                 try:
@@ -312,7 +312,7 @@ class ModelResult(BaseModel):
         aggregation_level: Literal["subset", "split", "task"] = "task",
         aggregation_fn: Callable[[list[Score]], Any] | str | None = None,
         include_model_revision: bool = False,
-        format: Literal["wide", "long"] = "wide",
+        format: Literal["wide", "long"] = "wide",  # noqa: A002  # public API, renaming would break callers
     ) -> pd.DataFrame:
         """Get a DataFrame with the scores for all models and tasks.
 
@@ -364,7 +364,7 @@ class ModelResult(BaseModel):
             df,
             columns=_columns,
             aggregation_level=aggregation_level,
-            format=format,
+            output_format=format,
             aggregation_fn=aggregation_fn,
         )
 

--- a/mteb/tasks/retrieval/code/code_rag.py
+++ b/mteb/tasks/retrieval/code/code_rag.py
@@ -85,10 +85,10 @@ class CodeRAGProgrammingSolutionsRetrieval(AbsTaskRetrieval):
             # text = query + "\n" + doc(code)
             query, doc = split_by_first_newline(text)
 
-            id = mt["task_id"]
+            task_id = mt["task_id"]
 
-            query_id = id
-            doc_id = f"doc_{id}"
+            query_id = task_id
+            doc_id = f"doc_{task_id}"
             self.queries[split][query_id] = query
             self.corpus[split][doc_id] = {"title": "", "text": doc}
 
@@ -138,15 +138,15 @@ class CodeRAGOnlineTutorialsRetrieval(AbsTaskRetrieval):
         titles = ds["title"]
         texts = ds["text"]
         parsed = ds["parsed"]
-        id = 0
+        idx = 0
         for title, text, _mt in zip(titles, texts, parsed, strict=True):
             # in code-rag-bench,
             # query=doc(code)
             # text=query+doc(code)
             query, doc = title, text
 
-            query_id = str(id)
-            doc_id = f"doc_{id}"
+            query_id = str(idx)
+            doc_id = f"doc_{idx}"
             self.queries[split][query_id] = query
             self.corpus[split][doc_id] = {"title": "", "text": doc}
 
@@ -154,7 +154,7 @@ class CodeRAGOnlineTutorialsRetrieval(AbsTaskRetrieval):
                 doc_id: 1
             }  # only one correct matches
 
-            id += 1
+            idx += 1
 
 
 class CodeRAGLibraryDocumentationSolutionsRetrieval(AbsTaskRetrieval):
@@ -197,7 +197,7 @@ class CodeRAGLibraryDocumentationSolutionsRetrieval(AbsTaskRetrieval):
 
         texts = ds["doc_content"]
 
-        id = 0
+        idx = 0
         for text in texts:
             # text format "document title \n document content"
             query, doc = split_by_first_newline(text)
@@ -205,13 +205,13 @@ class CodeRAGLibraryDocumentationSolutionsRetrieval(AbsTaskRetrieval):
             # some library documents doesn't have query-doc pair
             if not doc:
                 continue
-            query_id = str(id)
-            doc_id = f"doc_{id}"
+            query_id = str(idx)
+            doc_id = f"doc_{idx}"
             self.queries[split][query_id] = query
             self.corpus[split][doc_id] = {"title": "", "text": doc}
             # only one correct match
             self.relevant_docs[split][query_id] = {doc_id: 1}
-            id += 1
+            idx += 1
 
 
 class CodeRAGStackoverflowPostsRetrieval(AbsTaskRetrieval):
@@ -253,18 +253,18 @@ class CodeRAGStackoverflowPostsRetrieval(AbsTaskRetrieval):
         self.corpus[split] = {}
 
         texts = ds["text"]
-        id = 0
+        idx = 0
         for text in texts:
             # in code-rag-bench,
             # text = query + "\n" + doc
             query, doc = split_by_first_newline(text)
 
-            query_id = str(id)
-            doc_id = f"doc_{id}"
+            query_id = str(idx)
+            doc_id = f"doc_{idx}"
             self.queries[split][query_id] = query
             self.corpus[split][doc_id] = {"title": "", "text": doc}
 
             self.relevant_docs[split][query_id] = {
                 doc_id: 1
             }  # only one correct matches
-            id += 1
+            idx += 1

--- a/mteb/tasks/retrieval/ell/greek_civics_qa.py
+++ b/mteb/tasks/retrieval/ell/greek_civics_qa.py
@@ -43,8 +43,10 @@ class GreekCivicsQA(AbsTaskRetrieval):
         relevant_docs = {eval_split: {}}
 
         question_ids = {
-            question: str(id)
-            for id, question in zip(data_raw["id"], data_raw["question"], strict=True)
+            question: str(question_id)
+            for question_id, question in zip(
+                data_raw["id"], data_raw["question"], strict=True
+            )
         }
 
         context_ids = {

--- a/mteb/tasks/retrieval/multilingual/x_qu_ad_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/x_qu_ad_retrieval.py
@@ -80,8 +80,10 @@ class XQuADRetrieval(AbsTaskRetrieval):
             data = data.filter(lambda x: x["answers"]["text"] != "")  # noqa: PLC1901
 
             question_ids = {
-                question: id
-                for id, question in zip(data["id"], data["question"], strict=True)
+                question: question_id
+                for question_id, question in zip(
+                    data["id"], data["question"], strict=True
+                )
             }
             context_ids = {
                 context: sha256(context.encode("utf-8")).hexdigest()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -334,6 +334,7 @@ select = [
     "ISC",     # implicit string concatenation
     "B",       # flake8-bugbear
     "PT",      # flake8-pytest-style
+    "A",       # flake8-builtins, don't shadow builtins
 ]
 
 ignore = [

--- a/tests/test_deprecated/test_MTEB.py
+++ b/tests/test_deprecated/test_MTEB.py
@@ -17,8 +17,8 @@ def test_run_using_benchmark(model: mteb.EncoderProtocol, tmp_path: Path):
         name="test_bench", tasks=mteb.get_tasks(tasks=["STS12", "SummEval"])
     )
 
-    eval = mteb.MTEB(tasks=[bench])
-    eval.run(
+    evaluation = mteb.MTEB(tasks=[bench])
+    evaluation.run(
         model, output_folder=tmp_path.as_posix(), overwrite_results=True
     )  # we just want to test that it runs
 
@@ -32,7 +32,7 @@ def test_run_using_list_of_benchmark(model: mteb.EncoderProtocol, tmp_path: Path
         )
     ]
 
-    eval = mteb.MTEB(tasks=bench)
-    eval.run(
+    evaluation = mteb.MTEB(tasks=bench)
+    evaluation.run(
         model, output_folder=tmp_path.as_posix(), overwrite_results=True
     )  # we just want to test that it runs


### PR DESCRIPTION
refs #2416 
Enables the full `A` rule family, which flags names that shadow Python builtins. This is a rename-only change — no behavior or logic changes. Every fix is a variable or parameter rename; no control flow, signatures-as-contracts, or serialized data were altered.

27 violations across 15 files:

- **A001** (variables, 16): `license` → `license_str`, `id` → `task_id` / `idx` / `question_id` / `cur_doc_id`, `eval` → `evaluation` (matches the existing `evaluation = MTEB(...)` convention already used in `scripts/` and other tests).
- **A002** (arguments, 11): 9 renamed on private/internal functions (`format` → `output_format` / `file_format` / `image_format`, `property` → `property_name`, `input` → `inputs`).
- A003–A006 were already clean.

- `ruff check` and `ruff format --check` clean
- `mypy` clean on touched files (relevant since `_get_scores` has `@overload`s)
- 221 tests pass (`test_results`, `test_deprecated`, `test_leaderboard`, `test_get_tasks`, `test_filter_tasks`)