### PR TITLE
dataset: add Indic DiarBench multilingual speaker retrieval (a2a, 20 Indian languages)

### DIFF
--- a/mteb/abstasks/task_metadata.py
+++ b/mteb/abstasks/task_metadata.py
@@ -94,6 +94,7 @@ TaskSubtype = Literal[
     "Spoken Language Identification",
     "Stroke Classification of Musical Instrument",
     "Tonic Classification of Musical Instrument",
+    "Speaker Identification",
     "Speaker Count Identification",
     "Species Classification",
     "Spoken Digit Classification",

--- a/mteb/descriptive_stats/Image/Any2AnyMultilingualRetrieval/IndicDiarBenchSpeakerA2ARetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyMultilingualRetrieval/IndicDiarBenchSpeakerA2ARetrieval.json
@@ -1,0 +1,928 @@
+{
+    "test": {
+        "num_samples": 6984,
+        "num_queries": 1884,
+        "num_documents": 5100,
+        "number_of_characters": 0,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": {
+            "total_duration_seconds": 27970.453125,
+            "min_duration_seconds": 2.0,
+            "average_duration_seconds": 5.484402573529412,
+            "max_duration_seconds": 15.0,
+            "unique_audios": 5100,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 5100
+            }
+        },
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": null,
+        "queries_audio_statistics": {
+            "total_duration_seconds": 10174.158375,
+            "min_duration_seconds": 2.0,
+            "average_duration_seconds": 5.4002963773885355,
+            "max_duration_seconds": 14.995,
+            "unique_audios": 1884,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 1884
+            }
+        },
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 15300,
+            "min_relevant_docs_per_query": 2,
+            "average_relevant_docs_per_query": 8.121019108280255,
+            "max_relevant_docs_per_query": 9,
+            "unique_relevant_docs": 5100,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null,
+        "hf_subset_descriptive_stats": {
+            "asm": {
+                "num_samples": 80,
+                "num_queries": 24,
+                "num_documents": 56,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 283.58412500000003,
+                    "min_duration_seconds": 2.017875,
+                    "average_duration_seconds": 5.064002232142857,
+                    "max_duration_seconds": 14.8119375,
+                    "unique_audios": 56,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 56
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 132.1661875,
+                    "min_duration_seconds": 2.012,
+                    "average_duration_seconds": 5.506924479166667,
+                    "max_duration_seconds": 13.916,
+                    "unique_audios": 24,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 24
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 168,
+                    "min_relevant_docs_per_query": 2,
+                    "average_relevant_docs_per_query": 7.0,
+                    "max_relevant_docs_per_query": 9,
+                    "unique_relevant_docs": 56,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "ben": {
+                "num_samples": 720,
+                "num_queries": 180,
+                "num_documents": 540,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 2949.169,
+                    "min_duration_seconds": 2.0,
+                    "average_duration_seconds": 5.461424074074074,
+                    "max_duration_seconds": 14.772,
+                    "unique_audios": 540,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 540
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 949.9813125,
+                    "min_duration_seconds": 2.0,
+                    "average_duration_seconds": 5.277673958333333,
+                    "max_duration_seconds": 14.824,
+                    "unique_audios": 180,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 180
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 1620,
+                    "min_relevant_docs_per_query": 9,
+                    "average_relevant_docs_per_query": 9.0,
+                    "max_relevant_docs_per_query": 9,
+                    "unique_relevant_docs": 540,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "brx": {
+                "num_samples": 110,
+                "num_queries": 30,
+                "num_documents": 80,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 408.466,
+                    "min_duration_seconds": 2.076,
+                    "average_duration_seconds": 5.105825,
+                    "max_duration_seconds": 14.076,
+                    "unique_audios": 80,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 80
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 156.179125,
+                    "min_duration_seconds": 2.012,
+                    "average_duration_seconds": 5.205970833333334,
+                    "max_duration_seconds": 14.204,
+                    "unique_audios": 30,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 30
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 240,
+                    "min_relevant_docs_per_query": 2,
+                    "average_relevant_docs_per_query": 8.0,
+                    "max_relevant_docs_per_query": 9,
+                    "unique_relevant_docs": 80,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "doi": {
+                "num_samples": 58,
+                "num_queries": 18,
+                "num_documents": 40,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 188.92125,
+                    "min_duration_seconds": 2.023625,
+                    "average_duration_seconds": 4.72303125,
+                    "max_duration_seconds": 12.828,
+                    "unique_audios": 40,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 40
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 75.439125,
+                    "min_duration_seconds": 2.108,
+                    "average_duration_seconds": 4.1910625,
+                    "max_duration_seconds": 7.5065,
+                    "unique_audios": 18,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 18
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 120,
+                    "min_relevant_docs_per_query": 2,
+                    "average_relevant_docs_per_query": 6.666666666666667,
+                    "max_relevant_docs_per_query": 9,
+                    "unique_relevant_docs": 40,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "guj": {
+                "num_samples": 705,
+                "num_queries": 180,
+                "num_documents": 525,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 3633.1795,
+                    "min_duration_seconds": 2.0,
+                    "average_duration_seconds": 6.920341904761905,
+                    "max_duration_seconds": 14.94,
+                    "unique_audios": 525,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 525
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 1216.0946875,
+                    "min_duration_seconds": 2.0,
+                    "average_duration_seconds": 6.756081597222222,
+                    "max_duration_seconds": 14.92,
+                    "unique_audios": 180,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 180
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 1575,
+                    "min_relevant_docs_per_query": 6,
+                    "average_relevant_docs_per_query": 8.75,
+                    "max_relevant_docs_per_query": 9,
+                    "unique_relevant_docs": 525,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "hin": {
+                "num_samples": 621,
+                "num_queries": 180,
+                "num_documents": 441,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 2586.4994375,
+                    "min_duration_seconds": 2.024,
+                    "average_duration_seconds": 5.865078089569161,
+                    "max_duration_seconds": 14.77,
+                    "unique_audios": 441,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 441
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 1154.36875,
+                    "min_duration_seconds": 2.033,
+                    "average_duration_seconds": 6.413159722222223,
+                    "max_duration_seconds": 14.86,
+                    "unique_audios": 180,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 180
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 1323,
+                    "min_relevant_docs_per_query": 4,
+                    "average_relevant_docs_per_query": 7.35,
+                    "max_relevant_docs_per_query": 9,
+                    "unique_relevant_docs": 441,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "kan": {
+                "num_samples": 683,
+                "num_queries": 180,
+                "num_documents": 503,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 2487.538,
+                    "min_duration_seconds": 2.0,
+                    "average_duration_seconds": 4.945403578528827,
+                    "max_duration_seconds": 14.86,
+                    "unique_audios": 503,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 503
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 823.2639375,
+                    "min_duration_seconds": 2.0,
+                    "average_duration_seconds": 4.573688541666667,
+                    "max_duration_seconds": 14.64,
+                    "unique_audios": 180,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 180
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 1509,
+                    "min_relevant_docs_per_query": 5,
+                    "average_relevant_docs_per_query": 8.383333333333333,
+                    "max_relevant_docs_per_query": 9,
+                    "unique_relevant_docs": 503,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "kas": {
+                "num_samples": 58,
+                "num_queries": 18,
+                "num_documents": 40,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 194.8025625,
+                    "min_duration_seconds": 2.044,
+                    "average_duration_seconds": 4.8700640625,
+                    "max_duration_seconds": 12.06,
+                    "unique_audios": 40,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 40
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 73.699,
+                    "min_duration_seconds": 2.012,
+                    "average_duration_seconds": 4.094388888888889,
+                    "max_duration_seconds": 9.372,
+                    "unique_audios": 18,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 18
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 120,
+                    "min_relevant_docs_per_query": 2,
+                    "average_relevant_docs_per_query": 6.666666666666667,
+                    "max_relevant_docs_per_query": 9,
+                    "unique_relevant_docs": 40,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "kok": {
+                "num_samples": 59,
+                "num_queries": 18,
+                "num_documents": 41,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 223.2095625,
+                    "min_duration_seconds": 2.0063125,
+                    "average_duration_seconds": 5.444135670731708,
+                    "max_duration_seconds": 14.812,
+                    "unique_audios": 41,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 41
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 119.19200000000001,
+                    "min_duration_seconds": 2.044,
+                    "average_duration_seconds": 6.621777777777778,
+                    "max_duration_seconds": 14.172,
+                    "unique_audios": 18,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 18
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 123,
+                    "min_relevant_docs_per_query": 2,
+                    "average_relevant_docs_per_query": 6.833333333333333,
+                    "max_relevant_docs_per_query": 9,
+                    "unique_relevant_docs": 41,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "mal": {
+                "num_samples": 414,
+                "num_queries": 135,
+                "num_documents": 279,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 1526.4123125,
+                    "min_duration_seconds": 2.02,
+                    "average_duration_seconds": 5.471011872759857,
+                    "max_duration_seconds": 15.0,
+                    "unique_audios": 279,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 279
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 781.3273125,
+                    "min_duration_seconds": 2.04,
+                    "average_duration_seconds": 5.787609722222222,
+                    "max_duration_seconds": 14.9000625,
+                    "unique_audios": 135,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 135
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 837,
+                    "min_relevant_docs_per_query": 2,
+                    "average_relevant_docs_per_query": 6.2,
+                    "max_relevant_docs_per_query": 9,
+                    "unique_relevant_docs": 279,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "mar": {
+                "num_samples": 709,
+                "num_queries": 180,
+                "num_documents": 529,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 2907.0791875,
+                    "min_duration_seconds": 2.0,
+                    "average_duration_seconds": 5.4954237948960305,
+                    "max_duration_seconds": 15.0,
+                    "unique_audios": 529,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 529
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 934.136,
+                    "min_duration_seconds": 2.009,
+                    "average_duration_seconds": 5.189644444444444,
+                    "max_duration_seconds": 14.995,
+                    "unique_audios": 180,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 180
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 1587,
+                    "min_relevant_docs_per_query": 7,
+                    "average_relevant_docs_per_query": 8.816666666666666,
+                    "max_relevant_docs_per_query": 9,
+                    "unique_relevant_docs": 529,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "mni": {
+                "num_samples": 62,
+                "num_queries": 21,
+                "num_documents": 41,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 242.7675625,
+                    "min_duration_seconds": 2.076,
+                    "average_duration_seconds": 5.92116006097561,
+                    "max_duration_seconds": 14.524,
+                    "unique_audios": 41,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 41
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 109.24775,
+                    "min_duration_seconds": 2.332,
+                    "average_duration_seconds": 5.20227380952381,
+                    "max_duration_seconds": 9.756,
+                    "unique_audios": 21,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 21
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 123,
+                    "min_relevant_docs_per_query": 2,
+                    "average_relevant_docs_per_query": 5.857142857142857,
+                    "max_relevant_docs_per_query": 9,
+                    "unique_relevant_docs": 41,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "npi": {
+                "num_samples": 72,
+                "num_queries": 24,
+                "num_documents": 48,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 218.5558125,
+                    "min_duration_seconds": 2.14,
+                    "average_duration_seconds": 4.55324609375,
+                    "max_duration_seconds": 13.532,
+                    "unique_audios": 48,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 48
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 121.015375,
+                    "min_duration_seconds": 2.076,
+                    "average_duration_seconds": 5.042307291666667,
+                    "max_duration_seconds": 10.46,
+                    "unique_audios": 24,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 24
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 144,
+                    "min_relevant_docs_per_query": 2,
+                    "average_relevant_docs_per_query": 6.0,
+                    "max_relevant_docs_per_query": 9,
+                    "unique_relevant_docs": 48,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "ory": {
+                "num_samples": 289,
+                "num_queries": 93,
+                "num_documents": 196,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 1142.2980625,
+                    "min_duration_seconds": 2.0,
+                    "average_duration_seconds": 5.8280513392857145,
+                    "max_duration_seconds": 14.972,
+                    "unique_audios": 196,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 196
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 513.8193125,
+                    "min_duration_seconds": 2.0,
+                    "average_duration_seconds": 5.524938844086022,
+                    "max_duration_seconds": 14.56,
+                    "unique_audios": 93,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 93
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 588,
+                    "min_relevant_docs_per_query": 2,
+                    "average_relevant_docs_per_query": 6.32258064516129,
+                    "max_relevant_docs_per_query": 9,
+                    "unique_relevant_docs": 196,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "pan": {
+                "num_samples": 720,
+                "num_queries": 180,
+                "num_documents": 540,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 2793.7114375,
+                    "min_duration_seconds": 2.0,
+                    "average_duration_seconds": 5.173539699074074,
+                    "max_duration_seconds": 14.81,
+                    "unique_audios": 540,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 540
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 845.9093124999999,
+                    "min_duration_seconds": 2.0,
+                    "average_duration_seconds": 4.699496180555555,
+                    "max_duration_seconds": 14.678,
+                    "unique_audios": 180,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 180
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 1620,
+                    "min_relevant_docs_per_query": 9,
+                    "average_relevant_docs_per_query": 9.0,
+                    "max_relevant_docs_per_query": 9,
+                    "unique_relevant_docs": 540,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "san": {
+                "num_samples": 86,
+                "num_queries": 24,
+                "num_documents": 62,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 311.60975,
+                    "min_duration_seconds": 2.076,
+                    "average_duration_seconds": 5.02596370967742,
+                    "max_duration_seconds": 14.524,
+                    "unique_audios": 62,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 62
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 110.20375,
+                    "min_duration_seconds": 2.076,
+                    "average_duration_seconds": 4.591822916666667,
+                    "max_duration_seconds": 12.254375,
+                    "unique_audios": 24,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 24
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 186,
+                    "min_relevant_docs_per_query": 3,
+                    "average_relevant_docs_per_query": 7.75,
+                    "max_relevant_docs_per_query": 9,
+                    "unique_relevant_docs": 62,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "sat": {
+                "num_samples": 69,
+                "num_queries": 24,
+                "num_documents": 45,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 273.9330625,
+                    "min_duration_seconds": 2.077,
+                    "average_duration_seconds": 6.087401388888889,
+                    "max_duration_seconds": 14.908,
+                    "unique_audios": 45,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 45
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 175.104,
+                    "min_duration_seconds": 2.172,
+                    "average_duration_seconds": 7.296,
+                    "max_duration_seconds": 14.428,
+                    "unique_audios": 24,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 24
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 135,
+                    "min_relevant_docs_per_query": 2,
+                    "average_relevant_docs_per_query": 5.625,
+                    "max_relevant_docs_per_query": 9,
+                    "unique_relevant_docs": 45,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "tam": {
+                "num_samples": 706,
+                "num_queries": 180,
+                "num_documents": 526,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 2837.2299375,
+                    "min_duration_seconds": 2.005,
+                    "average_duration_seconds": 5.393973265209125,
+                    "max_duration_seconds": 14.94,
+                    "unique_audios": 526,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 526
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 929.095125,
+                    "min_duration_seconds": 2.002,
+                    "average_duration_seconds": 5.161639583333334,
+                    "max_duration_seconds": 14.68,
+                    "unique_audios": 180,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 180
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 1578,
+                    "min_relevant_docs_per_query": 7,
+                    "average_relevant_docs_per_query": 8.766666666666667,
+                    "max_relevant_docs_per_query": 9,
+                    "unique_relevant_docs": 526,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "tel": {
+                "num_samples": 703,
+                "num_queries": 180,
+                "num_documents": 523,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 2522.54475,
+                    "min_duration_seconds": 2.0,
+                    "average_duration_seconds": 4.8232213193116635,
+                    "max_duration_seconds": 14.88,
+                    "unique_audios": 523,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 523
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 871.606125,
+                    "min_duration_seconds": 2.012,
+                    "average_duration_seconds": 4.84225625,
+                    "max_duration_seconds": 14.9,
+                    "unique_audios": 180,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 180
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 1569,
+                    "min_relevant_docs_per_query": 6,
+                    "average_relevant_docs_per_query": 8.716666666666667,
+                    "max_relevant_docs_per_query": 9,
+                    "unique_relevant_docs": 523,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "urd": {
+                "num_samples": 60,
+                "num_queries": 15,
+                "num_documents": 45,
+                "number_of_characters": 0,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 238.9418125,
+                    "min_duration_seconds": 2.03175,
+                    "average_duration_seconds": 5.309818055555556,
+                    "max_duration_seconds": 12.359875,
+                    "unique_audios": 45,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 45
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 82.3101875,
+                    "min_duration_seconds": 2.524,
+                    "average_duration_seconds": 5.487345833333333,
+                    "max_duration_seconds": 9.948,
+                    "unique_audios": 15,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 15
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 135,
+                    "min_relevant_docs_per_query": 9,
+                    "average_relevant_docs_per_query": 9.0,
+                    "max_relevant_docs_per_query": 9,
+                    "unique_relevant_docs": 45,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            }
+        }
+    }
+}

--- a/mteb/tasks/retrieval/multilingual/__init__.py
+++ b/mteb/tasks/retrieval/multilingual/__init__.py
@@ -21,6 +21,7 @@ from .fleurs import (
     FleursT2ARetrievalV2,
 )
 from .google_svq import GoogleSVQA2TRetrieval, GoogleSVQT2ARetrieval
+from .indic_diarbench_speaker_retrieval import IndicDiarBenchSpeakerA2ARetrieval
 from .indic_qa_retrieval import IndicQARetrieval
 from .jam_alt import (
     JamAltArtistA2ARetrieval,
@@ -172,6 +173,7 @@ __all__ = [
     "GlobalNewsRetrieval",
     "GoogleSVQA2TRetrieval",
     "GoogleSVQT2ARetrieval",
+    "IndicDiarBenchSpeakerA2ARetrieval",
     "IndicQARetrieval",
     "JamAltArtistA2ARetrieval",
     "JamAltLyricA2TRetrieval",

--- a/mteb/tasks/retrieval/multilingual/indic_diarbench_speaker_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/indic_diarbench_speaker_retrieval.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from datasets import load_dataset
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.retrieval_dataset_loaders import RetrievalSplitData
+from mteb.abstasks.task_metadata import TaskMetadata
+
+_DATASET_PATH = "vnahata/IndicDiarBench-speaker-retrieval"
+_DATASET_REVISION = "0e426b97c9a792fa6c10efc12b2d0800a1ff4257"
+
+_LANGUAGES = {
+    "asm": ["asm-Beng"],
+    "ben": ["ben-Beng"],
+    "brx": ["brx-Deva"],
+    "doi": ["doi-Deva"],
+    "guj": ["guj-Gujr"],
+    "hin": ["hin-Deva"],
+    "kan": ["kan-Knda"],
+    "kas": ["kas-Arab"],
+    "kok": ["gom-Deva"],
+    "mal": ["mal-Mlym"],
+    "mar": ["mar-Deva"],
+    "mni": ["mni-Beng"],
+    "npi": ["npi-Deva"],
+    "ory": ["ory-Orya"],
+    "pan": ["pan-Guru"],
+    "san": ["san-Deva"],
+    "sat": ["sat-Olck"],
+    "tam": ["tam-Taml"],
+    "tel": ["tel-Telu"],
+    "urd": ["urd-Arab"],
+}
+
+_BIBTEX = r"""
+@inproceedings{mehendale2026indicdiarbench,
+  author = {Mehendale, Deovrat and Mehndiratta, Aditya and Rathi, Dhruv and Bhogale, Kaushal and Khapra, Mitesh M.},
+  booktitle = {Interspeech},
+  title = {{Indic DiarBench}: A Multilingual Joint Diarization and {ASR} Benchmark for {Indian} Languages},
+  year = {2026},
+}
+"""
+
+
+class IndicDiarBenchSpeakerA2ARetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="IndicDiarBenchSpeakerA2ARetrieval",
+        description=(
+            "Speaker retrieval over conversational speech in 20 scheduled languages of "
+            "India: given a clip of one speaker, find other clips of that same speaker. "
+            "Speaker labels are numbered per recording session, so identity pairs the "
+            "session with the speaker, and the corpus holds the other speakers of the "
+            "same session as the hardest distractors: same room, same channel, different "
+            "voice. Built from the official test split by cutting annotated turns to "
+            "clips of 2 to 15 seconds, dropping turns that overlap a different speaker "
+            "by more than 0.5s, and keeping speakers with at least five clips. Maithili "
+            "and Sindhi are excluded because the source gives them only four speakers "
+            "each. Construction script: "
+            "scripts/data/indic_diarbench_speaker/create_data.py."
+        ),
+        reference="https://arxiv.org/abs/2607.23808",
+        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        type="Any2AnyMultilingualRetrieval",
+        category="a2a",
+        modalities=["audio"],
+        eval_splits=["test"],
+        eval_langs=_LANGUAGES,
+        main_score="ndcg_at_10",
+        date=("2025-01-01", "2026-07-26"),
+        domains=["Spoken"],
+        task_subtypes=["Speaker Identification"],
+        license="cc-by-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        prompt={"query": "Find other recordings of this speaker."},
+        bibtex_citation=_BIBTEX,
+        is_beta=True,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        if self.data_loaded:
+            return
+
+        split = self.metadata.eval_splits[0]
+        self.dataset = {}
+        for lang in _LANGUAGES:
+            queries = load_dataset(
+                _DATASET_PATH,
+                f"{lang}-queries",
+                revision=_DATASET_REVISION,
+                split=split,
+            )
+            corpus = load_dataset(
+                _DATASET_PATH, f"{lang}-corpus", revision=_DATASET_REVISION, split=split
+            )
+
+            # Read the identity columns directly; iterating full rows would decode audio.
+            by_identity: dict[str, list[str]] = {}
+            for doc_id, identity in zip(corpus["id"], corpus["identity"], strict=True):
+                by_identity.setdefault(identity, []).append(doc_id)
+
+            qrels = {
+                qid: dict.fromkeys(by_identity.get(identity, []), 1)
+                for qid, identity in zip(
+                    queries["id"], queries["identity"], strict=True
+                )
+            }
+
+            self.dataset[lang] = {
+                split: RetrievalSplitData(
+                    queries=queries.select_columns(["id", "audio"]),
+                    corpus=corpus.select_columns(["id", "audio"]),
+                    relevant_docs=qrels,
+                    top_ranked=None,
+                )
+            }
+        self.data_loaded = True

--- a/scripts/data/indic_diarbench_speaker/create_data.py
+++ b/scripts/data/indic_diarbench_speaker/create_data.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Build the Indic DiarBench multilingual speaker retrieval tasks for MTEB.
+
+Source is `sarvamai/indic-diarbench` at a pinned revision, a joint diarization and ASR
+benchmark covering all 22 scheduled languages of India (Mehendale et al., Interspeech
+2026). It ships only a `test` split, so nothing here is drawn from training data.
+
+The corpus is conversational: each row is a chunk of a recording session carrying
+human-corrected, time-aligned, speaker-attributed turns. Speaker labels are stable across
+the chunks of one session, so a speaker recurs in several chunks and retrieving them is
+not a matter of matching the same audio twice.
+
+Turns are cut into clips by their annotated times. Three filters apply:
+
+- clips shorter than 2s or longer than 15s are dropped, since very short turns carry too
+  little voice to identify a speaker;
+- a turn overlapping any turn of a different speaker is dropped, because the corpus has a
+  12.8% overlap ratio and such a clip contains two voices;
+- a speaker must keep at least five clips, so every query has a positive in the corpus.
+
+Identity is the session and speaker together, since speaker labels are numbered per
+session. The corpus therefore holds other speakers from the same session as the hardest
+distractors: same room, same channel, different voice.
+
+Examples:
+  # Build the reshaped tables locally.
+  uv run python scripts/data/indic_diarbench_speaker/create_data.py --stage build
+
+  # Build and publish.
+  uv run python scripts/data/indic_diarbench_speaker/create_data.py --stage all --push
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+from pathlib import Path
+
+import pyarrow.parquet as pq
+import soundfile as sf
+from datasets import Audio, Dataset
+from huggingface_hub import HfApi, hf_hub_download
+
+_SOURCE_REPO = "sarvamai/indic-diarbench"
+_SOURCE_REV = "92877bad8aab6e598167d91c6ee02aa8ca6ede09"
+_TARGET = "vnahata/IndicDiarBench-speaker-retrieval"
+_LICENSE = "cc-by-4.0"
+
+# source config name -> published subset name
+_LANGS = {
+    "Assamese": "asm",
+    "Bengali": "ben",
+    "Bodo": "brx",
+    "Dogri": "doi",
+    "Gujarati": "guj",
+    "Hindi": "hin",
+    "Kannada": "kan",
+    "Kashmiri": "kas",
+    "Konkani": "kok",
+    "Maithili": "mai",
+    "Malayalam": "mal",
+    "Manipuri": "mni",
+    "Marathi": "mar",
+    "Nepali": "npi",
+    "Odia": "ory",
+    "Punjabi": "pan",
+    "Sanskrit": "san",
+    "Santali": "sat",
+    "Sindhi": "snd",
+    "Tamil": "tam",
+    "Telugu": "tel",
+    "Urdu": "urd",
+}
+
+_MIN_DUR, _MAX_DUR = 2.0, 15.0
+# Turns may overlap a different speaker by up to this much. Conversational turns brush
+# against each other at the boundaries; only a longer overlap puts two voices in the clip.
+_OVERLAP_TOLERANCE = 0.5
+_PER_IDENTITY = 12  # clips kept per speaker
+_MAX_IDENTITIES = 60  # per language, keeping the speakers with the most clips
+_QUERIES_PER_IDENTITY = 3
+_MIN_CLIPS = 5  # queries plus at least two corpus clips
+# A language is skipped below this many speakers. Ranking a handful of voices says little
+# about a model, and the source gives Maithili and Sindhi only four speakers apiece.
+_MIN_IDENTITIES = 5
+
+
+def _usable_turns(rows: list[dict]) -> list[tuple[str, str, float, float, int]]:
+    """Return (identity, sample_id, start, end, row_index) for non-overlapping turns."""
+    out = []
+    for idx, row in enumerate(rows):
+        turns = row["annotated_transcript"]
+        for i, turn in enumerate(turns):
+            start, end = turn["start_time"], turn["end_time"]
+            if not _MIN_DUR <= end - start <= _MAX_DUR:
+                continue
+            speaker = turn["speaker_id"]
+            overlap = max(
+                (
+                    min(end, other["end_time"]) - max(start, other["start_time"])
+                    for j, other in enumerate(turns)
+                    if j != i and other["speaker_id"] != speaker
+                ),
+                default=0.0,
+            )
+            if overlap > _OVERLAP_TOLERANCE:
+                continue
+            out.append(
+                (f"{row['recording_id']}|{speaker}", row["sample_id"], start, end, idx)
+            )
+    return out
+
+
+def _slice(audio_bytes: bytes, start: float, end: float) -> bytes:
+    data, rate = sf.read(io.BytesIO(audio_bytes), dtype="float32")
+    if data.ndim > 1:
+        data = data[:, 0]
+    clip = data[int(start * rate) : int(end * rate)]
+    buf = io.BytesIO()
+    sf.write(buf, clip, rate, format="WAV", subtype="PCM_16")
+    return buf.getvalue()
+
+
+def stage_build(work: Path) -> dict:
+    work.mkdir(parents=True, exist_ok=True)
+    counts: dict[str, dict[str, int]] = {}
+
+    for name, code in _LANGS.items():
+        q_path, c_path = (
+            work / f"{code}_queries.parquet",
+            work / f"{code}_corpus.parquet",
+        )
+        if q_path.exists() and c_path.exists():
+            counts[code] = {
+                "queries": pq.read_metadata(q_path).num_rows,
+                "corpus": pq.read_metadata(c_path).num_rows,
+            }
+            print(f"  {code}: cached {counts[code]}", flush=True)
+            continue
+
+        local = hf_hub_download(
+            _SOURCE_REPO,
+            f"{name}/test-00000-of-00001.parquet",
+            repo_type="dataset",
+            revision=_SOURCE_REV,
+        )
+        table = pq.read_table(local)
+        meta = table.drop(["audio"]).to_pylist()
+        turns = _usable_turns(meta)
+
+        by_identity: dict[str, list] = {}
+        for identity, sample_id, start, end, idx in turns:
+            by_identity.setdefault(identity, []).append((sample_id, start, end, idx))
+        # keep the speakers with the most turns, so subsets stay balanced in size
+        ranked = sorted(
+            ((k, v) for k, v in by_identity.items() if len(v) >= _MIN_CLIPS),
+            key=lambda kv: (-len(kv[1]), kv[0]),
+        )[:_MAX_IDENTITIES]
+        if len(ranked) < _MIN_IDENTITIES:
+            print(f"  {code}: skipped, only {len(ranked)} speakers", flush=True)
+            Path(local).unlink(missing_ok=True)
+            continue
+        keep = {k: v[:_PER_IDENTITY] for k, v in ranked}
+
+        audio_col = table.column("audio")
+        queries, corpus = [], []
+        for identity, items in sorted(keep.items()):
+            for n, (sample_id, start, end, idx) in enumerate(items):
+                raw = audio_col[idx].as_py()["bytes"]
+                # identity has to be part of the id: one chunk holds turns from several
+                # speakers, so the sample id alone collides across them
+                row = {
+                    "id": f"{code}-{identity.replace('|', '-')}-{n}",
+                    "audio": {"bytes": _slice(raw, start, end), "path": None},
+                    "identity": identity,
+                }
+                (queries if n < _QUERIES_PER_IDENTITY else corpus).append(row)
+
+        for rows, path in ((queries, q_path), (corpus, c_path)):
+            Dataset.from_list(rows).cast_column(
+                "audio", Audio(sampling_rate=16000)
+            ).to_parquet(str(path))
+
+        counts[code] = {
+            "queries": len(queries),
+            "corpus": len(corpus),
+            "speakers": len(keep),
+        }
+        print(f"  {code}: {counts[code]}", flush=True)
+        Path(local).unlink(missing_ok=True)
+
+    (work / "counts.json").write_text(json.dumps(counts, indent=2), encoding="utf-8")
+    print("built", json.dumps(counts))
+    return counts
+
+
+def _card(codes: list[str]) -> str:
+    lines = [
+        "---",
+        f"license: {_LICENSE}",
+        "task_categories:",
+        "  - audio-classification",
+        "language:",
+        *[f"  - {c}" for c in codes],
+        "tags:",
+        "  - mteb",
+        "  - retrieval",
+        "  - multilingual",
+        "configs:",
+    ]
+    for c in codes:
+        for kind in ("queries", "corpus"):
+            lines += [
+                f"  - config_name: {c}-{kind}",
+                "    data_files:",
+                "      - split: test",
+                f"        path: {c}_{kind}.parquet",
+            ]
+    lines += [
+        "---",
+        "",
+        "# Indic DiarBench speaker retrieval (MTEB)",
+        "",
+        "Indic DiarBench reshaped for speaker retrieval across the 22 scheduled languages",
+        "of India: given a clip of one speaker, find other clips of that same speaker.",
+        "",
+        f"Source: `{_SOURCE_REPO}` at revision `{_SOURCE_REV[:7]}`, {_LICENSE}, official",
+        "`test` split. Turns are cut by their annotated times, restricted to 2 to 15",
+        "seconds, and turns overlapping a different speaker are dropped. `identity` pairs",
+        "the recording session with the speaker, because speaker labels are numbered per",
+        "session.",
+        "",
+        "Built by `scripts/data/indic_diarbench_speaker/create_data.py` in the MTEB repo.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def stage_push(work: Path) -> None:
+    api = HfApi()
+    api.create_repo(_TARGET, repo_type="dataset", exist_ok=True)
+    codes = [c for c in _LANGS.values() if (work / f"{c}_queries.parquet").exists()]
+    for c in codes:
+        for kind in ("queries", "corpus"):
+            api.upload_file(
+                path_or_fileobj=str(work / f"{c}_{kind}.parquet"),
+                path_in_repo=f"{c}_{kind}.parquet",
+                repo_id=_TARGET,
+                repo_type="dataset",
+            )
+        print(f"  pushed {c}", flush=True)
+    api.upload_file(
+        path_or_fileobj=io.BytesIO(_card(codes).encode()),
+        path_in_repo="README.md",
+        repo_id=_TARGET,
+        repo_type="dataset",
+    )
+    print(f"pushed {_TARGET}: {len(codes)} languages")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--stage", choices=["build", "push", "all"], default="all")
+    parser.add_argument("--work-dir", type=Path, default=Path("indic_diar_work"))
+    parser.add_argument("--push", action="store_true")
+    args = parser.parse_args()
+
+    print(f"source: {_SOURCE_REPO}@{_SOURCE_REV[:7]} (license {_LICENSE})")
+    if args.stage in ("build", "all"):
+        stage_build(args.work_dir)
+    if args.stage == "push" or (args.push and args.stage == "all"):
+        stage_push(args.work_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds `IndicDiarBenchSpeakerA2ARetrieval` over [Indic DiarBench](https://arxiv.org/abs/2607.23808) (Mehendale et al., Interspeech 2026): given a clip of one speaker, retrieve other clips of that speaker, across **20 scheduled languages of India**. Part of #4842.

## Gap

`a2a` has 26 tasks and only **one** is multilingual, so this is where multilingual coverage is thinnest. The source is new to mteb and none of these 20 languages have an existing a2a task.

Speaker labels are numbered per session, so identity pairs session with speaker. The corpus keeps other speakers of the same session as the hardest distractors: same room, same channel, different voice.

## Construction

Official **test** split only. In `scripts/data/indic_diarbench_speaker/create_data.py`:

- Annotated turns cut to clips of 2 to 15 seconds; shorter turns carry too little voice to identify a speaker.
- A turn overlapping a different speaker by more than 0.5s is dropped, since the corpus has a 12.8% overlap ratio and such a clip holds two voices. Keeping brief boundary overlap roughly doubles usable clips.
- A speaker needs at least 5 clips, capped at 12, with 3 as queries. Languages capped at 60 speakers so subsets stay comparable.
- **Maithili and Sindhi excluded**: the source gives them only four speakers each, too few to rank meaningfully.

Result: **1,884 queries over 5,100 clips**. License **CC-BY-4.0**, as the source.

## Results

nDCG@10, mean over the 20 subsets:

| model | mean | range |
|---|---|---|
| `mteb/baseline-random-encoder` | 0.1006 | 0.015 to 0.263 |
| `laion/clap-htsat-fused` | 0.4948 | 0.320 to 0.719 |

CLAP is 5x random, so the task is learnable and far from saturated. Random tracks how many speakers a language has, which is a property of the source.

## Checklist

- [x] Outlined why this fills a gap
- [x] Tested that it runs with `mteb`
- [x] Two encoders run, see table
- [x] Size considered, official test split
- [x] `test_task_quality.py` passes with no exemptions
