### PR TITLE
Enables `SIM` (flake8-simplify) Ruff Rule

### DIFF
--- a/mteb/_create_dataloaders.py
+++ b/mteb/_create_dataloaders.py
@@ -284,13 +284,12 @@ def _prepare_dataset(
                 num_proc=num_proc,
             )
     for modality in ("audio", "video"):
-        if modality in modalities:
-            if (
-                input_column
-                and input_column in dataset.column_names
-                and modality not in dataset.column_names
-            ):
-                dataset = dataset.rename_column(input_column, modality)
+        if modality in modalities and (
+            input_column
+            and input_column in dataset.column_names
+            and modality not in dataset.column_names
+        ):
+            dataset = dataset.rename_column(input_column, modality)
 
     # Drop modality columns not needed for this prompt type to avoid
     # None values in the collate function (e.g. text=None in image-only corpus)

--- a/mteb/_evaluators/retrieval_metrics.py
+++ b/mteb/_evaluators/retrieval_metrics.py
@@ -386,7 +386,7 @@ def paired_accuracy(
     """
     # group the queries by the query id
     query_keys = set()
-    for key in qrels.keys():
+    for key in qrels:
         query_keys.add(key.split("_")[0])
 
     paired_scores = []
@@ -417,7 +417,7 @@ def robustness_at_10(
         The robustness at 10 score
     """
     query_keys = defaultdict(list)
-    for key in qrels.keys():
+    for key in qrels:
         query_keys[key.split("_")[0]].append(key)
 
     robustness_scores = []
@@ -494,7 +494,7 @@ def parse_metrics_from_scores(
         defaultdict(list),
     )
 
-    for query_id in scores.keys():
+    for query_id in scores:
         for k in k_values:
             all_ndcgs[f"NDCG@{k}"].append(scores[query_id]["ndcg_cut_" + str(k)])
             all_aps[f"MAP@{k}"].append(scores[query_id]["map_cut_" + str(k)])
@@ -542,7 +542,7 @@ def max_over_subqueries(
         A dictionary with the scores, prefixed with "max_over_subqueries_"
     """
     query_keys = defaultdict(list)
-    for key in qrels.keys():
+    for key in qrels:
         query_keys["_".join(key.split("_")[:-1])].append(key)
 
     new_results = {}
@@ -619,7 +619,7 @@ def calculate_retrieval_scores(  # noqa: PLR0914
     )
     naucs_mrr = evaluate_abstention(results, mrr_scores)
 
-    avg_mrr = {k: sum(mrr_scores[k]) / len(mrr_scores[k]) for k in mrr_scores.keys()}
+    avg_mrr = {k: sum(mrr_scores[k]) / len(mrr_scores[k]) for k in mrr_scores}
     return RetrievalEvaluationResult(
         all_scores=scores,
         ndcg=ndcg,

--- a/mteb/_evaluators/text/bitext_mining_evaluator.py
+++ b/mteb/_evaluators/text/bitext_mining_evaluator.py
@@ -48,9 +48,7 @@ class BitextMiningEvaluator(Evaluator):
     ) -> dict[str, list[dict[str, float]]]:
         pair_elements = {p for pair in self.pairs for p in pair}
         if isinstance(self.sentences, Dataset):
-            subsets = [
-                col for col in self.sentences.features.keys() if col in pair_elements
-            ]
+            subsets = [col for col in self.sentences.features if col in pair_elements]
         else:
             # BUCC outputs a dict instead of a Dataset
             subsets = list(pair_elements)

--- a/mteb/abstasks/abstask.py
+++ b/mteb/abstasks/abstask.py
@@ -401,7 +401,7 @@ class AbsTask(ABC):  # noqa: PLR0904
         """
         self.dataset = {}
         merged_dataset = load_dataset(**self.metadata.dataset)  # load "default" subset
-        for split in merged_dataset.keys():
+        for split in merged_dataset:
             df_split = merged_dataset[split].to_polars()
             df_grouped = dict(df_split.group_by(["lang"]))
             for lang in set(df_split["lang"].unique()) & set(self.hf_subsets):
@@ -580,9 +580,12 @@ class AbsTask(ABC):  # noqa: PLR0904
                         subsets_to_keep.append(hf_subset)
                         break
 
-            if exclusive_language_filter is True and languages:
-                if lang_scripts.contains_languages(langs):
-                    subsets_to_keep.append(hf_subset)
+            if (
+                exclusive_language_filter is True
+                and languages
+                and lang_scripts.contains_languages(langs)
+            ):
+                subsets_to_keep.append(hf_subset)
 
         if len(subsets_to_keep) == 0:
             raise ValueError(

--- a/mteb/abstasks/classification.py
+++ b/mteb/abstasks/classification.py
@@ -438,7 +438,7 @@ class AbsTaskClassification(AbsTask):
                 if (values := [s[k] for s in scores if s[k] is not None])  # type: ignore[literal-required]
                 else np.nan
             )
-            for k in scores[0].keys()
+            for k in scores[0]
         }
         logger.info(f"Running {self.metadata.name} - Finished.")
         return FullClassificationMetrics(  # type: ignore[no-any-return]

--- a/mteb/abstasks/multilabel_classification.py
+++ b/mteb/abstasks/multilabel_classification.py
@@ -229,7 +229,7 @@ class AbsTaskMultilabelClassification(AbsTaskClassification):
 
         avg_scores: dict[str, np.floating[Any]] = {
             k: np.mean([s[k] for s in scores])  # type: ignore[literal-required]
-            for k in scores[0].keys()
+            for k in scores[0]
         }
         logger.info("Running multilabel classification - Finished.")
         return FullMultilabelClassificationMetrics(  # type: ignore[no-any-return]

--- a/mteb/abstasks/pair_classification.py
+++ b/mteb/abstasks/pair_classification.py
@@ -348,19 +348,16 @@ class AbsTaskPairClassification(AbsTask):
 
         best_f1 = best_precision = best_recall = 0.0
         threshold = 0
-        nextract = 0
         ncorrect = 0
         total_num_duplicates = sum(labels)
 
-        for i in range(len(rows) - 1):
-            score, label = rows[i]
-            nextract += 1
-
+        for i, (_score, label) in enumerate(rows[:-1]):
             if label == 1:
                 ncorrect += 1
 
             if ncorrect > 0:
-                precision = ncorrect / nextract
+                # i is 0-based, so i + 1 is the number of rows extracted so far
+                precision = ncorrect / (i + 1)
                 recall = ncorrect / total_num_duplicates
                 f1 = 2 * precision * recall / (precision + recall)
                 if f1 > best_f1:

--- a/mteb/api/warmup.py
+++ b/mteb/api/warmup.py
@@ -49,33 +49,37 @@ def _prewarm_training_datasets() -> None:
 
     Why: first summary build otherwise pays ~2.5s per first-seen model.
     """
-    with _timed(f"training-datasets ({len(MODEL_REGISTRY)} models)"):
-        with ThreadPoolExecutor(max_workers=16, thread_name_prefix="warm-td") as ex:
-            list(ex.map(_training_datasets_cached, MODEL_REGISTRY))
+    with (
+        _timed(f"training-datasets ({len(MODEL_REGISTRY)} models)"),
+        ThreadPoolExecutor(max_workers=16, thread_name_prefix="warm-td") as ex,
+    ):
+        list(ex.map(_training_datasets_cached, MODEL_REGISTRY))
 
 
 def _prewarm_list_schemas() -> None:
     """Pre-build the unfiltered list schemas + serialised bytes (threaded)."""
-    with _timed("list schemas"):
-        with ThreadPoolExecutor(max_workers=4, thread_name_prefix="warm-list") as ex:
-            futures = [
-                ex.submit(_menu_schemas_bytes),
-                ex.submit(_benchmark_schemas_bytes),
-                ex.submit(_filtered_task_schemas_bytes, None, None, None, None, None),
-                ex.submit(
-                    _filtered_model_schemas_bytes,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    False,
-                ),
-            ]
-            for f in futures:
-                f.result()
+    with (
+        _timed("list schemas"),
+        ThreadPoolExecutor(max_workers=4, thread_name_prefix="warm-list") as ex,
+    ):
+        futures = [
+            ex.submit(_menu_schemas_bytes),
+            ex.submit(_benchmark_schemas_bytes),
+            ex.submit(_filtered_task_schemas_bytes, None, None, None, None, None),
+            ex.submit(
+                _filtered_model_schemas_bytes,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                False,
+            ),
+        ]
+        for f in futures:
+            f.result()
 
 
 def _load_per_benchmark_frames_logged() -> None:

--- a/mteb/cache/result_cache.py
+++ b/mteb/cache/result_cache.py
@@ -361,9 +361,9 @@ class ResultCache:
                 remote=True,
                 experiment_name=experiment_name,
             )
-            if remote_result_path.exists() and prioritize_remote:
-                result_path = remote_result_path
-            elif not result_path.exists():
+            if (
+                remote_result_path.exists() and prioritize_remote
+            ) or not result_path.exists():
                 result_path = remote_result_path
 
         if not result_path.exists():
@@ -867,7 +867,7 @@ class ResultCache:
 
         def _get_paths(base_path: Path, experiments: LoadExperimentEnum) -> list[Path]:
             paths = _cache_paths(base_path)
-            if not experiments == LoadExperimentEnum.NO_EXPERIMENTS:
+            if experiments != LoadExperimentEnum.NO_EXPERIMENTS:
                 paths += _experiments_paths(base_path)
             return paths
 

--- a/mteb/deprecated_evaluator.py
+++ b/mteb/deprecated_evaluator.py
@@ -201,11 +201,10 @@ class MTEB:
 
         missing_splits = []
         for split in task_eval_splits:
-            if split not in existing_results.scores:
-                missing_splits.append(split)
-            elif not existing_results.scores[
-                split
-            ]:  # Check if the split has any scores
+            if (
+                split not in existing_results.scores
+                or not existing_results.scores[split]
+            ):
                 missing_splits.append(split)
 
         return missing_splits

--- a/mteb/languages/language_scripts.py
+++ b/mteb/languages/language_scripts.py
@@ -89,9 +89,7 @@ class LanguageScripts:
         else:
             _lang = language
 
-        if _lang in self.languages:
-            return True
-        return False
+        return _lang in self.languages
 
     def contains_languages(self, languages: Iterable[str]) -> bool:
         """Whether is containing all the languages
@@ -102,10 +100,7 @@ class LanguageScripts:
         Returns:
             True if all languages are contained in the set, False otherwise.
         """
-        for l in languages:
-            if not self.contains_language(l):
-                return False
-        return True
+        return all(self.contains_language(l) for l in languages)
 
     def contains_script(self, script: str) -> bool:
         """Whether the set contains a specific script.
@@ -127,7 +122,4 @@ class LanguageScripts:
         Returns:
             True if all scripts are contained in the set, False otherwise.
         """
-        for s in scripts:
-            if not self.contains_script(s):
-                return False
-        return True
+        return all(self.contains_script(s) for s in scripts)

--- a/mteb/leaderboard/app.py
+++ b/mteb/leaderboard/app.py
@@ -80,9 +80,9 @@ def _set_benchmark_on_load(request: gr.Request):
 
 
 def _download_table(table: pd.DataFrame) -> str:
-    file = tempfile.NamedTemporaryFile(delete=False, suffix=".csv")
-    table.to_csv(file)
-    return file.name
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".csv") as file:
+        table.to_csv(file)
+        return file.name
 
 
 def _update_citation(benchmark_name: str) -> str:
@@ -219,9 +219,8 @@ def _filter_models(
         if is_model_zero_shot is None:
             if zero_shot_setting in ["remove_unknown", "only_zero_shot"]:  # noqa: PLR6201
                 continue
-        elif not is_model_zero_shot:
-            if zero_shot_setting == "only_zero_shot":
-                continue
+        elif not is_model_zero_shot and zero_shot_setting == "only_zero_shot":
+            continue
         models_to_keep.add(model_meta.name)
     return list(models_to_keep)
 
@@ -229,9 +228,7 @@ def _filter_models(
 def _should_show_zero_shot_filter(benchmark_name: str) -> bool:
     benchmark = mteb.get_benchmark(benchmark_name)
 
-    if isinstance(benchmark, RtebBenchmark):
-        return False
-    return True
+    return not isinstance(benchmark, RtebBenchmark)
 
 
 @cachetools.cached(

--- a/mteb/load_results.py
+++ b/mteb/load_results.py
@@ -120,12 +120,15 @@ def load_results(  # noqa: PLR0914
             model_name = model_name.replace("__", "/")
             if models_to_keep is not None and model_name not in models_to_keep:
                 continue
-            if models_to_keep is not None and models_to_keep[model_name] is not None:
-                if models_to_keep[model_name] != revision:
-                    continue
+            if (
+                models_to_keep is not None
+                and models_to_keep[model_name] is not None
+                and models_to_keep[model_name] != revision
+            ):
+                continue
 
             task_json_files = [
-                f for f in revision_path.glob("*.json") if "model_meta.json" != f.name
+                f for f in revision_path.glob("*.json") if f.name != "model_meta.json"
             ]
             _results = []
             for f in task_json_files:

--- a/mteb/mocks/mock_run.py
+++ b/mteb/mocks/mock_run.py
@@ -193,9 +193,12 @@ def get_compatible_mock_tasks(
             continue
 
         # SearchProtocol / Retrieval-only models (like BM25)
-        if isinstance(model, SearchProtocol) and not isinstance(model, EncoderProtocol):
-            if not task._support_search:
-                continue
+        if (
+            isinstance(model, SearchProtocol)
+            and not isinstance(model, EncoderProtocol)
+            and not task._support_search
+        ):
+            continue
 
         # CrossEncoder models
         if isinstance(model, CrossEncoderProtocol) and not task._support_cross_encoder:

--- a/mteb/models/abs_encoder.py
+++ b/mteb/models/abs_encoder.py
@@ -264,10 +264,11 @@ class AbsEncoder(ABC):
             The instruction to be used for encoding sentences.
         """
         instruction = self.get_instruction(task_metadata, prompt_type)
-        if self.instruction_template:
-            # Always invoke callables. Issue https://github.com/embeddings-benchmark/mteb/issues/4683
-            if callable(self.instruction_template) or len(instruction) > 0:
-                return self.format_instruction(instruction, prompt_type)
+        # Always invoke callables. Issue https://github.com/embeddings-benchmark/mteb/issues/4683
+        if self.instruction_template and (
+            callable(self.instruction_template) or len(instruction) > 0
+        ):
+            return self.format_instruction(instruction, prompt_type)
         return instruction
 
     def similarity(self, embeddings1: Array, embeddings2: Array) -> Array:

--- a/mteb/models/get_model_meta.py
+++ b/mteb/models/get_model_meta.py
@@ -65,11 +65,11 @@ def get_model_metas(  # noqa: PLR0913, PLR0917
     for model_meta in model_metas:
         if (model_names is not None) and (model_meta.name not in model_names):
             continue
-        if languages is not None:
-            if (model_meta.languages is None) or not (
-                languages <= set(model_meta.languages)
-            ):
-                continue
+        if languages is not None and (
+            (model_meta.languages is None)
+            or not (languages <= set(model_meta.languages))
+        ):
+            continue
         if (open_weights is not None) and (model_meta.open_weights != open_weights):
             continue
         if (frameworks is not None) and not (frameworks <= set(model_meta.framework)):
@@ -99,9 +99,8 @@ def get_model_metas(  # noqa: PLR0913, PLR0917
             if lower is not None and n_parameters < lower:
                 continue
 
-        if zero_shot_on is not None:
-            if not model_meta.is_zero_shot_on(zero_shot_on):
-                continue
+        if zero_shot_on is not None and not model_meta.is_zero_shot_on(zero_shot_on):
+            continue
         res.append(model_meta)
     return res
 
@@ -208,7 +207,7 @@ def get_model_meta(
     not_found_msg += " nor on the Huggingface Hub." if fetch_from_hf else "."
 
     close_matches = difflib.get_close_matches(model_name, MODEL_REGISTRY.keys())
-    model_names_no_org = {mdl: mdl.split("/")[-1] for mdl in MODEL_REGISTRY.keys()}
+    model_names_no_org = {mdl: mdl.split("/")[-1] for mdl in MODEL_REGISTRY}
     if model_name in model_names_no_org:
         close_matches = [model_names_no_org[model_name]] + close_matches
 

--- a/mteb/models/modality_collators.py
+++ b/mteb/models/modality_collators.py
@@ -69,10 +69,7 @@ class AudioCollator:
             collated_inputs.append(row)
         return cast(
             "BatchedInput",
-            {
-                key: [row[key] for row in collated_inputs]
-                for key in collated_inputs[0].keys()
-            },
+            {key: [row[key] for row in collated_inputs] for key in collated_inputs[0]},
         )
 
     @staticmethod
@@ -178,10 +175,7 @@ class FramesCollator:
             collated_inputs.append(row)
         return cast(
             "BatchedInput",
-            {
-                key: [row[key] for row in collated_inputs]
-                for key in collated_inputs[0].keys()
-            },
+            {key: [row[key] for row in collated_inputs] for key in collated_inputs[0]},
         )
 
     @staticmethod
@@ -304,8 +298,5 @@ class VideoCollator:
             collated_inputs.append(row)
         return cast(
             "BatchedInput",
-            {
-                key: [row[key] for row in collated_inputs]
-                for key in collated_inputs[0].keys()
-            },
+            {key: [row[key] for row in collated_inputs] for key in collated_inputs[0]},
         )

--- a/mteb/models/model_implementations/colqwen_models.py
+++ b/mteb/models/model_implementations/colqwen_models.py
@@ -171,11 +171,10 @@ class ColQwen3_5Wrapper(AbsEncoder):  # noqa: N801
                     texts = batch["text"]
                 else:
                     texts = None
-                if contains_both:
-                    if len(imgs) != len(texts):
-                        raise ValueError(
-                            f"The number of texts and images must have the same length, got {len(imgs)} and {len(texts)}"
-                        )
+                if contains_both and len(imgs) != len(texts):
+                    raise ValueError(
+                        f"The number of texts and images must have the same length, got {len(imgs)} and {len(texts)}"
+                    )
 
                 if contains_image:
                     imgs = [img.convert("RGB") for img in imgs]
@@ -303,11 +302,10 @@ class ColQwen3Wrapper(AbsEncoder):
                     texts = batch["text"]
                 else:
                     texts = None
-                if contains_both:
-                    if len(imgs) != len(texts):
-                        raise ValueError(
-                            f"The number of texts and images must have the same length, got {len(imgs)} and {len(texts)}"
-                        )
+                if contains_both and len(imgs) != len(texts):
+                    raise ValueError(
+                        f"The number of texts and images must have the same length, got {len(imgs)} and {len(texts)}"
+                    )
 
                 inputs = self.processor(images=imgs, text=texts)
                 inputs = {k: v.to(self.device) for k, v in inputs.items()}

--- a/mteb/models/model_implementations/geevec_models.py
+++ b/mteb/models/model_implementations/geevec_models.py
@@ -538,25 +538,24 @@ class GeeVecAPIModel(AbsEncoder):
                 optional_fields = {}
                 continue
 
-            if response.status_code == 400 and self._is_context_window_error(
-                response.text
+            # Adaptive fallback: progressively shorten each input until it fits.
+            if (
+                response.status_code == 400
+                and self._is_context_window_error(response.text)
+                and current_max_chars > self._min_input_chars
             ):
-                # Adaptive fallback: progressively shorten each input until it fits.
-                if current_max_chars > self._min_input_chars:
-                    next_max_chars = max(
-                        self._min_input_chars, int(current_max_chars * 0.8)
+                next_max_chars = max(
+                    self._min_input_chars, int(current_max_chars * 0.8)
+                )
+                if next_max_chars < current_max_chars:
+                    logger.warning(
+                        "GeeVec API context window exceeded; reducing max chars per text from %s to %s and retrying.",
+                        current_max_chars,
+                        next_max_chars,
                     )
-                    if next_max_chars < current_max_chars:
-                        logger.warning(
-                            "GeeVec API context window exceeded; reducing max chars per text from %s to %s and retrying.",
-                            current_max_chars,
-                            next_max_chars,
-                        )
-                        current_max_chars = next_max_chars
-                        req_texts = self._truncate_texts_by_chars(
-                            texts, current_max_chars
-                        )
-                        continue
+                    current_max_chars = next_max_chars
+                    req_texts = self._truncate_texts_by_chars(texts, current_max_chars)
+                    continue
 
             if response.status_code >= 400:
                 raise RuntimeError(

--- a/mteb/models/model_implementations/google_gemini.py
+++ b/mteb/models/model_implementations/google_gemini.py
@@ -236,15 +236,14 @@ def _video_to_mp4_bytes(frames: torch.Tensor, *, fps: float) -> bytes:
         raise ValueError(f"Expected a positive video FPS, got {fps}")
 
     video_frames = frames.detach().cpu()
-    if video_frames.is_floating_point():
-        # TorchCodec currently returns uint8, but accepting normalized tensors
-        # makes this boundary safe for other frame providers too.
-        if video_frames.numel():
-            min_value = video_frames.min().item()
-            max_value = video_frames.max().item()
+    # TorchCodec currently returns uint8, but accepting normalized tensors
+    # makes this boundary safe for other frame providers too.
+    if video_frames.is_floating_point() and video_frames.numel():
+        min_value = video_frames.min().item()
+        max_value = video_frames.max().item()
 
-            if min_value >= 0 and max_value <= 1:
-                video_frames = torch.mul(video_frames, 255)
+        if min_value >= 0 and max_value <= 1:
+            video_frames = torch.mul(video_frames, 255)
     if video_frames.dtype != torch.uint8:
         video_frames = video_frames.clamp(0, 255).to(torch.uint8)
 

--- a/mteb/models/model_implementations/msclap_models.py
+++ b/mteb/models/model_implementations/msclap_models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import logging
 import tempfile
 from pathlib import Path
@@ -74,8 +75,11 @@ class MSClapWrapper(AbsEncoder):
             try:
                 for array in audio_arrays:
                     # Write to temp file - msclap expects file paths
-                    temp_file = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
-                    temp_files.append(temp_file.name)
+                    with tempfile.NamedTemporaryFile(
+                        suffix=".wav", delete=False
+                    ) as temp_file:
+                        temp_files.append(temp_file.name)
+                    # write after closing the handle so soundfile owns the file
                     sf.write(temp_file.name, array, self.sampling_rate)
 
                 with torch.no_grad():
@@ -93,10 +97,8 @@ class MSClapWrapper(AbsEncoder):
                 # Clean up temp files
 
                 for f in temp_files:
-                    try:
+                    with contextlib.suppress(OSError):
                         Path(f).unlink()
-                    except OSError:
-                        pass
 
         return np.vstack(all_embeddings)
 

--- a/mteb/models/model_implementations/omnivinci_models.py
+++ b/mteb/models/model_implementations/omnivinci_models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import os
 import pathlib
 import tempfile
@@ -182,10 +183,8 @@ class OmniVinciWrapper(AbsEncoder):
 
         finally:
             for f in temp_files:
-                try:
+                with contextlib.suppress(OSError):
                     pathlib.Path(f).unlink()
-                except OSError:
-                    pass
 
     @torch.inference_mode()
     def encode(

--- a/mteb/models/model_implementations/openai_models.py
+++ b/mteb/models/model_implementations/openai_models.py
@@ -113,7 +113,7 @@ class OpenAIModel(AbsEncoder):
         # Set dimensions only for models that support it
         dimensions = (
             self._embed_dim or NotGiven()
-            if not self.model_name == "text-embedding-ada-002"
+            if self.model_name != "text-embedding-ada-002"
             else NotGiven()
         )
         default_kwargs = dict(

--- a/mteb/models/model_implementations/repllama_models.py
+++ b/mteb/models/model_implementations/repllama_models.py
@@ -116,18 +116,17 @@ class RepLLaMAModel(AbsEncoder):
                 key: value.to(self.model.device) for key, value in batch_dict.items()
             }
 
-            with torch.cuda.amp.autocast():
-                with torch.no_grad():
-                    outputs = self.model(**batch_dict)
-                    last_hidden_state = outputs.last_hidden_state
-                    sequence_lengths = batch_dict["attention_mask"].sum(dim=1) - 1
-                    batch_size = last_hidden_state.shape[0]
-                    reps = last_hidden_state[
-                        torch.arange(batch_size, device=last_hidden_state.device),
-                        sequence_lengths,
-                    ]
-                    embeddings = F.normalize(reps, p=2, dim=-1)
-                    all_embeddings.append(embeddings.cpu().detach().numpy())
+            with torch.cuda.amp.autocast(), torch.no_grad():
+                outputs = self.model(**batch_dict)
+                last_hidden_state = outputs.last_hidden_state
+                sequence_lengths = batch_dict["attention_mask"].sum(dim=1) - 1
+                batch_size = last_hidden_state.shape[0]
+                reps = last_hidden_state[
+                    torch.arange(batch_size, device=last_hidden_state.device),
+                    sequence_lengths,
+                ]
+                embeddings = F.normalize(reps, p=2, dim=-1)
+                all_embeddings.append(embeddings.cpu().detach().numpy())
 
         return np.concatenate(all_embeddings, axis=0)
 

--- a/mteb/models/model_implementations/rerankers_monot5_based.py
+++ b/mteb/models/model_implementations/rerankers_monot5_based.py
@@ -78,8 +78,8 @@ class MonoT5Reranker(RerankerWrapper):
         self.token_false_id, self.token_true_id = self.get_prediction_tokens(
             model_name_or_path,
             self.tokenizer,
-            kwargs["token_false"] if "token_false" in kwargs else None,
-            kwargs["token_true"] if "token_true" in kwargs else None,
+            kwargs.get("token_false"),
+            kwargs.get("token_true"),
         )
         logger.info(f"Using max_length of {self.tokenizer.model_max_length}")
         logger.info(f"Using token_false_id of {self.token_false_id}")

--- a/mteb/models/model_implementations/seed_models.py
+++ b/mteb/models/model_implementations/seed_models.py
@@ -79,10 +79,7 @@ class SeedTextEmbeddingModel(AbsEncoder):
             )
 
         if prompt_type == PromptType("query") or prompt_type is None:
-            if task_name in TASK_NAME_TO_INSTRUCTION:
-                instruction = TASK_NAME_TO_INSTRUCTION[task_name]
-            else:
-                instruction = DEFAULT_INSTRUCTION
+            instruction = TASK_NAME_TO_INSTRUCTION.get(task_name, DEFAULT_INSTRUCTION)
             inputs = [instruction + i for i in inputs]
 
         response = self._client.embeddings.create(

--- a/mteb/models/model_implementations/viclip_models.py
+++ b/mteb/models/model_implementations/viclip_models.py
@@ -61,9 +61,7 @@ class ViCLIPWrapper(AbsEncoder):
         """Normalize (T, C, H, W) frame tensor to ViCLIP input format."""
         import torch.nn.functional as F
 
-        if frames.dtype == torch.uint8:
-            frames = frames.float() / 255.0
-        elif frames.max() > 1.0:
+        if frames.dtype == torch.uint8 or frames.max() > 1.0:
             frames = frames.float() / 255.0
         else:
             frames = frames.float()

--- a/mteb/models/model_meta.py
+++ b/mteb/models/model_meta.py
@@ -1084,9 +1084,8 @@ class ModelMeta(BaseModel):  # noqa: PLR0904
         sbert_config = _get_json_from_hub(
             model_name, "sentence_bert_config.json", "model", revision=revision
         )
-        if sbert_config:
-            if max_tokens is None:
-                max_tokens = sbert_config.get("max_seq_length", None)
+        if sbert_config and max_tokens is None:
+            max_tokens = sbert_config.get("max_seq_length", None)
         # have model type, similarity function fields
         config_sbert = _get_json_from_hub(
             model_name, "config_sentence_transformers.json", "model", revision=revision

--- a/mteb/results/benchmark_results.py
+++ b/mteb/results/benchmark_results.py
@@ -206,9 +206,10 @@ class BenchmarkResults(BaseModel):  # noqa: PLR0904
         for model_res in self.model_results:
             model_name = model_res.model_name
             revision = model_res.model_revision
-            if model_name in name_rev:
-                if name_rev[model_name] is None or revision == name_rev[model_name]:
-                    models_res.append(model_res)
+            if model_name in name_rev and (
+                name_rev[model_name] is None or revision == name_rev[model_name]
+            ):
+                models_res.append(model_res)
 
         return type(self).model_construct(model_results=models_res)
 

--- a/mteb/results/task_result.py
+++ b/mteb/results/task_result.py
@@ -526,9 +526,9 @@ class TaskResult(BaseModel):  # noqa: PLR0904
             "1.1.3.dev0",
         ]:
             scores["test"]["fr"] = scores["test"].pop("default")
-        if task_name == "XPQARetrieval":  # subset were renamed from "fr" to "fra-fra"
-            if "test" in scores and "fr" in scores["test"]:
-                scores["test"]["fra-fra"] = scores["test"].pop("fr")
+        # subset were renamed from "fr" to "fra-fra"
+        if task_name == "XPQARetrieval" and "test" in scores and "fr" in scores["test"]:
+            scores["test"]["fra-fra"] = scores["test"].pop("fr")
 
         result: TaskResult = TaskResult.from_task_results(
             task,

--- a/mteb/tasks/bitext_mining/multilingual/ntrex_bitext_mining.py
+++ b/mteb/tasks/bitext_mining/multilingual/ntrex_bitext_mining.py
@@ -220,19 +220,18 @@ def extend_lang_pairs() -> dict[str, list[str]]:
     - source and target are from same language grouping
     """
     hf_lang_subset2isolang = {}
-    for x in _LANGUAGES.keys():
-        for y in _LANGUAGES.keys():
-            if x != y:
-                if (
-                    ("eng_Latn" in (x, y))  # noqa: PLR6201
-                    or (all(var in _BRIDGE_LANGUAGES for var in (x, y)))
-                    or (_LANGUAGES[x]["group"] == _LANGUAGES[y]["group"])
-                ):
-                    pair = f"{x}-{y}"
-                    hf_lang_subset2isolang[pair] = [
-                        x.replace("_", "-"),
-                        y.replace("_", "-"),
-                    ]
+    for x in _LANGUAGES:
+        for y in _LANGUAGES:
+            if x != y and (
+                ("eng_Latn" in (x, y))  # noqa: PLR6201
+                or (all(var in _BRIDGE_LANGUAGES for var in (x, y)))
+                or (_LANGUAGES[x]["group"] == _LANGUAGES[y]["group"])
+            ):
+                pair = f"{x}-{y}"
+                hf_lang_subset2isolang[pair] = [
+                    x.replace("_", "-"),
+                    y.replace("_", "-"),
+                ]
 
     return hf_lang_subset2isolang
 

--- a/mteb/tasks/classification/eng/common_language_age_detection.py
+++ b/mteb/tasks/classification/eng/common_language_age_detection.py
@@ -46,7 +46,7 @@ Mirco Ravanelli},
 
     def dataset_transform(self, **kwargs):
         # remove rows where age is "not_defined" or "eighties" <- only 1 label so messes up stratified subsampling
-        for split in self.dataset.keys():
+        for split in self.dataset:
             self.dataset[split] = self.dataset[split].filter(
                 lambda example: example["age"] not in ["not_defined", "eighties"]  # noqa: PLR6201
             )

--- a/mteb/tasks/classification/eng/vox_populi_accent_id.py
+++ b/mteb/tasks/classification/eng/vox_populi_accent_id.py
@@ -64,9 +64,7 @@ Dupoux, Emmanuel},
             # require at least 500 samples (so that Kaldi fbank(window_size=400) won't fail)
             if (audio_arr is None) or (len(audio_arr) < 500):
                 return False
-            if np.isnan(audio_arr).any() or np.isinf(audio_arr).any():
-                return False
-            return True
+            return not (np.isnan(audio_arr).any() or np.isinf(audio_arr).any())
 
         filtered_test = test_ds.filter(is_valid_audio)
 

--- a/mteb/tasks/classification/multilingual/masakha_news_classification.py
+++ b/mteb/tasks/classification/multilingual/masakha_news_classification.py
@@ -59,7 +59,7 @@ class MasakhaNEWSClassification(AbsTaskClassification):
         self,
         num_proc: int | None = None,
     ):
-        for lang in self.dataset.keys():
+        for lang in self.dataset:
             self.dataset[lang] = self.dataset[lang].rename_columns(
                 {"category": "label"}
             )

--- a/mteb/tasks/classification/multilingual/multi_hate_classification.py
+++ b/mteb/tasks/classification/multilingual/multi_hate_classification.py
@@ -91,7 +91,7 @@ Talat, Zeerak},
         num_proc: int | None = None,
     ):
         # for each language perform some transforms
-        for lang in self.dataset.keys():
+        for lang in self.dataset:
             _dataset = self.dataset[lang]
             _dataset = _dataset.rename_columns({"is_hateful": "label"})
             for label in ["label", "functionality"]:

--- a/mteb/tasks/classification/multilingual/multilingual_sentiment_classification.py
+++ b/mteb/tasks/classification/multilingual/multilingual_sentiment_classification.py
@@ -95,7 +95,7 @@ Vylomova, Ekaterina},
     ):
         # create a train set from the test set for Welsh language (cym)
         lang = "cym"
-        if lang in self.dataset.keys():
+        if lang in self.dataset:
             _dataset = self.dataset[lang]
             _dataset = _dataset.class_encode_column("label")
             _dataset = _dataset["test"].train_test_split(

--- a/mteb/tasks/classification/multilingual/scala_classification.py
+++ b/mteb/tasks/classification/multilingual/scala_classification.py
@@ -58,7 +58,7 @@ Fishel, Mark},
         self,
         num_proc: int | None = None,
     ):
-        for lang in self.dataset.keys():
+        for lang in self.dataset:
             # convert label to a 0/1 label
             labels = self.dataset[lang]["train"]["label"]
             lab2idx = {lab: idx for idx, lab in enumerate(set(labels))}

--- a/mteb/tasks/classification/multilingual/sib200_classification.py
+++ b/mteb/tasks/classification/multilingual/sib200_classification.py
@@ -239,7 +239,7 @@ class SIB200Classification(AbsTaskClassification):
         self,
         num_proc: int | None = None,
     ):
-        for lang in self.dataset.keys():
+        for lang in self.dataset:
             self.dataset[lang] = self.dataset[lang].class_encode_column("category")
             self.dataset[lang] = self.dataset[lang].rename_columns(
                 {"category": "label"}

--- a/mteb/tasks/classification/multilingual/vox_populi_language_id.py
+++ b/mteb/tasks/classification/multilingual/vox_populi_language_id.py
@@ -70,9 +70,7 @@ Dupoux, Emmanuel},
             # require at least 500 samples (so that Kaldi fbank(window_size=400) won't fail)
             if (audio_arr is None) or (len(audio_arr) < 500):
                 return False
-            if np.isnan(audio_arr).any() or np.isinf(audio_arr).any():
-                return False
-            return True
+            return not (np.isnan(audio_arr).any() or np.isinf(audio_arr).any())
 
         filtered_test = test_ds.filter(is_valid_audio)
 

--- a/mteb/tasks/retrieval/code/code_rag.py
+++ b/mteb/tasks/retrieval/code/code_rag.py
@@ -138,8 +138,9 @@ class CodeRAGOnlineTutorialsRetrieval(AbsTaskRetrieval):
         titles = ds["title"]
         texts = ds["text"]
         parsed = ds["parsed"]
-        idx = 0
-        for title, text, _mt in zip(titles, texts, parsed, strict=True):
+        for idx, (title, text, _mt) in enumerate(
+            zip(titles, texts, parsed, strict=True)
+        ):
             # in code-rag-bench,
             # query=doc(code)
             # text=query+doc(code)
@@ -153,8 +154,6 @@ class CodeRAGOnlineTutorialsRetrieval(AbsTaskRetrieval):
             self.relevant_docs[split][query_id] = {
                 doc_id: 1
             }  # only one correct matches
-
-            idx += 1
 
 
 class CodeRAGLibraryDocumentationSolutionsRetrieval(AbsTaskRetrieval):
@@ -253,8 +252,7 @@ class CodeRAGStackoverflowPostsRetrieval(AbsTaskRetrieval):
         self.corpus[split] = {}
 
         texts = ds["text"]
-        idx = 0
-        for text in texts:
+        for idx, text in enumerate(texts):
             # in code-rag-bench,
             # text = query + "\n" + doc
             query, doc = split_by_first_newline(text)
@@ -267,4 +265,3 @@ class CodeRAGStackoverflowPostsRetrieval(AbsTaskRetrieval):
             self.relevant_docs[split][query_id] = {
                 doc_id: 1
             }  # only one correct matches
-            idx += 1

--- a/mteb/tasks/retrieval/dan/danrag_retrieval.py
+++ b/mteb/tasks/retrieval/dan/danrag_retrieval.py
@@ -65,7 +65,7 @@ def _load_danrag_data(
             relevant_docs = {
                 query_id: dict.fromkeys(valid_pages, 1)
                 for query_id, valid_pages in zip(
-                    raw_queries["id"], raw_queries["valid_pages"]
+                    raw_queries["id"], raw_queries["valid_pages"], strict=True
                 )
             }
 

--- a/mteb/tasks/retrieval/eng/bright_v1_1_retrieval.py
+++ b/mteb/tasks/retrieval/eng/bright_v1_1_retrieval.py
@@ -122,7 +122,7 @@ class BrightBiologyRetrieval(AbsTaskRetrieval):
                 path=self.metadata.dataset["path"],
                 eval_splits=self.metadata.eval_splits,
                 domain="biology",
-                cache_dir=kwargs.get("cache_dir", None),
+                cache_dir=kwargs.get("cache_dir"),
                 revision=self.metadata.dataset["revision"],
             )
         )
@@ -166,7 +166,7 @@ class BrightEarthScienceRetrieval(AbsTaskRetrieval):
                 path=self.metadata.dataset["path"],
                 eval_splits=self.metadata.eval_splits,
                 domain="earth_science",
-                cache_dir=kwargs.get("cache_dir", None),
+                cache_dir=kwargs.get("cache_dir"),
                 revision=self.metadata.dataset["revision"],
             )
         )
@@ -210,7 +210,7 @@ class BrightEconomicsRetrieval(AbsTaskRetrieval):
                 path=self.metadata.dataset["path"],
                 eval_splits=self.metadata.eval_splits,
                 domain="economics",
-                cache_dir=kwargs.get("cache_dir", None),
+                cache_dir=kwargs.get("cache_dir"),
                 revision=self.metadata.dataset["revision"],
             )
         )
@@ -254,7 +254,7 @@ class BrightPsychologyRetrieval(AbsTaskRetrieval):
                 path=self.metadata.dataset["path"],
                 eval_splits=self.metadata.eval_splits,
                 domain="psychology",
-                cache_dir=kwargs.get("cache_dir", None),
+                cache_dir=kwargs.get("cache_dir"),
                 revision=self.metadata.dataset["revision"],
             )
         )
@@ -298,7 +298,7 @@ class BrightRoboticsRetrieval(AbsTaskRetrieval):
                 path=self.metadata.dataset["path"],
                 eval_splits=self.metadata.eval_splits,
                 domain="robotics",
-                cache_dir=kwargs.get("cache_dir", None),
+                cache_dir=kwargs.get("cache_dir"),
                 revision=self.metadata.dataset["revision"],
             )
         )
@@ -342,7 +342,7 @@ class BrightStackoverflowRetrieval(AbsTaskRetrieval):
                 path=self.metadata.dataset["path"],
                 eval_splits=self.metadata.eval_splits,
                 domain="stackoverflow",
-                cache_dir=kwargs.get("cache_dir", None),
+                cache_dir=kwargs.get("cache_dir"),
                 revision=self.metadata.dataset["revision"],
             )
         )
@@ -386,7 +386,7 @@ class BrightSustainableLivingRetrieval(AbsTaskRetrieval):
                 path=self.metadata.dataset["path"],
                 eval_splits=self.metadata.eval_splits,
                 domain="sustainable_living",
-                cache_dir=kwargs.get("cache_dir", None),
+                cache_dir=kwargs.get("cache_dir"),
                 revision=self.metadata.dataset["revision"],
             )
         )
@@ -430,7 +430,7 @@ class BrightPonyRetrieval(AbsTaskRetrieval):
                 path=self.metadata.dataset["path"],
                 eval_splits=self.metadata.eval_splits,
                 domain="pony",
-                cache_dir=kwargs.get("cache_dir", None),
+                cache_dir=kwargs.get("cache_dir"),
                 revision=self.metadata.dataset["revision"],
             )
         )
@@ -474,7 +474,7 @@ class BrightLeetcodeRetrieval(AbsTaskRetrieval):
                 path=self.metadata.dataset["path"],
                 eval_splits=self.metadata.eval_splits,
                 domain="leetcode",
-                cache_dir=kwargs.get("cache_dir", None),
+                cache_dir=kwargs.get("cache_dir"),
                 revision=self.metadata.dataset["revision"],
             )
         )
@@ -518,7 +518,7 @@ class BrightAopsRetrieval(AbsTaskRetrieval):
                 path=self.metadata.dataset["path"],
                 eval_splits=self.metadata.eval_splits,
                 domain="aops",
-                cache_dir=kwargs.get("cache_dir", None),
+                cache_dir=kwargs.get("cache_dir"),
                 revision=self.metadata.dataset["revision"],
             )
         )
@@ -562,7 +562,7 @@ class BrightTheoremQATheoremsRetrieval(AbsTaskRetrieval):
                 path=self.metadata.dataset["path"],
                 eval_splits=self.metadata.eval_splits,
                 domain="theoremqa_theorems",
-                cache_dir=kwargs.get("cache_dir", None),
+                cache_dir=kwargs.get("cache_dir"),
                 revision=self.metadata.dataset["revision"],
             )
         )
@@ -606,7 +606,7 @@ class BrightTheoremQAQuestionsRetrieval(AbsTaskRetrieval):
                 path=self.metadata.dataset["path"],
                 eval_splits=self.metadata.eval_splits,
                 domain="theoremqa_questions",
-                cache_dir=kwargs.get("cache_dir", None),
+                cache_dir=kwargs.get("cache_dir"),
                 revision=self.metadata.dataset["revision"],
             )
         )
@@ -650,7 +650,7 @@ class BrightBiologyLongRetrieval(AbsTaskRetrieval):
                 path=self.metadata.dataset["path"],
                 eval_splits=self.metadata.eval_splits,
                 domain="biology",
-                cache_dir=kwargs.get("cache_dir", None),
+                cache_dir=kwargs.get("cache_dir"),
                 revision=self.metadata.dataset["revision"],
             )
         )
@@ -694,7 +694,7 @@ class BrightEarthScienceLongRetrieval(AbsTaskRetrieval):
                 path=self.metadata.dataset["path"],
                 eval_splits=self.metadata.eval_splits,
                 domain="earth_science",
-                cache_dir=kwargs.get("cache_dir", None),
+                cache_dir=kwargs.get("cache_dir"),
                 revision=self.metadata.dataset["revision"],
             )
         )
@@ -738,7 +738,7 @@ class BrightEconomicsLongRetrieval(AbsTaskRetrieval):
                 path=self.metadata.dataset["path"],
                 eval_splits=self.metadata.eval_splits,
                 domain="economics",
-                cache_dir=kwargs.get("cache_dir", None),
+                cache_dir=kwargs.get("cache_dir"),
                 revision=self.metadata.dataset["revision"],
             )
         )
@@ -782,7 +782,7 @@ class BrightPsychologyLongRetrieval(AbsTaskRetrieval):
                 path=self.metadata.dataset["path"],
                 eval_splits=self.metadata.eval_splits,
                 domain="psychology",
-                cache_dir=kwargs.get("cache_dir", None),
+                cache_dir=kwargs.get("cache_dir"),
                 revision=self.metadata.dataset["revision"],
             )
         )
@@ -826,7 +826,7 @@ class BrightRoboticsLongRetrieval(AbsTaskRetrieval):
                 path=self.metadata.dataset["path"],
                 eval_splits=self.metadata.eval_splits,
                 domain="robotics",
-                cache_dir=kwargs.get("cache_dir", None),
+                cache_dir=kwargs.get("cache_dir"),
                 revision=self.metadata.dataset["revision"],
             )
         )
@@ -870,7 +870,7 @@ class BrightStackoverflowLongRetrieval(AbsTaskRetrieval):
                 path=self.metadata.dataset["path"],
                 eval_splits=self.metadata.eval_splits,
                 domain="stackoverflow",
-                cache_dir=kwargs.get("cache_dir", None),
+                cache_dir=kwargs.get("cache_dir"),
                 revision=self.metadata.dataset["revision"],
             )
         )
@@ -914,7 +914,7 @@ class BrightSustainableLivingLongRetrieval(AbsTaskRetrieval):
                 path=self.metadata.dataset["path"],
                 eval_splits=self.metadata.eval_splits,
                 domain="sustainable_living",
-                cache_dir=kwargs.get("cache_dir", None),
+                cache_dir=kwargs.get("cache_dir"),
                 revision=self.metadata.dataset["revision"],
             )
         )
@@ -958,7 +958,7 @@ class BrightPonyLongRetrieval(AbsTaskRetrieval):
                 path=self.metadata.dataset["path"],
                 eval_splits=self.metadata.eval_splits,
                 domain="pony",
-                cache_dir=kwargs.get("cache_dir", None),
+                cache_dir=kwargs.get("cache_dir"),
                 revision=self.metadata.dataset["revision"],
             )
         )

--- a/mteb/tasks/retrieval/multilingual/cross_lingual_semantic_discrimination_wmt19.py
+++ b/mteb/tasks/retrieval/multilingual/cross_lingual_semantic_discrimination_wmt19.py
@@ -85,10 +85,9 @@ class CrossLingualSemanticDiscriminationWMT19(AbsTaskRetrieval):
                 relevant_docs[lang_pair][split] = {}
 
                 # Generate unique IDs for queries and documents
-                query_id_counter = 1
                 document_id_counter = 1
 
-                for row in dataset_raw[lang_pair]:
+                for query_id_counter, row in enumerate(dataset_raw[lang_pair], start=1):
                     query_text = row["Source"]
                     positive_text = [row["Target"]]
                     negative_texts = [
@@ -101,7 +100,6 @@ class CrossLingualSemanticDiscriminationWMT19(AbsTaskRetrieval):
                     # Assign unique ID to the query
                     query_id = f"Q{query_id_counter}"
                     queries[lang_pair][split][query_id] = query_text
-                    query_id_counter += 1
 
                     # Add true parallel and distractors to corpus with unique id.
                     for text in positive_text + negative_texts:

--- a/mteb/tasks/retrieval/multilingual/cross_lingual_semantic_discrimination_wmt21.py
+++ b/mteb/tasks/retrieval/multilingual/cross_lingual_semantic_discrimination_wmt21.py
@@ -86,10 +86,9 @@ class CrossLingualSemanticDiscriminationWMT21(AbsTaskRetrieval):
                 relevant_docs[lang_pair][split] = {}
 
                 # Generate unique IDs for queries and documents
-                query_id_counter = 1
                 document_id_counter = 1
 
-                for row in dataset_raw[lang_pair]:
+                for query_id_counter, row in enumerate(dataset_raw[lang_pair], start=1):
                     query_text = row["Source"]
                     positive_text = [row["Target"]]
                     negative_texts = [
@@ -102,7 +101,6 @@ class CrossLingualSemanticDiscriminationWMT21(AbsTaskRetrieval):
                     # Assign unique ID to the query
                     query_id = f"Q{query_id_counter}"
                     queries[lang_pair][split][query_id] = query_text
-                    query_id_counter += 1
 
                     # Add true parallel and distractors to corpus with unique id.
                     for text in positive_text + negative_texts:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -336,6 +336,7 @@ select = [
     "PT",      # flake8-pytest-style
     "A",       # flake8-builtins, don't shadow builtins
     "RET",     # flake8-return
+    "SIM",     # flake8-simplify
 ]
 
 ignore = [
@@ -360,6 +361,7 @@ ignore = [
     "ISC001",   # single-line implicit concat; conflicts with `ruff format`
     "PT018",    # composite assertions; splitting `assert a and b` is not always clearer
     "RET504",   # unnecessary-assign; named intermediate results often aid readability
+    "SIM108",   # ternary over if/else is a style preference, and displaces inline comments
 ]
 future-annotations = true  # For TC rules
 typing-modules = ["typing_extensions", "mteb.types", "collections.abc"]
@@ -405,6 +407,8 @@ preview = true
     # gradio would try to validate typehints
     "TC002",
     "TC001",
+    # nested `with` blocks mirror the gradio layout hierarchy; collapsing them hides it
+    "SIM117",
 ]
 "mteb/types/statistics.py" = [
     # pydantic / FastAPI resolve TypedDict annotations at runtime when building

--- a/tests/test_deprecated/test_MTEB_splits.py
+++ b/tests/test_deprecated/test_MTEB_splits.py
@@ -37,7 +37,7 @@ def test_all_splits_evaluated(model, tasks, tmp_path):
         verbosity=2,
     )
 
-    assert "MockRetrievalTask" == results[0].task_name
+    assert results[0].task_name == "MockRetrievalTask"
     last_evaluated_splits = evaluation._get_last_evaluated_splits()
     assert set(last_evaluated_splits["MockRetrievalTask"]) == {"val", "test"}
     assert len(last_evaluated_splits["MockRetrievalTask"]) == 2
@@ -53,7 +53,7 @@ def test_one_missing_split(model, tasks, tmp_path):
         verbosity=2,
     )
 
-    assert "MockRetrievalTask" == results[0].task_name
+    assert results[0].task_name == "MockRetrievalTask"
     last_evaluated_splits = evaluation._get_last_evaluated_splits()
     assert set(last_evaluated_splits["MockRetrievalTask"]) == {"val"}
     assert len(last_evaluated_splits["MockRetrievalTask"]) == 1
@@ -66,7 +66,7 @@ def test_one_missing_split(model, tasks, tmp_path):
         verbosity=2,
     )
 
-    assert "MockRetrievalTask" == results2[0].task_name
+    assert results2[0].task_name == "MockRetrievalTask"
     last_evaluated_splits = evaluation._get_last_evaluated_splits()
     assert set(last_evaluated_splits["MockRetrievalTask"]) == {"test"}
     assert len(last_evaluated_splits["MockRetrievalTask"]) == 1
@@ -109,7 +109,7 @@ def test_all_languages_evaluated(model, multilingual_tasks, tmp_path):
         verbosity=2,
         eval_subsets=None,
     )
-    assert "MockMultilingualRetrievalTask" == results[0].task_name
+    assert results[0].task_name == "MockMultilingualRetrievalTask"
     last_evaluated_splits = evaluation._get_last_evaluated_splits()
     assert "MockMultilingualRetrievalTask" in last_evaluated_splits
     assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 1
@@ -128,7 +128,7 @@ def test_missing_language(model, multilingual_tasks, tmp_path):
         eval_subsets=["eng"],
     )
 
-    assert "MockMultilingualRetrievalTask" == results[0].task_name
+    assert results[0].task_name == "MockMultilingualRetrievalTask"
     last_evaluated_splits = evaluation._get_last_evaluated_splits()
     assert "MockMultilingualRetrievalTask" in last_evaluated_splits
     assert len(last_evaluated_splits["MockMultilingualRetrievalTask"]) == 1
@@ -307,7 +307,7 @@ def test_all_splits_evaluated_with_overwrite(model, tasks, tmp_path):
         verbosity=2,
     )
 
-    assert "MockRetrievalTask" == results[0].task_name
+    assert results[0].task_name == "MockRetrievalTask"
     last_evaluated_splits = evaluation._get_last_evaluated_splits()
     assert len(last_evaluated_splits["MockRetrievalTask"]) == 1
     assert set(last_evaluated_splits["MockRetrievalTask"]) == {"val"}
@@ -320,7 +320,7 @@ def test_all_splits_evaluated_with_overwrite(model, tasks, tmp_path):
         verbosity=2,
         overwrite_results=True,
     )
-    assert "MockRetrievalTask" == results2[0].task_name
+    assert results2[0].task_name == "MockRetrievalTask"
     last_evaluated_splits = evaluation._get_last_evaluated_splits()
     assert len(last_evaluated_splits["MockRetrievalTask"]) == 2
     assert set(last_evaluated_splits["MockRetrievalTask"]) == {"val", "test"}

--- a/tests/test_result_cache.py
+++ b/tests/test_result_cache.py
@@ -633,13 +633,15 @@ def test_pr_creation_failure_cleans_up_branch(tmp_path):
 
     # Avoid fetching from the remote so the test reliably reaches PR creation.
     # Mock _create_pull_request to fail.
-    with patch.object(cache, "download_from_remote", return_value=None):
-        with patch(
+    with (
+        patch.object(cache, "download_from_remote", return_value=None),
+        patch(
             "mteb._reversible_workflow.git_utils.create_pull_request",
             side_effect=Exception("GitHub API error"),
-        ):
-            with pytest.raises(Exception, match="GitHub API error"):
-                cache.submit_results(models=[test_model], create_pr=True)
+        ),
+        pytest.raises(Exception, match="GitHub API error"),
+    ):
+        cache.submit_results(models=[test_model], create_pr=True)
 
     # Verify user is back on original branch
     result = subprocess.run(

--- a/tests/test_tasks/test_metadata.py
+++ b/tests/test_tasks/test_metadata.py
@@ -48,11 +48,15 @@ def test_all_metadata_is_filled_and_valid(task: AbsTask):
     )
     assert task.metadata.n_samples is not None
 
-    if task.metadata.prompt is not None and isinstance(task.metadata.prompt, dict):
-        if not (
+    # Retrieval tasks and TERRa.V2 have a dict prompt, but other tasks should not
+    if (
+        task.metadata.prompt is not None
+        and isinstance(task.metadata.prompt, dict)
+        and not (
             isinstance(task, AbsTaskRetrieval) or task.metadata.name in ["TERRa.V2"]  # noqa: PLR6201
-        ):
-            # Retrieval tasks and TERRa.V2 have a dict prompt, but other tasks should not
-            raise ValueError(
-                f"Task {task.metadata.name} has a dict prompt, but it should be a string. Please check the metadata of the task."
-            )
+        )
+    ):
+        # Retrieval tasks and TERRa.V2 have a dict prompt, but other tasks should not
+        raise ValueError(
+            f"Task {task.metadata.name} has a dict prompt, but it should be a string. Please check the metadata of the task."
+        )


### PR DESCRIPTION
Enables `SIM` (flake8-simplify), from #2416.  104 violations at the base commit; 93 fixed, 11 deliberately not enforced.

### Rules fixed

| Rule | n | What it catches |
|---|---|---|
| `SIM118` in-dict-keys | 21 | `for k in d.keys()` → `for k in d` — `.keys()` is redundant when iterating or using `in` |
| `SIM910` dict-get-with-none-default | 20 | `d.get(k, None)` → `d.get(k)` — `None` is already the default |
| `SIM102` collapsible-if | 17 | `if a: if b:` → `if a and b:` — removes a level of nesting |
| `SIM300` yoda-conditions | 8 | `"x" == var` → `var == "x"` — put the variable first |
| `SIM113` enumerate-for-loop | 5 | A manually incremented counter in a loop → `enumerate()` |
| `SIM103` needless-bool | 4 | `if cond: return True; return False` → `return cond` |
| `SIM117` multiple-with-statements | 4 | `with a: with b:` → `with a, b:` |
| `SIM114` if-with-same-arms | 3 | Two branches with identical bodies → combine with `or` |
| `SIM401` if-else-block-instead-of-dict-get | 3 | `if k in d: x = d[k] else: x = default` → `d.get(k, default)` |
| `SIM105` suppressible-exception | 2 | `try: ... except X: pass` → `contextlib.suppress(X)` |
| `SIM110` reimplemented-builtin | 2 | A loop that returns `True`/`False` → `any()` / `all()` |
| `SIM115` open-file-with-context-handler | 2 | A file opened without `with`, so it is never reliably closed |
| `SIM201` negate-equal-op | 2 | `not a == b` → `a != b` |

### Not enforced

- **`SIM108`** (if-else-block-instead-of-if-exp, 11 hits) — rewriting `if/else` into a ternary is a style preference with no functional benefit, and 3 of the 11 sites carry an explanatory comment or a `# noqa` that a ternary displaces. Added to `ignore`, alongside the existing `ISC001` / `PT018` / `RET504` entries.
- **`SIM117`** is per-file-ignored for `mteb/leaderboard/app.py`, where nested `with gr.Accordion() / gr.Column() / gr.Row()` blocks *are* the layout hierarchy.

### Notes

- `SIM115` found two real defects: two `NamedTemporaryFile(delete=False)` handles were never closed, so the data was not deterministically flushed (and one leaked a descriptor per file while soundfile wrote to the same path).
- `SIM118` was applied as an *unsafe* fix, so every site was checked by hand: dropping `.keys()` is only safe when `iter(obj)` matches `obj.keys()`, which fails for `pandas.Series`. All 21 sites are `Mapping`s (`DatasetDict`, `Features`, `RelevantDocumentsType`, plain dicts).
- Three rewrites on result-affecting paths were verified by execution rather than inspection: `_find_best_f1_and_threshold` (600 randomised inputs, 0 mismatches), `extend_lang_pairs()` (1916 pairs, identical), and `contains_languages` / `contains_scripts` (13 cases incl. empty, 0 mismatches).
- One `SIM113` site (`code_rag.py:200`) has a `continue`, so its counter is not the loop index; correctly left alone.