### PR TITLE
dataset: add MCIF multilingual video and audio retrieval (t2v, v2t, t2a, a2t)

### DIFF
--- a/mteb/descriptive_stats/Image/Any2AnyMultilingualRetrieval/MCIFA2TRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyMultilingualRetrieval/MCIFA2TRetrieval.json
@@ -1,0 +1,204 @@
+{
+    "test": {
+        "num_samples": 1048,
+        "num_queries": 516,
+        "num_documents": 532,
+        "number_of_characters": 28877,
+        "documents_text_statistics": {
+            "total_text_length": 28877,
+            "min_text_length": 8,
+            "average_text_length": 54.28007518796993,
+            "max_text_length": 172,
+            "unique_texts": 532
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": null,
+        "queries_audio_statistics": {
+            "total_duration_seconds": 10722.16,
+            "min_duration_seconds": 3.903875,
+            "average_duration_seconds": 20.77937984496124,
+            "max_duration_seconds": 62.1020625,
+            "unique_audios": 125,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 516
+            }
+        },
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 532,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0310077519379846,
+            "max_relevant_docs_per_query": 2,
+            "unique_relevant_docs": 532,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null,
+        "hf_subset_descriptive_stats": {
+            "en": {
+                "num_samples": 262,
+                "num_queries": 129,
+                "num_documents": 133,
+                "number_of_characters": 8051,
+                "documents_text_statistics": {
+                    "total_text_length": 8051,
+                    "min_text_length": 15,
+                    "average_text_length": 60.53383458646616,
+                    "max_text_length": 126,
+                    "unique_texts": 133
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 2680.54,
+                    "min_duration_seconds": 3.903875,
+                    "average_duration_seconds": 20.77937984496124,
+                    "max_duration_seconds": 62.1020625,
+                    "unique_audios": 125,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 129
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 133,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0310077519379846,
+                    "max_relevant_docs_per_query": 2,
+                    "unique_relevant_docs": 133,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "de": {
+                "num_samples": 262,
+                "num_queries": 129,
+                "num_documents": 133,
+                "number_of_characters": 8981,
+                "documents_text_statistics": {
+                    "total_text_length": 8981,
+                    "min_text_length": 15,
+                    "average_text_length": 67.52631578947368,
+                    "max_text_length": 158,
+                    "unique_texts": 133
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 2680.54,
+                    "min_duration_seconds": 3.903875,
+                    "average_duration_seconds": 20.77937984496124,
+                    "max_duration_seconds": 62.1020625,
+                    "unique_audios": 125,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 129
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 133,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0310077519379846,
+                    "max_relevant_docs_per_query": 2,
+                    "unique_relevant_docs": 133,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "it": {
+                "num_samples": 262,
+                "num_queries": 129,
+                "num_documents": 133,
+                "number_of_characters": 9261,
+                "documents_text_statistics": {
+                    "total_text_length": 9261,
+                    "min_text_length": 13,
+                    "average_text_length": 69.63157894736842,
+                    "max_text_length": 172,
+                    "unique_texts": 133
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 2680.54,
+                    "min_duration_seconds": 3.903875,
+                    "average_duration_seconds": 20.77937984496124,
+                    "max_duration_seconds": 62.1020625,
+                    "unique_audios": 125,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 129
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 133,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0310077519379846,
+                    "max_relevant_docs_per_query": 2,
+                    "unique_relevant_docs": 133,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "zh": {
+                "num_samples": 262,
+                "num_queries": 129,
+                "num_documents": 133,
+                "number_of_characters": 2584,
+                "documents_text_statistics": {
+                    "total_text_length": 2584,
+                    "min_text_length": 8,
+                    "average_text_length": 19.428571428571427,
+                    "max_text_length": 46,
+                    "unique_texts": 133
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 2680.54,
+                    "min_duration_seconds": 3.903875,
+                    "average_duration_seconds": 20.77937984496124,
+                    "max_duration_seconds": 62.1020625,
+                    "unique_audios": 125,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 129
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 133,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0310077519379846,
+                    "max_relevant_docs_per_query": 2,
+                    "unique_relevant_docs": 133,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            }
+        }
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyMultilingualRetrieval/MCIFT2ARetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyMultilingualRetrieval/MCIFT2ARetrieval.json
@@ -1,0 +1,204 @@
+{
+    "test": {
+        "num_samples": 3552,
+        "num_queries": 532,
+        "num_documents": 3020,
+        "number_of_characters": 28877,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": {
+            "total_duration_seconds": 34425.83425,
+            "min_duration_seconds": 1.381375,
+            "average_duration_seconds": 11.39928286423841,
+            "max_duration_seconds": 62.1020625,
+            "unique_audios": 745,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 3020
+            }
+        },
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 28877,
+            "min_text_length": 8,
+            "average_text_length": 54.28007518796993,
+            "max_text_length": 172,
+            "unique_texts": 532
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 532,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 516,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null,
+        "hf_subset_descriptive_stats": {
+            "en": {
+                "num_samples": 888,
+                "num_queries": 133,
+                "num_documents": 755,
+                "number_of_characters": 8051,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 8606.4585625,
+                    "min_duration_seconds": 1.381375,
+                    "average_duration_seconds": 11.39928286423841,
+                    "max_duration_seconds": 62.1020625,
+                    "unique_audios": 745,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 755
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 8051,
+                    "min_text_length": 15,
+                    "average_text_length": 60.53383458646616,
+                    "max_text_length": 126,
+                    "unique_texts": 133
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 133,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 129,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "de": {
+                "num_samples": 888,
+                "num_queries": 133,
+                "num_documents": 755,
+                "number_of_characters": 8981,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 8606.4585625,
+                    "min_duration_seconds": 1.381375,
+                    "average_duration_seconds": 11.39928286423841,
+                    "max_duration_seconds": 62.1020625,
+                    "unique_audios": 745,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 755
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 8981,
+                    "min_text_length": 15,
+                    "average_text_length": 67.52631578947368,
+                    "max_text_length": 158,
+                    "unique_texts": 133
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 133,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 129,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "it": {
+                "num_samples": 888,
+                "num_queries": 133,
+                "num_documents": 755,
+                "number_of_characters": 9261,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 8606.4585625,
+                    "min_duration_seconds": 1.381375,
+                    "average_duration_seconds": 11.39928286423841,
+                    "max_duration_seconds": 62.1020625,
+                    "unique_audios": 745,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 755
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 9261,
+                    "min_text_length": 13,
+                    "average_text_length": 69.63157894736842,
+                    "max_text_length": 172,
+                    "unique_texts": 133
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 133,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 129,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "zh": {
+                "num_samples": 888,
+                "num_queries": 133,
+                "num_documents": 755,
+                "number_of_characters": 2584,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 8606.4585625,
+                    "min_duration_seconds": 1.381375,
+                    "average_duration_seconds": 11.39928286423841,
+                    "max_duration_seconds": 62.1020625,
+                    "unique_audios": 745,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 755
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 2584,
+                    "min_text_length": 8,
+                    "average_text_length": 19.428571428571427,
+                    "max_text_length": 46,
+                    "unique_texts": 133
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 133,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 129,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            }
+        }
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyMultilingualRetrieval/MCIFT2VRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyMultilingualRetrieval/MCIFT2VRetrieval.json
@@ -1,0 +1,364 @@
+{
+    "test": {
+        "num_samples": 3552,
+        "num_queries": 532,
+        "num_documents": 3020,
+        "number_of_characters": 28877,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": {
+            "total_duration_seconds": 34373.776633663365,
+            "total_frames": 2012280,
+            "min_width": 948,
+            "average_width": 1655.266225165563,
+            "max_width": 1920,
+            "min_height": 468,
+            "average_height": 948.2198675496688,
+            "max_height": 1080,
+            "min_duration_seconds": 1.353135313531353,
+            "average_duration_seconds": 11.38204524293489,
+            "max_duration_seconds": 62.1,
+            "unique_videos": 745,
+            "average_fps": 62.06622516556291,
+            "fps": {
+                "25": 1584,
+                "30": 1328,
+                "1000": 108
+            },
+            "min_resolution": [
+                948,
+                468
+            ],
+            "average_resolution": [
+                1655.266225165563,
+                948.2198675496688
+            ],
+            "max_resolution": [
+                1920,
+                1080
+            ],
+            "resolutions": {
+                "1920x1080": 1732,
+                "948x468": 124,
+                "1280x720": 284,
+                "1440x900": 200,
+                "1470x956": 128,
+                "1470x920": 132,
+                "1496x934": 168,
+                "1172x638": 108,
+                "1002x562": 144
+            }
+        },
+        "queries_text_statistics": {
+            "total_text_length": 28877,
+            "min_text_length": 8,
+            "average_text_length": 54.28007518796993,
+            "max_text_length": 172,
+            "unique_texts": 532
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 532,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 516,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null,
+        "hf_subset_descriptive_stats": {
+            "en": {
+                "num_samples": 888,
+                "num_queries": 133,
+                "num_documents": 755,
+                "number_of_characters": 8051,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": {
+                    "total_duration_seconds": 8593.444158415841,
+                    "total_frames": 503070,
+                    "min_width": 948,
+                    "average_width": 1655.266225165563,
+                    "max_width": 1920,
+                    "min_height": 468,
+                    "average_height": 948.2198675496688,
+                    "max_height": 1080,
+                    "min_duration_seconds": 1.353135313531353,
+                    "average_duration_seconds": 11.38204524293489,
+                    "max_duration_seconds": 62.1,
+                    "unique_videos": 745,
+                    "average_fps": 62.06622516556291,
+                    "fps": {
+                        "25": 396,
+                        "30": 332,
+                        "1000": 27
+                    },
+                    "min_resolution": [
+                        948,
+                        468
+                    ],
+                    "average_resolution": [
+                        1655.266225165563,
+                        948.2198675496688
+                    ],
+                    "max_resolution": [
+                        1920,
+                        1080
+                    ],
+                    "resolutions": {
+                        "1920x1080": 433,
+                        "948x468": 31,
+                        "1280x720": 71,
+                        "1440x900": 50,
+                        "1470x956": 32,
+                        "1470x920": 33,
+                        "1496x934": 42,
+                        "1172x638": 27,
+                        "1002x562": 36
+                    }
+                },
+                "queries_text_statistics": {
+                    "total_text_length": 8051,
+                    "min_text_length": 15,
+                    "average_text_length": 60.53383458646616,
+                    "max_text_length": 126,
+                    "unique_texts": 133
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 133,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 129,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "de": {
+                "num_samples": 888,
+                "num_queries": 133,
+                "num_documents": 755,
+                "number_of_characters": 8981,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": {
+                    "total_duration_seconds": 8593.444158415841,
+                    "total_frames": 503070,
+                    "min_width": 948,
+                    "average_width": 1655.266225165563,
+                    "max_width": 1920,
+                    "min_height": 468,
+                    "average_height": 948.2198675496688,
+                    "max_height": 1080,
+                    "min_duration_seconds": 1.353135313531353,
+                    "average_duration_seconds": 11.38204524293489,
+                    "max_duration_seconds": 62.1,
+                    "unique_videos": 745,
+                    "average_fps": 62.06622516556291,
+                    "fps": {
+                        "25": 396,
+                        "30": 332,
+                        "1000": 27
+                    },
+                    "min_resolution": [
+                        948,
+                        468
+                    ],
+                    "average_resolution": [
+                        1655.266225165563,
+                        948.2198675496688
+                    ],
+                    "max_resolution": [
+                        1920,
+                        1080
+                    ],
+                    "resolutions": {
+                        "1920x1080": 433,
+                        "948x468": 31,
+                        "1280x720": 71,
+                        "1440x900": 50,
+                        "1470x956": 32,
+                        "1470x920": 33,
+                        "1496x934": 42,
+                        "1172x638": 27,
+                        "1002x562": 36
+                    }
+                },
+                "queries_text_statistics": {
+                    "total_text_length": 8981,
+                    "min_text_length": 15,
+                    "average_text_length": 67.52631578947368,
+                    "max_text_length": 158,
+                    "unique_texts": 133
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 133,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 129,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "it": {
+                "num_samples": 888,
+                "num_queries": 133,
+                "num_documents": 755,
+                "number_of_characters": 9261,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": {
+                    "total_duration_seconds": 8593.444158415841,
+                    "total_frames": 503070,
+                    "min_width": 948,
+                    "average_width": 1655.266225165563,
+                    "max_width": 1920,
+                    "min_height": 468,
+                    "average_height": 948.2198675496688,
+                    "max_height": 1080,
+                    "min_duration_seconds": 1.353135313531353,
+                    "average_duration_seconds": 11.38204524293489,
+                    "max_duration_seconds": 62.1,
+                    "unique_videos": 745,
+                    "average_fps": 62.06622516556291,
+                    "fps": {
+                        "25": 396,
+                        "30": 332,
+                        "1000": 27
+                    },
+                    "min_resolution": [
+                        948,
+                        468
+                    ],
+                    "average_resolution": [
+                        1655.266225165563,
+                        948.2198675496688
+                    ],
+                    "max_resolution": [
+                        1920,
+                        1080
+                    ],
+                    "resolutions": {
+                        "1920x1080": 433,
+                        "948x468": 31,
+                        "1280x720": 71,
+                        "1440x900": 50,
+                        "1470x956": 32,
+                        "1470x920": 33,
+                        "1496x934": 42,
+                        "1172x638": 27,
+                        "1002x562": 36
+                    }
+                },
+                "queries_text_statistics": {
+                    "total_text_length": 9261,
+                    "min_text_length": 13,
+                    "average_text_length": 69.63157894736842,
+                    "max_text_length": 172,
+                    "unique_texts": 133
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 133,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 129,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "zh": {
+                "num_samples": 888,
+                "num_queries": 133,
+                "num_documents": 755,
+                "number_of_characters": 2584,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": {
+                    "total_duration_seconds": 8593.444158415841,
+                    "total_frames": 503070,
+                    "min_width": 948,
+                    "average_width": 1655.266225165563,
+                    "max_width": 1920,
+                    "min_height": 468,
+                    "average_height": 948.2198675496688,
+                    "max_height": 1080,
+                    "min_duration_seconds": 1.353135313531353,
+                    "average_duration_seconds": 11.38204524293489,
+                    "max_duration_seconds": 62.1,
+                    "unique_videos": 745,
+                    "average_fps": 62.06622516556291,
+                    "fps": {
+                        "25": 396,
+                        "30": 332,
+                        "1000": 27
+                    },
+                    "min_resolution": [
+                        948,
+                        468
+                    ],
+                    "average_resolution": [
+                        1655.266225165563,
+                        948.2198675496688
+                    ],
+                    "max_resolution": [
+                        1920,
+                        1080
+                    ],
+                    "resolutions": {
+                        "1920x1080": 433,
+                        "948x468": 31,
+                        "1280x720": 71,
+                        "1440x900": 50,
+                        "1470x956": 32,
+                        "1470x920": 33,
+                        "1496x934": 42,
+                        "1172x638": 27,
+                        "1002x562": 36
+                    }
+                },
+                "queries_text_statistics": {
+                    "total_text_length": 2584,
+                    "min_text_length": 8,
+                    "average_text_length": 19.428571428571427,
+                    "max_text_length": 46,
+                    "unique_texts": 133
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 133,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 129,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            }
+        }
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyMultilingualRetrieval/MCIFV2TRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyMultilingualRetrieval/MCIFV2TRetrieval.json
@@ -1,0 +1,364 @@
+{
+    "test": {
+        "num_samples": 1048,
+        "num_queries": 516,
+        "num_documents": 532,
+        "number_of_characters": 28877,
+        "documents_text_statistics": {
+            "total_text_length": 28877,
+            "min_text_length": 8,
+            "average_text_length": 54.28007518796993,
+            "max_text_length": 172,
+            "unique_texts": 532
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": {
+            "total_duration_seconds": 10713.998508250825,
+            "total_frames": 581044,
+            "min_width": 948,
+            "average_width": 1658.2945736434108,
+            "max_width": 1920,
+            "min_height": 468,
+            "average_height": 948.9302325581396,
+            "max_height": 1080,
+            "min_duration_seconds": 3.88,
+            "average_duration_seconds": 20.763563000486094,
+            "max_duration_seconds": 62.1,
+            "unique_videos": 125,
+            "average_fps": 72.55813953488372,
+            "fps": {
+                "25": 264,
+                "30": 228,
+                "1000": 24
+            },
+            "min_resolution": [
+                948,
+                468
+            ],
+            "average_resolution": [
+                1658.2945736434108,
+                948.9302325581396
+            ],
+            "max_resolution": [
+                1920,
+                1080
+            ],
+            "resolutions": {
+                "948x468": 16,
+                "1280x720": 48,
+                "1920x1080": 300,
+                "1470x956": 20,
+                "1496x934": 28,
+                "1470x920": 24,
+                "1172x638": 24,
+                "1002x562": 28,
+                "1440x900": 28
+            }
+        },
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 532,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0310077519379846,
+            "max_relevant_docs_per_query": 2,
+            "unique_relevant_docs": 532,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null,
+        "hf_subset_descriptive_stats": {
+            "en": {
+                "num_samples": 262,
+                "num_queries": 129,
+                "num_documents": 133,
+                "number_of_characters": 8051,
+                "documents_text_statistics": {
+                    "total_text_length": 8051,
+                    "min_text_length": 15,
+                    "average_text_length": 60.53383458646616,
+                    "max_text_length": 126,
+                    "unique_texts": 133
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": {
+                    "total_duration_seconds": 2678.499627062706,
+                    "total_frames": 145261,
+                    "min_width": 948,
+                    "average_width": 1658.2945736434108,
+                    "max_width": 1920,
+                    "min_height": 468,
+                    "average_height": 948.9302325581396,
+                    "max_height": 1080,
+                    "min_duration_seconds": 3.88,
+                    "average_duration_seconds": 20.763563000486094,
+                    "max_duration_seconds": 62.1,
+                    "unique_videos": 125,
+                    "average_fps": 72.55813953488372,
+                    "fps": {
+                        "25": 66,
+                        "30": 57,
+                        "1000": 6
+                    },
+                    "min_resolution": [
+                        948,
+                        468
+                    ],
+                    "average_resolution": [
+                        1658.2945736434108,
+                        948.9302325581396
+                    ],
+                    "max_resolution": [
+                        1920,
+                        1080
+                    ],
+                    "resolutions": {
+                        "948x468": 4,
+                        "1280x720": 12,
+                        "1920x1080": 75,
+                        "1470x956": 5,
+                        "1496x934": 7,
+                        "1470x920": 6,
+                        "1172x638": 6,
+                        "1002x562": 7,
+                        "1440x900": 7
+                    }
+                },
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 133,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0310077519379846,
+                    "max_relevant_docs_per_query": 2,
+                    "unique_relevant_docs": 133,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "de": {
+                "num_samples": 262,
+                "num_queries": 129,
+                "num_documents": 133,
+                "number_of_characters": 8981,
+                "documents_text_statistics": {
+                    "total_text_length": 8981,
+                    "min_text_length": 15,
+                    "average_text_length": 67.52631578947368,
+                    "max_text_length": 158,
+                    "unique_texts": 133
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": {
+                    "total_duration_seconds": 2678.499627062706,
+                    "total_frames": 145261,
+                    "min_width": 948,
+                    "average_width": 1658.2945736434108,
+                    "max_width": 1920,
+                    "min_height": 468,
+                    "average_height": 948.9302325581396,
+                    "max_height": 1080,
+                    "min_duration_seconds": 3.88,
+                    "average_duration_seconds": 20.763563000486094,
+                    "max_duration_seconds": 62.1,
+                    "unique_videos": 125,
+                    "average_fps": 72.55813953488372,
+                    "fps": {
+                        "25": 66,
+                        "30": 57,
+                        "1000": 6
+                    },
+                    "min_resolution": [
+                        948,
+                        468
+                    ],
+                    "average_resolution": [
+                        1658.2945736434108,
+                        948.9302325581396
+                    ],
+                    "max_resolution": [
+                        1920,
+                        1080
+                    ],
+                    "resolutions": {
+                        "948x468": 4,
+                        "1280x720": 12,
+                        "1920x1080": 75,
+                        "1470x956": 5,
+                        "1496x934": 7,
+                        "1470x920": 6,
+                        "1172x638": 6,
+                        "1002x562": 7,
+                        "1440x900": 7
+                    }
+                },
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 133,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0310077519379846,
+                    "max_relevant_docs_per_query": 2,
+                    "unique_relevant_docs": 133,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "it": {
+                "num_samples": 262,
+                "num_queries": 129,
+                "num_documents": 133,
+                "number_of_characters": 9261,
+                "documents_text_statistics": {
+                    "total_text_length": 9261,
+                    "min_text_length": 13,
+                    "average_text_length": 69.63157894736842,
+                    "max_text_length": 172,
+                    "unique_texts": 133
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": {
+                    "total_duration_seconds": 2678.499627062706,
+                    "total_frames": 145261,
+                    "min_width": 948,
+                    "average_width": 1658.2945736434108,
+                    "max_width": 1920,
+                    "min_height": 468,
+                    "average_height": 948.9302325581396,
+                    "max_height": 1080,
+                    "min_duration_seconds": 3.88,
+                    "average_duration_seconds": 20.763563000486094,
+                    "max_duration_seconds": 62.1,
+                    "unique_videos": 125,
+                    "average_fps": 72.55813953488372,
+                    "fps": {
+                        "25": 66,
+                        "30": 57,
+                        "1000": 6
+                    },
+                    "min_resolution": [
+                        948,
+                        468
+                    ],
+                    "average_resolution": [
+                        1658.2945736434108,
+                        948.9302325581396
+                    ],
+                    "max_resolution": [
+                        1920,
+                        1080
+                    ],
+                    "resolutions": {
+                        "948x468": 4,
+                        "1280x720": 12,
+                        "1920x1080": 75,
+                        "1470x956": 5,
+                        "1496x934": 7,
+                        "1470x920": 6,
+                        "1172x638": 6,
+                        "1002x562": 7,
+                        "1440x900": 7
+                    }
+                },
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 133,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0310077519379846,
+                    "max_relevant_docs_per_query": 2,
+                    "unique_relevant_docs": 133,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "zh": {
+                "num_samples": 262,
+                "num_queries": 129,
+                "num_documents": 133,
+                "number_of_characters": 2584,
+                "documents_text_statistics": {
+                    "total_text_length": 2584,
+                    "min_text_length": 8,
+                    "average_text_length": 19.428571428571427,
+                    "max_text_length": 46,
+                    "unique_texts": 133
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": {
+                    "total_duration_seconds": 2678.499627062706,
+                    "total_frames": 145261,
+                    "min_width": 948,
+                    "average_width": 1658.2945736434108,
+                    "max_width": 1920,
+                    "min_height": 468,
+                    "average_height": 948.9302325581396,
+                    "max_height": 1080,
+                    "min_duration_seconds": 3.88,
+                    "average_duration_seconds": 20.763563000486094,
+                    "max_duration_seconds": 62.1,
+                    "unique_videos": 125,
+                    "average_fps": 72.55813953488372,
+                    "fps": {
+                        "25": 66,
+                        "30": 57,
+                        "1000": 6
+                    },
+                    "min_resolution": [
+                        948,
+                        468
+                    ],
+                    "average_resolution": [
+                        1658.2945736434108,
+                        948.9302325581396
+                    ],
+                    "max_resolution": [
+                        1920,
+                        1080
+                    ],
+                    "resolutions": {
+                        "948x468": 4,
+                        "1280x720": 12,
+                        "1920x1080": 75,
+                        "1470x956": 5,
+                        "1496x934": 7,
+                        "1470x920": 6,
+                        "1172x638": 6,
+                        "1002x562": 7,
+                        "1440x900": 7
+                    }
+                },
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 133,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0310077519379846,
+                    "max_relevant_docs_per_query": 2,
+                    "unique_relevant_docs": 133,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            }
+        }
+    }
+}

--- a/mteb/tasks/retrieval/multilingual/__init__.py
+++ b/mteb/tasks/retrieval/multilingual/__init__.py
@@ -72,6 +72,12 @@ from .jina_vdr_bench_retrieval import (
     JinaVDRWikimediaCommonsDocumentsRetrieval,
     JinaVDRWikimediaCommonsMapsRetrieval,
 )
+from .mcif_retrieval import (
+    MCIFA2TRetrieval,
+    MCIFT2ARetrieval,
+    MCIFT2VRetrieval,
+    MCIFV2TRetrieval,
+)
 from .mintaka_retrieval import MintakaRetrieval
 from .miracl_retrieval import (
     MIRACLRetrieval,
@@ -219,6 +225,10 @@ __all__ = [
     "JinaVDRTweetStockSyntheticsRetrieval",
     "JinaVDRWikimediaCommonsDocumentsRetrieval",
     "JinaVDRWikimediaCommonsMapsRetrieval",
+    "MCIFA2TRetrieval",
+    "MCIFT2ARetrieval",
+    "MCIFT2VRetrieval",
+    "MCIFV2TRetrieval",
     "MIRACLRetrieval",
     "MIRACLRetrievalHardNegatives",
     "MIRACLRetrievalHardNegativesV2",

--- a/mteb/tasks/retrieval/multilingual/mcif_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/mcif_retrieval.py
@@ -7,7 +7,7 @@ from mteb.abstasks.retrieval_dataset_loaders import RetrievalSplitData
 from mteb.abstasks.task_metadata import TaskMetadata
 
 _DATASET_PATH = "vnahata/MCIF-retrieval"
-_DATASET_REVISION = "112f5bb92217b25845cf3fc28be529bc1439cc1f"
+_DATASET_REVISION = "7a1761cb7cf7378b8d2cf16e3715309482952c2c"
 
 _LANGUAGES = {
     "en": ["eng-Latn"],

--- a/mteb/tasks/retrieval/multilingual/mcif_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/mcif_retrieval.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from datasets import load_dataset
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.retrieval_dataset_loaders import RetrievalSplitData
+from mteb.abstasks.task_metadata import TaskMetadata
+
+_DATASET_PATH = "vnahata/MCIF-retrieval"
+_DATASET_REVISION = "112f5bb92217b25845cf3fc28be529bc1439cc1f"
+
+_LANGUAGES = {
+    "en": ["eng-Latn"],
+    "de": ["deu-Latn"],
+    "it": ["ita-Latn"],
+    "zh": ["cmn-Hans"],
+}
+
+_BIBTEX = r"""
+@article{papi2025mcif,
+  author = {Papi, Sara and Z{\"u}fle, Maike and Gaido, Marco and Savoldi, Beatrice and Liu, Danni and Douros, Ioannis and Bentivogli, Luisa and Niehues, Jan},
+  journal = {arXiv preprint arXiv:2507.19634},
+  title = {{MCIF}: Multimodal Crosslingual Instruction-Following Benchmark from Scientific Talks},
+  year = {2025},
+}
+"""
+
+_DESCRIPTION = (
+    "Retrieval over recorded scientific talks from MCIF. The talks are delivered in "
+    "English while the questions are parallel across English, German, Italian and "
+    "Chinese, so the three non-English subsets score cross-lingual grounding rather "
+    "than same-language matching."
+)
+
+_CONSTRUCTION = (
+    "Built from MCIF's question-answering samples, the only entries binding one question "
+    "to one clip; its recognition and translation samples group roughly 33 clips behind a "
+    "single reference. Unanswerable questions and ones about the speaker or affiliation "
+    "are dropped as they match many talks, leaving 133 content-specific questions per "
+    "language against all 755 clips. Construction script: "
+    "scripts/data/mcif_retrieval/create_data.py."
+)
+
+_COMMON = {
+    "reference": "https://arxiv.org/abs/2507.19634",
+    "dataset": {"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+    "type": "Any2AnyMultilingualRetrieval",
+    "eval_splits": ["test"],
+    "eval_langs": _LANGUAGES,
+    "main_score": "ndcg_at_10",
+    "date": ("2023-07-01", "2025-07-25"),
+    "domains": ["Academic", "Spoken"],
+    "task_subtypes": ["Cross-Modal Retrieval"],
+    "license": "cc-by-4.0",
+    "annotations_creators": "human-annotated",
+    "dialect": [],
+    "sample_creation": "created",
+    "bibtex_citation": _BIBTEX,
+    "is_beta": True,
+}
+
+
+def _load_mcif(task: AbsTaskRetrieval, media_col: str, to_text: bool) -> None:
+    """Load one MCIF direction across the four question languages.
+
+    `to_text` selects media->question; otherwise question->media. Only the requested
+    media column is exposed, so the video tasks cannot be answered from the audio track.
+    """
+    if task.data_loaded:
+        return
+
+    split = task.metadata.eval_splits[0]
+    media = load_dataset(
+        _DATASET_PATH, "media", revision=_DATASET_REVISION, split=split
+    ).select_columns(["id", media_col])
+    questions = load_dataset(
+        _DATASET_PATH, "questions", revision=_DATASET_REVISION, split=split
+    )
+
+    # Read the link columns directly; iterating full rows would decode every clip.
+    links = list(zip(questions["id"], questions["media_id"], strict=True))
+    # Every question points at a clip, so the queried subset is the same in all languages.
+    asked = {mid for _, mid in links}
+    wanted = [i for i, id_ in enumerate(media["id"]) if id_ in asked]
+
+    task.dataset = {}
+    for lang in _LANGUAGES:
+        text_ds = questions.select_columns(["id", f"text_{lang}"]).rename_column(
+            f"text_{lang}", "text"
+        )
+        if to_text:
+            qrels: dict[str, dict[str, int]] = {}
+            for qid, mid in links:
+                qrels.setdefault(mid, {})[qid] = 1
+            # select() by index rather than filter(), which would decode every clip
+            queries, corpus = media.select(wanted), text_ds
+        else:
+            queries, corpus = text_ds, media
+            qrels = {qid: {mid: 1} for qid, mid in links}
+
+        task.dataset[lang] = {
+            split: RetrievalSplitData(
+                queries=queries, corpus=corpus, relevant_docs=qrels, top_ranked=None
+            )
+        }
+    task.data_loaded = True
+
+
+class MCIFT2VRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="MCIFT2VRetrieval",
+        description=f"{_DESCRIPTION} Retrieve the talk segment answering a question. {_CONSTRUCTION}",
+        category="t2v",
+        modalities=["text", "video"],
+        prompt={"query": "Find the talk segment that answers this question."},
+        **_COMMON,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_mcif(self, "video", to_text=False)
+
+
+class MCIFV2TRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="MCIFV2TRetrieval",
+        description=f"{_DESCRIPTION} Retrieve the question a talk segment answers. {_CONSTRUCTION}",
+        category="v2t",
+        modalities=["video", "text"],
+        prompt={"query": "Find the question that this talk segment answers."},
+        **_COMMON,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_mcif(self, "video", to_text=True)
+
+
+class MCIFT2ARetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="MCIFT2ARetrieval",
+        description=f"{_DESCRIPTION} Retrieve the talk audio answering a question. {_CONSTRUCTION}",
+        category="t2a",
+        modalities=["text", "audio"],
+        prompt={"query": "Find the talk audio that answers this question."},
+        **_COMMON,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_mcif(self, "audio", to_text=False)
+
+
+class MCIFA2TRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="MCIFA2TRetrieval",
+        description=f"{_DESCRIPTION} Retrieve the question a talk audio answers. {_CONSTRUCTION}",
+        category="a2t",
+        modalities=["audio", "text"],
+        prompt={"query": "Find the question that this talk audio answers."},
+        **_COMMON,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_mcif(self, "audio", to_text=True)

--- a/scripts/data/mcif_retrieval/create_data.py
+++ b/scripts/data/mcif_retrieval/create_data.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Build the MCIF multilingual audio-visual retrieval tasks for MTEB.
+
+Source is `FBK-MT/MCIF` at a pinned revision, the MCIF benchmark (Papi et al. 2025) of
+recorded ACL conference talks. MCIF ships only a `test` split and hosts its own media,
+both under CC-BY-4.0, so nothing needs to be scraped or re-licensed here.
+
+MCIF is an instruction-following benchmark rather than a retrieval one. The conversion
+keeps only the question-answering samples, which are the sole entries that bind one
+question to one clip; the ASR and translation samples group ~33 clips behind a single
+reference and cannot be aligned per clip. Within the QA samples two further filters
+apply: `qa_type="NA"` is dropped because those questions are deliberately unanswerable,
+and `qa_origin="General"` is dropped because those ask about the speaker or affiliation
+and so match many talks rather than one. That leaves 133 content-specific questions,
+each unique in all four languages, against the full 755-clip corpus.
+
+The instruction prefix ("Answer the following question concisely given the English
+content: ") is stripped so the query is the bare question rather than a prompt template
+repeated 133 times.
+
+Media is written once with both tracks; each task exposes only the column it is allowed
+to see, so the video tasks cannot be solved from the audio track.
+
+Examples:
+  # Build the reshaped tables locally.
+  uv run python scripts/data/mcif_retrieval/create_data.py --stage build
+
+  # Build and publish.
+  uv run python scripts/data/mcif_retrieval/create_data.py --stage all --push
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from datasets import Audio, Dataset, Video
+from huggingface_hub import HfApi, hf_hub_download, snapshot_download
+
+_SOURCE_REPO = "FBK-MT/MCIF"
+_SOURCE_REV = "e24065b919758263cfe5d157057278affe76ea7b"
+_TARGET = "vnahata/MCIF-retrieval"
+_LANGS = ["en", "de", "it", "zh"]
+_LICENSE = "cc-by-4.0"
+
+# QA samples only; these two filters remove the entries that cannot act as queries
+_KEEP_TYPES = {"AV", "V", "A"}  # drops "NA", which is unanswerable by construction
+_KEEP_ORIGINS = {"Transcript", "Abstract"}  # drops "General", which matches many talks
+
+
+def _strip_prefix(prompt: str, lang: str) -> str:
+    """Remove MCIF's fixed instruction prefix, leaving the bare question."""
+    sep = "：" if lang == "zh" else ": "
+    head, found, tail = prompt.partition(sep)
+    return (tail if found else prompt).strip()
+
+
+def stage_build(work: Path) -> dict:
+    work.mkdir(parents=True, exist_ok=True)
+    meta = pq.read_table(
+        hf_hub_download(
+            _SOURCE_REPO,
+            "short_fixedprompt/test-00000-of-00001.parquet",
+            repo_type="dataset",
+            revision=_SOURCE_REV,
+        )
+    ).to_pylist()
+
+    qa = [
+        r
+        for r in meta
+        if r["metadata"].get("qa_type") in _KEEP_TYPES
+        and r["metadata"].get("qa_origin") in _KEEP_ORIGINS
+    ]
+
+    local = Path(
+        snapshot_download(
+            _SOURCE_REPO,
+            repo_type="dataset",
+            revision=_SOURCE_REV,
+            allow_patterns=["MCIF_DATA/SHORT_VIDEOS/*", "MCIF_DATA/SHORT_AUDIOS/*"],
+        )
+    )
+    clips = sorted(p.stem for p in (local / "MCIF_DATA" / "SHORT_VIDEOS").glob("*.mp4"))
+    pq.write_table(
+        pa.Table.from_pylist(
+            [
+                {
+                    "id": c,
+                    "video": str(local / "MCIF_DATA" / "SHORT_VIDEOS" / f"{c}.mp4"),
+                    "audio": str(local / "MCIF_DATA" / "SHORT_AUDIOS" / f"{c}.wav"),
+                }
+                for c in clips
+            ]
+        ),
+        work / "media.parquet",
+    )
+
+    rows = []
+    for r in qa:
+        row = {"id": f"q-{r['id']}", "media_id": Path(r["video"]).stem}
+        for lang in _LANGS:
+            row[f"text_{lang}"] = _strip_prefix(r[f"prompt_{lang}"], lang)
+        rows.append(row)
+    pq.write_table(pa.Table.from_pylist(rows), work / "questions.parquet")
+
+    counts = {"clips": len(clips), "questions": len(rows)}
+    for lang in _LANGS:
+        counts[f"unique_{lang}"] = len({r[f"text_{lang}"] for r in rows})
+    (work / "counts.json").write_text(json.dumps(counts, indent=2), encoding="utf-8")
+    print("built", json.dumps(counts))
+    return counts
+
+
+def _card() -> str:
+    return (
+        "\n".join(
+            [
+                "---",
+                f"license: {_LICENSE}",
+                "task_categories:",
+                "  - text-to-video",
+                "  - text-to-speech",
+                "language:",
+                *[f"  - {lg}" for lg in _LANGS],
+                "tags:",
+                "  - mteb",
+                "  - retrieval",
+                "  - multilingual",
+                "configs:",
+                "  - config_name: media",
+                "    data_files:",
+                "      - split: test",
+                "        path: media/test-*.parquet",
+                "  - config_name: questions",
+                "    data_files:",
+                "      - split: test",
+                "        path: questions/test-*.parquet",
+                "---",
+                "",
+                "# MCIF multilingual audio-visual retrieval (MTEB)",
+                "",
+                "MCIF reshaped for retrieval: find the recorded conference-talk segment that",
+                "answers a question asked in English, German, Italian or Chinese. The questions",
+                "are parallel across the four languages while the talks are spoken in English,",
+                "so the non-English subsets measure cross-lingual grounding.",
+                "",
+                f"Source: `{_SOURCE_REPO}` at revision `{_SOURCE_REV[:7]}`, {_LICENSE}. Only the",
+                "question-answering samples are used, restricted to answerable and",
+                "content-specific ones; the corpus keeps all 755 clips so unquestioned clips act",
+                "as distractors.",
+                "",
+                "Built by `scripts/data/mcif_retrieval/create_data.py` in the MTEB repo.",
+            ]
+        )
+        + "\n"
+    )
+
+
+def stage_push(work: Path) -> None:
+    api = HfApi()
+    api.create_repo(_TARGET, repo_type="dataset", exist_ok=True)
+    (
+        Dataset.from_parquet(str(work / "media.parquet"))
+        .cast_column("video", Video())
+        .cast_column("audio", Audio(sampling_rate=16000))
+        .push_to_hub(_TARGET, config_name="media", split="test")
+    )
+    Dataset.from_parquet(str(work / "questions.parquet")).push_to_hub(
+        _TARGET, config_name="questions", split="test"
+    )
+    api.upload_file(
+        path_or_fileobj=io.BytesIO(_card().encode()),
+        path_in_repo="README.md",
+        repo_id=_TARGET,
+        repo_type="dataset",
+    )
+    print(f"pushed {_TARGET}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--stage", choices=["build", "push", "all"], default="all")
+    parser.add_argument("--work-dir", type=Path, default=Path("mcif_work"))
+    parser.add_argument("--push", action="store_true")
+    args = parser.parse_args()
+
+    print(f"source: {_SOURCE_REPO}@{_SOURCE_REV[:7]} (license {_LICENSE})")
+    if args.stage in ("build", "all"):
+        stage_build(args.work_dir)
+    if args.stage == "push" or (args.push and args.stage == "all"):
+        stage_push(args.work_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_tasks/test_task_quality.py
+++ b/tests/test_tasks/test_task_quality.py
@@ -895,6 +895,8 @@ KNOWN_ISSUES: dict[str, list[str]] = {
         "Kinetics600VAZeroShot",
         "Kinetics700VA",
         "Kinetics700VAZeroShot",
+        "MCIFA2TRetrieval",  # the same talk corpus is reused across languages
+        "MCIFT2ARetrieval",
         "NSynth",  # repeated notes across instrument/pitch/velocity combinations
         "NSynthInstrumentFamilyClustering",  # same upstream duplicate notes as NSynth
         "SpeechCommands",  # many repeated recordings of the same short command word
@@ -906,6 +908,8 @@ KNOWN_ISSUES: dict[str, list[str]] = {
         "WorldSenseAudioVideoZeroShot",
     ],
     "duplicate_video": [
+        "MCIFT2VRetrieval",  # the same talk corpus is reused across languages
+        "MCIFV2TRetrieval",
         "DenseWebVidCoVRVT2VRetrieval",  # multiple rows have same video with different instruction
         "InsAVE80KVT2VRetrieval",  # reverse couples re-release the same clip under two names
         "MMVUVideoCentricQA",


### PR DESCRIPTION
Adds four directions over [MCIF](https://arxiv.org/abs/2507.19634) (Papi et al. 2025): t2v/v2t and t2a/a2t, each across English, German, Italian and Chinese. Part of #4842.

## Gap

mteb has no multilingual video task and no multilingual audio+video task. Every existing video and audio+image task is English-only retrieval, so these are the first in both cells. Talks are spoken in English while the questions are parallel across all four languages, so the non-English subsets score cross-lingual grounding.

## Construction

Official **test** split only; MCIF ships nothing else.

Only the QA samples bind one question to one clip; recognition and translation samples group ~33 clips behind one reference. Unanswerable questions and ones about the speaker or affiliation are dropped, leaving **133 content-specific questions per language** against the full **755-clip corpus**. The fixed instruction prefix is stripped.

Media is stored once with both tracks; each task exposes only the column it may see, so video directions cannot be solved off the audio track.

License **CC-BY-4.0**: the paper states MCIF "is released under CC-BY 4.0 license", and FBK hosts the media itself.

## Results

nDCG@10 mean over subsets:

| direction | random | X-CLIP |
|---|---|---|
| v2t | 0.0342 | **0.1234** |
| t2v | 0.0041 | **0.0250** |
| a2t | 0.0374 | |
| t2a | 0.0083 | |

By subset, v2t: en 0.2288, de 0.0918, it 0.1095, zh 0.0634. t2v: en 0.0541, de 0.0084, it 0.0243, zh 0.0131.

## Checklist

- [x] Outlined why this fills a gap
- [x] Tested that it runs with `mteb`
- [x] Two encoders on both video directions, see table. The audio directions need a speech-text model; CLAP is trained on audio captions, not speech, and scores at the random floor here.
- [x] Size considered, official test split
- [x] `test_task_quality.py` passes; exempted for `duplicate_audio`/`duplicate_video` as one corpus is reused across the four language subsets, as XM3600 is for `duplicate_image`


