### PR TITLE
dataset: add CAMEO multilingual speech emotion classification (a2c, 5 languages)

### DIFF
--- a/mteb/descriptive_stats/AudioClassification/CAMEOEmotionClassification.json
+++ b/mteb/descriptive_stats/AudioClassification/CAMEOEmotionClassification.json
@@ -1,0 +1,519 @@
+{
+    "test": {
+        "num_samples": 5945,
+        "samples_in_train": 0,
+        "text_statistics": null,
+        "image_statistics": null,
+        "audio_statistics": {
+            "total_duration_seconds": 22882.602,
+            "min_duration_seconds": 0.885,
+            "average_duration_seconds": 3.849049957947855,
+            "max_duration_seconds": 17.58,
+            "unique_audios": 5945,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 5945
+            }
+        },
+        "video_statistics": null,
+        "label_statistics": {
+            "min_labels_per_text": 1,
+            "average_label_per_text": 1.0,
+            "max_labels_per_text": 1,
+            "unique_labels": 6,
+            "labels": {
+                "0": {
+                    "count": 1127
+                },
+                "1": {
+                    "count": 962
+                },
+                "2": {
+                    "count": 1153
+                },
+                "3": {
+                    "count": 1069
+                },
+                "4": {
+                    "count": 896
+                },
+                "5": {
+                    "count": 738
+                }
+            }
+        },
+        "hf_subset_descriptive_stats": {
+            "ben": {
+                "num_samples": 1500,
+                "samples_in_train": 0,
+                "text_statistics": null,
+                "image_statistics": null,
+                "audio_statistics": {
+                    "total_duration_seconds": 6038.842375,
+                    "min_duration_seconds": 2.751625,
+                    "average_duration_seconds": 4.025894916666667,
+                    "max_duration_seconds": 6.025625,
+                    "unique_audios": 1500,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 1500
+                    }
+                },
+                "video_statistics": null,
+                "label_statistics": {
+                    "min_labels_per_text": 1,
+                    "average_label_per_text": 1.0,
+                    "max_labels_per_text": 1,
+                    "unique_labels": 6,
+                    "labels": {
+                        "0": {
+                            "count": 250
+                        },
+                        "1": {
+                            "count": 250
+                        },
+                        "2": {
+                            "count": 250
+                        },
+                        "3": {
+                            "count": 250
+                        },
+                        "4": {
+                            "count": 250
+                        },
+                        "5": {
+                            "count": 250
+                        }
+                    }
+                }
+            },
+            "eng": {
+                "num_samples": 983,
+                "samples_in_train": 0,
+                "text_statistics": null,
+                "image_statistics": null,
+                "audio_statistics": {
+                    "total_duration_seconds": 6607.1895625,
+                    "min_duration_seconds": 1.65,
+                    "average_duration_seconds": 6.7214542853509665,
+                    "max_duration_seconds": 17.58,
+                    "unique_audios": 983,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 983
+                    }
+                },
+                "video_statistics": null,
+                "label_statistics": {
+                    "min_labels_per_text": 1,
+                    "average_label_per_text": 1.0,
+                    "max_labels_per_text": 1,
+                    "unique_labels": 5,
+                    "labels": {
+                        "3": {
+                            "count": 209
+                        },
+                        "5": {
+                            "count": 153
+                        },
+                        "4": {
+                            "count": 210
+                        },
+                        "0": {
+                            "count": 193
+                        },
+                        "2": {
+                            "count": 218
+                        }
+                    }
+                }
+            },
+            "fra": {
+                "num_samples": 462,
+                "samples_in_train": 0,
+                "text_statistics": null,
+                "image_statistics": null,
+                "audio_statistics": {
+                    "total_duration_seconds": 1952.311375,
+                    "min_duration_seconds": 2.556875,
+                    "average_duration_seconds": 4.225782196969697,
+                    "max_duration_seconds": 6.4209375,
+                    "unique_audios": 462,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 462
+                    }
+                },
+                "video_statistics": null,
+                "label_statistics": {
+                    "min_labels_per_text": 1,
+                    "average_label_per_text": 1.0,
+                    "max_labels_per_text": 1,
+                    "unique_labels": 6,
+                    "labels": {
+                        "0": {
+                            "count": 84
+                        },
+                        "1": {
+                            "count": 84
+                        },
+                        "2": {
+                            "count": 84
+                        },
+                        "3": {
+                            "count": 42
+                        },
+                        "4": {
+                            "count": 84
+                        },
+                        "5": {
+                            "count": 84
+                        }
+                    }
+                }
+            },
+            "ita": {
+                "num_samples": 1500,
+                "samples_in_train": 0,
+                "text_statistics": null,
+                "image_statistics": null,
+                "audio_statistics": {
+                    "total_duration_seconds": 4545.2156875,
+                    "min_duration_seconds": 1.1145625,
+                    "average_duration_seconds": 3.0301437916666667,
+                    "max_duration_seconds": 9.5963125,
+                    "unique_audios": 1500,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 1500
+                    }
+                },
+                "video_statistics": null,
+                "label_statistics": {
+                    "min_labels_per_text": 1,
+                    "average_label_per_text": 1.0,
+                    "max_labels_per_text": 1,
+                    "unique_labels": 5,
+                    "labels": {
+                        "0": {
+                            "count": 350
+                        },
+                        "1": {
+                            "count": 380
+                        },
+                        "2": {
+                            "count": 350
+                        },
+                        "3": {
+                            "count": 314
+                        },
+                        "4": {
+                            "count": 106
+                        }
+                    }
+                }
+            },
+            "pol": {
+                "num_samples": 1500,
+                "samples_in_train": 0,
+                "text_statistics": null,
+                "image_statistics": null,
+                "audio_statistics": {
+                    "total_duration_seconds": 3739.043,
+                    "min_duration_seconds": 0.885,
+                    "average_duration_seconds": 2.4926953333333333,
+                    "max_duration_seconds": 5.655,
+                    "unique_audios": 1500,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 1500
+                    }
+                },
+                "video_statistics": null,
+                "label_statistics": {
+                    "min_labels_per_text": 1,
+                    "average_label_per_text": 1.0,
+                    "max_labels_per_text": 1,
+                    "unique_labels": 6,
+                    "labels": {
+                        "5": {
+                            "count": 251
+                        },
+                        "3": {
+                            "count": 254
+                        },
+                        "2": {
+                            "count": 251
+                        },
+                        "4": {
+                            "count": 246
+                        },
+                        "0": {
+                            "count": 250
+                        },
+                        "1": {
+                            "count": 248
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "train": {
+        "num_samples": 6761,
+        "samples_in_train": null,
+        "text_statistics": null,
+        "image_statistics": null,
+        "audio_statistics": {
+            "total_duration_seconds": 21205.1430625,
+            "min_duration_seconds": 0.912,
+            "average_duration_seconds": 3.136391519375832,
+            "max_duration_seconds": 11.268375,
+            "unique_audios": 6758,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 6761
+            }
+        },
+        "video_statistics": null,
+        "label_statistics": {
+            "min_labels_per_text": 1,
+            "average_label_per_text": 1.0,
+            "max_labels_per_text": 1,
+            "unique_labels": 6,
+            "labels": {
+                "0": {
+                    "count": 1615
+                },
+                "1": {
+                    "count": 1445
+                },
+                "2": {
+                    "count": 1198
+                },
+                "3": {
+                    "count": 756
+                },
+                "4": {
+                    "count": 952
+                },
+                "5": {
+                    "count": 795
+                }
+            }
+        },
+        "hf_subset_descriptive_stats": {
+            "ben": {
+                "num_samples": 1500,
+                "samples_in_train": null,
+                "text_statistics": null,
+                "image_statistics": null,
+                "audio_statistics": {
+                    "total_duration_seconds": 6033.559625,
+                    "min_duration_seconds": 3.622375,
+                    "average_duration_seconds": 4.022373083333333,
+                    "max_duration_seconds": 4.35375,
+                    "unique_audios": 1498,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 1500
+                    }
+                },
+                "video_statistics": null,
+                "label_statistics": {
+                    "min_labels_per_text": 1,
+                    "average_label_per_text": 1.0,
+                    "max_labels_per_text": 1,
+                    "unique_labels": 6,
+                    "labels": {
+                        "0": {
+                            "count": 250
+                        },
+                        "1": {
+                            "count": 250
+                        },
+                        "2": {
+                            "count": 250
+                        },
+                        "3": {
+                            "count": 250
+                        },
+                        "4": {
+                            "count": 250
+                        },
+                        "5": {
+                            "count": 250
+                        }
+                    }
+                }
+            },
+            "eng": {
+                "num_samples": 1500,
+                "samples_in_train": null,
+                "text_statistics": null,
+                "image_statistics": null,
+                "audio_statistics": {
+                    "total_duration_seconds": 3893.163375,
+                    "min_duration_seconds": 1.12,
+                    "average_duration_seconds": 2.59544225,
+                    "max_duration_seconds": 6.84,
+                    "unique_audios": 1500,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 1500
+                    }
+                },
+                "video_statistics": null,
+                "label_statistics": {
+                    "min_labels_per_text": 1,
+                    "average_label_per_text": 1.0,
+                    "max_labels_per_text": 1,
+                    "unique_labels": 6,
+                    "labels": {
+                        "2": {
+                            "count": 309
+                        },
+                        "0": {
+                            "count": 330
+                        },
+                        "4": {
+                            "count": 316
+                        },
+                        "1": {
+                            "count": 210
+                        },
+                        "5": {
+                            "count": 210
+                        },
+                        "3": {
+                            "count": 125
+                        }
+                    }
+                }
+            },
+            "fra": {
+                "num_samples": 761,
+                "samples_in_train": null,
+                "text_statistics": null,
+                "image_statistics": null,
+                "audio_statistics": {
+                    "total_duration_seconds": 2644.2320625,
+                    "min_duration_seconds": 1.0449375,
+                    "average_duration_seconds": 3.4746807654402105,
+                    "max_duration_seconds": 7.5975625,
+                    "unique_audios": 760,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 761
+                    }
+                },
+                "video_statistics": null,
+                "label_statistics": {
+                    "min_labels_per_text": 1,
+                    "average_label_per_text": 1.0,
+                    "max_labels_per_text": 1,
+                    "unique_labels": 6,
+                    "labels": {
+                        "0": {
+                            "count": 133
+                        },
+                        "1": {
+                            "count": 131
+                        },
+                        "2": {
+                            "count": 132
+                        },
+                        "3": {
+                            "count": 101
+                        },
+                        "4": {
+                            "count": 132
+                        },
+                        "5": {
+                            "count": 132
+                        }
+                    }
+                }
+            },
+            "ita": {
+                "num_samples": 1500,
+                "samples_in_train": null,
+                "text_statistics": null,
+                "image_statistics": null,
+                "audio_statistics": {
+                    "total_duration_seconds": 4935.185,
+                    "min_duration_seconds": 0.9288125,
+                    "average_duration_seconds": 3.2901233333333337,
+                    "max_duration_seconds": 11.268375,
+                    "unique_audios": 1500,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 1500
+                    }
+                },
+                "video_statistics": null,
+                "label_statistics": {
+                    "min_labels_per_text": 1,
+                    "average_label_per_text": 1.0,
+                    "max_labels_per_text": 1,
+                    "unique_labels": 3,
+                    "labels": {
+                        "0": {
+                            "count": 636
+                        },
+                        "1": {
+                            "count": 606
+                        },
+                        "2": {
+                            "count": 258
+                        }
+                    }
+                }
+            },
+            "pol": {
+                "num_samples": 1500,
+                "samples_in_train": null,
+                "text_statistics": null,
+                "image_statistics": null,
+                "audio_statistics": {
+                    "total_duration_seconds": 3699.003,
+                    "min_duration_seconds": 0.912,
+                    "average_duration_seconds": 2.466002,
+                    "max_duration_seconds": 4.822,
+                    "unique_audios": 1500,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 1500
+                    }
+                },
+                "video_statistics": null,
+                "label_statistics": {
+                    "min_labels_per_text": 1,
+                    "average_label_per_text": 1.0,
+                    "max_labels_per_text": 1,
+                    "unique_labels": 6,
+                    "labels": {
+                        "5": {
+                            "count": 203
+                        },
+                        "3": {
+                            "count": 280
+                        },
+                        "4": {
+                            "count": 254
+                        },
+                        "2": {
+                            "count": 249
+                        },
+                        "1": {
+                            "count": 248
+                        },
+                        "0": {
+                            "count": 266
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/mteb/tasks/classification/multilingual/__init__.py
+++ b/mteb/tasks/classification/multilingual/__init__.py
@@ -3,6 +3,7 @@ from .afri_senti_classification import AfriSentiClassification
 from .afri_senti_lang_classification import AfriSentiLangClassification
 from .amazon_counterfactual_classification import AmazonCounterfactualClassification
 from .amazon_reviews_classification import AmazonReviewsClassification
+from .cameo_emotion_classification import CAMEOEmotionClassification
 from .catalonia_tweet_classification import CataloniaTweetClassification
 from .cyrillic_turkic_lang_classification import CyrillicTurkicLangClassification
 from .hin_dialect_classification import HinDialectClassification
@@ -52,6 +53,7 @@ __all__ = [
     "AfriSentiLangClassification",
     "AmazonCounterfactualClassification",
     "AmazonReviewsClassification",
+    "CAMEOEmotionClassification",
     "CataloniaTweetClassification",
     "CyrillicTurkicLangClassification",
     "HUMEMultilingualSentimentClassification",

--- a/mteb/tasks/classification/multilingual/cameo_emotion_classification.py
+++ b/mteb/tasks/classification/multilingual/cameo_emotion_classification.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import ClassVar
+
+from mteb.abstasks.classification import AbsTaskClassification
+from mteb.abstasks.task_metadata import TaskMetadata
+
+_BIBTEX = r"""
+@misc{christop2025cameo,
+  author = {Christop, Iwona and Czajka, Maciej},
+  eprint = {2505.11051},
+  archiveprefix = {arXiv},
+  title = {{CAMEO}: Collection of Multilingual Emotional Speech Corpora},
+  year = {2025},
+}
+"""
+
+
+class CAMEOEmotionClassification(AbsTaskClassification):
+    input_column_name: ClassVar[str] = "audio"
+    samples_per_label: int = 16
+    n_experiments: int = 5
+
+    metadata = TaskMetadata(
+        name="CAMEOEmotionClassification",
+        description=(
+            "Speech emotion recognition across Bengali, English, French, Italian and "
+            "Polish, drawn from the CAMEO collection of emotional speech corpora. Every "
+            "audio emotion task in mteb is monolingual, so this scores whether an encoder "
+            "hears affect independently of the language being spoken. Only the six "
+            "emotions common to all five languages are kept, so subsets share a label set. "
+            "The source names its splits after the constituent corpora rather than train "
+            "and test, so the split here is by speaker, with no speaker in both sides, "
+            "since emotion rides on the voice and a shared speaker would let a model match "
+            "timbre instead. German, Russian and Spanish are excluded for having one "
+            "speaker or none identified, and CREMA-D and RAVDESS are excluded because mteb "
+            "already evaluates both separately. Construction script: "
+            "scripts/data/cameo_emotion/create_data.py."
+        ),
+        reference="https://arxiv.org/abs/2505.11051",
+        dataset={
+            "path": "vnahata/CAMEO-emotion-classification",
+            "revision": "a8abf264b656456c255e2435ef5103f6a04525e0",
+        },
+        type="AudioClassification",
+        category="a2c",
+        modalities=["audio"],
+        eval_splits=["test"],
+        eval_langs={
+            "ben": ["ben-Beng"],
+            "eng": ["eng-Latn"],
+            "fra": ["fra-Latn"],
+            "ita": ["ita-Latn"],
+            "pol": ["pol-Latn"],
+        },
+        main_score="accuracy",
+        date=("2023-01-01", "2025-05-16"),
+        domains=["Spoken"],
+        task_subtypes=["Emotion classification"],
+        license="cc-by-nc-sa-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_BIBTEX,
+        is_beta=True,
+    )

--- a/scripts/data/cameo_emotion/create_data.py
+++ b/scripts/data/cameo_emotion/create_data.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Build the CAMEO multilingual speech emotion classification task for MTEB.
+
+Source is `amu-cai/CAMEO` at a pinned revision (Christop and Czajka 2025), a curated
+collection of emotional speech corpora with emotion labels already harmonised to one
+inventory. mteb has thirteen audio emotion tasks and every one is monolingual, so the
+point of this build is emotion recognition across languages.
+
+CAMEO names its splits after the source corpora rather than train and test, so the split
+here is made by speaker: a speaker appears in train or in test, never both. Emotion is a
+property of the voice as much as the utterance, and letting one speaker straddle the split
+would let a model match timbre instead of affect.
+
+Three constraints narrow what is usable:
+
+- Only the six emotions common to every included language are kept (anger, fear,
+  happiness, neutral, sadness, surprise), so subsets share a label set and are comparable.
+- A language needs several speakers to be split at all. German, Russian and Spanish are
+  dropped: PAVOQUE is single speaker, and MESD and RESD carry no speaker identifiers.
+- CREMA-D and RAVDESS are dropped because mteb already evaluates both on their own, and
+  reusing them here would score the same recordings twice.
+
+Recordings are re-encoded to 16 kHz Opus, which keeps the published data small.
+
+Examples:
+  # Build the reshaped tables locally.
+  uv run python scripts/data/cameo_emotion/create_data.py --stage build
+
+  # Build and publish.
+  uv run python scripts/data/cameo_emotion/create_data.py --stage all --push
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+from math import gcd
+from pathlib import Path
+
+import pyarrow.parquet as pq
+import soundfile as sf
+from datasets import Audio, Dataset
+from huggingface_hub import HfApi, hf_hub_download
+from scipy.signal import resample_poly
+
+_SOURCE_REPO = "amu-cai/CAMEO"
+_SOURCE_REV = "38e9e968deb4636377e76b28bbb2062f92b898ab"
+_TARGET = "vnahata/CAMEO-emotion-classification"
+_LICENSE = "cc-by-nc-sa-4.0"
+
+# language -> source corpora, restricted to languages with enough speakers to split
+_LANGUAGES = {
+    "ben": ("Bengali", ["subesco"]),
+    "eng": ("English", ["emns", "enterface", "jl_corpus"]),
+    "fra": ("French", ["cafe", "oreau"]),
+    "ita": ("Italian", ["emozionalmente"]),
+    "pol": ("Polish", ["nemo"]),
+}
+
+# the emotions present in every included language; index here is the published label
+_EMOTIONS = ["anger", "fear", "happiness", "neutral", "sadness", "surprise"]
+_LABEL_OF = {name: i for i, name in enumerate(_EMOTIONS)}
+
+_TEST_FRACTION = 0.35
+_PER_LANGUAGE = 1500  # keeps the published audio near a few hundred megabytes
+_TARGET_RATE = 16000
+
+
+def _to_opus(raw: bytes) -> bytes:
+    data, rate = sf.read(io.BytesIO(raw), dtype="float32")
+    if data.ndim > 1:
+        data = data[:, 0]
+    if rate != _TARGET_RATE:
+        factor = gcd(rate, _TARGET_RATE)
+        data = resample_poly(data, _TARGET_RATE // factor, rate // factor)
+        rate = _TARGET_RATE
+    buf = io.BytesIO()
+    sf.write(buf, data, rate, format="OGG", subtype="OPUS")
+    return buf.getvalue()
+
+
+def stage_build(work: Path) -> dict:
+    work.mkdir(parents=True, exist_ok=True)
+    counts: dict[str, dict[str, int]] = {}
+
+    for code, (language, corpora) in _LANGUAGES.items():
+        paths = {s: work / f"{code}_{s}.parquet" for s in ("train", "test")}
+        if all(p.exists() for p in paths.values()):
+            counts[code] = {s: pq.read_metadata(p).num_rows for s, p in paths.items()}
+            print(f"  {code}: cached {counts[code]}", flush=True)
+            continue
+
+        # metadata first, so the split is decided before any audio is decoded
+        local = {
+            corpus: hf_hub_download(
+                _SOURCE_REPO,
+                f"data/{corpus}-00000-of-00001.parquet",
+                repo_type="dataset",
+                revision=_SOURCE_REV,
+            )
+            for corpus in corpora
+        }
+        rows = []
+        for corpus, path in local.items():
+            meta = pq.read_table(path).drop(["audio"]).to_pylist()
+            rows += [
+                {
+                    "speaker": f"{corpus}:{r.get('speaker_id')}",
+                    "label": _LABEL_OF[r["emotion"]],
+                    "corpus": corpus,
+                    "index": i,
+                }
+                for i, r in enumerate(meta)
+                if r["emotion"] in _LABEL_OF and r["language"] == language
+            ]
+
+        # Speakers hold very different numbers of clips, so test is filled by sample count
+        # rather than by speaker count, which otherwise leaves some languages lopsided.
+        per_speaker: dict[str, int] = {}
+        for r in rows:
+            per_speaker[r["speaker"]] = per_speaker.get(r["speaker"], 0) + 1
+        target = len(rows) * _TEST_FRACTION
+        test_speakers, taken = set(), 0
+        for speaker in sorted(per_speaker, key=lambda s: (-per_speaker[s], s)):
+            if taken >= target:
+                break
+            test_speakers.add(speaker)
+            taken += per_speaker[speaker]
+        wanted = {
+            split: [
+                r for r in rows if (r["speaker"] in test_speakers) == (split == "test")
+            ][:_PER_LANGUAGE]
+            for split in ("train", "test")
+        }
+
+        counts[code] = {}
+        for split, want in wanted.items():
+            out = []
+            for corpus, path in local.items():
+                need = [r for r in want if r["corpus"] == corpus]
+                if not need:
+                    continue
+                audio = pq.read_table(path, columns=["audio"]).column("audio")
+                out += [
+                    {
+                        "audio": {
+                            "bytes": _to_opus(audio[r["index"]].as_py()["bytes"]),
+                            "path": None,
+                        },
+                        "label": r["label"],
+                    }
+                    for r in need
+                ]
+            Dataset.from_list(out).cast_column(
+                "audio", Audio(sampling_rate=_TARGET_RATE)
+            ).to_parquet(str(paths[split]))
+            counts[code][split] = len(out)
+        for path in local.values():
+            Path(path).unlink(missing_ok=True)
+        counts[code]["speakers"] = len(per_speaker)
+        print(f"  {code}: {counts[code]}", flush=True)
+
+    (work / "counts.json").write_text(json.dumps(counts, indent=2), encoding="utf-8")
+    print("built", json.dumps(counts))
+    return counts
+
+
+def _card(codes: list[str]) -> str:
+    lines = [
+        "---",
+        f"license: {_LICENSE}",
+        "task_categories:",
+        "  - audio-classification",
+        "language:",
+        *[f"  - {c}" for c in codes],
+        "tags:",
+        "  - mteb",
+        "  - classification",
+        "  - multilingual",
+        "configs:",
+    ]
+    for c in codes:
+        lines += [f"  - config_name: {c}", "    data_files:"]
+        for split in ("train", "test"):
+            lines += [f"      - split: {split}", f"        path: {c}_{split}.parquet"]
+    lines += [
+        "---",
+        "",
+        "# CAMEO multilingual speech emotion classification (MTEB)",
+        "",
+        "Speech emotion recognition across five languages, drawn from the CAMEO collection.",
+        "",
+        "Labels index this list:",
+        "",
+        *[f"{i}. {name}" for i, name in enumerate(_EMOTIONS)],
+        "",
+        f"Source: `{_SOURCE_REPO}` at revision `{_SOURCE_REV[:7]}`, {_LICENSE}. Split by",
+        "speaker so no speaker appears in both train and test. Only the six emotions common",
+        "to every included language are kept. Audio is 16 kHz Opus.",
+        "",
+        "Built by `scripts/data/cameo_emotion/create_data.py` in the MTEB repo.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def stage_push(work: Path) -> None:
+    api = HfApi()
+    api.create_repo(_TARGET, repo_type="dataset", exist_ok=True)
+    codes = [c for c in _LANGUAGES if (work / f"{c}_test.parquet").exists()]
+    for code in codes:
+        for split in ("train", "test"):
+            api.upload_file(
+                path_or_fileobj=str(work / f"{code}_{split}.parquet"),
+                path_in_repo=f"{code}_{split}.parquet",
+                repo_id=_TARGET,
+                repo_type="dataset",
+            )
+        print(f"  pushed {code}", flush=True)
+    api.upload_file(
+        path_or_fileobj=io.BytesIO(_card(codes).encode()),
+        path_in_repo="README.md",
+        repo_id=_TARGET,
+        repo_type="dataset",
+    )
+    print(f"pushed {_TARGET}: {len(codes)} languages")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--stage", choices=["build", "push", "all"], default="all")
+    parser.add_argument("--work-dir", type=Path, default=Path("cameo_work"))
+    parser.add_argument("--push", action="store_true")
+    args = parser.parse_args()
+
+    print(f"source: {_SOURCE_REPO}@{_SOURCE_REV[:7]} (license {_LICENSE})")
+    if args.stage in ("build", "all"):
+        stage_build(args.work_dir)
+    if args.stage == "push" or (args.push and args.stage == "all"):
+        stage_push(args.work_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds `CAMEOEmotionClassification` over [CAMEO](https://arxiv.org/abs/2505.11051) (Christop and Czajka 2025): speech emotion recognition across **Bengali, English, French, Italian and Polish**. Part of #4842.

## Gap

mteb has **thirteen audio emotion tasks and every one is monolingual**. This scores whether an encoder hears affect independently of the language spoken. `a2c` also has only two multilingual tasks out of 33.

## Construction

CAMEO names its splits after the constituent corpora rather than train and test, so the split here is **by speaker, with no speaker on both sides**. Emotion rides on the voice as much as the utterance, and a shared speaker would let a model match timbre instead of affect. Test is filled by sample count, not speaker count, since speakers hold very different numbers of clips.

Three filters, all in `scripts/data/cameo_emotion/create_data.py`:

- Only the **six emotions common to all five languages** are kept (anger, fear, happiness, neutral, sadness, surprise), so subsets share a label set.
- **German, Russian and Spanish dropped.** PAVOQUE is single speaker, and MESD and RESD carry no speaker identifiers, so neither can be split without leakage.
- **CREMA-D and RAVDESS dropped**, since mteb already evaluates both separately and reusing them would score the same recordings twice.

Audio is re-encoded to 16 kHz Opus. Result: **6,761 train and 5,945 test** across 5 languages. License **CC-BY-NC-SA-4.0**, as the source.

## Results

Accuracy, mean over the 5 subsets. Chance is 0.167 for six classes.

| model | mean | range |
|---|---|---|
| `mteb/baseline-random-encoder` | 0.1805 | 0.164 to 0.238 |
| `laion/clap-htsat-fused` | 0.3408 | 0.237 to 0.477 |

## Checklist

- [x] Outlined why this fills a gap
- [x] Tested that it runs with `mteb`
- [x] Two encoders run, see table
- [x] Size considered, speaker-disjoint split
- [x] `test_task_quality.py` passes with no exemptions
