### PR TITLE
dataset: add WAXAL multilingual African speech-text retrieval

### DIFF
--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/WaxalA2TRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/WaxalA2TRetrieval.json
@@ -1,0 +1,684 @@
+{
+    "test": {
+        "num_samples": 3444,
+        "num_queries": 1722,
+        "num_documents": 1722,
+        "number_of_characters": 302783,
+        "documents_text_statistics": {
+            "total_text_length": 302783,
+            "min_text_length": 6,
+            "average_text_length": 175.8321718931475,
+            "max_text_length": 536,
+            "unique_texts": 1722
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": null,
+        "queries_audio_statistics": {
+            "total_duration_seconds": 31910.6133125,
+            "min_duration_seconds": 1.008,
+            "average_duration_seconds": 18.531134327816492,
+            "max_duration_seconds": 44.82,
+            "unique_audios": 1722,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 1722
+            }
+        },
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 1722,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 1722,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null,
+        "hf_subset_descriptive_stats": {
+            "ach": {
+                "num_samples": 100,
+                "num_queries": 50,
+                "num_documents": 50,
+                "number_of_characters": 9472,
+                "documents_text_statistics": {
+                    "total_text_length": 9472,
+                    "min_text_length": 52,
+                    "average_text_length": 189.44,
+                    "max_text_length": 395,
+                    "unique_texts": 50
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 1138.932,
+                    "min_duration_seconds": 3.6,
+                    "average_duration_seconds": 22.77864,
+                    "max_duration_seconds": 44.172,
+                    "unique_audios": 50,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 50
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 50,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 50,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "aka": {
+                "num_samples": 300,
+                "num_queries": 150,
+                "num_documents": 150,
+                "number_of_characters": 24704,
+                "documents_text_statistics": {
+                    "total_text_length": 24704,
+                    "min_text_length": 85,
+                    "average_text_length": 164.69333333333333,
+                    "max_text_length": 304,
+                    "unique_texts": 150
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 2915.4235,
+                    "min_duration_seconds": 15.386125,
+                    "average_duration_seconds": 19.436156666666665,
+                    "max_duration_seconds": 28.8391875,
+                    "unique_audios": 150,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 150
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 150,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 150,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "amh": {
+                "num_samples": 284,
+                "num_queries": 142,
+                "num_documents": 142,
+                "number_of_characters": 19160,
+                "documents_text_statistics": {
+                    "total_text_length": 19160,
+                    "min_text_length": 79,
+                    "average_text_length": 134.92957746478874,
+                    "max_text_length": 200,
+                    "unique_texts": 142
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 2478.0,
+                    "min_duration_seconds": 10.224,
+                    "average_duration_seconds": 17.450704225352112,
+                    "max_duration_seconds": 28.536,
+                    "unique_audios": 142,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 142
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 142,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 142,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "ewe": {
+                "num_samples": 300,
+                "num_queries": 150,
+                "num_documents": 150,
+                "number_of_characters": 23438,
+                "documents_text_statistics": {
+                    "total_text_length": 23438,
+                    "min_text_length": 92,
+                    "average_text_length": 156.25333333333333,
+                    "max_text_length": 292,
+                    "unique_texts": 150
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 2779.8900625,
+                    "min_duration_seconds": 15.08,
+                    "average_duration_seconds": 18.532600416666668,
+                    "max_duration_seconds": 28.76,
+                    "unique_audios": 150,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 150
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 150,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 150,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "ful": {
+                "num_samples": 300,
+                "num_queries": 150,
+                "num_documents": 150,
+                "number_of_characters": 26024,
+                "documents_text_statistics": {
+                    "total_text_length": 26024,
+                    "min_text_length": 14,
+                    "average_text_length": 173.49333333333334,
+                    "max_text_length": 434,
+                    "unique_texts": 150
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 2784.624,
+                    "min_duration_seconds": 7.704,
+                    "average_duration_seconds": 18.564159999999998,
+                    "max_duration_seconds": 30.576,
+                    "unique_audios": 150,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 150
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 150,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 150,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "lin": {
+                "num_samples": 218,
+                "num_queries": 109,
+                "num_documents": 109,
+                "number_of_characters": 16139,
+                "documents_text_statistics": {
+                    "total_text_length": 16139,
+                    "min_text_length": 31,
+                    "average_text_length": 148.06422018348624,
+                    "max_text_length": 336,
+                    "unique_texts": 109
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 1910.2708125,
+                    "min_duration_seconds": 1.008,
+                    "average_duration_seconds": 17.525420298165137,
+                    "max_duration_seconds": 35.304,
+                    "unique_audios": 109,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 109
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 109,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 109,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "lug": {
+                "num_samples": 102,
+                "num_queries": 51,
+                "num_documents": 51,
+                "number_of_characters": 11208,
+                "documents_text_statistics": {
+                    "total_text_length": 11208,
+                    "min_text_length": 59,
+                    "average_text_length": 219.76470588235293,
+                    "max_text_length": 536,
+                    "unique_texts": 51
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 1264.176,
+                    "min_duration_seconds": 5.688,
+                    "average_duration_seconds": 24.787764705882353,
+                    "max_duration_seconds": 42.984,
+                    "unique_audios": 51,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 51
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 51,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 51,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "mas": {
+                "num_samples": 116,
+                "num_queries": 58,
+                "num_documents": 58,
+                "number_of_characters": 10344,
+                "documents_text_statistics": {
+                    "total_text_length": 10344,
+                    "min_text_length": 31,
+                    "average_text_length": 178.3448275862069,
+                    "max_text_length": 407,
+                    "unique_texts": 58
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 1186.74,
+                    "min_duration_seconds": 15.516,
+                    "average_duration_seconds": 20.46103448275862,
+                    "max_duration_seconds": 35.316,
+                    "unique_audios": 58,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 58
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 58,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 58,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "mlg": {
+                "num_samples": 300,
+                "num_queries": 150,
+                "num_documents": 150,
+                "number_of_characters": 31174,
+                "documents_text_statistics": {
+                    "total_text_length": 31174,
+                    "min_text_length": 108,
+                    "average_text_length": 207.82666666666665,
+                    "max_text_length": 476,
+                    "unique_texts": 150
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 2670.4089375,
+                    "min_duration_seconds": 1.008,
+                    "average_duration_seconds": 17.80272625,
+                    "max_duration_seconds": 27.24,
+                    "unique_audios": 150,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 150
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 150,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 150,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "nyn": {
+                "num_samples": 108,
+                "num_queries": 54,
+                "num_documents": 54,
+                "number_of_characters": 9800,
+                "documents_text_statistics": {
+                    "total_text_length": 9800,
+                    "min_text_length": 69,
+                    "average_text_length": 181.4814814814815,
+                    "max_text_length": 383,
+                    "unique_texts": 54
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 1146.744,
+                    "min_duration_seconds": 15.732,
+                    "average_duration_seconds": 21.235999999999997,
+                    "max_duration_seconds": 44.064,
+                    "unique_audios": 54,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 54
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 54,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 54,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "orm": {
+                "num_samples": 278,
+                "num_queries": 139,
+                "num_documents": 139,
+                "number_of_characters": 31770,
+                "documents_text_statistics": {
+                    "total_text_length": 31770,
+                    "min_text_length": 138,
+                    "average_text_length": 228.5611510791367,
+                    "max_text_length": 408,
+                    "unique_texts": 139
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 2484.264,
+                    "min_duration_seconds": 11.376,
+                    "average_duration_seconds": 17.872402877697844,
+                    "max_duration_seconds": 28.824,
+                    "unique_audios": 139,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 139
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 139,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 139,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "sid": {
+                "num_samples": 244,
+                "num_queries": 122,
+                "num_documents": 122,
+                "number_of_characters": 24892,
+                "documents_text_statistics": {
+                    "total_text_length": 24892,
+                    "min_text_length": 74,
+                    "average_text_length": 204.0327868852459,
+                    "max_text_length": 374,
+                    "unique_texts": 122
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 2188.488,
+                    "min_duration_seconds": 5.736,
+                    "average_duration_seconds": 17.938426229508195,
+                    "max_duration_seconds": 30.576,
+                    "unique_audios": 122,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 122
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 122,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 122,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "sna": {
+                "num_samples": 230,
+                "num_queries": 115,
+                "num_documents": 115,
+                "number_of_characters": 22108,
+                "documents_text_statistics": {
+                    "total_text_length": 22108,
+                    "min_text_length": 87,
+                    "average_text_length": 192.24347826086955,
+                    "max_text_length": 399,
+                    "unique_texts": 115
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 2306.184,
+                    "min_duration_seconds": 1.008,
+                    "average_duration_seconds": 20.05377391304348,
+                    "max_duration_seconds": 32.664,
+                    "unique_audios": 115,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 115
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 115,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 115,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "sog": {
+                "num_samples": 106,
+                "num_queries": 53,
+                "num_documents": 53,
+                "number_of_characters": 9638,
+                "documents_text_statistics": {
+                    "total_text_length": 9638,
+                    "min_text_length": 73,
+                    "average_text_length": 181.8490566037736,
+                    "max_text_length": 473,
+                    "unique_texts": 53
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 1211.076,
+                    "min_duration_seconds": 15.912,
+                    "average_duration_seconds": 22.850490566037735,
+                    "max_duration_seconds": 44.82,
+                    "unique_audios": 53,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 53
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 53,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 53,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "tir": {
+                "num_samples": 300,
+                "num_queries": 150,
+                "num_documents": 150,
+                "number_of_characters": 19645,
+                "documents_text_statistics": {
+                    "total_text_length": 19645,
+                    "min_text_length": 6,
+                    "average_text_length": 130.96666666666667,
+                    "max_text_length": 243,
+                    "unique_texts": 150
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 2251.992,
+                    "min_duration_seconds": 6.504,
+                    "average_duration_seconds": 15.013280000000002,
+                    "max_duration_seconds": 27.696,
+                    "unique_audios": 150,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 150
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 150,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 150,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "wal": {
+                "num_samples": 158,
+                "num_queries": 79,
+                "num_documents": 79,
+                "number_of_characters": 13267,
+                "documents_text_statistics": {
+                    "total_text_length": 13267,
+                    "min_text_length": 108,
+                    "average_text_length": 167.9367088607595,
+                    "max_text_length": 235,
+                    "unique_texts": 79
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 1193.4,
+                    "min_duration_seconds": 11.424,
+                    "average_duration_seconds": 15.106329113924051,
+                    "max_duration_seconds": 19.056,
+                    "unique_audios": 79,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 79
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 79,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 79,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            }
+        }
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/WaxalT2ARetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/WaxalT2ARetrieval.json
@@ -1,0 +1,684 @@
+{
+    "test": {
+        "num_samples": 3444,
+        "num_queries": 1722,
+        "num_documents": 1722,
+        "number_of_characters": 302783,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": {
+            "total_duration_seconds": 31910.6133125,
+            "min_duration_seconds": 1.008,
+            "average_duration_seconds": 18.531134327816492,
+            "max_duration_seconds": 44.82,
+            "unique_audios": 1722,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 1722
+            }
+        },
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 302783,
+            "min_text_length": 6,
+            "average_text_length": 175.8321718931475,
+            "max_text_length": 536,
+            "unique_texts": 1722
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 1722,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 1722,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null,
+        "hf_subset_descriptive_stats": {
+            "ach": {
+                "num_samples": 100,
+                "num_queries": 50,
+                "num_documents": 50,
+                "number_of_characters": 9472,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 1138.932,
+                    "min_duration_seconds": 3.6,
+                    "average_duration_seconds": 22.77864,
+                    "max_duration_seconds": 44.172,
+                    "unique_audios": 50,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 50
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 9472,
+                    "min_text_length": 52,
+                    "average_text_length": 189.44,
+                    "max_text_length": 395,
+                    "unique_texts": 50
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 50,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 50,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "aka": {
+                "num_samples": 300,
+                "num_queries": 150,
+                "num_documents": 150,
+                "number_of_characters": 24704,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 2915.4235,
+                    "min_duration_seconds": 15.386125,
+                    "average_duration_seconds": 19.436156666666665,
+                    "max_duration_seconds": 28.8391875,
+                    "unique_audios": 150,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 150
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 24704,
+                    "min_text_length": 85,
+                    "average_text_length": 164.69333333333333,
+                    "max_text_length": 304,
+                    "unique_texts": 150
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 150,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 150,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "amh": {
+                "num_samples": 284,
+                "num_queries": 142,
+                "num_documents": 142,
+                "number_of_characters": 19160,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 2478.0,
+                    "min_duration_seconds": 10.224,
+                    "average_duration_seconds": 17.450704225352112,
+                    "max_duration_seconds": 28.536,
+                    "unique_audios": 142,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 142
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 19160,
+                    "min_text_length": 79,
+                    "average_text_length": 134.92957746478874,
+                    "max_text_length": 200,
+                    "unique_texts": 142
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 142,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 142,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "ewe": {
+                "num_samples": 300,
+                "num_queries": 150,
+                "num_documents": 150,
+                "number_of_characters": 23438,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 2779.8900625,
+                    "min_duration_seconds": 15.08,
+                    "average_duration_seconds": 18.532600416666668,
+                    "max_duration_seconds": 28.76,
+                    "unique_audios": 150,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 150
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 23438,
+                    "min_text_length": 92,
+                    "average_text_length": 156.25333333333333,
+                    "max_text_length": 292,
+                    "unique_texts": 150
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 150,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 150,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "ful": {
+                "num_samples": 300,
+                "num_queries": 150,
+                "num_documents": 150,
+                "number_of_characters": 26024,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 2784.624,
+                    "min_duration_seconds": 7.704,
+                    "average_duration_seconds": 18.564159999999998,
+                    "max_duration_seconds": 30.576,
+                    "unique_audios": 150,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 150
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 26024,
+                    "min_text_length": 14,
+                    "average_text_length": 173.49333333333334,
+                    "max_text_length": 434,
+                    "unique_texts": 150
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 150,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 150,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "lin": {
+                "num_samples": 218,
+                "num_queries": 109,
+                "num_documents": 109,
+                "number_of_characters": 16139,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 1910.2708125,
+                    "min_duration_seconds": 1.008,
+                    "average_duration_seconds": 17.525420298165137,
+                    "max_duration_seconds": 35.304,
+                    "unique_audios": 109,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 109
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 16139,
+                    "min_text_length": 31,
+                    "average_text_length": 148.06422018348624,
+                    "max_text_length": 336,
+                    "unique_texts": 109
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 109,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 109,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "lug": {
+                "num_samples": 102,
+                "num_queries": 51,
+                "num_documents": 51,
+                "number_of_characters": 11208,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 1264.176,
+                    "min_duration_seconds": 5.688,
+                    "average_duration_seconds": 24.787764705882353,
+                    "max_duration_seconds": 42.984,
+                    "unique_audios": 51,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 51
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 11208,
+                    "min_text_length": 59,
+                    "average_text_length": 219.76470588235293,
+                    "max_text_length": 536,
+                    "unique_texts": 51
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 51,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 51,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "mas": {
+                "num_samples": 116,
+                "num_queries": 58,
+                "num_documents": 58,
+                "number_of_characters": 10344,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 1186.74,
+                    "min_duration_seconds": 15.516,
+                    "average_duration_seconds": 20.46103448275862,
+                    "max_duration_seconds": 35.316,
+                    "unique_audios": 58,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 58
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 10344,
+                    "min_text_length": 31,
+                    "average_text_length": 178.3448275862069,
+                    "max_text_length": 407,
+                    "unique_texts": 58
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 58,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 58,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "mlg": {
+                "num_samples": 300,
+                "num_queries": 150,
+                "num_documents": 150,
+                "number_of_characters": 31174,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 2670.4089375,
+                    "min_duration_seconds": 1.008,
+                    "average_duration_seconds": 17.80272625,
+                    "max_duration_seconds": 27.24,
+                    "unique_audios": 150,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 150
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 31174,
+                    "min_text_length": 108,
+                    "average_text_length": 207.82666666666665,
+                    "max_text_length": 476,
+                    "unique_texts": 150
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 150,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 150,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "nyn": {
+                "num_samples": 108,
+                "num_queries": 54,
+                "num_documents": 54,
+                "number_of_characters": 9800,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 1146.744,
+                    "min_duration_seconds": 15.732,
+                    "average_duration_seconds": 21.235999999999997,
+                    "max_duration_seconds": 44.064,
+                    "unique_audios": 54,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 54
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 9800,
+                    "min_text_length": 69,
+                    "average_text_length": 181.4814814814815,
+                    "max_text_length": 383,
+                    "unique_texts": 54
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 54,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 54,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "orm": {
+                "num_samples": 278,
+                "num_queries": 139,
+                "num_documents": 139,
+                "number_of_characters": 31770,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 2484.264,
+                    "min_duration_seconds": 11.376,
+                    "average_duration_seconds": 17.872402877697844,
+                    "max_duration_seconds": 28.824,
+                    "unique_audios": 139,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 139
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 31770,
+                    "min_text_length": 138,
+                    "average_text_length": 228.5611510791367,
+                    "max_text_length": 408,
+                    "unique_texts": 139
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 139,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 139,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "sid": {
+                "num_samples": 244,
+                "num_queries": 122,
+                "num_documents": 122,
+                "number_of_characters": 24892,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 2188.488,
+                    "min_duration_seconds": 5.736,
+                    "average_duration_seconds": 17.938426229508195,
+                    "max_duration_seconds": 30.576,
+                    "unique_audios": 122,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 122
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 24892,
+                    "min_text_length": 74,
+                    "average_text_length": 204.0327868852459,
+                    "max_text_length": 374,
+                    "unique_texts": 122
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 122,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 122,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "sna": {
+                "num_samples": 230,
+                "num_queries": 115,
+                "num_documents": 115,
+                "number_of_characters": 22108,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 2306.184,
+                    "min_duration_seconds": 1.008,
+                    "average_duration_seconds": 20.05377391304348,
+                    "max_duration_seconds": 32.664,
+                    "unique_audios": 115,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 115
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 22108,
+                    "min_text_length": 87,
+                    "average_text_length": 192.24347826086955,
+                    "max_text_length": 399,
+                    "unique_texts": 115
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 115,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 115,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "sog": {
+                "num_samples": 106,
+                "num_queries": 53,
+                "num_documents": 53,
+                "number_of_characters": 9638,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 1211.076,
+                    "min_duration_seconds": 15.912,
+                    "average_duration_seconds": 22.850490566037735,
+                    "max_duration_seconds": 44.82,
+                    "unique_audios": 53,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 53
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 9638,
+                    "min_text_length": 73,
+                    "average_text_length": 181.8490566037736,
+                    "max_text_length": 473,
+                    "unique_texts": 53
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 53,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 53,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "tir": {
+                "num_samples": 300,
+                "num_queries": 150,
+                "num_documents": 150,
+                "number_of_characters": 19645,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 2251.992,
+                    "min_duration_seconds": 6.504,
+                    "average_duration_seconds": 15.013280000000002,
+                    "max_duration_seconds": 27.696,
+                    "unique_audios": 150,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 150
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 19645,
+                    "min_text_length": 6,
+                    "average_text_length": 130.96666666666667,
+                    "max_text_length": 243,
+                    "unique_texts": 150
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 150,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 150,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "wal": {
+                "num_samples": 158,
+                "num_queries": 79,
+                "num_documents": 79,
+                "number_of_characters": 13267,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 1193.4,
+                    "min_duration_seconds": 11.424,
+                    "average_duration_seconds": 15.106329113924051,
+                    "max_duration_seconds": 19.056,
+                    "unique_audios": 79,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 79
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 13267,
+                    "min_text_length": 108,
+                    "average_text_length": 167.9367088607595,
+                    "max_text_length": 235,
+                    "unique_texts": 79
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 79,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 79,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            }
+        }
+    }
+}

--- a/mteb/tasks/retrieval/multilingual/__init__.py
+++ b/mteb/tasks/retrieval/multilingual/__init__.py
@@ -136,6 +136,7 @@ from .vidore3_bench_retrieval import (
     Vidore3TelecomRetrieval,
     Vidore3TelecomRetrievalv2,
 )
+from .waxal_retrieval import WaxalA2TRetrieval, WaxalT2ARetrieval
 from .web_faq_retrieval import WebFAQRetrieval
 from .wikipedia_retrieval_multilingual import WikipediaRetrievalMultilingual
 from .wit_t2i_retrieval import WITT2IRetrieval
@@ -268,6 +269,8 @@ __all__ = [
     "Vidore3TelecomRetrieval",
     "Vidore3TelecomRetrievalv2",
     "WITT2IRetrieval",
+    "WaxalA2TRetrieval",
+    "WaxalT2ARetrieval",
     "WebFAQRetrieval",
     "WikipediaRetrievalMultilingual",
     "XFlickr30kCoT2IRetrieval",

--- a/mteb/tasks/retrieval/multilingual/waxal_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/waxal_retrieval.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from datasets import load_dataset
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.retrieval_dataset_loaders import RetrievalSplitData
+from mteb.abstasks.task_metadata import TaskMetadata
+
+_DATASET_PATH = "vnahata/waxal-audio-text-retrieval"
+_DATASET_REVISION = "f57c8af71955625a1dd49b3cf552a23e3e65dafb"
+
+# Keys are WAXAL's own directory names; values are ISO 639-3 plus the script the
+# transcriptions use. Two of WAXAL's short names collide with unrelated ISO codes and
+# are deliberately not passed through - see the comments on `mas` and `sog`.
+_WAXAL_LANGS = {
+    "ach": ["ach-Latn"],  # Acholi
+    "aka": ["aka-Latn"],  # Akan
+    "amh": ["amh-Ethi"],  # Amharic
+    "ewe": ["ewe-Latn"],  # Ewe
+    "ful": ["ful-Latn"],  # Fula
+    "lin": ["lin-Latn"],  # Lingala
+    "lug": ["lug-Latn"],  # Luganda
+    # WAXAL's "mas" is Masaaba (Lumasaaba, Uganda), not Maasai; ISO 639-3 `mas` is Maasai
+    "mas": ["myx-Latn"],
+    "mlg": ["mlg-Latn"],  # Malagasy
+    "nyn": ["nyn-Latn"],  # Nyankole
+    "orm": ["orm-Latn"],  # Oromo, written in Latin (Qubee)
+    "sid": ["sid-Latn"],  # Sidama, written in Latin since 1993
+    "sna": ["sna-Latn"],  # Shona
+    # WAXAL's "sog" is Soga (Lusoga, Uganda); ISO 639-3 `sog` is Sogdian, an extinct
+    # Iranian language, so the Lusoga code `xog` is used instead
+    "sog": ["xog-Latn"],
+    "tir": ["tir-Ethi"],  # Tigrinya
+    "wal": ["wal-Ethi"],  # Wolaytta
+}
+
+_BIBTEX = r"""
+@misc{diack2026waxal,
+  archiveprefix = {arXiv},
+  author = {Diack, Abdoulaye and Nelson, Perry and Agbesi, Kwaku and Nakalembe, Angela and MohamedKhair, MohamedElfatih and Dube, Vusumuzi and Siyavora, Tavonga and Venugopalan, Subhashini and Hickey, Jason and Okonkwo, Uche and Bapna, Abhishek and Wiafe, Isaac and Helegah, Raynard Dodzi and Atsakpo, Elikem Doe and Nutrokpor, Charles and Winful, Fiifi Baffoe Payin and Solaga, Kafui Kwashie and Abdulai, Jamal-Deen and Ekpezu, Akon Obu and Niyonkuru, Audace and Rutunda, Samuel and Ishimwe, Boris and Melese, Michael and Bainomugisha, Engineer and Nakatumba-Nabende, Joyce and Katumba, Andrew and Babirye, Claire and Mukiibi, Jonathan and Kimani, Vincent and Kibacia, Samuel and Maina, James and Emmah, Fridah and Shekarau, Ahmed Ibrahim and Adamu, Ibrahim Shehu and Abdullahi, Yusuf and Lakougna, Howard and MacDonald, Bob and Shemtov, Hadar and Walcott-Bryant, Aisha and Cisse, Moustapha and Hassidim, Avinatan and Dean, Jeff and Matias, Yossi},
+  eprint = {2602.02734},
+  title = {{WAXAL}: A Large-Scale Multilingual African Language Speech Corpus},
+  year = {2026},
+}
+"""
+
+_DESCRIPTION = (
+    "Multilingual speech-text retrieval over WAXAL, a corpus of image-prompted natural "
+    "speech in Sub-Saharan African languages. Most of these languages have no presence in "
+    "mteb's existing multilingual audio tasks, which cover mainly European and South/East "
+    "Asian languages. Each subset is scored against its own transcript pool."
+)
+
+
+def _load_waxal(task: AbsTaskRetrieval, direction: str) -> None:
+    """Shared loader for both directions."""
+    if task.data_loaded:
+        return
+
+    split = task.metadata.eval_splits[0]
+    task.dataset = {}
+
+    for lang in task.hf_subsets:
+        ds = load_dataset(_DATASET_PATH, lang, revision=_DATASET_REVISION, split=split)
+        audio_ds = ds.select_columns(["id", "audio"])
+        text_ds = ds.select_columns(["id", "text"])
+        ids = ds["id"]
+
+        if direction == "a2t":
+            queries, corpus = audio_ds, text_ds
+        else:
+            queries, corpus = text_ds, audio_ds
+
+        task.dataset[lang] = {
+            split: RetrievalSplitData(
+                queries=queries,
+                corpus=corpus,
+                relevant_docs={i: {i: 1} for i in ids},
+                top_ranked=None,
+            )
+        }
+
+    task.data_loaded = True
+
+
+class WaxalA2TRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="WaxalA2TRetrieval",
+        description=f"{_DESCRIPTION} Retrieve the transcription of a spoken utterance.",
+        reference="https://arxiv.org/abs/2602.02734",
+        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        type="Any2AnyRetrieval",
+        category="a2t",
+        eval_splits=["test"],
+        eval_langs=_WAXAL_LANGS,
+        main_score="hit_rate_at_5",
+        modalities=["audio", "text"],
+        date=("2024-01-01", "2026-02-28"),
+        domains=["Spoken"],
+        task_subtypes=["Speech Transcription Retrieval"],
+        license="cc-by-sa-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find the transcription of this spoken utterance."},
+        is_beta=True,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_waxal(self, "a2t")
+
+
+class WaxalT2ARetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="WaxalT2ARetrieval",
+        description=f"{_DESCRIPTION} Retrieve the recording matching a transcription.",
+        reference="https://arxiv.org/abs/2602.02734",
+        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        type="Any2AnyRetrieval",
+        category="t2a",
+        eval_splits=["test"],
+        eval_langs=_WAXAL_LANGS,
+        main_score="hit_rate_at_5",
+        modalities=["text", "audio"],
+        date=("2024-01-01", "2026-02-28"),
+        domains=["Spoken"],
+        task_subtypes=["Speech Transcription Retrieval"],
+        license="cc-by-sa-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        prompt={"query": "Find the recording of the following transcription."},
+        is_beta=True,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_waxal(self, "t2a")

--- a/scripts/data/waxal_retrieval/create_data.py
+++ b/scripts/data/waxal_retrieval/create_data.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Build the WAXAL multilingual speech-text retrieval tasks for MTEB.
+
+WAXAL is a corpus of image-prompted natural speech in Sub-Saharan African languages.
+Most of its languages have no presence in mteb's existing multilingual audio tasks,
+which cover mainly European and South/East Asian languages, so this is a coverage
+addition rather than another dataset in an already well-served direction.
+
+Only the official ASR test split is used. Within it the sample is speaker-capped and
+spread across row groups: WAXAL records long sessions per speaker, so a contiguous read
+would return one voice repeatedly and make the retrieval task easier than the language
+actually is. Languages whose test split yields too few usable utterances are dropped
+rather than shipped at a size that cannot be scored reliably.
+
+Examples:
+  # Sample the per-language evaluation subsets.
+  uv run python scripts/data/waxal_retrieval/create_data.py --stage sample
+
+  # Sample and publish.
+  uv run python scripts/data/waxal_retrieval/create_data.py --stage all --push
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from collections import defaultdict
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from datasets import Audio, Dataset
+from huggingface_hub import HfApi, HfFileSystem
+
+_SOURCE_REPO = "google/WaxalNLP"
+_SOURCE_URL = f"https://huggingface.co/datasets/{_SOURCE_REPO}"
+_TARGET_REPO = "vnahata/waxal-audio-text-retrieval"
+_LICENSE = "cc-by-4.0"
+_SPLIT = "test"
+
+_TARGET_PER_LANG = 150
+_MAX_PER_SPEAKER = 6
+_MIN_CHARS = 5
+_MIN_CLIPS = 25
+_ROW_GROUPS = 40
+
+_COLS = ["id", "speaker_id", "transcription", "language", "gender", "audio"]
+
+
+def _test_shards(api: HfApi) -> dict[str, list[str]]:
+    """Map each ASR language to its test shards."""
+    info = api.repo_info(_SOURCE_REPO, repo_type="dataset", files_metadata=True)
+    shards: dict[str, list[str]] = defaultdict(list)
+    for sibling in info.siblings:
+        path = sibling.rfilename
+        if "/ASR/" in path and path.endswith(".parquet") and "-test-" in path:
+            shards[path.split("/")[2]].append(path)
+    return {k: sorted(v) for k, v in shards.items()}
+
+
+def stage_sample(work: Path) -> dict[str, dict]:
+    """Sample a speaker-diverse evaluation subset per language."""
+    out = work / "audio_sample"
+    out.mkdir(parents=True, exist_ok=True)
+    fs = HfFileSystem()
+    manifest: dict[str, dict] = {}
+    t0 = time.time()
+
+    for lang, shards in sorted(_test_shards(HfApi()).items()):
+        dest = out / f"{lang}.parquet"
+        if dest.exists():
+            manifest[lang] = {"clips": pq.read_table(dest).num_rows}
+            continue
+        rows: list[dict] = []
+        per_speaker: defaultdict[str, int] = defaultdict(int)
+        for shard in shards:
+            if len(rows) >= _TARGET_PER_LANG:
+                break
+            with fs.open(f"datasets/{_SOURCE_REPO}/{shard}", "rb") as fh:
+                pf = pq.ParquetFile(fh)
+                n_rg = pf.metadata.num_row_groups
+                picks = sorted(
+                    {
+                        round(k * (n_rg - 1) / (_ROW_GROUPS - 1))
+                        for k in range(_ROW_GROUPS)
+                    }
+                )
+                for rg in picks:
+                    if len(rows) >= _TARGET_PER_LANG:
+                        break
+                    for r in pf.read_row_group(rg, columns=_COLS).to_pylist():
+                        if len(rows) >= _TARGET_PER_LANG:
+                            break
+                        text = (r.get("transcription") or "").strip()
+                        if len(text) < _MIN_CHARS or not r.get("audio"):
+                            continue
+                        speaker = r.get("speaker_id") or "?"
+                        if per_speaker[speaker] >= _MAX_PER_SPEAKER:
+                            continue
+                        per_speaker[speaker] += 1
+                        r["transcription"] = text
+                        rows.append(r)
+
+        if len(rows) >= _MIN_CLIPS:
+            pq.write_table(pa.Table.from_pylist(rows), dest)
+            manifest[lang] = {"clips": len(rows), "speakers": len(per_speaker)}
+            print(
+                f"  {lang}: {len(rows)} clips / {len(per_speaker)} speakers "
+                f"({time.time() - t0:.0f}s)",
+                flush=True,
+            )
+
+    (work / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+def stage_push(work: Path) -> None:
+    """Publish one config per language with aligned audio and transcription."""
+    api = HfApi()
+    api.create_repo(_TARGET_REPO, repo_type="dataset", exist_ok=True)
+    manifest = json.loads((work / "manifest.json").read_text(encoding="utf-8"))
+
+    for lang in sorted(manifest):
+        path = work / "audio_sample" / f"{lang}.parquet"
+        rows = pq.read_table(path).to_pylist()
+        ds = Dataset.from_dict(
+            {
+                "id": [f"{lang}-{i:05d}" for i in range(len(rows))],
+                "audio": [r["audio"] for r in rows],
+                "text": [r["transcription"] for r in rows],
+                "speaker_id": [r.get("speaker_id") for r in rows],
+                "gender": [r.get("gender") for r in rows],
+                "language": [r.get("language") for r in rows],
+            }
+        ).cast_column("audio", Audio(sampling_rate=16000))
+        ds.push_to_hub(_TARGET_REPO, config_name=lang, split=_SPLIT)
+        print(f"  pushed {lang}: {len(ds)} clips", flush=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--stage", choices=["sample", "push", "all"], default="all")
+    parser.add_argument("--work-dir", type=Path, default=Path("waxal_work"))
+    parser.add_argument("--push", action="store_true")
+    args = parser.parse_args()
+
+    args.work_dir.mkdir(parents=True, exist_ok=True)
+    print(f"source: {_SOURCE_URL} (license {_LICENSE})")
+
+    if args.stage in ("sample", "all"):
+        stage_sample(args.work_dir)
+    if args.stage == "push" or (args.push and args.stage == "all"):
+        stage_push(args.work_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds `WaxalA2TRetrieval` and `WaxalT2ARetrieval` over **16 Sub-Saharan African languages** (1,722 utterances). Part of #4842; issue #4155.

## Gap

mteb's multilingual audio tasks skew European and South/East Asian. Most of these have no presence in them: Acholi, Akan, Amharic, Ewe, Fula, Lingala, Luganda, Masaaba, Malagasy, Nyankole, Oromo, Sidama, Shona, Soga, Tigrinya, Wolaytta.

## Two language-code corrections

WAXAL's directory names are not all ISO 639-3, and two collide with unrelated languages:

- **`mas` is Masaaba** (Lumasaaba, Uganda), not Maasai → mapped to **`myx`**
- **`sog` is Soga** (Lusoga, Uganda) → mapped to **`xog`**; ISO 639-3 `sog` is Sogdian, an extinct Iranian language

Both confirmed against the source card (Makerere contributed "Acholi, Luganda, Masaaba, Nyankole, Soga") and the transcriptions.

## Licence

WAXAL is **mixed-licence**: the University of Ghana languages are CC-BY-4.0, while the Makerere and Digital Umuganda languages are CC-BY-SA-4.0. Share-alike propagates, so this derived dataset is **CC-BY-SA-4.0**.

## Construction

Official ASR **test** split only. Within it the sample is speaker-capped (max 6 utterances per speaker) and spread across row groups: WAXAL records long sessions per speaker, so a contiguous read returns one voice repeatedly and would make retrieval easier than the language actually is. Languages left under 25 usable utterances are dropped.

`main_score` is `hit_rate_at_5`, matching every existing audio↔text retrieval task in `mteb` (Fleurs, CommonVoice, AudioCaps, GoogleSVQ, Clotho, CMUArctic, EmoVDB).

## Checklist

- [x] Outlined why this fills a gap
- [x] Tested that it runs with `mteb` (both directions)
- [x] `mteb/baseline-random-encoder` hit_rate@5: a2t 0.0571, t2a 0.0566
- [x] `jina-embeddings-v5-omni-nano` hit_rate@5: a2t **0.5111**, t2a **0.4694**, roughly 9x and 8x the random floor
- [x] Size considered and reduced
- [x] `test_task_quality.py` passes


