### PR TITLE
dataset: add Afri-MCQA multilingual speech-image retrieval (a2i, i2a)

### DIFF
--- a/mteb/descriptive_stats/Image/Any2AnyMultilingualRetrieval/AfriMCQAA2IRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyMultilingualRetrieval/AfriMCQAA2IRetrieval.json
@@ -1,0 +1,718 @@
+{
+    "test": {
+        "num_samples": 6285,
+        "num_queries": 3855,
+        "num_documents": 2430,
+        "number_of_characters": 0,
+        "documents_text_statistics": null,
+        "documents_image_statistics": {
+            "min_image_width": 47,
+            "average_image_width": 1150.8810699588478,
+            "max_image_width": 5760,
+            "min_image_height": 70,
+            "average_image_height": 1159.2526748971193,
+            "max_image_height": 5700,
+            "unique_images": 2429
+        },
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": null,
+        "queries_audio_statistics": {
+            "total_duration_seconds": 30222.453125,
+            "min_duration_seconds": 3.489875,
+            "average_duration_seconds": 7.839806258106355,
+            "max_duration_seconds": 18.744875,
+            "unique_audios": 3855,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 3855
+            }
+        },
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 3855,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 2428,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null,
+        "hf_subset_descriptive_stats": {
+            "twi": {
+                "num_samples": 472,
+                "num_queries": 294,
+                "num_documents": 178,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": {
+                    "min_image_width": 169,
+                    "average_image_width": 772.7865168539325,
+                    "max_image_width": 4160,
+                    "min_image_height": 130,
+                    "average_image_height": 747.3988764044943,
+                    "max_image_height": 1872,
+                    "unique_images": 178
+                },
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 2194.339625,
+                    "min_duration_seconds": 4.0948125,
+                    "average_duration_seconds": 7.463740221088436,
+                    "max_duration_seconds": 16.0798125,
+                    "unique_audios": 294,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 294
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 294,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 178,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "amh": {
+                "num_samples": 442,
+                "num_queries": 275,
+                "num_documents": 167,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": {
+                    "min_image_width": 262,
+                    "average_image_width": 1640.874251497006,
+                    "max_image_width": 4288,
+                    "min_image_height": 177,
+                    "average_image_height": 1345.7365269461077,
+                    "max_image_height": 5700,
+                    "unique_images": 167
+                },
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 1679.784625,
+                    "min_duration_seconds": 3.889875,
+                    "average_duration_seconds": 6.108307727272727,
+                    "max_duration_seconds": 12.159875,
+                    "unique_audios": 275,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 275
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 275,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 167,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "nya": {
+                "num_samples": 412,
+                "num_queries": 246,
+                "num_documents": 166,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": {
+                    "min_image_width": 201,
+                    "average_image_width": 1494.8493975903614,
+                    "max_image_width": 4128,
+                    "min_image_height": 251,
+                    "average_image_height": 1659.7228915662652,
+                    "max_image_height": 4128,
+                    "unique_images": 166
+                },
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 1449.741625,
+                    "min_duration_seconds": 3.714875,
+                    "average_duration_seconds": 5.893258638211383,
+                    "max_duration_seconds": 11.544875,
+                    "unique_audios": 246,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 246
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 246,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 166,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "hau": {
+                "num_samples": 427,
+                "num_queries": 260,
+                "num_documents": 167,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": {
+                    "min_image_width": 330,
+                    "average_image_width": 1161.754491017964,
+                    "max_image_width": 4320,
+                    "min_image_height": 322,
+                    "average_image_height": 1597.5868263473053,
+                    "max_image_height": 4032,
+                    "unique_images": 167
+                },
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 2421.9429375,
+                    "min_duration_seconds": 6.5398125,
+                    "average_duration_seconds": 9.31516514423077,
+                    "max_duration_seconds": 13.6148125,
+                    "unique_audios": 260,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 260
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 260,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 167,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "ibo": {
+                "num_samples": 404,
+                "num_queries": 256,
+                "num_documents": 148,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": {
+                    "min_image_width": 137,
+                    "average_image_width": 1588.0337837837837,
+                    "max_image_width": 4608,
+                    "min_image_height": 108,
+                    "average_image_height": 1772.418918918919,
+                    "max_image_height": 4444,
+                    "unique_images": 148
+                },
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 1697.66,
+                    "min_duration_seconds": 4.6198125,
+                    "average_duration_seconds": 6.631484375,
+                    "max_duration_seconds": 10.6998125,
+                    "unique_audios": 256,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 256
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 256,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 148,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "kik": {
+                "num_samples": 373,
+                "num_queries": 232,
+                "num_documents": 141,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": {
+                    "min_image_width": 68,
+                    "average_image_width": 910.5531914893617,
+                    "max_image_width": 3456,
+                    "min_image_height": 101,
+                    "average_image_height": 881.4751773049645,
+                    "max_image_height": 2304,
+                    "unique_images": 141
+                },
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 1560.2438750000001,
+                    "min_duration_seconds": 4.2498125,
+                    "average_duration_seconds": 6.725189116379311,
+                    "max_duration_seconds": 12.7598125,
+                    "unique_audios": 232,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 232
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 232,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 141,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "kin": {
+                "num_samples": 299,
+                "num_queries": 177,
+                "num_documents": 122,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": {
+                    "min_image_width": 333,
+                    "average_image_width": 1323.360655737705,
+                    "max_image_width": 5616,
+                    "min_image_height": 258,
+                    "average_image_height": 1283.9180327868853,
+                    "max_image_height": 5184,
+                    "unique_images": 122
+                },
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 1332.1191875,
+                    "min_duration_seconds": 4.599875,
+                    "average_duration_seconds": 7.526097104519773,
+                    "max_duration_seconds": 11.579875,
+                    "unique_audios": 177,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 177
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 177,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 122,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "lin": {
+                "num_samples": 390,
+                "num_queries": 240,
+                "num_documents": 150,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": {
+                    "min_image_width": 280,
+                    "average_image_width": 761.2133333333334,
+                    "max_image_width": 3240,
+                    "min_image_height": 272,
+                    "average_image_height": 766.3133333333334,
+                    "max_image_height": 4320,
+                    "unique_images": 150
+                },
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 2258.3975625,
+                    "min_duration_seconds": 4.5998125,
+                    "average_duration_seconds": 9.40998984375,
+                    "max_duration_seconds": 18.744875,
+                    "unique_audios": 240,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 240
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 240,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 150,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "lug": {
+                "num_samples": 416,
+                "num_queries": 263,
+                "num_documents": 153,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": {
+                    "min_image_width": 176,
+                    "average_image_width": 868.1633986928105,
+                    "max_image_width": 3720,
+                    "min_image_height": 220,
+                    "average_image_height": 674.7908496732026,
+                    "max_image_height": 4080,
+                    "unique_images": 153
+                },
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 2184.3834375,
+                    "min_duration_seconds": 6.119875,
+                    "average_duration_seconds": 8.305640446768061,
+                    "max_duration_seconds": 12.8098125,
+                    "unique_audios": 263,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 263
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 263,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 153,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "orm": {
+                "num_samples": 406,
+                "num_queries": 257,
+                "num_documents": 149,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": {
+                    "min_image_width": 153,
+                    "average_image_width": 739.7114093959732,
+                    "max_image_width": 3200,
+                    "min_image_height": 140,
+                    "average_image_height": 693.3355704697987,
+                    "max_image_height": 3088,
+                    "unique_images": 149
+                },
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 2005.25875,
+                    "min_duration_seconds": 5.054875,
+                    "average_duration_seconds": 7.802563229571985,
+                    "max_duration_seconds": 14.2900625,
+                    "unique_audios": 257,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 257
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 257,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 149,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "sot": {
+                "num_samples": 274,
+                "num_queries": 148,
+                "num_documents": 126,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": {
+                    "min_image_width": 405,
+                    "average_image_width": 873.063492063492,
+                    "max_image_width": 4096,
+                    "min_image_height": 291,
+                    "average_image_height": 822.0396825396825,
+                    "max_image_height": 4096,
+                    "unique_images": 126
+                },
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 1450.2786875,
+                    "min_duration_seconds": 5.534875,
+                    "average_duration_seconds": 9.799180320945945,
+                    "max_duration_seconds": 16.7798125,
+                    "unique_audios": 148,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 148
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 148,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 124,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "tsn": {
+                "num_samples": 454,
+                "num_queries": 288,
+                "num_documents": 166,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": {
+                    "min_image_width": 149,
+                    "average_image_width": 2291.102409638554,
+                    "max_image_width": 5184,
+                    "min_image_height": 133,
+                    "average_image_height": 2192.614457831325,
+                    "max_image_height": 4608,
+                    "unique_images": 166
+                },
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 2391.364,
+                    "min_duration_seconds": 5.059875,
+                    "average_duration_seconds": 8.303347222222222,
+                    "max_duration_seconds": 14.159875,
+                    "unique_audios": 288,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 288
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 288,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 166,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "som": {
+                "num_samples": 435,
+                "num_queries": 253,
+                "num_documents": 182,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": {
+                    "min_image_width": 167,
+                    "average_image_width": 768.4560439560439,
+                    "max_image_width": 5760,
+                    "min_image_height": 117,
+                    "average_image_height": 748.4175824175824,
+                    "max_image_height": 3240,
+                    "unique_images": 182
+                },
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 1928.6254375,
+                    "min_duration_seconds": 4.339875,
+                    "average_duration_seconds": 7.623025444664032,
+                    "max_duration_seconds": 14.359875,
+                    "unique_audios": 253,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 253
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 253,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 182,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "tir": {
+                "num_samples": 452,
+                "num_queries": 290,
+                "num_documents": 162,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": {
+                    "min_image_width": 47,
+                    "average_image_width": 1269.6851851851852,
+                    "max_image_width": 5184,
+                    "min_image_height": 70,
+                    "average_image_height": 1129.932098765432,
+                    "max_image_height": 4928,
+                    "unique_images": 162
+                },
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 3049.440125,
+                    "min_duration_seconds": 6.4648125,
+                    "average_duration_seconds": 10.51531077586207,
+                    "max_duration_seconds": 16.8748125,
+                    "unique_audios": 290,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 290
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 290,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 162,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "yor": {
+                "num_samples": 405,
+                "num_queries": 255,
+                "num_documents": 150,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": {
+                    "min_image_width": 192,
+                    "average_image_width": 1050.9533333333334,
+                    "max_image_width": 3456,
+                    "min_image_height": 181,
+                    "average_image_height": 1110.64,
+                    "max_image_height": 2560,
+                    "unique_images": 150
+                },
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 1853.946875,
+                    "min_duration_seconds": 4.2148125,
+                    "average_duration_seconds": 7.270379901960784,
+                    "max_duration_seconds": 12.0998125,
+                    "unique_audios": 255,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 255
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 255,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 150,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "zul": {
+                "num_samples": 224,
+                "num_queries": 121,
+                "num_documents": 103,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": {
+                    "min_image_width": 159,
+                    "average_image_width": 653.2621359223301,
+                    "max_image_width": 720,
+                    "min_image_height": 283,
+                    "average_image_height": 958.7281553398059,
+                    "max_image_height": 1600,
+                    "unique_images": 103
+                },
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 764.926375,
+                    "min_duration_seconds": 3.489875,
+                    "average_duration_seconds": 6.321705578512397,
+                    "max_duration_seconds": 10.914875,
+                    "unique_audios": 121,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 121
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 121,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 103,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            }
+        }
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyMultilingualRetrieval/AfriMCQAI2ARetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyMultilingualRetrieval/AfriMCQAI2ARetrieval.json
@@ -1,0 +1,718 @@
+{
+    "test": {
+        "num_samples": 6283,
+        "num_queries": 2428,
+        "num_documents": 3855,
+        "number_of_characters": 0,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": {
+            "total_duration_seconds": 30222.453125,
+            "min_duration_seconds": 3.489875,
+            "average_duration_seconds": 7.839806258106355,
+            "max_duration_seconds": 18.744875,
+            "unique_audios": 3855,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 3855
+            }
+        },
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": {
+            "min_image_width": 47,
+            "average_image_width": 1150.6890444810545,
+            "max_image_width": 5760,
+            "min_image_height": 70,
+            "average_image_height": 1159.2429983525535,
+            "max_image_height": 5700,
+            "unique_images": 2427
+        },
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 3855,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.5877265238879736,
+            "max_relevant_docs_per_query": 5,
+            "unique_relevant_docs": 3855,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null,
+        "hf_subset_descriptive_stats": {
+            "twi": {
+                "num_samples": 472,
+                "num_queries": 178,
+                "num_documents": 294,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 2194.339625,
+                    "min_duration_seconds": 4.0948125,
+                    "average_duration_seconds": 7.463740221088436,
+                    "max_duration_seconds": 16.0798125,
+                    "unique_audios": 294,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 294
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": {
+                    "min_image_width": 169,
+                    "average_image_width": 772.7865168539325,
+                    "max_image_width": 4160,
+                    "min_image_height": 130,
+                    "average_image_height": 747.3988764044943,
+                    "max_image_height": 1872,
+                    "unique_images": 178
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 294,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.651685393258427,
+                    "max_relevant_docs_per_query": 5,
+                    "unique_relevant_docs": 294,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "amh": {
+                "num_samples": 442,
+                "num_queries": 167,
+                "num_documents": 275,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 1679.784625,
+                    "min_duration_seconds": 3.889875,
+                    "average_duration_seconds": 6.108307727272727,
+                    "max_duration_seconds": 12.159875,
+                    "unique_audios": 275,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 275
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": {
+                    "min_image_width": 262,
+                    "average_image_width": 1640.874251497006,
+                    "max_image_width": 4288,
+                    "min_image_height": 177,
+                    "average_image_height": 1345.7365269461077,
+                    "max_image_height": 5700,
+                    "unique_images": 167
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 275,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.6467065868263473,
+                    "max_relevant_docs_per_query": 3,
+                    "unique_relevant_docs": 275,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "nya": {
+                "num_samples": 412,
+                "num_queries": 166,
+                "num_documents": 246,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 1449.741625,
+                    "min_duration_seconds": 3.714875,
+                    "average_duration_seconds": 5.893258638211383,
+                    "max_duration_seconds": 11.544875,
+                    "unique_audios": 246,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 246
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": {
+                    "min_image_width": 201,
+                    "average_image_width": 1494.8493975903614,
+                    "max_image_width": 4128,
+                    "min_image_height": 251,
+                    "average_image_height": 1659.7228915662652,
+                    "max_image_height": 4128,
+                    "unique_images": 166
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 246,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.4819277108433735,
+                    "max_relevant_docs_per_query": 3,
+                    "unique_relevant_docs": 246,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "hau": {
+                "num_samples": 427,
+                "num_queries": 167,
+                "num_documents": 260,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 2421.9429375,
+                    "min_duration_seconds": 6.5398125,
+                    "average_duration_seconds": 9.31516514423077,
+                    "max_duration_seconds": 13.6148125,
+                    "unique_audios": 260,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 260
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": {
+                    "min_image_width": 330,
+                    "average_image_width": 1161.754491017964,
+                    "max_image_width": 4320,
+                    "min_image_height": 322,
+                    "average_image_height": 1597.5868263473053,
+                    "max_image_height": 4032,
+                    "unique_images": 167
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 260,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.5568862275449102,
+                    "max_relevant_docs_per_query": 3,
+                    "unique_relevant_docs": 260,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "ibo": {
+                "num_samples": 404,
+                "num_queries": 148,
+                "num_documents": 256,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 1697.66,
+                    "min_duration_seconds": 4.6198125,
+                    "average_duration_seconds": 6.631484375,
+                    "max_duration_seconds": 10.6998125,
+                    "unique_audios": 256,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 256
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": {
+                    "min_image_width": 137,
+                    "average_image_width": 1588.0337837837837,
+                    "max_image_width": 4608,
+                    "min_image_height": 108,
+                    "average_image_height": 1772.418918918919,
+                    "max_image_height": 4444,
+                    "unique_images": 148
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 256,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.7297297297297298,
+                    "max_relevant_docs_per_query": 3,
+                    "unique_relevant_docs": 256,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "kik": {
+                "num_samples": 373,
+                "num_queries": 141,
+                "num_documents": 232,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 1560.2438750000001,
+                    "min_duration_seconds": 4.2498125,
+                    "average_duration_seconds": 6.725189116379311,
+                    "max_duration_seconds": 12.7598125,
+                    "unique_audios": 232,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 232
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": {
+                    "min_image_width": 68,
+                    "average_image_width": 910.5531914893617,
+                    "max_image_width": 3456,
+                    "min_image_height": 101,
+                    "average_image_height": 881.4751773049645,
+                    "max_image_height": 2304,
+                    "unique_images": 141
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 232,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.6453900709219857,
+                    "max_relevant_docs_per_query": 3,
+                    "unique_relevant_docs": 232,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "kin": {
+                "num_samples": 299,
+                "num_queries": 122,
+                "num_documents": 177,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 1332.1191875,
+                    "min_duration_seconds": 4.599875,
+                    "average_duration_seconds": 7.526097104519773,
+                    "max_duration_seconds": 11.579875,
+                    "unique_audios": 177,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 177
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": {
+                    "min_image_width": 333,
+                    "average_image_width": 1323.360655737705,
+                    "max_image_width": 5616,
+                    "min_image_height": 258,
+                    "average_image_height": 1283.9180327868853,
+                    "max_image_height": 5184,
+                    "unique_images": 122
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 177,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.4508196721311475,
+                    "max_relevant_docs_per_query": 3,
+                    "unique_relevant_docs": 177,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "lin": {
+                "num_samples": 390,
+                "num_queries": 150,
+                "num_documents": 240,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 2258.3975625,
+                    "min_duration_seconds": 4.5998125,
+                    "average_duration_seconds": 9.40998984375,
+                    "max_duration_seconds": 18.744875,
+                    "unique_audios": 240,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 240
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": {
+                    "min_image_width": 280,
+                    "average_image_width": 761.2133333333334,
+                    "max_image_width": 3240,
+                    "min_image_height": 272,
+                    "average_image_height": 766.3133333333334,
+                    "max_image_height": 4320,
+                    "unique_images": 150
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 240,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.6,
+                    "max_relevant_docs_per_query": 4,
+                    "unique_relevant_docs": 240,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "lug": {
+                "num_samples": 416,
+                "num_queries": 153,
+                "num_documents": 263,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 2184.3834375,
+                    "min_duration_seconds": 6.119875,
+                    "average_duration_seconds": 8.305640446768061,
+                    "max_duration_seconds": 12.8098125,
+                    "unique_audios": 263,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 263
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": {
+                    "min_image_width": 176,
+                    "average_image_width": 868.1633986928105,
+                    "max_image_width": 3720,
+                    "min_image_height": 220,
+                    "average_image_height": 674.7908496732026,
+                    "max_image_height": 4080,
+                    "unique_images": 153
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 263,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.7189542483660132,
+                    "max_relevant_docs_per_query": 3,
+                    "unique_relevant_docs": 263,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "orm": {
+                "num_samples": 406,
+                "num_queries": 149,
+                "num_documents": 257,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 2005.25875,
+                    "min_duration_seconds": 5.054875,
+                    "average_duration_seconds": 7.802563229571985,
+                    "max_duration_seconds": 14.2900625,
+                    "unique_audios": 257,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 257
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": {
+                    "min_image_width": 153,
+                    "average_image_width": 739.7114093959732,
+                    "max_image_width": 3200,
+                    "min_image_height": 140,
+                    "average_image_height": 693.3355704697987,
+                    "max_image_height": 3088,
+                    "unique_images": 149
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 257,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.7248322147651007,
+                    "max_relevant_docs_per_query": 3,
+                    "unique_relevant_docs": 257,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "sot": {
+                "num_samples": 272,
+                "num_queries": 124,
+                "num_documents": 148,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 1450.2786875,
+                    "min_duration_seconds": 5.534875,
+                    "average_duration_seconds": 9.799180320945945,
+                    "max_duration_seconds": 16.7798125,
+                    "unique_audios": 148,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 148
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": {
+                    "min_image_width": 405,
+                    "average_image_width": 864.8225806451613,
+                    "max_image_width": 4096,
+                    "min_image_height": 291,
+                    "average_image_height": 816.4112903225806,
+                    "max_image_height": 4096,
+                    "unique_images": 124
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 148,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.1935483870967742,
+                    "max_relevant_docs_per_query": 2,
+                    "unique_relevant_docs": 148,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "tsn": {
+                "num_samples": 454,
+                "num_queries": 166,
+                "num_documents": 288,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 2391.364,
+                    "min_duration_seconds": 5.059875,
+                    "average_duration_seconds": 8.303347222222222,
+                    "max_duration_seconds": 14.159875,
+                    "unique_audios": 288,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 288
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": {
+                    "min_image_width": 149,
+                    "average_image_width": 2291.102409638554,
+                    "max_image_width": 5184,
+                    "min_image_height": 133,
+                    "average_image_height": 2192.614457831325,
+                    "max_image_height": 4608,
+                    "unique_images": 166
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 288,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.7349397590361446,
+                    "max_relevant_docs_per_query": 3,
+                    "unique_relevant_docs": 288,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "som": {
+                "num_samples": 435,
+                "num_queries": 182,
+                "num_documents": 253,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 1928.6254375,
+                    "min_duration_seconds": 4.339875,
+                    "average_duration_seconds": 7.623025444664032,
+                    "max_duration_seconds": 14.359875,
+                    "unique_audios": 253,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 253
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": {
+                    "min_image_width": 167,
+                    "average_image_width": 768.4560439560439,
+                    "max_image_width": 5760,
+                    "min_image_height": 117,
+                    "average_image_height": 748.4175824175824,
+                    "max_image_height": 3240,
+                    "unique_images": 182
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 253,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.39010989010989,
+                    "max_relevant_docs_per_query": 3,
+                    "unique_relevant_docs": 253,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "tir": {
+                "num_samples": 452,
+                "num_queries": 162,
+                "num_documents": 290,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 3049.440125,
+                    "min_duration_seconds": 6.4648125,
+                    "average_duration_seconds": 10.51531077586207,
+                    "max_duration_seconds": 16.8748125,
+                    "unique_audios": 290,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 290
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": {
+                    "min_image_width": 47,
+                    "average_image_width": 1269.6851851851852,
+                    "max_image_width": 5184,
+                    "min_image_height": 70,
+                    "average_image_height": 1129.932098765432,
+                    "max_image_height": 4928,
+                    "unique_images": 162
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 290,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.7901234567901234,
+                    "max_relevant_docs_per_query": 3,
+                    "unique_relevant_docs": 290,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "yor": {
+                "num_samples": 405,
+                "num_queries": 150,
+                "num_documents": 255,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 1853.946875,
+                    "min_duration_seconds": 4.2148125,
+                    "average_duration_seconds": 7.270379901960784,
+                    "max_duration_seconds": 12.0998125,
+                    "unique_audios": 255,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 255
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": {
+                    "min_image_width": 192,
+                    "average_image_width": 1050.9533333333334,
+                    "max_image_width": 3456,
+                    "min_image_height": 181,
+                    "average_image_height": 1110.64,
+                    "max_image_height": 2560,
+                    "unique_images": 150
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 255,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.7,
+                    "max_relevant_docs_per_query": 3,
+                    "unique_relevant_docs": 255,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "zul": {
+                "num_samples": 224,
+                "num_queries": 103,
+                "num_documents": 121,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 764.926375,
+                    "min_duration_seconds": 3.489875,
+                    "average_duration_seconds": 6.321705578512397,
+                    "max_duration_seconds": 10.914875,
+                    "unique_audios": 121,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 121
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": {
+                    "min_image_width": 159,
+                    "average_image_width": 653.2621359223301,
+                    "max_image_width": 720,
+                    "min_image_height": 283,
+                    "average_image_height": 958.7281553398059,
+                    "max_image_height": 1600,
+                    "unique_images": 103
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 121,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.174757281553398,
+                    "max_relevant_docs_per_query": 2,
+                    "unique_relevant_docs": 121,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            }
+        }
+    }
+}

--- a/mteb/tasks/retrieval/multilingual/__init__.py
+++ b/mteb/tasks/retrieval/multilingual/__init__.py
@@ -1,3 +1,4 @@
+from .afri_mcqa_retrieval import AfriMCQAA2IRetrieval, AfriMCQAI2ARetrieval
 from .audio_caps import AudioCapsA2TRetrieval, AudioCapsT2ARetrieval
 from .belebele_retrieval import BelebeleRetrieval
 from .common_voice import (
@@ -154,6 +155,8 @@ from .xm3600_t2i_retrieval import XM3600I2TRetrieval, XM3600T2IRetrieval
 from .xpqa_retrieval import XPQARetrieval
 
 __all__ = [
+    "AfriMCQAA2IRetrieval",
+    "AfriMCQAI2ARetrieval",
     "AudioCapsA2TRetrieval",
     "AudioCapsT2ARetrieval",
     "BelebeleRetrieval",

--- a/mteb/tasks/retrieval/multilingual/afri_mcqa_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/afri_mcqa_retrieval.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from datasets import load_dataset
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.retrieval_dataset_loaders import RetrievalSplitData
+from mteb.abstasks.task_metadata import TaskMetadata
+
+_DATASET_PATH = "vnahata/AfriMCQA-speech-image-retrieval"
+_DATASET_REVISION = "e189ac0e5b426bf423c9859a9e7c4d9219cd845b"
+
+_LANGUAGES = {
+    "twi": ["twi-Latn"],
+    "amh": ["amh-Ethi"],
+    "nya": ["nya-Latn"],
+    "hau": ["hau-Latn"],
+    "ibo": ["ibo-Latn"],
+    "kik": ["kik-Latn"],
+    "kin": ["kin-Latn"],
+    "lin": ["lin-Latn"],
+    "lug": ["lug-Latn"],
+    # Afri-MCQA's Oromo is the West Central variety, so `gaz` rather than the `orm` macrolanguage
+    "orm": ["gaz-Latn"],
+    "sot": ["sot-Latn"],
+    "tsn": ["tsn-Latn"],
+    "som": ["som-Latn"],
+    "tir": ["tir-Ethi"],
+    "yor": ["yor-Latn"],
+    "zul": ["zul-Latn"],
+}
+
+_BIBTEX = r"""
+@inproceedings{tonja2026afrimcqa,
+  author = {Tonja, Atnafu Lambebo and Anand, Srija and Villa-Cueva, Emilio and Azime, Israel Abebe and Alabi, Jesujoba Oluwadara and Mohamed, Muhidin A. and Yadeta, Debela Desalegn and Abadi, Negasi Haile and Oppong, Abigail and Obiefuna, Nnaemeka Casmir and Abdulmumin, Idris and Etori, Naome A},
+  title = {{Afri-MCQA}: Multimodal Cultural Question Answering for {African} Languages},
+  year = {2026},
+}
+"""
+
+_DESCRIPTION = (
+    "Speech-image retrieval over Afri-MCQA, a culturally grounded benchmark written and "
+    "recorded by native speakers of 16 African languages. Questions are spoken aloud in "
+    "the native language and grounded in a photograph."
+)
+
+_CONSTRUCTION = (
+    "Built from the official test split, keeping the question audio and dropping the four "
+    "spoken answer options, which describe candidate answers rather than the image. Images "
+    "are held per language because one photograph can carry questions in several "
+    "languages, so a pooled corpus would score a correct retrieval as wrong. Construction "
+    "script: scripts/data/afri_mcqa_retrieval/create_data.py."
+)
+
+_COMMON = {
+    "reference": "https://arxiv.org/abs/2601.05699",
+    "dataset": {"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+    "type": "Any2AnyMultilingualRetrieval",
+    "eval_splits": ["test"],
+    "eval_langs": _LANGUAGES,
+    "main_score": "ndcg_at_10",
+    "date": ("2025-01-01", "2026-01-15"),
+    "domains": ["Scene", "Spoken"],
+    "task_subtypes": ["Cross-Modal Retrieval"],
+    "license": "cc-by-nc-4.0",
+    "annotations_creators": "human-annotated",
+    "dialect": [],
+    "sample_creation": "created",
+    "bibtex_citation": _BIBTEX,
+    "is_beta": True,
+}
+
+
+def _load_afri_mcqa(task: AbsTaskRetrieval, to_image: bool) -> None:
+    """Load one Afri-MCQA direction for every language.
+
+    `to_image` selects question audio -> image; otherwise image -> question audio.
+    """
+    if task.data_loaded:
+        return
+
+    split = task.metadata.eval_splits[0]
+    task.dataset = {}
+    for lang in _LANGUAGES:
+        images = load_dataset(
+            _DATASET_PATH, f"{lang}-images", revision=_DATASET_REVISION, split=split
+        )
+        audio = load_dataset(
+            _DATASET_PATH, f"{lang}-audio", revision=_DATASET_REVISION, split=split
+        )
+
+        # Read the link columns directly; iterating full rows would decode every clip.
+        links = audio.select_columns(["id", "image_id"]).to_dict()
+        pairs = list(zip(links["id"], links["image_id"], strict=True))
+
+        if to_image:
+            queries = audio.select_columns(["id", "audio"])
+            corpus = images
+            qrels = {qid: {img: 1} for qid, img in pairs}
+        else:
+            qrels = {}
+            for qid, img in pairs:
+                qrels.setdefault(img, {})[qid] = 1
+            # select() by index rather than filter(), which would decode every image
+            wanted = [i for i, id_ in enumerate(images["id"]) if id_ in qrels]
+            queries = images.select(wanted)
+            corpus = audio.select_columns(["id", "audio"])
+
+        task.dataset[lang] = {
+            split: RetrievalSplitData(
+                queries=queries, corpus=corpus, relevant_docs=qrels, top_ranked=None
+            )
+        }
+    task.data_loaded = True
+
+
+class AfriMCQAA2IRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="AfriMCQAA2IRetrieval",
+        description=f"{_DESCRIPTION} Retrieve the photograph a spoken question asks about. {_CONSTRUCTION}",
+        category="a2i",
+        modalities=["audio", "image"],
+        prompt={"query": "Find the image that this spoken question is asking about."},
+        **_COMMON,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_afri_mcqa(self, to_image=True)
+
+
+class AfriMCQAI2ARetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="AfriMCQAI2ARetrieval",
+        description=f"{_DESCRIPTION} Retrieve the spoken question asked about a photograph. {_CONSTRUCTION}",
+        category="i2a",
+        modalities=["image", "audio"],
+        prompt={"query": "Find the spoken question that asks about this image."},
+        **_COMMON,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load_afri_mcqa(self, to_image=False)

--- a/scripts/data/afri_mcqa_retrieval/create_data.py
+++ b/scripts/data/afri_mcqa_retrieval/create_data.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Build the Afri-MCQA multilingual speech-image retrieval tasks for MTEB.
+
+Source is `Atnafu/Afri-MCQA` at a pinned revision, a culturally grounded question
+answering benchmark written and recorded by native speakers across 16 African languages
+(Tonja et al. 2026). It ships an official `test` split, so nothing here is drawn from
+training data.
+
+Each question is spoken aloud in the native language and grounded in one image, which is
+the pairing used here: retrieve the photograph a spoken question is asking about. Only
+the question audio is kept; the four spoken answer options are dropped because they
+describe candidate answers rather than the image.
+
+Images are held per language rather than pooled. The same photograph can carry questions
+in more than one language, so a pooled image corpus would mark a correct retrieval wrong
+whenever the model returned the twin belonging to another language.
+
+Examples:
+  # Build the reshaped tables locally.
+  uv run python scripts/data/afri_mcqa_retrieval/create_data.py --stage build
+
+  # Build and publish both directions.
+  uv run python scripts/data/afri_mcqa_retrieval/create_data.py --stage all --push
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import hashlib
+import json
+from pathlib import Path
+
+from datasets import Audio, Dataset, Image, load_dataset
+from huggingface_hub import HfApi
+
+_SOURCE_REPO = "Atnafu/Afri-MCQA"
+_SOURCE_REV = "8b8c53df57b0c2cf9d9798c53515ba1dd14df669"
+_TARGET = "vnahata/AfriMCQA-speech-image-retrieval"
+_LICENSE = "cc-by-nc-4.0"
+
+# dataset's `Language` column -> the subset name used on the Hub
+_LANGS = {
+    "Akan/Twi": "twi",
+    "Amharic": "amh",
+    "Chichewa": "nya",
+    "Hausa": "hau",
+    "Igbo": "ibo",
+    "Kikuyu": "kik",
+    "Kinyarwanda": "kin",
+    "Lingala": "lin",
+    "Luganda": "lug",
+    "Oromo": "orm",
+    "Sesotho": "sot",
+    "Setswana": "tsn",
+    "Somali": "som",
+    "Tigrinya": "tir",
+    "Yoruba": "yor",
+    "Zulu": "zul",
+}
+
+_KEEP = ["ID", "Language", "image", "native_audio_question"]
+
+
+def stage_build(work: Path) -> dict:
+    work.mkdir(parents=True, exist_ok=True)
+    ds = load_dataset(
+        _SOURCE_REPO, "all_test", revision=_SOURCE_REV, split="test"
+    ).select_columns(_KEEP)
+
+    # Read the two label columns on their own; filtering whole rows would decode media.
+    all_langs = ds["Language"]
+    all_ids = ds["ID"]
+
+    images_only = ds.select_columns(["image"])
+    audio_only = ds.select_columns(["native_audio_question"])
+
+    # Not every question was recorded, and a few images are missing. Read both columns
+    # undecoded to find the gaps cheaply, then drop those rows rather than publish
+    # entries that fail to load.
+    undecoded = ds.select_columns(["image", "native_audio_question"])
+    undecoded = undecoded.cast_column("image", Image(decode=False)).cast_column(
+        "native_audio_question", Audio(decode=False)
+    )
+    # Hashed in the same pass. A few photographs are byte-identical to another in the
+    # same language, and a few questions share one recording; both would leave an
+    # identical query or document relevant to only one of the rows it matches.
+    ok_img, ok_aud, img_hash, aud_hash = [], [], [], []
+    for rec in undecoded:
+        iv, av = rec["image"], rec["native_audio_question"]
+        ib = iv.get("bytes") if iv else None
+        ab = av.get("bytes") if av else None
+        ok_img.append(bool(ib))
+        ok_aud.append(bool(ab))
+        img_hash.append(hashlib.md5(ib).hexdigest() if ib else None)
+        aud_hash.append(hashlib.md5(ab).hexdigest() if ab else None)
+
+    dropped = sum(1 for a, i in zip(ok_aud, ok_img, strict=True) if not (a and i))
+    print(f"dropping {dropped} rows with no recording or no image", flush=True)
+
+    counts: dict[str, dict[str, int]] = {}
+    for name, code in _LANGS.items():
+        rows = [
+            i
+            for i, lg in enumerate(all_langs)
+            if lg == name and ok_aud[i] and ok_img[i]
+        ]
+        if not rows:
+            continue
+        img_path, aud_path = (
+            work / f"{code}_images.parquet",
+            work / f"{code}_audio.parquet",
+        )
+        if img_path.exists() and aud_path.exists():
+            import pyarrow.parquet as pq
+
+            counts[code] = {
+                "images": pq.read_metadata(img_path).num_rows,
+                "questions": pq.read_metadata(aud_path).num_rows,
+            }
+            print(f"  {code}: cached {counts[code]}", flush=True)
+            continue
+
+        # ID is "<image>_<question index>", so the stem groups questions on one image.
+        # Identical photographs collapse onto the first stem carrying that image.
+        canon: dict[str, str] = {}
+        stem_of_hash: dict[str, str] = {}
+        first: dict[str, int] = {}
+        keep_rows: list[int] = []
+        seen_audio: set[str] = set()
+        for i in rows:
+            stem = all_ids[i].split("_")[0]
+            target = stem_of_hash.setdefault(img_hash[i], stem)
+            canon[stem] = target
+            first.setdefault(target, i)
+            if aud_hash[i] in seen_audio:
+                continue
+            seen_audio.add(aud_hash[i])
+            keep_rows.append(i)
+
+        img = images_only.select(list(first.values()))
+        img = img.add_column("id", [f"{code}-img-{s}" for s in first])
+        img.cast_column("image", Image()).to_parquet(
+            str(work / f"{code}_images.parquet")
+        )
+
+        aud = audio_only.select(keep_rows).rename_column(
+            "native_audio_question", "audio"
+        )
+        aud = aud.add_column("id", [f"{code}-aud-{all_ids[i]}" for i in keep_rows])
+        aud = aud.add_column(
+            "image_id",
+            [f"{code}-img-{canon[all_ids[i].split('_')[0]]}" for i in keep_rows],
+        )
+        aud.cast_column("audio", Audio(sampling_rate=16000)).to_parquet(
+            str(work / f"{code}_audio.parquet")
+        )
+
+        counts[code] = {"images": img.num_rows, "questions": aud.num_rows}
+        print(f"  {code}: {counts[code]}", flush=True)
+
+    (work / "counts.json").write_text(json.dumps(counts, indent=2), encoding="utf-8")
+    print("built", json.dumps(counts))
+    return counts
+
+
+def _card(codes: list[str]) -> str:
+    lines = [
+        "---",
+        f"license: {_LICENSE}",
+        "task_categories:",
+        "  - image-to-text",
+        "  - audio-classification",
+        "language:",
+        *[f"  - {c}" for c in codes],
+        "tags:",
+        "  - mteb",
+        "  - retrieval",
+        "  - multilingual",
+        "configs:",
+    ]
+    for c in codes:
+        for suffix, src in (("images", f"{c}_images"), ("audio", f"{c}_audio")):
+            lines += [
+                f"  - config_name: {c}-{suffix}",
+                "    data_files:",
+                "      - split: test",
+                f"        path: {src}.parquet",
+            ]
+    lines += [
+        "---",
+        "",
+        "# Afri-MCQA speech-image retrieval (MTEB)",
+        "",
+        "Afri-MCQA reshaped for retrieval: find the photograph a spoken question is asking",
+        "about. Questions are spoken by native speakers in 16 African languages and are",
+        "grounded in culturally relevant images.",
+        "",
+        f"Source: `{_SOURCE_REPO}` at revision `{_SOURCE_REV[:7]}`, {_LICENSE}, official",
+        "`test` split. Images are stored per language because one photograph can carry",
+        "questions in several languages.",
+        "",
+        "Built by `scripts/data/afri_mcqa_retrieval/create_data.py` in the MTEB repo.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def stage_push(work: Path) -> None:
+    api = HfApi()
+    api.create_repo(_TARGET, repo_type="dataset", exist_ok=True)
+    codes = [c for c in _LANGS.values() if (work / f"{c}_images.parquet").exists()]
+    for c in codes:
+        for kind in ("images", "audio"):
+            api.upload_file(
+                path_or_fileobj=str(work / f"{c}_{kind}.parquet"),
+                path_in_repo=f"{c}_{kind}.parquet",
+                repo_id=_TARGET,
+                repo_type="dataset",
+            )
+        print(f"  pushed {c}", flush=True)
+    api.upload_file(
+        path_or_fileobj=io.BytesIO(_card(codes).encode()),
+        path_in_repo="README.md",
+        repo_id=_TARGET,
+        repo_type="dataset",
+    )
+    print(f"pushed {_TARGET}: {len(codes)} languages")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--stage", choices=["build", "push", "all"], default="all")
+    parser.add_argument("--work-dir", type=Path, default=Path("afri_mcqa_work"))
+    parser.add_argument("--push", action="store_true")
+    args = parser.parse_args()
+
+    print(f"source: {_SOURCE_REPO}@{_SOURCE_REV[:7]} (license {_LICENSE})")
+    if args.stage in ("build", "all"):
+        stage_build(args.work_dir)
+    if args.stage == "push" or (args.push and args.stage == "all"):
+        stage_push(args.work_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a2i/i2a over [Afri-MCQA](https://arxiv.org/abs/2601.05699) (Tonja et al. 2026) across **16 African languages**. Part of #4842.

## Gap

mteb has **no multilingual audio+image task**. All six existing audio+image tasks are English-only, so this is the first, and it covers languages with almost no non-text representation in the benchmark.

Questions are spoken by native speakers and grounded in culturally relevant photographs, so the task is speech-to-image grounding rather than transcript matching.

## Construction

Official **test** split only. Only the question audio is kept; the four spoken answer options are dropped because they describe candidate answers, not the image.

Three cleanups, all in `scripts/data/afri_mcqa_retrieval/create_data.py`:

- **432 rows dropped.** The source has questions with no recording and a few missing images, which fail on load. Detected by reading both columns undecoded.
- **Duplicates removed.** A few photographs are byte-identical within a language (twi 179 to 178, lin 152 to 150) and a few questions share a recording (sot 151 to 148). Questions on a collapsed image are remapped to the surviving one, so no qrel is orphaned.
- **Images held per language**, not pooled. One photograph can carry questions in several languages, and a pooled corpus would score a correct retrieval wrong when the model returned the twin from another language.

Result: **3,855 spoken questions over 2,430 images**. License **CC-BY-NC-4.0**, matching the source.

## Checklist

- [x] Outlined why this fills a gap
- [x] Tested that it runs with `mteb` (both directions)
- [x] `mteb/baseline-random-encoder` mean over 16 subsets gives a2i 0.0286, i2a 0.0208
- [ ] Second encoder not run: CPU-only hardware. Same rationale as #5344.
- [x] Size considered, official test split, no reduction
- [x] `test_task_quality.py` passes with no exemptions
