### PR TITLE
Enables `RET` (flake8-return) ruff rule

### DIFF
--- a/docs/overview/create_available_models.py
+++ b/docs/overview/create_available_models.py
@@ -130,9 +130,8 @@ def required_memory_string(mem_in_mb: int | None) -> str:
         return "not specified"
     if mem_in_mb < 1024:
         return f"{mem_in_mb} MB"
-    else:
-        mem_in_gb = mem_in_mb / 1024
-        return f"{mem_in_gb:.1f} GB"
+    mem_in_gb = mem_in_mb / 1024
+    return f"{mem_in_gb:.1f} GB"
 
 
 def format_model_entry(meta: ModelMeta) -> str:

--- a/mteb/_evaluators/retrieval_metrics.py
+++ b/mteb/_evaluators/retrieval_metrics.py
@@ -267,8 +267,7 @@ def evaluate_p_mrr_change(
 def rank_score(x: dict[str, float]) -> float:
     if x["og_rank"] >= x["new_rank"]:
         return ((1 / x["og_rank"]) / (1 / x["new_rank"])) - 1
-    else:
-        return 1 - ((1 / x["new_rank"]) / (1 / x["og_rank"]))
+    return 1 - ((1 / x["new_rank"]) / (1 / x["og_rank"]))
 
 
 def confidence_scores(sim_scores: list[float]) -> dict[str, float]:

--- a/mteb/abstasks/_stratification.py
+++ b/mteb/abstasks/_stratification.py
@@ -100,11 +100,10 @@ def _fold_tie_break(
     """
     if len(M) == 1:
         return int(M[0])
-    else:
-        max_val = max(desired_samples_per_fold[M])
-        m_prim = np.where(np.array(desired_samples_per_fold) == max_val)[0]
-        m_prim = np.array([x for x in m_prim if x in M])
-        return int(random_state.choice(m_prim, 1)[0])
+    max_val = max(desired_samples_per_fold[M])
+    m_prim = np.where(np.array(desired_samples_per_fold) == max_val)[0]
+    m_prim = np.array([x for x in m_prim if x in M])
+    return int(random_state.choice(m_prim, 1)[0])
 
 
 def _get_most_desired_combination(samples_with_combination: dict[Any, Any]) -> Any:

--- a/mteb/abstasks/abstask.py
+++ b/mteb/abstasks/abstask.py
@@ -333,8 +333,7 @@ class AbsTask(ABC):  # noqa: PLR0904
                     return _multilabel_subsampling(
                         dataset_dict, seed, splits, label, n_samples
                     )
-                else:
-                    raise e
+                raise e
 
         for split in splits:
             if n_samples >= len(dataset_dict[split]):

--- a/mteb/abstasks/text/reranking.py
+++ b/mteb/abstasks/text/reranking.py
@@ -53,7 +53,7 @@ class AbsTaskReranking(AbsTaskRetrieval):
             self.transform_old_dataset_format()
         else:
             # use AbsTaskRetrieval default to load the data
-            return super().load_data(num_proc=num_proc, timer=timer)
+            super().load_data(num_proc=num_proc, timer=timer)
 
     def _process_example(  # noqa: PLR6301
         self,

--- a/mteb/cli/_display_tasks.py
+++ b/mteb/cli/_display_tasks.py
@@ -51,16 +51,15 @@ def _display_tasks(task_list: Iterable[AbsTask], name: str | None = None) -> Non
         )
         if len(current_type_tasks) == 0:
             continue
-        else:
-            console.print(f"[bold]{task_type}[/]")
-            for task in current_type_tasks:  # will be sorted as input to this function
-                prefix = "    - "
-                name = f"{task.metadata.name}"
-                category = f", [italic grey39]{task.metadata.category}[/]"
-                multilingual = (
-                    f", [italic red]multilingual {len(task.hf_subsets)} / {len(task.metadata.eval_langs)} Subsets[/]"
-                    if task.metadata.is_multilingual
-                    else ""
-                )
-                console.print(f"{prefix}{name}{category}{multilingual}")
-            console.print("\n")
+        console.print(f"[bold]{task_type}[/]")
+        for task in current_type_tasks:  # will be sorted as input to this function
+            prefix = "    - "
+            name = f"{task.metadata.name}"
+            category = f", [italic grey39]{task.metadata.category}[/]"
+            multilingual = (
+                f", [italic red]multilingual {len(task.hf_subsets)} / {len(task.metadata.eval_langs)} Subsets[/]"
+                if task.metadata.is_multilingual
+                else ""
+            )
+            console.print(f"{prefix}{name}{category}{multilingual}")
+        console.print("\n")

--- a/mteb/deprecated_evaluator.py
+++ b/mteb/deprecated_evaluator.py
@@ -111,21 +111,18 @@ class MTEB:
             )
             if len(current_type_tasks) == 0:
                 continue
-            else:
-                console.print(f"[bold]{task_type}[/]")
-                for (
-                    task
-                ) in current_type_tasks:  # will be sorted as input to this function
-                    prefix = "    - "
-                    name = f"{task.metadata.name}"
-                    category = f", [italic grey39]{task.metadata.category}[/]"
-                    multilingual = (
-                        f", [italic red]multilingual {len(task.hf_subsets)} / {len(task.metadata.eval_langs)} Subsets[/]"
-                        if task.metadata.is_multilingual
-                        else ""
-                    )
-                    console.print(f"{prefix}{name}{category}{multilingual}")
-                console.print("\n")
+            console.print(f"[bold]{task_type}[/]")
+            for task in current_type_tasks:  # will be sorted as input to this function
+                prefix = "    - "
+                name = f"{task.metadata.name}"
+                category = f", [italic grey39]{task.metadata.category}[/]"
+                multilingual = (
+                    f", [italic red]multilingual {len(task.hf_subsets)} / {len(task.metadata.eval_langs)} Subsets[/]"
+                    if task.metadata.is_multilingual
+                    else ""
+                )
+                console.print(f"{prefix}{name}{category}{multilingual}")
+            console.print("\n")
 
     def mteb_benchmarks(self) -> None:
         """Get all benchmarks available in the MTEB."""

--- a/mteb/evaluate.py
+++ b/mteb/evaluate.py
@@ -314,7 +314,7 @@ def _check_model_modalities(
                 and query_mods.issubset(model_modalities)
             ):
                 continue
-            elif query_overlap and doc_overlap:
+            if query_overlap and doc_overlap:
                 warnings.append(
                     f"Model {model.name} supports {model.modalities}, partially overlapping "
                     f"with task {task.metadata.name} query={sorted(query_mods)}, document={sorted(doc_mods)}. "
@@ -330,11 +330,10 @@ def _check_model_modalities(
 
             if task_mods.issubset(model_modalities):
                 continue
-            else:
-                errors.append(
-                    f"Model {model.name} supports {model.modalities}, but none overlap with "
-                    f"task {task.metadata.name} modalities={task.metadata.modalities}."
-                )
+            errors.append(
+                f"Model {model.name} supports {model.modalities}, but none overlap with "
+                f"task {task.metadata.name} modalities={task.metadata.modalities}."
+            )
 
     if errors:
         raise ValueError("\n".join(errors))

--- a/mteb/get_tasks.py
+++ b/mteb/get_tasks.py
@@ -93,10 +93,9 @@ class MTEBTasks(tuple[AbsTask]):
     def _extract_property_from_task(task: AbsTask, property_name: str) -> Any:
         if hasattr(task.metadata, property_name):
             return getattr(task.metadata, property_name)
-        elif hasattr(task, property_name):
+        if hasattr(task, property_name):
             return getattr(task, property_name)
-        else:
-            raise KeyError("Property neither in Task attribute or in task metadata.")
+        raise KeyError("Property neither in Task attribute or in task metadata.")
 
     @property
     def languages(self) -> set[str]:
@@ -180,8 +179,7 @@ class MTEBTasks(tuple[AbsTask]):
             ending = "]" if isinstance(cell, list) else "}"
             cell = sorted(cell)
             return str(cell[:limit_n_entries])[:-1] + ", ..." + ending
-        else:
-            return str(cell)
+        return str(cell)
 
     def to_latex(
         self,

--- a/mteb/languages/check_language_code.py
+++ b/mteb/languages/check_language_code.py
@@ -25,10 +25,9 @@ def check_language_code(code: str) -> None:
     if script == "Code":
         if lang in PROGRAMMING_LANGS:
             return  # override for code
-        else:
-            raise ValueError(
-                f"Programming language {lang} is not a valid programming language."
-            )
+        raise ValueError(
+            f"Programming language {lang} is not a valid programming language."
+        )
     if (
         lang is not None
         and lang not in ISO_TO_LANGUAGE

--- a/mteb/leaderboard/benchmark_selector.py
+++ b/mteb/leaderboard/benchmark_selector.py
@@ -37,8 +37,7 @@ def _create_button(
     def _update_variant(state: str) -> gr.Button:
         if state == label_to_value[label]:
             return gr.Button(variant="primary")
-        else:
-            return gr.Button(variant="secondary")
+        return gr.Button(variant="secondary")
 
     def _update_value() -> str:
         return label_to_value[label]

--- a/mteb/leaderboard/table.py
+++ b/mteb/leaderboard/table.py
@@ -191,8 +191,7 @@ def _style_number_of_parameters(num_params: float) -> str:
     """Anything bigger than 1B is shown in billions with 1 decimal (e.g. 1.712 > 1.7) while anything smaller as 0.xxx B (e.g. 0.345 remains 0.345)"""
     if num_params >= 1:
         return f"{num_params:.1f}"
-    else:
-        return f"{num_params:.3f}"
+    return f"{num_params:.3f}"
 
 
 def _apply_summary_table_styling(joint_table: pd.DataFrame) -> gr.DataFrame:

--- a/mteb/load_results.py
+++ b/mteb/load_results.py
@@ -120,7 +120,7 @@ def load_results(  # noqa: PLR0914
             model_name = model_name.replace("__", "/")
             if models_to_keep is not None and model_name not in models_to_keep:
                 continue
-            elif models_to_keep is not None and models_to_keep[model_name] is not None:
+            if models_to_keep is not None and models_to_keep[model_name] is not None:
                 if models_to_keep[model_name] != revision:
                     continue
 

--- a/mteb/models/abs_encoder.py
+++ b/mteb/models/abs_encoder.py
@@ -177,12 +177,11 @@ class AbsEncoder(ABC):
 
         if raise_for_invalid_keys and invalid_task_messages:
             raise KeyError(invalid_task_messages)
-        elif raise_for_invalid_keys:
+        if raise_for_invalid_keys:
             return task_to_prompt
-        else:
-            return {
-                k: v for k, v in task_to_prompt.items() if k not in invalid_keys
-            }, tuple(invalid_task_messages)
+        return {
+            k: v for k, v in task_to_prompt.items() if k not in invalid_keys
+        }, tuple(invalid_task_messages)
 
     def get_instruction(
         self,
@@ -303,9 +302,9 @@ class AbsEncoder(ABC):
             return cos_sim(embeddings1, embeddings2)
         if self.mteb_model_meta.similarity_fn_name is ScoringFunction.COSINE:
             return cos_sim(embeddings1, embeddings2)
-        elif self.mteb_model_meta.similarity_fn_name is ScoringFunction.DOT_PRODUCT:
+        if self.mteb_model_meta.similarity_fn_name is ScoringFunction.DOT_PRODUCT:
             return dot_score(embeddings1, embeddings2)
-        elif self.mteb_model_meta.similarity_fn_name is ScoringFunction.MAX_SIM:
+        if self.mteb_model_meta.similarity_fn_name is ScoringFunction.MAX_SIM:
             return max_sim(embeddings1, embeddings2)
         raise ValueError("Similarity function not specified.")
 
@@ -341,9 +340,9 @@ class AbsEncoder(ABC):
             return pairwise_cos_sim(embeddings1, embeddings2)
         if self.mteb_model_meta.similarity_fn_name is ScoringFunction.COSINE:
             return pairwise_cos_sim(embeddings1, embeddings2)
-        elif self.mteb_model_meta.similarity_fn_name is ScoringFunction.DOT_PRODUCT:
+        if self.mteb_model_meta.similarity_fn_name is ScoringFunction.DOT_PRODUCT:
             return pairwise_dot_score(embeddings1, embeddings2)
-        elif self.mteb_model_meta.similarity_fn_name is ScoringFunction.MAX_SIM:
+        if self.mteb_model_meta.similarity_fn_name is ScoringFunction.MAX_SIM:
             return pairwise_max_sim(embeddings1, embeddings2)
         raise ValueError("Similarity function not specified.")
 

--- a/mteb/models/model_implementations/align_models.py
+++ b/mteb/models/model_implementations/align_models.py
@@ -105,9 +105,9 @@ class ALIGNModel(AbsEncoder):
                 )
             fused_embeddings = text_embeddings + image_embeddings
             return fused_embeddings
-        elif text_embeddings is not None:
+        if text_embeddings is not None:
             return text_embeddings
-        elif image_embeddings is not None:
+        if image_embeddings is not None:
             return image_embeddings
         raise ValueError
 

--- a/mteb/models/model_implementations/bedrock_models.py
+++ b/mteb/models/model_implementations/bedrock_models.py
@@ -97,14 +97,13 @@ class BedrockModel(AbsEncoder):
         )
         if self._provider == "amazon":
             return self._encode_amazon(inputs, show_progress_bar)
-        elif self._provider == "cohere":
+        if self._provider == "cohere":
             prompt_name = self.get_prompt_name(task_metadata, prompt_type)
             cohere_task_type = self.model_prompts.get(prompt_name, "search_document")
             return self._encode_cohere(inputs, cohere_task_type, show_progress_bar)
-        else:
-            raise ValueError(
-                f"Unknown provider '{self._provider}'. Must be 'amazon' or 'cohere'."
-            )
+        raise ValueError(
+            f"Unknown provider '{self._provider}'. Must be 'amazon' or 'cohere'."
+        )
 
     def _encode_amazon(
         self, sentences: list[str], show_progress_bar: bool = False

--- a/mteb/models/model_implementations/blip2_models.py
+++ b/mteb/models/model_implementations/blip2_models.py
@@ -149,9 +149,9 @@ def blip2_loader(model_name, **kwargs):
                     )
                 fused_embeddings = text_embeddings + image_embeddings
                 return fused_embeddings
-            elif text_embeddings is not None:
+            if text_embeddings is not None:
                 return text_embeddings
-            elif image_embeddings is not None:
+            if image_embeddings is not None:
                 return image_embeddings
             raise ValueError
 

--- a/mteb/models/model_implementations/blip_models.py
+++ b/mteb/models/model_implementations/blip_models.py
@@ -124,9 +124,9 @@ class BLIPModel(AbsEncoder):
                 )
             fused_embeddings = text_embeddings + image_embeddings
             return fused_embeddings
-        elif text_embeddings is not None:
+        if text_embeddings is not None:
             return text_embeddings
-        elif image_embeddings is not None:
+        if image_embeddings is not None:
             return image_embeddings
         raise ValueError
 

--- a/mteb/models/model_implementations/clap_models.py
+++ b/mteb/models/model_implementations/clap_models.py
@@ -128,9 +128,9 @@ class ClapZeroShotWrapper(AbsEncoder):
                 )
             fused_embeddings = text_embeddings + audio_embeddings
             return fused_embeddings
-        elif text_embeddings is not None:
+        if text_embeddings is not None:
             return text_embeddings
-        elif audio_embeddings is not None:
+        if audio_embeddings is not None:
             return audio_embeddings
         raise ValueError
 

--- a/mteb/models/model_implementations/clip_models.py
+++ b/mteb/models/model_implementations/clip_models.py
@@ -109,9 +109,9 @@ class CLIPModel(AbsEncoder):
                 )
             fused_embeddings = text_embeddings + image_embeddings
             return fused_embeddings
-        elif text_embeddings is not None:
+        if text_embeddings is not None:
             return text_embeddings
-        elif image_embeddings is not None:
+        if image_embeddings is not None:
             return image_embeddings
         raise ValueError
 

--- a/mteb/models/model_implementations/cohere_models.py
+++ b/mteb/models/model_implementations/cohere_models.py
@@ -213,6 +213,7 @@ def retry_with_rate_limit(
                         f"Cohere API error (attempt {attempt + 1}/{max_retries}): {e}. Retrying in {delay}s..."
                     )
                     time.sleep(delay)
+            return None
 
         return wrapper
 

--- a/mteb/models/model_implementations/cohere_v.py
+++ b/mteb/models/model_implementations/cohere_v.py
@@ -44,12 +44,11 @@ def _post_process_embeddings(
                     unpacked.append(1.0 if bit_val else -1.0)
             unpacked_embeddings.append(unpacked)
         return torch.tensor(unpacked_embeddings, dtype=torch.float32)
-    elif embedding_type in ["int8", "uint8"]:  # noqa: PLR6201
+    if embedding_type in ["int8", "uint8"]:  # noqa: PLR6201
         # Convert int8/uint8 embeddings to float32
         return embeddings_array.float()
-    else:
-        # For float and other types, return as-is
-        return embeddings_array
+    # For float and other types, return as-is
+    return embeddings_array
 
 
 all_languages = [
@@ -377,9 +376,9 @@ def cohere_v_loader(model_name, **kwargs):
                     )
                 fused_embeddings = text_embeddings + image_embeddings
                 return fused_embeddings
-            elif text_embeddings is not None:
+            if text_embeddings is not None:
                 return text_embeddings
-            elif image_embeddings is not None:
+            if image_embeddings is not None:
                 return image_embeddings
             raise ValueError
 

--- a/mteb/models/model_implementations/colpali_models.py
+++ b/mteb/models/model_implementations/colpali_models.py
@@ -77,9 +77,9 @@ class ColPaliEngineWrapper(AbsEncoder):
                 )
             fused_embeddings = torch.cat([text_embeddings, image_embeddings], dim=1)
             return fused_embeddings
-        elif text_embeddings is not None:
+        if text_embeddings is not None:
             return text_embeddings
-        elif image_embeddings is not None:
+        if image_embeddings is not None:
             return image_embeddings
         raise ValueError
 

--- a/mteb/models/model_implementations/conan_models.py
+++ b/mteb/models/model_implementations/conan_models.py
@@ -87,6 +87,7 @@ class RateLimiter:
                 else:
                     logger.error(f"Max retries reached. Last error: {str(e)}")
                     raise
+        return None
 
 
 class Client:

--- a/mteb/models/model_implementations/dino_models.py
+++ b/mteb/models/model_implementations/dino_models.py
@@ -95,9 +95,9 @@ class DINOModel(AbsEncoder):
 
         if text_embeddings is not None and image_embeddings is not None:
             raise ValueError("DINO models only support image encoding.")
-        elif text_embeddings is not None:
+        if text_embeddings is not None:
             return text_embeddings
-        elif image_embeddings is not None:
+        if image_embeddings is not None:
             return image_embeddings
         raise ValueError("No text or image data found.")
 

--- a/mteb/models/model_implementations/e5_v.py
+++ b/mteb/models/model_implementations/e5_v.py
@@ -139,9 +139,9 @@ class E5VModel(AbsEncoder):
                     ).hidden_states[-1][:, -1, :]
                     all_fused_embeddings.append(outputs.cpu())
             return torch.cat(all_fused_embeddings, dim=0)
-        elif "text" in inputs.dataset.features:
+        if "text" in inputs.dataset.features:
             return self.get_text_embeddings(inputs, **kwargs)
-        elif "image" in inputs.dataset.features:
+        if "image" in inputs.dataset.features:
             return self.get_image_embeddings(inputs, **kwargs)
         raise ValueError
 

--- a/mteb/models/model_implementations/evaclip_models.py
+++ b/mteb/models/model_implementations/evaclip_models.py
@@ -119,9 +119,9 @@ def evaclip_loader(model_name, **kwargs):
                     )
                 fused_embeddings = text_embeddings + image_embeddings
                 return fused_embeddings
-            elif text_embeddings is not None:
+            if text_embeddings is not None:
                 return text_embeddings
-            elif image_embeddings is not None:
+            if image_embeddings is not None:
                 return image_embeddings
             raise ValueError
 

--- a/mteb/models/model_implementations/google_gemini.py
+++ b/mteb/models/model_implementations/google_gemini.py
@@ -373,6 +373,9 @@ class GoogleGeminiEmbeddingModel(AbsEncoder):
                                 )
                             else:
                                 raise
+                    raise RuntimeError(
+                        "embed_one exhausted all retries without returning or raising"
+                    )
 
             if show_progress_bar:
                 from tqdm.asyncio import tqdm as async_tqdm

--- a/mteb/models/model_implementations/granite_vision_embedding_models.py
+++ b/mteb/models/model_implementations/granite_vision_embedding_models.py
@@ -142,9 +142,9 @@ class GraniteVisionEmbeddingWrapper:
                 )
             fused_embeddings = text_embeddings + image_embeddings
             return fused_embeddings
-        elif text_embeddings is not None:
+        if text_embeddings is not None:
             return text_embeddings
-        elif image_embeddings is not None:
+        if image_embeddings is not None:
             return image_embeddings
         raise ValueError
 

--- a/mteb/models/model_implementations/jina_clip.py
+++ b/mteb/models/model_implementations/jina_clip.py
@@ -116,9 +116,9 @@ class JinaCLIPModel(AbsEncoder):
                 )
             fused_embeddings = text_embeddings + image_embeddings
             return fused_embeddings
-        elif text_embeddings is not None:
+        if text_embeddings is not None:
             return text_embeddings
-        elif image_embeddings is not None:
+        if image_embeddings is not None:
             return image_embeddings
         raise ValueError
 

--- a/mteb/models/model_implementations/jina_models.py
+++ b/mteb/models/model_implementations/jina_models.py
@@ -621,7 +621,7 @@ class JinaV4Wrapper(AbsEncoder):
         """Convert numpy arrays to torch tensors if needed."""
         if isinstance(embeddings, np.ndarray):
             return torch.from_numpy(embeddings)
-        elif isinstance(embeddings, list):
+        if isinstance(embeddings, list):
             # Handle list of numpy arrays or tensors
             converted = []
             for emb in embeddings:
@@ -644,12 +644,11 @@ class JinaV4Wrapper(AbsEncoder):
 
         if self.vector_type == "single_vector":
             return self.score_single_vector(a_torch, b_torch)
-        elif self.vector_type == "multi_vector":
+        if self.vector_type == "multi_vector":
             return self.score_multi_vector(a_torch, b_torch)
-        else:
-            raise ValueError(
-                "vector_type must be one of the following: [`single_vector`, `multi_vector`]"
-            )
+        raise ValueError(
+            "vector_type must be one of the following: [`single_vector`, `multi_vector`]"
+        )
 
     def score_single_vector(
         self,
@@ -668,8 +667,8 @@ class JinaV4Wrapper(AbsEncoder):
         def normalize_input(x):
             if isinstance(x, torch.Tensor):
                 return x.unsqueeze(0) if x.ndim == 1 else x
-            else:  # list
-                return torch.stack(x) if len(x) > 1 else x[0].unsqueeze(0)
+            # list
+            return torch.stack(x) if len(x) > 1 else x[0].unsqueeze(0)
 
         qs_stacked = normalize_input(qs).to(device)
         ps_stacked = normalize_input(ps).to(device)

--- a/mteb/models/model_implementations/llm2clip_models.py
+++ b/mteb/models/model_implementations/llm2clip_models.py
@@ -167,9 +167,9 @@ def llm2clip_loader(model_name, **kwargs):
                     )
                 fused_embeddings = text_embeddings + image_embeddings
                 return fused_embeddings
-            elif text_embeddings is not None:
+            if text_embeddings is not None:
                 return text_embeddings
-            elif image_embeddings is not None:
+            if image_embeddings is not None:
                 return image_embeddings
             raise ValueError
 

--- a/mteb/models/model_implementations/metaclip_models.py
+++ b/mteb/models/model_implementations/metaclip_models.py
@@ -129,9 +129,9 @@ class MetaClip2Model(AbsEncoder):
                 )
             fused_embeddings = text_embeddings + image_embeddings
             return fused_embeddings
-        elif text_embeddings is not None:
+        if text_embeddings is not None:
             return text_embeddings
-        elif image_embeddings is not None:
+        if image_embeddings is not None:
             return image_embeddings
         raise ValueError
 

--- a/mteb/models/model_implementations/msclap_models.py
+++ b/mteb/models/model_implementations/msclap_models.py
@@ -153,9 +153,9 @@ class MSClapWrapper(AbsEncoder):
                 )
             fused_embeddings = text_embeddings + audio_embeddings
             return fused_embeddings
-        elif text_embeddings is not None:
+        if text_embeddings is not None:
             return text_embeddings
-        elif audio_embeddings is not None:
+        if audio_embeddings is not None:
             return audio_embeddings
         raise ValueError
 

--- a/mteb/models/model_implementations/muq_mulan_model.py
+++ b/mteb/models/model_implementations/muq_mulan_model.py
@@ -131,9 +131,9 @@ class MuQMuLanWrapper(AbsEncoder):
                 )
             fused_embeddings = text_embeddings + audio_embeddings
             return fused_embeddings
-        elif text_embeddings is not None:
+        if text_embeddings is not None:
             return text_embeddings
-        elif audio_embeddings is not None:
+        if audio_embeddings is not None:
             return audio_embeddings
         raise ValueError
 

--- a/mteb/models/model_implementations/nanovdr_models.py
+++ b/mteb/models/model_implementations/nanovdr_models.py
@@ -243,9 +243,8 @@ class NanoVDRWrapper(AbsEncoder):
 
         if prompt_type == PromptType.document:
             return self._encode_documents(inputs, show_progress_bar=show_progress_bar)
-        else:
-            # Use the lightweight student for queries and all non-retrieval tasks
-            return self._encode_queries(inputs, show_progress_bar=show_progress_bar)
+        # Use the lightweight student for queries and all non-retrieval tasks
+        return self._encode_queries(inputs, show_progress_bar=show_progress_bar)
 
 
 nanovdr_s_multi = ModelMeta(

--- a/mteb/models/model_implementations/nomic_models_vision.py
+++ b/mteb/models/model_implementations/nomic_models_vision.py
@@ -152,9 +152,9 @@ class NomicVisionModel(AbsEncoder):
                 )
             fused_embeddings = text_embeddings + image_embeddings
             return fused_embeddings
-        elif text_embeddings is not None:
+        if text_embeddings is not None:
             return text_embeddings
-        elif image_embeddings is not None:
+        if image_embeddings is not None:
             return image_embeddings
         raise ValueError
 

--- a/mteb/models/model_implementations/nomic_multimodal.py
+++ b/mteb/models/model_implementations/nomic_multimodal.py
@@ -92,9 +92,9 @@ class BiQwen2_5Wrapper(AbsEncoder):  # noqa: N801
                 )
             fused_embeddings = text_embeddings + image_embeddings
             return fused_embeddings
-        elif text_embeddings is not None:
+        if text_embeddings is not None:
             return text_embeddings
-        elif image_embeddings is not None:
+        if image_embeddings is not None:
             return image_embeddings
         raise ValueError
 

--- a/mteb/models/model_implementations/nvidia_nemotron_vl_models.py
+++ b/mteb/models/model_implementations/nvidia_nemotron_vl_models.py
@@ -132,9 +132,9 @@ class NemotronColEmbedVL(AbsEncoder):
             raise NotImplementedError(
                 "Fused embeddings are not supported yet. Please use get_text_embeddings or get_image_embeddings."
             )
-        elif text_embeddings is not None:
+        if text_embeddings is not None:
             return text_embeddings
-        elif image_embeddings is not None:
+        if image_embeddings is not None:
             return image_embeddings
         raise ValueError
 

--- a/mteb/models/model_implementations/openclip_models.py
+++ b/mteb/models/model_implementations/openclip_models.py
@@ -106,9 +106,9 @@ def openclip_loader(model_name, **kwargs):
                     )
                 fused_embeddings = text_embeddings + image_embeddings
                 return fused_embeddings
-            elif text_embeddings is not None:
+            if text_embeddings is not None:
                 return text_embeddings
-            elif image_embeddings is not None:
+            if image_embeddings is not None:
                 return image_embeddings
             raise ValueError
 

--- a/mteb/models/model_implementations/ops_colqwen3_models.py
+++ b/mteb/models/model_implementations/ops_colqwen3_models.py
@@ -77,9 +77,9 @@ class OpsColQwen3Wrapper(AbsEncoder):
                 )
             fused_embeddings = text_embeddings + image_embeddings
             return fused_embeddings
-        elif text_embeddings is not None:
+        if text_embeddings is not None:
             return text_embeddings
-        elif image_embeddings is not None:
+        if image_embeddings is not None:
             return image_embeddings
         raise ValueError("No text or image inputs found")
 

--- a/mteb/models/model_implementations/ps3_models.py
+++ b/mteb/models/model_implementations/ps3_models.py
@@ -168,9 +168,9 @@ class PS3Model(AbsEncoder):
             if len(text_embeddings) != len(image_embeddings):
                 raise ValueError("The number of texts and images must be equal")
             return text_embeddings + image_embeddings
-        elif text_embeddings is not None:
+        if text_embeddings is not None:
             return text_embeddings
-        elif image_embeddings is not None:
+        if image_embeddings is not None:
             return image_embeddings
         raise ValueError("No text or image features found in input")
 

--- a/mteb/models/model_implementations/rerankers_monot5_based.py
+++ b/mteb/models/model_implementations/rerankers_monot5_based.py
@@ -100,15 +100,13 @@ class MonoT5Reranker(RerankerWrapper):
                 token_false_id = tokenizer.get_vocab()[token_false]
                 token_true_id = tokenizer.get_vocab()[token_true]
                 return token_false_id, token_true_id
-            else:
-                raise Exception(
-                    f"We don't know the indexes for the non-relevant/relevant tokens for\
+            raise Exception(
+                f"We don't know the indexes for the non-relevant/relevant tokens for\
                         the checkpoint {model_name_or_path} and you did not provide any."
-                )
-        else:
-            token_false_id = tokenizer.get_vocab()[token_false]
-            token_true_id = tokenizer.get_vocab()[token_true]
-            return token_false_id, token_true_id
+            )
+        token_false_id = tokenizer.get_vocab()[token_false]
+        token_true_id = tokenizer.get_vocab()[token_true]
+        return token_false_id, token_true_id
 
     @torch.inference_mode()
     def predict(

--- a/mteb/models/model_implementations/siglip_models.py
+++ b/mteb/models/model_implementations/siglip_models.py
@@ -119,9 +119,9 @@ class SiglipModelWrapper(AbsEncoder):
                 )
             fused_embeddings = text_embeddings + image_embeddings
             return fused_embeddings
-        elif text_embeddings is not None:
+        if text_embeddings is not None:
             return text_embeddings
-        elif image_embeddings is not None:
+        if image_embeddings is not None:
             return image_embeddings
         raise ValueError
 

--- a/mteb/models/model_implementations/slm_models.py
+++ b/mteb/models/model_implementations/slm_models.py
@@ -97,9 +97,9 @@ class SLMBaseWrapper(AbsEncoder):
                 )
             fused_embeddings = text_embeddings + image_embeddings
             return fused_embeddings
-        elif text_embeddings is not None:
+        if text_embeddings is not None:
             return text_embeddings
-        elif image_embeddings is not None:
+        if image_embeddings is not None:
             return image_embeddings
         raise ValueError("No text or image features found in inputs")
 

--- a/mteb/models/model_implementations/speecht5_models.py
+++ b/mteb/models/model_implementations/speecht5_models.py
@@ -282,9 +282,9 @@ class SpeechT2Multimodal(AbsEncoder):
                 )
             fused_embeddings = text_embeddings + audio_embeddings
             return fused_embeddings
-        elif text_embeddings is not None:
+        if text_embeddings is not None:
             return text_embeddings
-        elif audio_embeddings is not None:
+        if audio_embeddings is not None:
             return audio_embeddings
         raise ValueError
 

--- a/mteb/models/model_implementations/tipsv2_models.py
+++ b/mteb/models/model_implementations/tipsv2_models.py
@@ -122,9 +122,9 @@ class TIPSv2Model(AbsEncoder):
             if len(text_embeddings) != len(image_embeddings):
                 raise ValueError("The number of texts and images must be equal")
             return text_embeddings + image_embeddings
-        elif text_embeddings is not None:
+        if text_embeddings is not None:
             return text_embeddings
-        elif image_embeddings is not None:
+        if image_embeddings is not None:
             return image_embeddings
         raise ValueError("No text or image features found in input")
 

--- a/mteb/models/model_implementations/viclip_models.py
+++ b/mteb/models/model_implementations/viclip_models.py
@@ -153,9 +153,9 @@ class ViCLIPWrapper(AbsEncoder):
             if len(text_embeddings) != len(video_embeddings):
                 raise ValueError("Number of texts and videos must match")
             return text_embeddings + video_embeddings
-        elif text_embeddings is not None:
+        if text_embeddings is not None:
             return text_embeddings
-        elif video_embeddings is not None:
+        if video_embeddings is not None:
             return video_embeddings
 
         raise ValueError(

--- a/mteb/models/model_implementations/vista_models.py
+++ b/mteb/models/model_implementations/vista_models.py
@@ -219,14 +219,14 @@ def vista_loader(model_name, **kwargs):
                             .to(torch.float32)
                         )
                 return torch.cat(all_fused_embeddings, dim=0)
-            elif "text" in inputs.dataset.features:
+            if "text" in inputs.dataset.features:
                 return self.get_text_embeddings(
                     inputs,
                     task_metadata=task_metadata,
                     prompt_type=prompt_type,
                     **kwargs,
                 )
-            elif "image" in inputs.dataset.features:
+            if "image" in inputs.dataset.features:
                 return self.get_image_embeddings(
                     inputs,
                     task_metadata=task_metadata,

--- a/mteb/models/model_implementations/voiceclap_models.py
+++ b/mteb/models/model_implementations/voiceclap_models.py
@@ -117,9 +117,9 @@ class VoiceCLAPSmallWrapper(AbsEncoder):
                     "The number of texts and audios must have the same length"
                 )
             return text_embeddings + audio_embeddings
-        elif text_embeddings is not None:
+        if text_embeddings is not None:
             return text_embeddings
-        elif audio_embeddings is not None:
+        if audio_embeddings is not None:
             return audio_embeddings
         raise ValueError
 

--- a/mteb/models/model_implementations/voyage_v.py
+++ b/mteb/models/model_implementations/voyage_v.py
@@ -174,7 +174,7 @@ def voyage_v_loader(model_name, **kwargs):
                     interleaved_embeddings.append(torch.tensor(embeddings))
                 interleaved_embeddings = torch.vstack(interleaved_embeddings)
                 return interleaved_embeddings
-            elif "text" in inputs.dataset.features:
+            if "text" in inputs.dataset.features:
                 text_embeddings = self.get_text_embeddings(
                     inputs, input_type=input_type
                 )
@@ -185,7 +185,7 @@ def voyage_v_loader(model_name, **kwargs):
 
             if text_embeddings is not None:
                 return text_embeddings
-            elif image_embeddings is not None:
+            if image_embeddings is not None:
                 return image_embeddings
             raise ValueError
 

--- a/mteb/models/model_implementations/wav2clip_model.py
+++ b/mteb/models/model_implementations/wav2clip_model.py
@@ -143,9 +143,9 @@ class Wav2ClipZeroShotWrapper(AbsEncoder):
                 )
             fused_embeddings = text_embeddings + audio_embeddings
             return fused_embeddings
-        elif text_embeddings is not None:
+        if text_embeddings is not None:
             return text_embeddings
-        elif audio_embeddings is not None:
+        if audio_embeddings is not None:
             return audio_embeddings
         raise ValueError
 

--- a/mteb/models/model_implementations/webai_models.py
+++ b/mteb/models/model_implementations/webai_models.py
@@ -75,9 +75,9 @@ class ColVec1Wrapper(AbsEncoder):
                     "The number of texts and images must have the same length"
                 )
             return text_embeddings + image_embeddings
-        elif text_embeddings is not None:
+        if text_embeddings is not None:
             return text_embeddings
-        elif image_embeddings is not None:
+        if image_embeddings is not None:
             return image_embeddings
         raise ValueError("No text or image features found in inputs.")
 

--- a/mteb/models/model_implementations/xclip_models.py
+++ b/mteb/models/model_implementations/xclip_models.py
@@ -121,9 +121,9 @@ class XCLIPModel(AbsEncoder):
                     "The number of texts and videos must have the same length"
                 )
             return text_embeddings + video_embeddings
-        elif text_embeddings is not None:
+        if text_embeddings is not None:
             return text_embeddings
-        elif video_embeddings is not None:
+        if video_embeddings is not None:
             return video_embeddings
 
         raise ValueError(

--- a/mteb/models/model_meta.py
+++ b/mteb/models/model_meta.py
@@ -510,7 +510,7 @@ class ModelMeta(BaseModel):  # noqa: PLR0904
                     "Model does not support loading with a different embedding dimension. "
                     "You can change supported embedding dimensions in `meta.embed_dim`."
                 )
-            elif isinstance(_self.embed_dim, list) and embed_dim not in _self.embed_dim:
+            if isinstance(_self.embed_dim, list) and embed_dim not in _self.embed_dim:
                 raise ValueError(
                     f"Requested embedding dimension {embed_dim} is not in the model's supported embedding dimensions {_self.embed_dim}."
                 )
@@ -786,12 +786,11 @@ class ModelMeta(BaseModel):  # noqa: PLR0904
 
         if st_model_type == "CrossEncoder":
             return CrossEncoderWrapper, "cross-encoder", modalities
-        elif st_model_type == "SparseEncoder":
+        if st_model_type == "SparseEncoder":
             return SparseEncoderWrapper, "sparse", modalities
-        elif st_model_type == "SentenceTransformer":
+        if st_model_type == "SentenceTransformer":
             return SentenceTransformerEncoderWrapper, "dense", modalities
-        else:
-            raise ValueError("Unsupported model type")
+        raise ValueError("Unsupported model type")
 
     @classmethod
     def _detect_model_type_and_loader(
@@ -944,7 +943,7 @@ class ModelMeta(BaseModel):  # noqa: PLR0904
         ):
             emb = model.model.get_input_embeddings()
             return int(np.prod(emb.weight.shape))
-        elif isinstance(model, SentenceTransformer):
+        if isinstance(model, SentenceTransformer):
             vocab = None
             try:
                 vocab = len(model.tokenizer.vocab)

--- a/mteb/models/sentence_transformer_wrapper.py
+++ b/mteb/models/sentence_transformer_wrapper.py
@@ -161,7 +161,7 @@ def _select_encode_function(
     if prompt_type and has_query_encode:
         if prompt_type == PromptType.query:
             return model.encode_query  # type: ignore[no-any-return]
-        elif prompt_type == PromptType.document:
+        if prompt_type == PromptType.document:
             return model.encode_document  # type: ignore[no-any-return]
         raise ValueError(f"Unknown prompt type: {prompt_type}")
     return model.encode

--- a/mteb/results/model_result.py
+++ b/mteb/results/model_result.py
@@ -78,12 +78,15 @@ def _aggregate_and_pivot(
             aggfunc=aggregation_fn_pandas,  # type: ignore[arg-type]
             observed=True,
         ).reset_index()
-    elif output_format == "long":
+    if output_format == "long":
         return (
             df.groupby(columns + index_columns, observed=True)
             .agg(score=("score", aggregation_fn_pandas))
             .reset_index()
         )
+    raise ValueError(
+        f"Unknown output_format {output_format!r}, expected 'wide' or 'long'."
+    )
 
 
 class ModelResult(BaseModel):
@@ -286,6 +289,9 @@ class ModelResult(BaseModel):
                         stacklevel=2,
                     )
             return entries
+        raise ValueError(
+            f"Unknown output_format {output_format!r}, expected 'wide' or 'long'."
+        )
 
     def _get_score_for_table(self) -> list[dict[str, str | float | list[str]]]:
         scores_data = []

--- a/mteb/results/task_result.py
+++ b/mteb/results/task_result.py
@@ -612,7 +612,7 @@ class TaskResult(BaseModel):  # noqa: PLR0904
                     raise ValueError(f"Missing main score for subset: {hf_subset}")
                 if subsets and hf_subset not in subsets:
                     continue
-                elif subsets:
+                if subsets:
                     val_sum += main_score
                     n_val += 1
                     continue

--- a/mteb/similarity_functions.py
+++ b/mteb/similarity_functions.py
@@ -66,9 +66,9 @@ def select_similarity(
     """
     if similarity_fn is ScoringFunction.COSINE:
         return cos_sim(embedding1, embedding2)
-    elif similarity_fn is ScoringFunction.DOT_PRODUCT:
+    if similarity_fn is ScoringFunction.DOT_PRODUCT:
         return dot_score(embedding1, embedding2)
-    elif similarity_fn is ScoringFunction.EUCLIDEAN:
+    if similarity_fn is ScoringFunction.EUCLIDEAN:
         return euclidean_sim(embedding1, embedding2)
     raise ValueError(f"Unsupported similarity function: {similarity_fn}")
 
@@ -90,9 +90,9 @@ def select_pairwise_similarity(
     """
     if similarity_fn is ScoringFunction.COSINE:
         return pairwise_cos_sim(embedding1, embedding2)
-    elif similarity_fn is ScoringFunction.DOT_PRODUCT:
+    if similarity_fn is ScoringFunction.DOT_PRODUCT:
         return pairwise_dot_score(embedding1, embedding2)
-    elif similarity_fn is ScoringFunction.EUCLIDEAN:
+    if similarity_fn is ScoringFunction.EUCLIDEAN:
         return pairwise_euclidean_sim(embedding1, embedding2)
     raise ValueError(f"Unsupported similarity function: {similarity_fn}")
 
@@ -147,8 +147,7 @@ def cos_sim(a: Array, b: Array) -> torch.Tensor:
     if should_compile:
         _cos_sim_core_compiled = torch.compile(_cos_sim_core)
         return _cos_sim_core_compiled(a, b)
-    else:
-        return _cos_sim_core(a, b)
+    return _cos_sim_core(a, b)
 
 
 # https://github.com/UKPLab/sentence-transformers/blob/3fd59c3d122f2148e22b6338447b45d850fb6ea4/sentence_transformers/util.py#L125
@@ -276,8 +275,7 @@ def dot_score(a: Array, b: Array) -> torch.Tensor:
     ):
         _dot_score_core_compiled = torch.compile(_dot_score_core)
         return _dot_score_core_compiled(a, b)
-    else:
-        return _dot_score_core(a, b)
+    return _dot_score_core(a, b)
 
 
 def pairwise_dot_score(a: Array, b: Array) -> Array:

--- a/mteb/tasks/bitext_mining/multilingual/bible_nlp_bitext_mining.py
+++ b/mteb/tasks/bitext_mining/multilingual/bible_nlp_bitext_mining.py
@@ -941,5 +941,4 @@ class BibleNLPBitextMining(AbsTaskBitextMining):
             parts[index1], parts[index2] = parts[index2], parts[index1]
             new_string = "-".join(parts)
             return new_string
-        else:
-            return string
+        return string

--- a/mteb/tasks/bitext_mining/multilingual/in22_conv_bitext_mining.py
+++ b/mteb/tasks/bitext_mining/multilingual/in22_conv_bitext_mining.py
@@ -58,8 +58,7 @@ def check_uniques(example, uniques):
     if example["hash"] in uniques:
         uniques.remove(example["hash"])
         return True
-    else:
-        return False
+    return False
 
 
 class IN22ConvBitextMining(AbsTaskBitextMining):

--- a/mteb/types/_encoder_io.py
+++ b/mteb/types/_encoder_io.py
@@ -180,9 +180,9 @@ class OutputDType(HelpfulStrEnum):
         """
         if self == OutputDType.UINT4:
             return torch.uint8
-        elif self == OutputDType.INT4:
+        if self == OutputDType.INT4:
             return torch.int8
-        elif self == OutputDType.BINARY:
+        if self == OutputDType.BINARY:
             return torch.bool
         return cast("torch.dtype", getattr(torch, self.value))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -335,6 +335,7 @@ select = [
     "B",       # flake8-bugbear
     "PT",      # flake8-pytest-style
     "A",       # flake8-builtins, don't shadow builtins
+    "RET",     # flake8-return
 ]
 
 ignore = [
@@ -358,6 +359,7 @@ ignore = [
     "PLW0717",  # too-many-statements-in-try-clause
     "ISC001",   # single-line implicit concat; conflicts with `ruff format`
     "PT018",    # composite assertions; splitting `assert a and b` is not always clearer
+    "RET504",   # unnecessary-assign; named intermediate results often aid readability
 ]
 future-annotations = true  # For TC rules
 typing-modules = ["typing_extensions", "mteb.types", "collections.abc"]
@@ -616,6 +618,7 @@ extend-ignore-re = [
     "author.*",  # ignore authors in citations
     "editor.*",  # ignore authors in citations
     "FIne-Grained Music retrievAl",  # stylised paper title (FIGMA)
+    "@\\w+\\{[^,\n]+,",  # bibtex entry keys are arbitrary identifiers
 ]
 
 [tool.typos.files]

--- a/tests/test_models/model_loading.py
+++ b/tests/test_models/model_loading.py
@@ -28,7 +28,7 @@ def get_model_below_n_param_threshold(model_name: str, threshold: float = 2e9) -
     if model_meta.n_parameters is not None:
         if model_meta.n_parameters >= threshold:
             return "Over threshold. Not tested."
-        elif "API" in model_meta.framework:
+        if "API" in model_meta.framework:
             try:
                 m = get_model(model_name)
                 if m is not None:
@@ -47,6 +47,7 @@ def get_model_below_n_param_threshold(model_name: str, threshold: float = 2e9) -
         except Exception as e:
             logger.warning(f"Failed to load model {model_name} with error {e}")
             return str(e)
+    return "n_parameters not specified. Not tested."
 
 
 def parse_args():


### PR DESCRIPTION
refs #2416.
Enables `RET` (flake8-return) ruff rule. `RET504` (unnecessary-assign) is **not** enabled — it accounts for 117 of the 197 hits and removes named intermediate results that often aid readability. It's in `ignore` with a comment.

| Rule | n | Fix |
|---|---|---|
| `RET505` superfluous-else-return | 62 | Dropped `else` after `return` |
| `RET503` implicit-return | 7 | See below |
| `RET507` superfluous-else-continue | 6 | Autofix |
| `RET506` superfluous-else-raise | 4 | Autofix |
| `RET502` implicit-return-value | 1 | Autofix |

118 fixes were applied rather than 80: de-indenting an `else` block exposes more of the same pattern nested within, and ruff iterates to a fixpoint.

The 7 `RET503` were fixed at the cause rather than by appending `return None`:

- A `-> None` method was propagating `super()`'s return value.
- Two functions dispatching on `Literal["wide", "long"]` used two separate `if`s, so an unexpected value silently returned `None`. The second branch is now the exhaustive fall-through.
- Two untyped retry loops get an explicit `return None` (behaviour-identical).
- One `-> list[float]` coroutine raises instead, since `None` would contradict the annotation and the tail is unreachable.
- A `-> str` test helper returned `None` for models with no `n_parameters`, serialising as `null`; it now returns a descriptive string.