### PR TITLE
dataset: add Jaco Play image-video retrieval (i2v, v2i)

### DIFF
--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/JacoPlayI2VRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/JacoPlayI2VRetrieval.json
@@ -1,0 +1,66 @@
+{
+    "test": {
+        "num_samples": 1034,
+        "num_queries": 130,
+        "num_documents": 904,
+        "number_of_characters": 0,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": {
+            "total_duration_seconds": 6555.900000000002,
+            "total_frames": 65559,
+            "min_width": 224,
+            "average_width": 224.0,
+            "max_width": 224,
+            "min_height": 224,
+            "average_height": 224.0,
+            "max_height": 224,
+            "min_duration_seconds": 2.199999999999818,
+            "average_duration_seconds": 7.252101769911507,
+            "max_duration_seconds": 15.100000000000364,
+            "unique_videos": 904,
+            "average_fps": 10.0,
+            "fps": {
+                "10": 904
+            },
+            "min_resolution": [
+                224,
+                224
+            ],
+            "average_resolution": [
+                224.0,
+                224.0
+            ],
+            "max_resolution": [
+                224,
+                224
+            ],
+            "resolutions": {
+                "224x224": 904
+            }
+        },
+        "queries_text_statistics": null,
+        "queries_image_statistics": {
+            "min_image_width": 224,
+            "average_image_width": 224.0,
+            "max_image_width": 224,
+            "min_image_height": 224,
+            "average_image_height": 224.0,
+            "max_image_height": 224,
+            "unique_images": 130
+        },
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 1808,
+            "min_relevant_docs_per_query": 2,
+            "average_relevant_docs_per_query": 13.907692307692308,
+            "max_relevant_docs_per_query": 69,
+            "unique_relevant_docs": 904,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/JacoPlayV2IRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/JacoPlayV2IRetrieval.json
@@ -1,0 +1,66 @@
+{
+    "test": {
+        "num_samples": 1034,
+        "num_queries": 904,
+        "num_documents": 130,
+        "number_of_characters": 0,
+        "documents_text_statistics": null,
+        "documents_image_statistics": {
+            "min_image_width": 224,
+            "average_image_width": 224.0,
+            "max_image_width": 224,
+            "min_image_height": 224,
+            "average_image_height": 224.0,
+            "max_image_height": 224,
+            "unique_images": 130
+        },
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": {
+            "total_duration_seconds": 6555.900000000002,
+            "total_frames": 65559,
+            "min_width": 224,
+            "average_width": 224.0,
+            "max_width": 224,
+            "min_height": 224,
+            "average_height": 224.0,
+            "max_height": 224,
+            "min_duration_seconds": 2.199999999999818,
+            "average_duration_seconds": 7.252101769911507,
+            "max_duration_seconds": 15.100000000000364,
+            "unique_videos": 904,
+            "average_fps": 10.0,
+            "fps": {
+                "10": 904
+            },
+            "min_resolution": [
+                224,
+                224
+            ],
+            "average_resolution": [
+                224.0,
+                224.0
+            ],
+            "max_resolution": [
+                224,
+                224
+            ],
+            "resolutions": {
+                "224x224": 904
+            }
+        },
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 1808,
+            "min_relevant_docs_per_query": 2,
+            "average_relevant_docs_per_query": 2.0,
+            "max_relevant_docs_per_query": 2,
+            "unique_relevant_docs": 130,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/tasks/retrieval/zxx/__init__.py
+++ b/mteb/tasks/retrieval/zxx/__init__.py
@@ -1,6 +1,7 @@
 from .abo_i2v_retrieval import ABOI2VRetrieval
 from .bridge_retrieval import BridgeV2VRetrieval
 from .evve_retrieval import EVVERetrieval
+from .jaco_play_retrieval import JacoPlayI2VRetrieval, JacoPlayV2IRetrieval
 from .libero_retrieval import LIBEROI2VRetrieval, LIBEROV2IRetrieval
 from .lp_music_caps import LPMusicCapsMTTA2TRetrieval, LPMusicCapsMTTT2ARetrieval
 from .maniskill_retrieval import ManiSkillI2VRetrieval, ManiSkillV2IRetrieval
@@ -24,6 +25,8 @@ __all__ = [
     "ABOI2VRetrieval",
     "BridgeV2VRetrieval",
     "EVVERetrieval",
+    "JacoPlayI2VRetrieval",
+    "JacoPlayV2IRetrieval",
     "LIBEROI2VRetrieval",
     "LIBEROV2IRetrieval",
     "LPMusicCapsMTTA2TRetrieval",

--- a/mteb/tasks/retrieval/zxx/jaco_play_retrieval.py
+++ b/mteb/tasks/retrieval/zxx/jaco_play_retrieval.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.task_metadata import TaskMetadata
+
+_JACO_BIBTEX = r"""
+@software{dass2023jacoplay,
+  author = {Dass, Shivin and Yapeter, Jullian and Zhang, Jesse and Zhang, Jiahui and Pertsch, Karl and Nikolaidis, Stefanos and Lim, Joseph J.},
+  title = {{CLVR} Jaco Play Dataset},
+  url = {https://github.com/clvrai/clvr_jaco_play_dataset},
+  version = {1.0.0},
+  year = {2023},
+}
+"""
+
+_JACO_DESCRIPTION_TAIL = (
+    "Built from the CLVR Jaco Play dataset (1,085 teleoperated Jaco arm episodes over 89 "
+    "language-annotated tabletop tasks, scene camera at 224x224, 10 fps). Tasks with fewer "
+    "than 4 demonstrations are dropped, leaving 65 tasks. Per task, 2 episodes are held out "
+    "to supply queries and the remaining episodes form the corpus, so a query's own episode "
+    "never appears in the corpus and exact frame matching cannot solve the task. A corpus "
+    "item is relevant if and only if it comes from an episode of the same task as the query; "
+    "episodes recorded in the same scene that accomplish a different goal are non-relevant, "
+    "so matching the scene alone is not enough."
+)
+
+
+class JacoPlayI2VRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="JacoPlayI2VRetrieval",
+        description=(
+            "Image-to-video retrieval over robot manipulation episodes: given a goal-state "
+            "image (the final frame of a held-out episode), retrieve manipulation videos "
+            "that accomplish the same task. " + _JACO_DESCRIPTION_TAIL
+        ),
+        reference="https://github.com/clvrai/clvr_jaco_play_dataset",
+        dataset={
+            "path": "vnahata/JacoPlay-I2V",
+            "revision": "50d295dc35edd70b0d2d103a7aecb853b926776f",
+        },
+        type="Any2AnyRetrieval",
+        category="i2v",
+        modalities=["image", "video"],
+        eval_splits=["test"],
+        eval_langs=["zxx-Zxxx"],
+        main_score="ndcg_at_10",
+        date=("2023-01-01", "2023-12-31"),
+        domains=["Robotics", "Scene"],
+        task_subtypes=["Cross-Modal Retrieval"],
+        license="cc-by-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        is_beta=True,
+        bibtex_citation=_JACO_BIBTEX,
+        prompt={
+            "query": (
+                "Retrieve robot manipulation videos that accomplish the task whose "
+                "completed goal state is shown in the image."
+            )
+        },
+    )
+
+
+class JacoPlayV2IRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="JacoPlayV2IRetrieval",
+        description=(
+            "Video-to-image retrieval over robot manipulation episodes: given a "
+            "manipulation video, retrieve goal-state images (final frames of held-out "
+            "episodes) of the same task. " + _JACO_DESCRIPTION_TAIL
+        ),
+        reference="https://github.com/clvrai/clvr_jaco_play_dataset",
+        dataset={
+            "path": "vnahata/JacoPlay-V2I",
+            "revision": "e3937da6f16d5e25391f741621dc8f8fcf46ad02",
+        },
+        type="Any2AnyRetrieval",
+        category="v2i",
+        modalities=["image", "video"],
+        eval_splits=["test"],
+        eval_langs=["zxx-Zxxx"],
+        main_score="ndcg_at_10",
+        date=("2023-01-01", "2023-12-31"),
+        domains=["Robotics", "Scene"],
+        task_subtypes=["Cross-Modal Retrieval"],
+        license="cc-by-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        is_beta=True,
+        bibtex_citation=_JACO_BIBTEX,
+        prompt={
+            "query": (
+                "Retrieve goal-state images of the task accomplished in the robot "
+                "manipulation video."
+            )
+        },
+    )

--- a/scripts/data/jaco_play_retrieval/create_data.py
+++ b/scripts/data/jaco_play_retrieval/create_data.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Build the Jaco Play image<->video retrieval tasks for MTEB.
+
+Follows the construction already merged for LIBERO and ManiSkill: the query is the goal
+state of a held-out episode (its final frame) and the corpus is other episodes' videos,
+with a corpus item relevant iff it comes from the same task. Held-out episodes never
+appear in the corpus, so the task cannot be solved by matching identical frames, and
+episodes recorded in the same scene that accomplish a different goal stay non-relevant so
+matching the scene alone is not enough.
+
+Tasks with fewer than `--min-episodes` demonstrations are dropped, so every query has
+several distinct relevant videos rather than a single one.
+
+Two source details matter:
+
+1. LeRobot concatenates all episodes into one mp4 per camera and addresses each episode
+   by a `[from_timestamp, to_timestamp]` range, so clips are cut by timestamp rather than
+   read as separate files.
+
+2. The encoder must be given the source frame rate as an exact `Fraction`. Rounding it to
+   an int puts the encoder in a different time base from the incoming frames and every
+   mux fails with EINVAL.
+
+The v2i direction is the same media with the roles swapped: videos become queries, goal
+images become the corpus, and the qrels are reversed.
+
+Examples:
+  # Build both directions locally.
+  uv run python scripts/data/jaco_play_retrieval/create_data.py --stage build
+
+  # Build and publish.
+  uv run python scripts/data/jaco_play_retrieval/create_data.py --stage all --push
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import io
+import json
+from fractions import Fraction
+from pathlib import Path
+
+import av
+import pyarrow as pa
+import pyarrow.parquet as pq
+from datasets import Dataset, Image, Video
+from huggingface_hub import HfApi, snapshot_download
+
+_SOURCE_REPO = "lerobot/jaco_play"
+_HOMEPAGE = "https://github.com/clvrai/clvr_jaco_play_dataset"
+_LICENSE = "cc-by-4.0"
+_TARGET_I2V = "vnahata/JacoPlay-I2V"
+_TARGET_V2I = "vnahata/JacoPlay-V2I"
+_SPLIT = "test"
+
+# the scene camera; the wrist camera is too close-up to identify a task from one frame
+_VIDEO_KEY = "observation.images.image"
+
+
+def _episodes(src: Path) -> list[dict]:
+    cols = [
+        "episode_index",
+        "tasks",
+        f"videos/{_VIDEO_KEY}/from_timestamp",
+        f"videos/{_VIDEO_KEY}/to_timestamp",
+    ]
+    rows = pq.read_table(
+        src / "meta/episodes/chunk-000/file-000.parquet", columns=cols
+    ).to_pylist()
+    return [
+        {
+            "episode": r["episode_index"],
+            "task": r["tasks"][0],
+            "start": r[f"videos/{_VIDEO_KEY}/from_timestamp"],
+            "end": r[f"videos/{_VIDEO_KEY}/to_timestamp"],
+        }
+        for r in rows
+        if r["tasks"]
+    ]
+
+
+def _cut(video: Path, start: float, end: float) -> tuple[bytes, bytes] | None:
+    """Return (clip mp4 bytes, final frame jpeg bytes) for one episode."""
+    with av.open(str(video)) as inp:
+        vs = inp.streams.video[0]
+        rate = vs.average_rate or Fraction(10, 1)  # exact; see module docstring
+        buf, last, wrote = io.BytesIO(), None, 0
+        with av.open(buf, "w", format="mp4") as out:
+            ov = out.add_stream("libx264", rate=rate)
+            ov.width = vs.codec_context.width
+            ov.height = vs.codec_context.height
+            ov.pix_fmt = "yuv420p"
+            if vs.time_base:
+                inp.seek(int(start / vs.time_base), stream=vs)
+            for frame in inp.decode(vs):
+                t = float(frame.pts * vs.time_base) if frame.pts is not None else 0.0
+                if t < start:
+                    continue
+                if t >= end:
+                    break
+                out.mux(ov.encode(frame))
+                last, wrote = frame, wrote + 1
+            out.mux(ov.encode(None))
+        if not wrote or last is None:
+            return None
+    img = io.BytesIO()
+    last.to_image().save(img, format="JPEG", quality=92)
+    return buf.getvalue(), img.getvalue()
+
+
+def stage_build(work: Path, min_episodes: int, per_task: int) -> dict:
+    src = Path(snapshot_download(_SOURCE_REPO, repo_type="dataset"))
+    out_i2v, out_v2i = work / "i2v", work / "v2i"
+    out_i2v.mkdir(parents=True, exist_ok=True)
+    out_v2i.mkdir(parents=True, exist_ok=True)
+
+    by_task: dict[str, list[dict]] = collections.defaultdict(list)
+    for e in _episodes(src):
+        by_task[e["task"]].append(e)
+    kept = {
+        t: sorted(v, key=lambda x: x["episode"])
+        for t, v in by_task.items()
+        if len(v) >= min_episodes
+    }
+    print(f"tasks kept: {len(kept)} of {len(by_task)}")
+
+    video = src / f"videos/{_VIDEO_KEY}/chunk-000/file-000.mp4"
+    queries, corpus, qrels, dropped = [], [], [], 0
+
+    for _task, episodes in sorted(kept.items()):
+        q_eps, c_eps = episodes[:per_task], episodes[per_task:]
+        for e in c_eps:
+            cut = _cut(video, e["start"], e["end"])
+            if cut is None:
+                dropped += 1
+                continue
+            cid = f"ep{e['episode']:05d}"
+            corpus.append({"id": cid, "video": {"bytes": cut[0], "path": f"{cid}.mp4"}})
+        for e in q_eps:
+            cut = _cut(video, e["start"], e["end"])
+            if cut is None:
+                dropped += 1
+                continue
+            qid = f"goal{e['episode']:05d}"
+            queries.append(
+                {"id": qid, "image": {"bytes": cut[1], "path": f"{qid}.jpg"}}
+            )
+            qrels.extend(
+                {"query-id": qid, "corpus-id": f"ep{c['episode']:05d}", "score": 1}
+                for c in c_eps
+            )
+
+    pq.write_table(pa.Table.from_pylist(queries), out_i2v / "queries.parquet")
+    pq.write_table(pa.Table.from_pylist(corpus), out_i2v / "corpus.parquet")
+    pq.write_table(pa.Table.from_pylist(qrels), out_i2v / "qrels.parquet")
+
+    # v2i is the same media with the roles swapped
+    pq.write_table(pa.Table.from_pylist(corpus), out_v2i / "queries.parquet")
+    pq.write_table(pa.Table.from_pylist(queries), out_v2i / "corpus.parquet")
+    pq.write_table(
+        pa.Table.from_pylist(
+            [
+                {"query-id": r["corpus-id"], "corpus-id": r["query-id"], "score": 1}
+                for r in qrels
+            ]
+        ),
+        out_v2i / "qrels.parquet",
+    )
+
+    stats = {
+        "tasks": len(kept),
+        "i2v_queries": len(queries),
+        "i2v_corpus": len(corpus),
+        "qrels": len(qrels),
+        "dropped": dropped,
+    }
+    (work / "stats.json").write_text(json.dumps(stats, indent=2), encoding="utf-8")
+    print("built", json.dumps(stats))
+    return stats
+
+
+def stage_push(work: Path) -> None:
+    api = HfApi()
+    for sub, repo, qcol, ccol in (
+        ("i2v", _TARGET_I2V, Image(), Video()),
+        ("v2i", _TARGET_V2I, Video(), Image()),
+    ):
+        api.create_repo(repo, repo_type="dataset", exist_ok=True)
+        d = work / sub
+        qname = "image" if isinstance(qcol, Image) else "video"
+        cname = "image" if isinstance(ccol, Image) else "video"
+        Dataset.from_parquet(str(d / "queries.parquet")).cast_column(
+            qname, qcol
+        ).push_to_hub(repo, config_name="queries", split=_SPLIT, max_shard_size="400MB")
+        Dataset.from_parquet(str(d / "corpus.parquet")).cast_column(
+            cname, ccol
+        ).push_to_hub(repo, config_name="corpus", split=_SPLIT, max_shard_size="400MB")
+        Dataset.from_parquet(str(d / "qrels.parquet")).push_to_hub(
+            repo, config_name="qrels", split=_SPLIT
+        )
+        print(f"pushed {repo}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--stage", choices=["build", "push", "all"], default="all")
+    parser.add_argument("--work-dir", type=Path, default=Path("jaco_work"))
+    parser.add_argument("--min-episodes", type=int, default=4)
+    parser.add_argument("--queries-per-task", type=int, default=2)
+    parser.add_argument("--push", action="store_true")
+    args = parser.parse_args()
+
+    args.work_dir.mkdir(parents=True, exist_ok=True)
+    print(f"source: {_HOMEPAGE} (license {_LICENSE})")
+
+    if args.stage in ("build", "all"):
+        stage_build(args.work_dir, args.min_episodes, args.queries_per_task)
+    if args.stage == "push" or (args.push and args.stage == "all"):
+        stage_push(args.work_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds `JacoPlayI2VRetrieval` and `JacoPlayV2IRetrieval` over the CLVR Jaco Play dataset, filling two of the open image↔video slots in #4842.

## Construction

Follows the construction already merged for LIBERO (#5255) and ManiSkill (#5257): the query is the goal state of a held-out episode (its final frame) and the corpus is other episodes' videos, with a corpus item relevant iff it comes from the same task.

Held-out episodes never appear in the corpus, so identical-frame matching cannot solve it, and episodes recorded in the same scene that accomplish a different goal stay non-relevant, so matching the scene alone is not enough.

Tasks with fewer than 4 demonstrations are dropped, leaving **65 of 89 tasks**, so every query has several distinct relevant videos rather than a single one. That gives 130 queries, 904 corpus videos and 1,808 qrels. `v2i` is the same media with the roles swapped.

## Source detail worth noting

LeRobot concatenates all episodes into one mp4 per camera and addresses each episode by a `[from_timestamp, to_timestamp]` range, so clips are cut by timestamp rather than read as separate files. The scene camera is used rather than the wrist camera, which is too close-up to identify a task from a single frame.

Source: `lerobot/jaco_play`, **cc-by-4.0**, citation from the project's `CITATION.cff` (Dass et al. 2023).

## Checklist

- [x] Outlined why this fills a gap
- [x] Runs with `mteb`, both directions
- [x] `mteb/baseline-random-encoder` on the full task → i2v 0.017, v2i 0.038
- [ ] Second encoder not run yet. Happy to add one before merge
- [x] Verified 0 dangling qrels, 0 query/corpus id overlap, 0 duplicate media, and 0 episode leakage between queries and corpus
- [x] `test_task_quality.py` passes


