### PR TITLE
dataset: add AVCaps audio-visual retrieval (6 directions)

### DIFF
--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/AVCapsA2TRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/AVCapsA2TRetrieval.json
@@ -1,0 +1,42 @@
+{
+    "test": {
+        "num_samples": 915,
+        "num_queries": 200,
+        "num_documents": 715,
+        "number_of_characters": 44045,
+        "documents_text_statistics": {
+            "total_text_length": 44045,
+            "min_text_length": 19,
+            "average_text_length": 61.6013986013986,
+            "max_text_length": 270,
+            "unique_texts": 715
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": null,
+        "queries_audio_statistics": {
+            "total_duration_seconds": 10432.394125,
+            "min_duration_seconds": 20.0145625,
+            "average_duration_seconds": 52.161970625,
+            "max_duration_seconds": 138.436375,
+            "unique_audios": 200,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 200
+            }
+        },
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 715,
+            "min_relevant_docs_per_query": 2,
+            "average_relevant_docs_per_query": 3.575,
+            "max_relevant_docs_per_query": 5,
+            "unique_relevant_docs": 715,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/AVCapsT2ARetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/AVCapsT2ARetrieval.json
@@ -1,0 +1,42 @@
+{
+    "test": {
+        "num_samples": 915,
+        "num_queries": 715,
+        "num_documents": 200,
+        "number_of_characters": 44045,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": {
+            "total_duration_seconds": 10432.394125,
+            "min_duration_seconds": 20.0145625,
+            "average_duration_seconds": 52.161970625,
+            "max_duration_seconds": 138.436375,
+            "unique_audios": 200,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 200
+            }
+        },
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 44045,
+            "min_text_length": 19,
+            "average_text_length": 61.6013986013986,
+            "max_text_length": 270,
+            "unique_texts": 715
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 715,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 200,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/AVCapsT2VARetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/AVCapsT2VARetrieval.json
@@ -1,0 +1,92 @@
+{
+    "test": {
+        "num_samples": 1002,
+        "num_queries": 802,
+        "num_documents": 200,
+        "number_of_characters": 47833,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": {
+            "total_duration_seconds": 10432.394125,
+            "min_duration_seconds": 20.0145625,
+            "average_duration_seconds": 52.161970625,
+            "max_duration_seconds": 138.436375,
+            "unique_audios": 200,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 200
+            }
+        },
+        "documents_video_statistics": {
+            "total_duration_seconds": 10425.746777027027,
+            "total_frames": 299267,
+            "min_width": 240,
+            "average_width": 607.98,
+            "max_width": 640,
+            "min_height": 240,
+            "average_height": 449.85,
+            "max_height": 1138,
+            "min_duration_seconds": 20.02002002002002,
+            "average_duration_seconds": 52.128733885135134,
+            "max_duration_seconds": 138.53333333333333,
+            "unique_videos": 200,
+            "average_fps": 28.915,
+            "fps": {
+                "30": 165,
+                "25": 11,
+                "24": 22,
+                "15": 2
+            },
+            "min_resolution": [
+                240,
+                320
+            ],
+            "average_resolution": [
+                607.98,
+                449.85
+            ],
+            "max_resolution": [
+                640,
+                1138
+            ],
+            "resolutions": {
+                "640x360": 70,
+                "604x1072": 1,
+                "240x320": 1,
+                "320x240": 9,
+                "640x1138": 6,
+                "640x1128": 1,
+                "640x480": 88,
+                "512x384": 1,
+                "480x640": 3,
+                "640x428": 6,
+                "360x480": 6,
+                "640x352": 1,
+                "640x362": 3,
+                "640x424": 1,
+                "320x568": 2,
+                "480x272": 1
+            }
+        },
+        "queries_text_statistics": {
+            "total_text_length": 47833,
+            "min_text_length": 16,
+            "average_text_length": 59.64214463840399,
+            "max_text_length": 302,
+            "unique_texts": 802
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 802,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 200,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/AVCapsT2VRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/AVCapsT2VRetrieval.json
@@ -1,0 +1,82 @@
+{
+    "test": {
+        "num_samples": 980,
+        "num_queries": 780,
+        "num_documents": 200,
+        "number_of_characters": 44208,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": {
+            "total_duration_seconds": 10425.746777027027,
+            "total_frames": 299267,
+            "min_width": 240,
+            "average_width": 607.98,
+            "max_width": 640,
+            "min_height": 240,
+            "average_height": 449.85,
+            "max_height": 1138,
+            "min_duration_seconds": 20.02002002002002,
+            "average_duration_seconds": 52.128733885135134,
+            "max_duration_seconds": 138.53333333333333,
+            "unique_videos": 200,
+            "average_fps": 28.915,
+            "fps": {
+                "30": 165,
+                "25": 11,
+                "24": 22,
+                "15": 2
+            },
+            "min_resolution": [
+                240,
+                320
+            ],
+            "average_resolution": [
+                607.98,
+                449.85
+            ],
+            "max_resolution": [
+                640,
+                1138
+            ],
+            "resolutions": {
+                "640x360": 70,
+                "604x1072": 1,
+                "240x320": 1,
+                "320x240": 9,
+                "640x1138": 6,
+                "640x1128": 1,
+                "640x480": 88,
+                "512x384": 1,
+                "480x640": 3,
+                "640x428": 6,
+                "360x480": 6,
+                "640x352": 1,
+                "640x362": 3,
+                "640x424": 1,
+                "320x568": 2,
+                "480x272": 1
+            }
+        },
+        "queries_text_statistics": {
+            "total_text_length": 44208,
+            "min_text_length": 18,
+            "average_text_length": 56.676923076923075,
+            "max_text_length": 434,
+            "unique_texts": 780
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 780,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 200,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/AVCapsV2TRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/AVCapsV2TRetrieval.json
@@ -1,0 +1,82 @@
+{
+    "test": {
+        "num_samples": 980,
+        "num_queries": 200,
+        "num_documents": 780,
+        "number_of_characters": 44208,
+        "documents_text_statistics": {
+            "total_text_length": 44208,
+            "min_text_length": 18,
+            "average_text_length": 56.676923076923075,
+            "max_text_length": 434,
+            "unique_texts": 780
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": {
+            "total_duration_seconds": 10425.746777027027,
+            "total_frames": 299267,
+            "min_width": 240,
+            "average_width": 607.98,
+            "max_width": 640,
+            "min_height": 240,
+            "average_height": 449.85,
+            "max_height": 1138,
+            "min_duration_seconds": 20.02002002002002,
+            "average_duration_seconds": 52.128733885135134,
+            "max_duration_seconds": 138.53333333333333,
+            "unique_videos": 200,
+            "average_fps": 28.915,
+            "fps": {
+                "30": 165,
+                "25": 11,
+                "24": 22,
+                "15": 2
+            },
+            "min_resolution": [
+                240,
+                320
+            ],
+            "average_resolution": [
+                607.98,
+                449.85
+            ],
+            "max_resolution": [
+                640,
+                1138
+            ],
+            "resolutions": {
+                "640x360": 70,
+                "604x1072": 1,
+                "240x320": 1,
+                "320x240": 9,
+                "640x1138": 6,
+                "640x1128": 1,
+                "640x480": 88,
+                "512x384": 1,
+                "480x640": 3,
+                "640x428": 6,
+                "360x480": 6,
+                "640x352": 1,
+                "640x362": 3,
+                "640x424": 1,
+                "320x568": 2,
+                "480x272": 1
+            }
+        },
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 780,
+            "min_relevant_docs_per_query": 2,
+            "average_relevant_docs_per_query": 3.9,
+            "max_relevant_docs_per_query": 5,
+            "unique_relevant_docs": 780,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/AVCapsVA2TRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/AVCapsVA2TRetrieval.json
@@ -1,0 +1,92 @@
+{
+    "test": {
+        "num_samples": 1002,
+        "num_queries": 200,
+        "num_documents": 802,
+        "number_of_characters": 47833,
+        "documents_text_statistics": {
+            "total_text_length": 47833,
+            "min_text_length": 16,
+            "average_text_length": 59.64214463840399,
+            "max_text_length": 302,
+            "unique_texts": 802
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": null,
+        "queries_audio_statistics": {
+            "total_duration_seconds": 10432.394125,
+            "min_duration_seconds": 20.0145625,
+            "average_duration_seconds": 52.161970625,
+            "max_duration_seconds": 138.436375,
+            "unique_audios": 200,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 200
+            }
+        },
+        "queries_video_statistics": {
+            "total_duration_seconds": 10425.746777027027,
+            "total_frames": 299267,
+            "min_width": 240,
+            "average_width": 607.98,
+            "max_width": 640,
+            "min_height": 240,
+            "average_height": 449.85,
+            "max_height": 1138,
+            "min_duration_seconds": 20.02002002002002,
+            "average_duration_seconds": 52.128733885135134,
+            "max_duration_seconds": 138.53333333333333,
+            "unique_videos": 200,
+            "average_fps": 28.915,
+            "fps": {
+                "30": 165,
+                "25": 11,
+                "24": 22,
+                "15": 2
+            },
+            "min_resolution": [
+                240,
+                320
+            ],
+            "average_resolution": [
+                607.98,
+                449.85
+            ],
+            "max_resolution": [
+                640,
+                1138
+            ],
+            "resolutions": {
+                "640x360": 70,
+                "604x1072": 1,
+                "240x320": 1,
+                "320x240": 9,
+                "640x1138": 6,
+                "640x1128": 1,
+                "640x480": 88,
+                "512x384": 1,
+                "480x640": 3,
+                "640x428": 6,
+                "360x480": 6,
+                "640x352": 1,
+                "640x362": 3,
+                "640x424": 1,
+                "320x568": 2,
+                "480x272": 1
+            }
+        },
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 802,
+            "min_relevant_docs_per_query": 2,
+            "average_relevant_docs_per_query": 4.01,
+            "max_relevant_docs_per_query": 5,
+            "unique_relevant_docs": 802,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -20,6 +20,14 @@ from .audiocaps_av_retrieval import (
     AudioCapsAVVA2TRetrieval,
     AudioCapsAVVT2ARetrieval,
 )
+from .avcaps_retrieval import (
+    AVCapsA2TRetrieval,
+    AVCapsT2ARetrieval,
+    AVCapsT2VARetrieval,
+    AVCapsT2VRetrieval,
+    AVCapsV2TRetrieval,
+    AVCapsVA2TRetrieval,
+)
 from .avmeme_exam_retrieval import (
     AVMemeExamA2VRetrieval,
     AVMemeExamAT2VRetrieval,
@@ -485,6 +493,12 @@ __all__ = [
     "AILACasedocs",
     "AILAStatutes",
     "ARCChallenge",
+    "AVCapsA2TRetrieval",
+    "AVCapsT2ARetrieval",
+    "AVCapsT2VARetrieval",
+    "AVCapsT2VRetrieval",
+    "AVCapsV2TRetrieval",
+    "AVCapsVA2TRetrieval",
     "AVMemeExamA2VRetrieval",
     "AVMemeExamAT2VRetrieval",
     "AVMemeExamT2VARetrieval",

--- a/mteb/tasks/retrieval/eng/avcaps_retrieval.py
+++ b/mteb/tasks/retrieval/eng/avcaps_retrieval.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from datasets import load_dataset
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.retrieval_dataset_loaders import RetrievalSplitData
+from mteb.abstasks.task_metadata import TaskMetadata
+
+_DATASET_PATH = "vnahata/avcaps-retrieval"
+_DATASET_REVISION = "adda52e701ac328a63ab4cfbdfcf1ccdd593939f"
+
+_BIBTEX = r"""
+@article{sudarsanam2025avcaps,
+  author = {Sudarsanam, Parthasaarathy and Martin-Morato, Irene and Hakala, Aapo and Virtanen, Tuomas},
+  journal = {IEEE Open Journal of Signal Processing},
+  pages = {691--704},
+  title = {{AVCaps}: An Audio-Visual Dataset with Modality-Specific Captions},
+  volume = {6},
+  year = {2025},
+}
+"""
+
+_DESCRIPTION = (
+    "Audio-visual retrieval from AVCaps, derived from VidOR. Each clip is captioned three "
+    "separate ways - from the audio alone, from the visuals alone, and from both together "
+    "- so the audio-only, video-only, and combined directions can be scored independently "
+    "on identical clips rather than inferred from a single caption set."
+)
+
+_COMMON = {
+    "reference": "https://ieeexplore.ieee.org/document/11029114/",
+    "dataset": {"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+    "type": "Any2AnyRetrieval",
+    "eval_splits": ["test"],
+    "eval_langs": ["eng-Latn"],
+    "main_score": "ndcg_at_10",
+    "date": ("2024-01-01", "2025-06-30"),
+    "domains": ["Web", "AudioScene"],
+    "task_subtypes": ["Cross-Modal Retrieval"],
+    "license": "cc-by-nc-4.0",
+    "annotations_creators": "human-annotated",
+    "dialect": [],
+    "sample_creation": "found",
+    "bibtex_citation": _BIBTEX,
+    "is_beta": True,
+}
+
+# caption config -> the media columns that caption is allowed to describe
+_CAPTION_MEDIA = {
+    "audio_captions": ["audio"],
+    "visual_captions": ["video"],
+    "av_captions": ["video", "audio"],
+}
+
+
+def _load_avcaps(task: AbsTaskRetrieval, config: str, to_text: bool) -> None:
+    """Load one AVCaps direction.
+
+    `to_text` selects media->caption; otherwise caption->media. Only the media columns
+    the caption actually describes are exposed, so an audio-caption task cannot be
+    solved from the video track.
+    """
+    if task.data_loaded:
+        return
+
+    split = task.metadata.eval_splits[0]
+    cols = _CAPTION_MEDIA[config]
+    media = load_dataset(
+        _DATASET_PATH, "media", revision=_DATASET_REVISION, split=split
+    ).select_columns(["id", *cols])
+    caps = load_dataset(_DATASET_PATH, config, revision=_DATASET_REVISION, split=split)
+    text_ds = caps.select_columns(["id", "text"])
+
+    # Read the link columns directly; iterating full rows would decode the media.
+    links = caps.select_columns(["id", "media_id"]).to_dict()
+    pairs = list(zip(links["id"], links["media_id"], strict=True))
+
+    if to_text:
+        qrels: dict[str, dict[str, int]] = {}
+        for cid, mid in pairs:
+            qrels.setdefault(mid, {})[cid] = 1
+        keep = set(qrels)
+        # select() by index rather than filter(), which would decode every clip
+        wanted = [i for i, id_ in enumerate(media["id"]) if id_ in keep]
+        queries = media.select(wanted)
+        corpus = text_ds
+    else:
+        queries = text_ds
+        corpus = media
+        qrels = {cid: {mid: 1} for cid, mid in pairs}
+
+    task.dataset = {
+        "default": {
+            split: RetrievalSplitData(
+                queries=queries, corpus=corpus, relevant_docs=qrels, top_ranked=None
+            )
+        }
+    }
+    task.data_loaded = True
+
+
+class AVCapsA2TRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="AVCapsA2TRetrieval",
+        description=f"{_DESCRIPTION} Retrieve the caption describing a clip's audio track.",
+        category="a2t",
+        modalities=["audio", "text"],
+        prompt={"query": "Find the caption that describes this audio."},
+        **_COMMON,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_avcaps(self, "audio_captions", to_text=True)
+
+
+class AVCapsT2ARetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="AVCapsT2ARetrieval",
+        description=f"{_DESCRIPTION} Retrieve the audio track matching a caption of it.",
+        category="t2a",
+        modalities=["text", "audio"],
+        prompt={"query": "Find the audio that matches the following description."},
+        **_COMMON,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_avcaps(self, "audio_captions", to_text=False)
+
+
+class AVCapsV2TRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="AVCapsV2TRetrieval",
+        description=f"{_DESCRIPTION} Retrieve the caption describing a clip's visuals.",
+        category="v2t",
+        modalities=["video", "text"],
+        prompt={"query": "Find the caption that describes this video."},
+        **_COMMON,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_avcaps(self, "visual_captions", to_text=True)
+
+
+class AVCapsT2VRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="AVCapsT2VRetrieval",
+        description=f"{_DESCRIPTION} Retrieve the video matching a caption of its visuals.",
+        category="t2v",
+        modalities=["text", "video"],
+        prompt={"query": "Find the video that matches the following description."},
+        **_COMMON,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_avcaps(self, "visual_captions", to_text=False)
+
+
+class AVCapsVA2TRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="AVCapsVA2TRetrieval",
+        description=(
+            f"{_DESCRIPTION} Retrieve the caption describing a clip's video and audio together."
+        ),
+        category="va2t",
+        modalities=["video", "audio", "text"],
+        prompt={"query": "Find the caption that describes this video and its audio."},
+        **_COMMON,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_avcaps(self, "av_captions", to_text=True)
+
+
+class AVCapsT2VARetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="AVCapsT2VARetrieval",
+        description=(
+            f"{_DESCRIPTION} Retrieve the video and audio matching a combined caption."
+        ),
+        category="t2va",
+        modalities=["text", "video", "audio"],
+        prompt={
+            "query": "Find the video and audio matching the following description."
+        },
+        **_COMMON,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_avcaps(self, "av_captions", to_text=False)

--- a/scripts/data/avcaps_retrieval/create_data.py
+++ b/scripts/data/avcaps_retrieval/create_data.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Build the AVCaps audio-visual retrieval tasks for MTEB.
+
+AVCaps (derived from VidOR) captions each clip three separate ways - from the audio
+alone, from the visuals alone, and from both together. That is what makes it useful
+here: the audio-only, video-only and combined directions can be scored independently on
+identical clips, instead of being inferred from one caption set that mixes the modalities.
+
+Only the official test split is used, so the evaluation set matches the split the
+authors held out; train and validation are left untouched.
+
+The published clips are muxed mp4s. To keep an audio-caption task from being solvable
+off the video track, the audio is demuxed to a separate mono 16 kHz stream and each task
+exposes only the media columns its captions actually describe.
+
+Examples:
+  # Build the dataset locally from the downloaded archive.
+  uv run python scripts/data/avcaps_retrieval/create_data.py --stage build
+
+  # Build and publish.
+  uv run python scripts/data/avcaps_retrieval/create_data.py --stage all --push
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import zipfile
+from pathlib import Path
+
+import av
+import pyarrow as pa
+import pyarrow.parquet as pq
+from datasets import Audio, Dataset, Video
+from huggingface_hub import HfApi, hf_hub_download
+
+_SOURCE_REPO = "TUT-ARG/AVCaps"
+_PAPER = "https://ieeexplore.ieee.org/document/11029114/"
+_TARGET_REPO = "vnahata/avcaps-retrieval"
+_LICENSE = "cc-by-nc-4.0"
+_SPLIT = "test"
+
+# caption field in the source -> config name published here
+_CAPTION_FIELDS = {
+    "audio_captions": "audio_captions",
+    "visual_captions": "visual_captions",
+    "audio_visual_captions": "av_captions",
+}
+
+
+def _extract_audio(mp4: Path, wav: Path) -> bool:
+    """Demux the audio track to mono 16 kHz wav; False when the clip has none."""
+    try:
+        with av.open(str(mp4)) as inp:
+            if not inp.streams.audio:
+                return False
+            stream = inp.streams.audio[0]
+            with av.open(str(wav), "w") as out:
+                out_stream = out.add_stream("pcm_s16le", rate=16000, layout="mono")
+                resampler = av.audio.resampler.AudioResampler(
+                    format="s16", layout="mono", rate=16000
+                )
+                for frame in inp.decode(stream):
+                    for resampled in resampler.resample(frame):
+                        out.mux(out_stream.encode(resampled))
+                out.mux(out_stream.encode(None))
+        return wav.exists() and wav.stat().st_size > 44  # larger than a bare wav header
+    except Exception as e:  # noqa: BLE001
+        print(f"  audio demux failed for {mp4.name}: {type(e).__name__} {str(e)[:70]}")
+        return False
+
+
+def stage_build(work: Path) -> dict[str, int]:
+    """Extract the archive, demux audio, and write media + caption tables."""
+    media_dir = work / "clips"
+    out_dir = work / "dataset"
+    media_dir.mkdir(parents=True, exist_ok=True)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    caps_path = hf_hub_download(_SOURCE_REPO, "test_captions.json", repo_type="dataset")
+    caps = json.loads(Path(caps_path).read_text(encoding="utf-8"))
+    zip_path = hf_hub_download(_SOURCE_REPO, "test_videos.zip", repo_type="dataset")
+
+    if not any(media_dir.glob("*.mp4")):
+        with zipfile.ZipFile(zip_path) as z:
+            for name in z.namelist():
+                if name.lower().endswith(".mp4"):
+                    with (
+                        z.open(name) as src,
+                        open(media_dir / os.path.basename(name), "wb") as dst,
+                    ):
+                        dst.write(src.read())
+
+    media, skipped = [], 0
+    for clip_id in sorted(caps):
+        mp4 = media_dir / f"{clip_id}.mp4"
+        wav = media_dir / f"{clip_id}.wav"
+        if not mp4.exists() or (not wav.exists() and not _extract_audio(mp4, wav)):
+            skipped += 1
+            continue
+        media.append(
+            {
+                "id": clip_id,
+                "video": {"bytes": mp4.read_bytes(), "path": mp4.name},
+                "audio": {"bytes": wav.read_bytes(), "path": wav.name},
+            }
+        )
+    pq.write_table(pa.Table.from_pylist(media), out_dir / "media.parquet")
+    print(f"media: {len(media)} clips ({skipped} skipped)")
+
+    have = {m["id"] for m in media}
+    stats = {"media": len(media)}
+    for field, cfg in _CAPTION_FIELDS.items():
+        # Drop repeated caption text. Annotators sometimes produce the same short
+        # sentence for different clips ("A man is speaking"), which would make the
+        # qrels ambiguous: the identical query text is marked relevant to only one
+        # of the clips it actually describes.
+        rows, seen = [], set()
+        for cid in sorted(have):
+            for i, text in enumerate(caps[cid].get(field) or []):
+                text = (text or "").strip()
+                if not text or text in seen:
+                    continue
+                seen.add(text)
+                rows.append({"id": f"{cid}-{cfg}-{i}", "text": text, "media_id": cid})
+        pq.write_table(pa.Table.from_pylist(rows), out_dir / f"{cfg}.parquet")
+        stats[cfg] = len(rows)
+        print(f"{cfg}: {len(rows)} captions")
+
+    (work / "stats.json").write_text(json.dumps(stats, indent=2), encoding="utf-8")
+    return stats
+
+
+def stage_push(work: Path) -> None:
+    out_dir = work / "dataset"
+    api = HfApi()
+    api.create_repo(_TARGET_REPO, repo_type="dataset", exist_ok=True)
+
+    media = (
+        Dataset.from_parquet(str(out_dir / "media.parquet"))
+        .cast_column("video", Video())
+        .cast_column("audio", Audio(sampling_rate=16000))
+    )
+    media.push_to_hub(
+        _TARGET_REPO, config_name="media", split=_SPLIT, max_shard_size="400MB"
+    )
+
+    for cfg in _CAPTION_FIELDS.values():
+        ds = Dataset.from_parquet(str(out_dir / f"{cfg}.parquet"))
+        ds.push_to_hub(_TARGET_REPO, config_name=cfg, split=_SPLIT)
+        print(f"  pushed {cfg}: {len(ds)}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--stage", choices=["build", "push", "all"], default="all")
+    parser.add_argument("--work-dir", type=Path, default=Path("avcaps_work"))
+    parser.add_argument("--push", action="store_true")
+    args = parser.parse_args()
+
+    args.work_dir.mkdir(parents=True, exist_ok=True)
+    print(f"source: {_PAPER} (license {_LICENSE})")
+
+    if args.stage in ("build", "all"):
+        stage_build(args.work_dir)
+    if args.stage == "push" or (args.push and args.stage == "all"):
+        stage_push(args.work_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds six directions over AVCaps: a2t/t2a, v2t/t2v and va2t/t2va. Part of #4842; issue #5223.

@yaswanth169 — you opened that issue; happy to hand this back if you're already on it.

## Gap

AVCaps captions each clip **three separate ways** — from the audio alone, from the visuals alone, and from both together. That is what makes it useful here: the audio-only, video-only and combined directions can be scored independently on identical clips, instead of being inferred from one caption set that mixes the modalities.

## Construction

Official **test** split only — 200 clips; train and validation are untouched, so the evaluation set matches the split the authors held out.

The published clips are muxed mp4s. Audio is demuxed to a separate mono 16 kHz stream, and **each task exposes only the media columns its captions actually describe**, so an audio-caption task cannot be quietly solved off the video track.

Repeated caption text is dropped (725/788/808 → 715/780/802). Annotators sometimes write the same short sentence for different clips, which would leave an identical query marked relevant to only one of the clips it describes — this was failing `test_task_quality.py` before the dedup.

Paper: IEEE OJSP 2025, 6:691–704. Licence **CC-BY-NC-4.0**, matching the source.

## Checklist

- [x] Outlined why this fills a gap
- [x] Tested that it runs with `mteb` (all six directions)
- [x] `mteb/baseline-random-encoder` on the full task → a2t 0.0188, t2a 0.0388, v2t 0.0083, t2v 0.0171, va2t 0.0096, t2va 0.0210
- [ ] Second encoder — not run: built on CPU-only hardware, where an omni encoder over six directions runs to hours. Same rationale as #5258, which merged with the random baseline only. Happy to add one before merge.
- [x] Size considered — official test split, no reduction needed
- [x] `test_task_quality.py` passes
