### PR TITLE
dataset: add Spoken Wikipedia speech-text retrieval (a2t, t2a, 5 languages)

### DIFF
--- a/mteb/descriptive_stats/Image/Any2AnyMultilingualRetrieval/SpokenWikipediaA2TRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyMultilingualRetrieval/SpokenWikipediaA2TRetrieval.json
@@ -1,0 +1,244 @@
+{
+    "test": {
+        "num_samples": 1500,
+        "num_queries": 750,
+        "num_documents": 750,
+        "number_of_characters": 903278,
+        "documents_text_statistics": {
+            "total_text_length": 903278,
+            "min_text_length": 204,
+            "average_text_length": 1204.3706666666667,
+            "max_text_length": 6305,
+            "unique_texts": 750
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": null,
+        "queries_audio_statistics": {
+            "total_duration_seconds": 44245.446,
+            "min_duration_seconds": 18.16625,
+            "average_duration_seconds": 58.993928000000004,
+            "max_duration_seconds": 60.0,
+            "unique_audios": 750,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 750
+            }
+        },
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 750,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 750,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null,
+        "hf_subset_descriptive_stats": {
+            "nld": {
+                "num_samples": 300,
+                "num_queries": 150,
+                "num_documents": 150,
+                "number_of_characters": 110317,
+                "documents_text_statistics": {
+                    "total_text_length": 110317,
+                    "min_text_length": 204,
+                    "average_text_length": 735.4466666666667,
+                    "max_text_length": 2180,
+                    "unique_texts": 150
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 8373.7131875,
+                    "min_duration_seconds": 18.16625,
+                    "average_duration_seconds": 55.82475458333333,
+                    "max_duration_seconds": 60.0,
+                    "unique_audios": 150,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 150
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 150,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 150,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "eng": {
+                "num_samples": 300,
+                "num_queries": 150,
+                "num_documents": 150,
+                "number_of_characters": 190152,
+                "documents_text_statistics": {
+                    "total_text_length": 190152,
+                    "min_text_length": 221,
+                    "average_text_length": 1267.68,
+                    "max_text_length": 4146,
+                    "unique_texts": 150
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 8943.3711875,
+                    "min_duration_seconds": 31.1879375,
+                    "average_duration_seconds": 59.622474583333336,
+                    "max_duration_seconds": 60.0,
+                    "unique_audios": 150,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 150
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 150,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 150,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "deu": {
+                "num_samples": 300,
+                "num_queries": 150,
+                "num_documents": 150,
+                "number_of_characters": 162574,
+                "documents_text_statistics": {
+                    "total_text_length": 162574,
+                    "min_text_length": 207,
+                    "average_text_length": 1083.8266666666666,
+                    "max_text_length": 6305,
+                    "unique_texts": 150
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 9000.0,
+                    "min_duration_seconds": 60.0,
+                    "average_duration_seconds": 60.0,
+                    "max_duration_seconds": 60.0,
+                    "unique_audios": 150,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 150
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 150,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 150,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "spa": {
+                "num_samples": 300,
+                "num_queries": 150,
+                "num_documents": 150,
+                "number_of_characters": 207979,
+                "documents_text_statistics": {
+                    "total_text_length": 207979,
+                    "min_text_length": 208,
+                    "average_text_length": 1386.5266666666666,
+                    "max_text_length": 5760,
+                    "unique_texts": 150
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 8962.5130625,
+                    "min_duration_seconds": 46.3935,
+                    "average_duration_seconds": 59.750087083333334,
+                    "max_duration_seconds": 60.0,
+                    "unique_audios": 150,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 150
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 150,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 150,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "fra": {
+                "num_samples": 300,
+                "num_queries": 150,
+                "num_documents": 150,
+                "number_of_characters": 232256,
+                "documents_text_statistics": {
+                    "total_text_length": 232256,
+                    "min_text_length": 287,
+                    "average_text_length": 1548.3733333333332,
+                    "max_text_length": 4595,
+                    "unique_texts": 150
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 8965.8485625,
+                    "min_duration_seconds": 34.1376875,
+                    "average_duration_seconds": 59.77232375,
+                    "max_duration_seconds": 60.0,
+                    "unique_audios": 150,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 150
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 150,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 150,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            }
+        }
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyMultilingualRetrieval/SpokenWikipediaT2ARetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyMultilingualRetrieval/SpokenWikipediaT2ARetrieval.json
@@ -1,0 +1,244 @@
+{
+    "test": {
+        "num_samples": 1500,
+        "num_queries": 750,
+        "num_documents": 750,
+        "number_of_characters": 903278,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": {
+            "total_duration_seconds": 44245.446,
+            "min_duration_seconds": 18.16625,
+            "average_duration_seconds": 58.993928000000004,
+            "max_duration_seconds": 60.0,
+            "unique_audios": 750,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 750
+            }
+        },
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 903278,
+            "min_text_length": 204,
+            "average_text_length": 1204.3706666666667,
+            "max_text_length": 6305,
+            "unique_texts": 750
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 750,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 750,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null,
+        "hf_subset_descriptive_stats": {
+            "nld": {
+                "num_samples": 300,
+                "num_queries": 150,
+                "num_documents": 150,
+                "number_of_characters": 110317,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 8373.7131875,
+                    "min_duration_seconds": 18.16625,
+                    "average_duration_seconds": 55.82475458333333,
+                    "max_duration_seconds": 60.0,
+                    "unique_audios": 150,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 150
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 110317,
+                    "min_text_length": 204,
+                    "average_text_length": 735.4466666666667,
+                    "max_text_length": 2180,
+                    "unique_texts": 150
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 150,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 150,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "eng": {
+                "num_samples": 300,
+                "num_queries": 150,
+                "num_documents": 150,
+                "number_of_characters": 190152,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 8943.3711875,
+                    "min_duration_seconds": 31.1879375,
+                    "average_duration_seconds": 59.622474583333336,
+                    "max_duration_seconds": 60.0,
+                    "unique_audios": 150,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 150
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 190152,
+                    "min_text_length": 221,
+                    "average_text_length": 1267.68,
+                    "max_text_length": 4146,
+                    "unique_texts": 150
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 150,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 150,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "deu": {
+                "num_samples": 300,
+                "num_queries": 150,
+                "num_documents": 150,
+                "number_of_characters": 162574,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 9000.0,
+                    "min_duration_seconds": 60.0,
+                    "average_duration_seconds": 60.0,
+                    "max_duration_seconds": 60.0,
+                    "unique_audios": 150,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 150
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 162574,
+                    "min_text_length": 207,
+                    "average_text_length": 1083.8266666666666,
+                    "max_text_length": 6305,
+                    "unique_texts": 150
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 150,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 150,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "spa": {
+                "num_samples": 300,
+                "num_queries": 150,
+                "num_documents": 150,
+                "number_of_characters": 207979,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 8962.5130625,
+                    "min_duration_seconds": 46.3935,
+                    "average_duration_seconds": 59.750087083333334,
+                    "max_duration_seconds": 60.0,
+                    "unique_audios": 150,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 150
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 207979,
+                    "min_text_length": 208,
+                    "average_text_length": 1386.5266666666666,
+                    "max_text_length": 5760,
+                    "unique_texts": 150
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 150,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 150,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "fra": {
+                "num_samples": 300,
+                "num_queries": 150,
+                "num_documents": 150,
+                "number_of_characters": 232256,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 8965.8485625,
+                    "min_duration_seconds": 34.1376875,
+                    "average_duration_seconds": 59.77232375,
+                    "max_duration_seconds": 60.0,
+                    "unique_audios": 150,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 150
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 232256,
+                    "min_text_length": 287,
+                    "average_text_length": 1548.3733333333332,
+                    "max_text_length": 4595,
+                    "unique_texts": 150
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 150,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 150,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            }
+        }
+    }
+}

--- a/mteb/tasks/retrieval/multilingual/__init__.py
+++ b/mteb/tasks/retrieval/multilingual/__init__.py
@@ -117,6 +117,10 @@ from .omnilingual_asr_retrieval import (
 )
 from .public_health_qa_retrieval import PublicHealthQARetrieval
 from .ru_sci_bench_retrieval import RuSciBenchCiteRetrieval, RuSciBenchCociteRetrieval
+from .spoken_wikipedia_retrieval import (
+    SpokenWikipediaA2TRetrieval,
+    SpokenWikipediaT2ARetrieval,
+)
 from .statcan_dialogue_dataset_retrieval import StatcanDialogueDatasetRetrieval
 from .vdr_multilingual_retrieval import VDRMultilingualRetrieval
 from .vidore2_bench_retrieval import (
@@ -263,6 +267,8 @@ __all__ = [
     "PublicNewsRetrieval",
     "RuSciBenchCiteRetrieval",
     "RuSciBenchCociteRetrieval",
+    "SpokenWikipediaA2TRetrieval",
+    "SpokenWikipediaT2ARetrieval",
     "StatcanDialogueDatasetRetrieval",
     "VDRMultilingualRetrieval",
     "Vidore2BioMedicalLecturesRetrieval",

--- a/mteb/tasks/retrieval/multilingual/spoken_wikipedia_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/spoken_wikipedia_retrieval.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from datasets import load_dataset
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.retrieval_dataset_loaders import RetrievalSplitData
+from mteb.abstasks.task_metadata import TaskMetadata
+
+_DATASET_PATH = "vnahata/SpokenWikipedia-retrieval"
+_DATASET_REVISION = "edaf5feb7f04a64a1a49e54660bc5b5dcc35f7f7"
+
+_LANGUAGES = {
+    "nld": ["nld-Latn"],
+    "eng": ["eng-Latn"],
+    "deu": ["deu-Latn"],
+    "spa": ["spa-Latn"],
+    "fra": ["fra-Latn"],
+}
+
+_BIBTEX = r"""
+@misc{spokenwikipedia,
+  author = {{Wikimedia Commons contributors}},
+  howpublished = {\url{https://commons.wikimedia.org/wiki/Category:Spoken_Wikipedia}},
+  title = {Spoken {Wikipedia}},
+  year = {2026},
+}
+"""
+
+_DESCRIPTION = (
+    "Volunteer readings of Wikipedia articles paired with the article lead, in Dutch, "
+    "English, German, Spanish and French. The pairing is which article a recording is of, "
+    "so it holds however much of the reading is kept."
+)
+
+_CONSTRUCTION = (
+    "Recordings come from the Spoken Wikipedia categories on Wikimedia Commons, which is "
+    "free by site policy, and the lead text from each Wikipedia, which is CC-BY-SA. "
+    "Readings run to tens of minutes, so only the opening 60 seconds is kept: readers "
+    "start at the lead, so the opening and the lead describe the same subject. The article "
+    "for a recording is found from the file's global usage, restricted to main-namespace "
+    "pages on the matching Wikipedia so that project and portal pages are excluded, "
+    "falling back to the filename where a file is no longer embedded in its article. Leads "
+    "under 200 characters are dropped as too thin to identify, and one recording is kept "
+    "per article. Construction script: scripts/data/spoken_wikipedia/create_data.py."
+)
+
+_COMMON = {
+    "reference": "https://commons.wikimedia.org/wiki/Category:Spoken_Wikipedia",
+    "dataset": {"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+    "type": "Any2AnyMultilingualRetrieval",
+    "eval_splits": ["test"],
+    "eval_langs": _LANGUAGES,
+    "main_score": "ndcg_at_10",
+    "date": ("2005-01-01", "2026-09-01"),
+    "domains": ["Spoken", "Encyclopaedic"],
+    "task_subtypes": ["Cross-Modal Retrieval"],
+    "license": "cc-by-sa-4.0",
+    "annotations_creators": "derived",
+    "dialect": [],
+    "sample_creation": "found",
+    "bibtex_citation": _BIBTEX,
+    "is_beta": True,
+}
+
+
+def _load(task: AbsTaskRetrieval, to_text: bool) -> None:
+    """Load one direction. `to_text` selects reading->lead, otherwise the reverse."""
+    if task.data_loaded:
+        return
+
+    split = task.metadata.eval_splits[0]
+    task.dataset = {}
+    for lang in _LANGUAGES:
+        rows = load_dataset(
+            _DATASET_PATH, lang, revision=_DATASET_REVISION, split=split
+        )
+        audio = rows.select_columns(["id", "audio"])
+        text = rows.select_columns(["id", "text"])
+        qrels = {i: {i: 1} for i in rows["id"]}
+
+        task.dataset[lang] = {
+            split: RetrievalSplitData(
+                queries=audio if to_text else text,
+                corpus=text if to_text else audio,
+                relevant_docs=qrels,
+                top_ranked=None,
+            )
+        }
+    task.data_loaded = True
+
+
+class SpokenWikipediaA2TRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="SpokenWikipediaA2TRetrieval",
+        description=f"{_DESCRIPTION} Retrieve the article a reading is of. {_CONSTRUCTION}",
+        category="a2t",
+        modalities=["audio", "text"],
+        prompt={"query": "Find the article this recording is reading."},
+        **_COMMON,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load(self, to_text=True)
+
+
+class SpokenWikipediaT2ARetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="SpokenWikipediaT2ARetrieval",
+        description=f"{_DESCRIPTION} Retrieve the reading of an article. {_CONSTRUCTION}",
+        category="t2a",
+        modalities=["text", "audio"],
+        prompt={"query": "Find the recording that reads this article."},
+        **_COMMON,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load(self, to_text=False)

--- a/scripts/data/spoken_wikipedia/create_data.py
+++ b/scripts/data/spoken_wikipedia/create_data.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Build the Spoken Wikipedia speech-text retrieval tasks for MTEB.
+
+Source is Wikimedia Commons, where volunteers read Wikipedia articles aloud and upload the
+recording, and the matching article text from each Wikipedia. Everything on Commons is
+free by site policy, and the article text is CC-BY-SA, so the published set is CC-BY-SA
+4.0. Nothing here is scraped from outside Wikimedia.
+
+The pairing is "which article is this a recording of", which stays true no matter how much
+of the recording is kept. Recordings run to tens of minutes, so only the opening is kept:
+readers start at the article lead, so the opening and the lead describe the same thing.
+
+Finding the article for a recording takes two passes, because neither route is reliable
+alone. First the file's global usage is read and the first main-namespace page on the
+matching Wikipedia is taken; that misses files no longer embedded in their article, and
+project pages such as `Portal:Gesprochene_Wikipedia` have to be filtered out. Where that
+finds nothing, the article is parsed out of the filename, whose shape differs per language
+(`En-Title-article.oga`, `FR-Title.ogg`, `ES-Title-article.ogg`).
+
+Articles whose lead is too short to identify are dropped, as are duplicates, since one
+article read twice would be relevant to only one of its recordings.
+
+Examples:
+  # Build the reshaped tables locally.
+  uv run python scripts/data/spoken_wikipedia/create_data.py --stage build
+
+  # Build and publish.
+  uv run python scripts/data/spoken_wikipedia/create_data.py --stage all --push
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import re
+import time
+from math import gcd
+from pathlib import Path
+
+import requests
+import soundfile as sf
+from datasets import Audio, Dataset
+from huggingface_hub import HfApi
+from scipy.signal import resample_poly
+
+_TARGET = "vnahata/SpokenWikipedia-retrieval"
+_LICENSE = "cc-by-sa-4.0"
+_UA = "mteb-dataset-builder/1.0 (https://github.com/embeddings-benchmark/mteb)"
+_COMMONS = "https://commons.wikimedia.org/w/api.php"
+
+# published code -> (Commons category language word, wiki subdomain, filename prefixes)
+_LANGUAGES = {
+    "nld": ("Dutch", "nl", ["Nl-"]),
+    "eng": ("English", "en", ["En-"]),
+    "deu": ("German", "de", ["De-"]),
+    "spa": ("Spanish", "es", ["ES-", "Es-"]),
+    "fra": ("French", "fr", ["FR-", "Fr-"]),
+}
+
+_PER_LANGUAGE = 150
+_CLIP_SECONDS = 60
+_MIN_LEAD_CHARS = 200
+_TARGET_RATE = 16000
+
+
+def _get(url: str, params: dict) -> dict:
+    for attempt in range(4):
+        try:
+            r = requests.get(
+                url,
+                params={**params, "format": "json"},
+                headers={"User-Agent": _UA},
+                timeout=60,
+            )
+            r.raise_for_status()
+            return r.json()
+        except Exception:
+            if attempt == 3:
+                raise
+            time.sleep(2 * (attempt + 1))
+    return {}
+
+
+def _category_files(category: str) -> list[str]:
+    out, cont = [], {}
+    while True:
+        d = _get(
+            _COMMONS,
+            {
+                "action": "query",
+                "list": "categorymembers",
+                "cmtitle": f"Category:{category}",
+                "cmtype": "file",
+                "cmlimit": 500,
+                **cont,
+            },
+        )
+        out += [m["title"] for m in d.get("query", {}).get("categorymembers", [])]
+        if "continue" not in d:
+            return out
+        cont = {"cmcontinue": d["continue"]["cmcontinue"]}
+
+
+def _article_titles(files: list[str], wiki: str, prefixes: list[str]) -> dict[str, str]:
+    """Map Commons file title to a main-namespace article on `wiki`."""
+    found: dict[str, str] = {}
+    for i in range(0, len(files), 40):
+        batch = files[i : i + 40]
+        d = _get(
+            _COMMONS,
+            {
+                "action": "query",
+                "titles": "|".join(batch),
+                "prop": "globalusage",
+                "gulimit": 50,
+            },
+        )
+        for page in (d.get("query") or {}).get("pages", {}).values():
+            for use in page.get("globalusage", []):
+                # main namespace only; project and portal pages carry a colon
+                if use["wiki"] == f"{wiki}.wikipedia.org" and ":" not in use["title"]:
+                    found[page["title"]] = (use["title"].replace("_", " "), "usage")
+                    break
+        time.sleep(0.3)
+
+    for f in files:
+        if f in found:
+            continue
+        stem = re.sub(
+            r"\.(oga|ogg|wav|mp3|flac)$", "", f.replace("File:", ""), flags=re.I
+        )
+        for p in prefixes:
+            if stem.startswith(p):
+                stem = stem[len(p) :]
+                break
+        # a missing prefix is not disqualifying; some uploads are named after the article
+        # alone. A guess that is not a real article is dropped later, when its lead fails
+        # to resolve.
+        stem = re.sub(r"\s*-\s*article$", "", stem, flags=re.I).strip()
+        if stem:
+            found[f] = (stem, "filename")
+    return found
+
+
+def _leads(titles: list[str], wiki: str) -> dict[str, str]:
+    """Fetch the lead section of each article."""
+    out: dict[str, str] = {}
+    api = f"https://{wiki}.wikipedia.org/w/api.php"
+    for i in range(0, len(titles), 20):
+        d = _get(
+            api,
+            {
+                "action": "query",
+                "titles": "|".join(titles[i : i + 20]),
+                "prop": "extracts",
+                "exintro": 1,
+                "explaintext": 1,
+                "redirects": 1,
+            },
+        )
+        for page in (d.get("query") or {}).get("pages", {}).values():
+            text = (page.get("extract") or "").strip()
+            if len(text) >= _MIN_LEAD_CHARS:
+                out[page["title"]] = " ".join(text.split())
+        time.sleep(0.3)
+    return out
+
+
+def _clip(url: str) -> bytes | None:
+    r = requests.get(url, headers={"User-Agent": _UA}, timeout=180)
+    r.raise_for_status()
+    data, rate = sf.read(io.BytesIO(r.content), dtype="float32")
+    if data.ndim > 1:
+        data = data[:, 0]
+    data = data[: int(_CLIP_SECONDS * rate)]
+    if len(data) < rate * 5:
+        return None
+    if rate != _TARGET_RATE:
+        factor = gcd(int(rate), _TARGET_RATE)
+        data = resample_poly(data, _TARGET_RATE // factor, int(rate) // factor)
+    buf = io.BytesIO()
+    sf.write(buf, data, _TARGET_RATE, format="OGG", subtype="OPUS")
+    return buf.getvalue()
+
+
+def stage_build(work: Path) -> dict:
+    work.mkdir(parents=True, exist_ok=True)
+    counts: dict[str, int] = {}
+
+    for code, (category_word, wiki, prefixes) in _LANGUAGES.items():
+        out_path = work / f"{code}.parquet"
+        if out_path.exists():
+            import pyarrow.parquet as pq
+
+            counts[code] = pq.read_metadata(out_path).num_rows
+            print(f"  {code}: cached {counts[code]}", flush=True)
+            continue
+
+        files = _category_files(f"Spoken {category_word} Wikipedia")
+        mapping = _article_titles(files, wiki, prefixes)
+        leads = _leads(sorted({t for t, _ in mapping.values()}), wiki)
+        by_usage = sum(1 for _, route in mapping.values() if route == "usage")
+        print(
+            f"  {code}: {len(files)} files, {len(mapping)} mapped "
+            f"({by_usage} via usage), {len(leads)} leads",
+            flush=True,
+        )
+
+        rows, seen_article, routes = [], set(), {"usage": 0, "filename": 0}
+        for f, (article, route) in mapping.items():
+            if len(rows) >= _PER_LANGUAGE:
+                break
+            lead = leads.get(article)
+            if not lead or article in seen_article:
+                continue
+            d = _get(
+                _COMMONS,
+                {"action": "query", "titles": f, "prop": "imageinfo", "iiprop": "url"},
+            )
+            page = next(iter((d.get("query") or {}).get("pages", {}).values()), {})
+            info = (page.get("imageinfo") or [{}])[0]
+            if not info.get("url"):
+                continue
+            try:
+                audio = _clip(info["url"])
+            except Exception:
+                continue
+            if audio is None:
+                continue
+            seen_article.add(article)
+            routes[route] += 1
+            rows.append(
+                {
+                    "id": f"{code}-{len(rows)}",
+                    "audio": {"bytes": audio, "path": None},
+                    "text": lead,
+                }
+            )
+            time.sleep(0.2)
+
+        Dataset.from_list(rows).cast_column(
+            "audio", Audio(sampling_rate=_TARGET_RATE)
+        ).to_parquet(str(out_path))
+        counts[code] = len(rows)
+        print(f"  {code}: {len(rows)} pairs, routes {routes}", flush=True)
+
+    (work / "counts.json").write_text(json.dumps(counts, indent=2), encoding="utf-8")
+    print("built", json.dumps(counts))
+    return counts
+
+
+def _card(codes: list[str]) -> str:
+    lines = [
+        "---",
+        f"license: {_LICENSE}",
+        "task_categories:",
+        "  - automatic-speech-recognition",
+        "language:",
+        *[f"  - {c}" for c in codes],
+        "tags:",
+        "  - mteb",
+        "  - retrieval",
+        "  - multilingual",
+        "configs:",
+    ]
+    for c in codes:
+        lines += [
+            f"  - config_name: {c}",
+            "    data_files:",
+            "      - split: test",
+            f"        path: {c}.parquet",
+        ]
+    lines += [
+        "---",
+        "",
+        "# Spoken Wikipedia speech-text retrieval (MTEB)",
+        "",
+        "Volunteer readings of Wikipedia articles paired with the article lead, in Dutch,",
+        "English, German, Spanish and French.",
+        "",
+        "Recordings come from Wikimedia Commons, which is free by site policy, and the lead",
+        f"text from each Wikipedia, which is CC-BY-SA. The set is published as {_LICENSE}.",
+        f"Only the first {_CLIP_SECONDS} seconds of each reading is kept, since readers start",
+        "at the lead. One recording per article.",
+        "",
+        "Built by `scripts/data/spoken_wikipedia/create_data.py` in the MTEB repo.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def stage_push(work: Path) -> None:
+    api = HfApi()
+    api.create_repo(_TARGET, repo_type="dataset", exist_ok=True)
+    codes = sorted(p.stem for p in work.glob("*.parquet"))
+    for code in codes:
+        api.upload_file(
+            path_or_fileobj=str(work / f"{code}.parquet"),
+            path_in_repo=f"{code}.parquet",
+            repo_id=_TARGET,
+            repo_type="dataset",
+        )
+        print(f"  pushed {code}", flush=True)
+    api.upload_file(
+        path_or_fileobj=io.BytesIO(_card(codes).encode()),
+        path_in_repo="README.md",
+        repo_id=_TARGET,
+        repo_type="dataset",
+    )
+    print(f"pushed {_TARGET}: {len(codes)} languages")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--stage", choices=["build", "push", "all"], default="all")
+    parser.add_argument("--work-dir", type=Path, default=Path("spokenwiki_work"))
+    parser.add_argument("--push", action="store_true")
+    args = parser.parse_args()
+
+    print(f"source: Wikimedia Commons and Wikipedia (license {_LICENSE})")
+    if args.stage in ("build", "all"):
+        stage_build(args.work_dir)
+    if args.stage == "push" or (args.push and args.stage == "all"):
+        stage_push(args.work_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds `SpokenWikipediaA2TRetrieval` and `SpokenWikipediaT2ARetrieval`: volunteer readings of Wikipedia articles paired with the article lead, in **Dutch, English, German, Spanish and French**. Part of #4842, and a first piece of the audio side of #5254.

## Gap

No task in mteb uses Wikimedia audio. #5254 asks for an omnimodal Wikipedia covering audio and video as well as text and images. This is a self-contained slice of that: the recordings exist, they are free by Commons policy, and each already points at an article.

## Construction

Built from the Commons and Wikipedia APIs, in `scripts/data/spoken_wikipedia/create_data.py`.

- The article for a recording comes from the file's **global usage**, restricted to main-namespace pages so project pages are excluded. Where a file is no longer embedded in its article, the title is parsed from the filename, whose shape differs per language (`En-Title-article.oga`, `FR-Title.ogg`). A guess that is not a real article is dropped when its lead fails to resolve.
- Readings run to tens of minutes, so **only the opening 60 seconds is kept**. Readers start at the lead, so "which article is this a recording of" holds however much is kept.
- Leads under 200 characters are dropped as too thin to identify, and **one recording per article**.

Result: **150 pairs per language, 750 total, all texts unique**. Audio is 16 kHz Opus. License **CC-BY-SA-4.0**: Commons media is free by policy, Wikipedia text is CC-BY-SA.

## Checklist

- [x] Outlined why this fills a gap
- [x] Tested that it runs with `mteb`
- [x] `mteb/baseline-random-encoder` nDCG@10: a2t 0.0383, t2a 0.0421, against a 0.030 floor for a 150 item corpus
- [x] `jina-embeddings-v5-omni-nano` nDCG@10: a2t **0.5533**, t2a **0.7169**, 14x and 17x the floor. a2t by language: eng 0.8432, deu 0.5809, nld 0.5163, fra 0.4815, spa 0.3448, a 2.4x spread, so not uniformly easy
- [x] Size considered, one recording per article
- [x] `test_task_quality.py` passes with no exemptions

