### PR TITLE
dataset: add MTVQA multilingual image+text retrieval (it2t, 9 languages)

### DIFF
--- a/mteb/descriptive_stats/Image/Any2AnyMultilingualRetrieval/MTVQAIT2TRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyMultilingualRetrieval/MTVQAIT2TRetrieval.json
@@ -1,0 +1,444 @@
+{
+    "test": {
+        "num_samples": 12751,
+        "num_queries": 6778,
+        "num_documents": 5973,
+        "number_of_characters": 415655,
+        "documents_text_statistics": {
+            "total_text_length": 190942,
+            "min_text_length": 1,
+            "average_text_length": 31.967520508956973,
+            "max_text_length": 843,
+            "unique_texts": 5942
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 224713,
+            "min_text_length": 3,
+            "average_text_length": 33.15329005606374,
+            "max_text_length": 426,
+            "unique_texts": 5758
+        },
+        "queries_image_statistics": {
+            "min_image_width": 296,
+            "average_image_width": 2122.000590144585,
+            "max_image_width": 6000,
+            "min_image_height": 234,
+            "average_image_height": 2132.4417232221895,
+            "max_image_height": 5312,
+            "unique_images": 2112
+        },
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 6778,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 5973,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null,
+        "hf_subset_descriptive_stats": {
+            "ara": {
+                "num_samples": 1290,
+                "num_queries": 703,
+                "num_documents": 587,
+                "number_of_characters": 33452,
+                "documents_text_statistics": {
+                    "total_text_length": 14425,
+                    "min_text_length": 1,
+                    "average_text_length": 24.574105621805792,
+                    "max_text_length": 243,
+                    "unique_texts": 587
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 19027,
+                    "min_text_length": 9,
+                    "average_text_length": 27.06543385490754,
+                    "max_text_length": 69,
+                    "unique_texts": 537
+                },
+                "queries_image_statistics": {
+                    "min_image_width": 480,
+                    "average_image_width": 1194.2916073968706,
+                    "max_image_width": 4624,
+                    "min_image_height": 234,
+                    "average_image_height": 1381.5192034139402,
+                    "max_image_height": 4624,
+                    "unique_images": 250
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 703,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 587,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "deu": {
+                "num_samples": 1915,
+                "num_queries": 1048,
+                "num_documents": 867,
+                "number_of_characters": 62028,
+                "documents_text_statistics": {
+                    "total_text_length": 25201,
+                    "min_text_length": 1,
+                    "average_text_length": 29.066897347174162,
+                    "max_text_length": 424,
+                    "unique_texts": 867
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 36827,
+                    "min_text_length": 12,
+                    "average_text_length": 35.14026717557252,
+                    "max_text_length": 112,
+                    "unique_texts": 739
+                },
+                "queries_image_statistics": {
+                    "min_image_width": 680,
+                    "average_image_width": 2759.007633587786,
+                    "max_image_width": 6000,
+                    "min_image_height": 720,
+                    "average_image_height": 2725.789122137405,
+                    "max_image_height": 4128,
+                    "unique_images": 250
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 1048,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 867,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "fra": {
+                "num_samples": 1629,
+                "num_queries": 886,
+                "num_documents": 743,
+                "number_of_characters": 58111,
+                "documents_text_statistics": {
+                    "total_text_length": 20737,
+                    "min_text_length": 1,
+                    "average_text_length": 27.909825033647376,
+                    "max_text_length": 484,
+                    "unique_texts": 743
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 37374,
+                    "min_text_length": 12,
+                    "average_text_length": 42.182844243792324,
+                    "max_text_length": 134,
+                    "unique_texts": 679
+                },
+                "queries_image_statistics": {
+                    "min_image_width": 440,
+                    "average_image_width": 2026.1185101580136,
+                    "max_image_width": 2048,
+                    "min_image_height": 487,
+                    "average_image_height": 1847.2212189616253,
+                    "max_image_height": 3284,
+                    "unique_images": 248
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 886,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 743,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "ita": {
+                "num_samples": 1701,
+                "num_queries": 884,
+                "num_documents": 817,
+                "number_of_characters": 75012,
+                "documents_text_statistics": {
+                    "total_text_length": 34962,
+                    "min_text_length": 1,
+                    "average_text_length": 42.79314565483476,
+                    "max_text_length": 373,
+                    "unique_texts": 817
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 40050,
+                    "min_text_length": 11,
+                    "average_text_length": 45.30542986425339,
+                    "max_text_length": 163,
+                    "unique_texts": 807
+                },
+                "queries_image_statistics": {
+                    "min_image_width": 750,
+                    "average_image_width": 2379.4049773755655,
+                    "max_image_width": 3936,
+                    "min_image_height": 831,
+                    "average_image_height": 2022.0780542986424,
+                    "max_image_height": 5312,
+                    "unique_images": 249
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 884,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 817,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "jpn": {
+                "num_samples": 1520,
+                "num_queries": 828,
+                "num_documents": 692,
+                "number_of_characters": 26415,
+                "documents_text_statistics": {
+                    "total_text_length": 12638,
+                    "min_text_length": 1,
+                    "average_text_length": 18.26300578034682,
+                    "max_text_length": 164,
+                    "unique_texts": 692
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 13777,
+                    "min_text_length": 4,
+                    "average_text_length": 16.63888888888889,
+                    "max_text_length": 104,
+                    "unique_texts": 781
+                },
+                "queries_image_statistics": {
+                    "min_image_width": 455,
+                    "average_image_width": 2316.399758454106,
+                    "max_image_width": 4032,
+                    "min_image_height": 1152,
+                    "average_image_height": 2024.5966183574878,
+                    "max_image_height": 4032,
+                    "unique_images": 250
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 828,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 692,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "kor": {
+                "num_samples": 1066,
+                "num_queries": 558,
+                "num_documents": 508,
+                "number_of_characters": 22382,
+                "documents_text_statistics": {
+                    "total_text_length": 11869,
+                    "min_text_length": 1,
+                    "average_text_length": 23.364173228346456,
+                    "max_text_length": 205,
+                    "unique_texts": 508
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 10513,
+                    "min_text_length": 5,
+                    "average_text_length": 18.840501792114697,
+                    "max_text_length": 95,
+                    "unique_texts": 510
+                },
+                "queries_image_statistics": {
+                    "min_image_width": 1080,
+                    "average_image_width": 2236.2401433691757,
+                    "max_image_width": 4128,
+                    "min_image_height": 1080,
+                    "average_image_height": 2046.5125448028673,
+                    "max_image_height": 4128,
+                    "unique_images": 250
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 558,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 508,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "rus": {
+                "num_samples": 1481,
+                "num_queries": 756,
+                "num_documents": 725,
+                "number_of_characters": 66960,
+                "documents_text_statistics": {
+                    "total_text_length": 36317,
+                    "min_text_length": 1,
+                    "average_text_length": 50.09241379310345,
+                    "max_text_length": 843,
+                    "unique_texts": 725
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 30643,
+                    "min_text_length": 9,
+                    "average_text_length": 40.533068783068785,
+                    "max_text_length": 426,
+                    "unique_texts": 700
+                },
+                "queries_image_statistics": {
+                    "min_image_width": 2048,
+                    "average_image_width": 2048.0,
+                    "max_image_width": 2048,
+                    "min_image_height": 741,
+                    "average_image_height": 2880.69708994709,
+                    "max_image_height": 3347,
+                    "unique_images": 250
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 756,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 725,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "tha": {
+                "num_samples": 438,
+                "num_queries": 231,
+                "num_documents": 207,
+                "number_of_characters": 11771,
+                "documents_text_statistics": {
+                    "total_text_length": 5723,
+                    "min_text_length": 2,
+                    "average_text_length": 27.647342995169083,
+                    "max_text_length": 149,
+                    "unique_texts": 207
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 6048,
+                    "min_text_length": 6,
+                    "average_text_length": 26.181818181818183,
+                    "max_text_length": 85,
+                    "unique_texts": 217
+                },
+                "queries_image_statistics": {
+                    "min_image_width": 621,
+                    "average_image_width": 1766.5584415584415,
+                    "max_image_width": 4032,
+                    "min_image_height": 499,
+                    "average_image_height": 1829.935064935065,
+                    "max_image_height": 4032,
+                    "unique_images": 116
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 231,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 207,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "vie": {
+                "num_samples": 1711,
+                "num_queries": 884,
+                "num_documents": 827,
+                "number_of_characters": 59524,
+                "documents_text_statistics": {
+                    "total_text_length": 29070,
+                    "min_text_length": 1,
+                    "average_text_length": 35.15114873035066,
+                    "max_text_length": 771,
+                    "unique_texts": 827
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 30454,
+                    "min_text_length": 3,
+                    "average_text_length": 34.45022624434389,
+                    "max_text_length": 234,
+                    "unique_texts": 788
+                },
+                "queries_image_statistics": {
+                    "min_image_width": 296,
+                    "average_image_width": 1845.2420814479638,
+                    "max_image_width": 4160,
+                    "min_image_height": 299,
+                    "average_image_height": 2016.8076923076924,
+                    "max_image_height": 4160,
+                    "unique_images": 249
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 884,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 827,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            }
+        }
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyMultilingualRetrieval/MTVQAIT2TRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyMultilingualRetrieval/MTVQAIT2TRetrieval.json
@@ -41,7 +41,12 @@
             "num_missing_query_ids": 0,
             "num_missing_corpus_ids": 0
         },
-        "top_ranked_statistics": null,
+        "top_ranked_statistics": {
+            "num_top_ranked": 72217,
+            "min_top_ranked_per_query": 10,
+            "average_top_ranked_per_query": 10.654617881380938,
+            "max_top_ranked_per_query": 11
+        },
         "hf_subset_descriptive_stats": {
             "ara": {
                 "num_samples": 1290,
@@ -85,7 +90,12 @@
                     "num_missing_query_ids": 0,
                     "num_missing_corpus_ids": 0
                 },
-                "top_ranked_statistics": null
+                "top_ranked_statistics": {
+                    "num_top_ranked": 7484,
+                    "min_top_ranked_per_query": 10,
+                    "average_top_ranked_per_query": 10.645803698435277,
+                    "max_top_ranked_per_query": 11
+                }
             },
             "deu": {
                 "num_samples": 1915,
@@ -129,7 +139,12 @@
                     "num_missing_query_ids": 0,
                     "num_missing_corpus_ids": 0
                 },
-                "top_ranked_statistics": null
+                "top_ranked_statistics": {
+                    "num_top_ranked": 11248,
+                    "min_top_ranked_per_query": 10,
+                    "average_top_ranked_per_query": 10.732824427480915,
+                    "max_top_ranked_per_query": 11
+                }
             },
             "fra": {
                 "num_samples": 1629,
@@ -173,7 +188,12 @@
                     "num_missing_query_ids": 0,
                     "num_missing_corpus_ids": 0
                 },
-                "top_ranked_statistics": null
+                "top_ranked_statistics": {
+                    "num_top_ranked": 9486,
+                    "min_top_ranked_per_query": 10,
+                    "average_top_ranked_per_query": 10.706546275395034,
+                    "max_top_ranked_per_query": 11
+                }
             },
             "ita": {
                 "num_samples": 1701,
@@ -217,7 +237,12 @@
                     "num_missing_query_ids": 0,
                     "num_missing_corpus_ids": 0
                 },
-                "top_ranked_statistics": null
+                "top_ranked_statistics": {
+                    "num_top_ranked": 9450,
+                    "min_top_ranked_per_query": 10,
+                    "average_top_ranked_per_query": 10.690045248868778,
+                    "max_top_ranked_per_query": 11
+                }
             },
             "jpn": {
                 "num_samples": 1520,
@@ -261,7 +286,12 @@
                     "num_missing_query_ids": 0,
                     "num_missing_corpus_ids": 0
                 },
-                "top_ranked_statistics": null
+                "top_ranked_statistics": {
+                    "num_top_ranked": 8743,
+                    "min_top_ranked_per_query": 10,
+                    "average_top_ranked_per_query": 10.559178743961352,
+                    "max_top_ranked_per_query": 11
+                }
             },
             "kor": {
                 "num_samples": 1066,
@@ -305,7 +335,12 @@
                     "num_missing_query_ids": 0,
                     "num_missing_corpus_ids": 0
                 },
-                "top_ranked_statistics": null
+                "top_ranked_statistics": {
+                    "num_top_ranked": 5907,
+                    "min_top_ranked_per_query": 10,
+                    "average_top_ranked_per_query": 10.586021505376344,
+                    "max_top_ranked_per_query": 11
+                }
             },
             "rus": {
                 "num_samples": 1481,
@@ -349,7 +384,12 @@
                     "num_missing_query_ids": 0,
                     "num_missing_corpus_ids": 0
                 },
-                "top_ranked_statistics": null
+                "top_ranked_statistics": {
+                    "num_top_ranked": 8003,
+                    "min_top_ranked_per_query": 10,
+                    "average_top_ranked_per_query": 10.585978835978835,
+                    "max_top_ranked_per_query": 11
+                }
             },
             "tha": {
                 "num_samples": 438,
@@ -393,7 +433,12 @@
                     "num_missing_query_ids": 0,
                     "num_missing_corpus_ids": 0
                 },
-                "top_ranked_statistics": null
+                "top_ranked_statistics": {
+                    "num_top_ranked": 2393,
+                    "min_top_ranked_per_query": 10,
+                    "average_top_ranked_per_query": 10.35930735930736,
+                    "max_top_ranked_per_query": 11
+                }
             },
             "vie": {
                 "num_samples": 1711,
@@ -437,7 +482,12 @@
                     "num_missing_query_ids": 0,
                     "num_missing_corpus_ids": 0
                 },
-                "top_ranked_statistics": null
+                "top_ranked_statistics": {
+                    "num_top_ranked": 9503,
+                    "min_top_ranked_per_query": 10,
+                    "average_top_ranked_per_query": 10.75,
+                    "max_top_ranked_per_query": 11
+                }
             }
         }
     }

--- a/mteb/tasks/retrieval/multilingual/__init__.py
+++ b/mteb/tasks/retrieval/multilingual/__init__.py
@@ -83,6 +83,7 @@ from .mkqa_retrieval import MKQARetrieval
 from .mlqa_retrieval import MLQARetrieval
 from .mmarco_retrieval import MMarcoRetrievalMultilingual
 from .mr_tidy_retrieval import MrTidyRetrieval
+from .mtvqa_retrieval import MTVQAIT2TRetrieval
 from .multi_long_doc_retrieval import MultiLongDocRetrieval
 from .mupler_retrieval import MuPLeRRetrieval
 from .nanobeir_multilingual import (
@@ -226,6 +227,7 @@ __all__ = [
     "MKQARetrieval",
     "MLQARetrieval",
     "MMarcoRetrievalMultilingual",
+    "MTVQAIT2TRetrieval",
     "MintakaRetrieval",
     "MrTidyRetrieval",
     "MuPLeRRetrieval",

--- a/mteb/tasks/retrieval/multilingual/mtvqa_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/mtvqa_retrieval.py
@@ -31,7 +31,7 @@ class MTVQAIT2TRetrieval(AbsTaskRetrieval):
         reference="https://arxiv.org/abs/2405.11985",
         dataset={
             "path": "vnahata/MTVQA-it2t-retrieval",
-            "revision": "72f2324b9ed1e46ca2e41576a3b81b7df480cf3c",
+            "revision": "f2d2ab47cf576e94ef89807d9c2dd8012515cf84",
         },
         type="Any2AnyMultilingualRetrieval",
         category="it2t",
@@ -48,7 +48,7 @@ class MTVQAIT2TRetrieval(AbsTaskRetrieval):
             "tha": ["tha-Thai"],
             "vie": ["vie-Latn"],
         },
-        main_score="ndcg_at_10",
+        main_score="accuracy",
         date=("2023-01-01", "2024-05-20"),
         domains=["Scene", "Written"],
         task_subtypes=["Rendered Texts Understanding"],

--- a/mteb/tasks/retrieval/multilingual/mtvqa_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/mtvqa_retrieval.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.task_metadata import TaskMetadata
+
+_BIBTEX = r"""
+@article{tang2024mtvqa,
+  author = {Tang, Jingqun and Liu, Qi and Ye, Yongjie and Lu, Jinghui and Wei, Shu and Lin, Chunhui and Li, Wanqing and Mahmood, Mohamad Fitri Faiz Bin and Feng, Hao and Zhao, Zhen and Wang, Yanjie and Liu, Yuliang and Liu, Hao and Bai, Xiang and Huang, Can},
+  journal = {arXiv preprint arXiv:2405.11985},
+  title = {{MTVQA}: Benchmarking Multilingual Text-Centric Visual Question Answering},
+  year = {2024},
+}
+"""
+
+
+class MTVQAIT2TRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="MTVQAIT2TRetrieval",
+        description=(
+            "Retrieve the answer to a question about the text inside an image, across "
+            "nine languages. The query is the image together with the question, and the "
+            "corpus is the answers for that language. mteb has thirteen it2t tasks and "
+            "none of them is multilingual, so this scores whether a model reads text in "
+            "a picture in a language other than English. Built from the official test "
+            "split. Answers repeat across questions, because different images can share "
+            "a short answer such as a price or a name, so the corpus is deduplicated by "
+            "answer text and every question with that answer points at the surviving "
+            "document rather than dropping the question. Construction script: "
+            "scripts/data/mtvqa_retrieval/create_data.py."
+        ),
+        reference="https://arxiv.org/abs/2405.11985",
+        dataset={
+            "path": "vnahata/MTVQA-it2t-retrieval",
+            "revision": "72f2324b9ed1e46ca2e41576a3b81b7df480cf3c",
+        },
+        type="Any2AnyMultilingualRetrieval",
+        category="it2t",
+        modalities=["image", "text"],
+        eval_splits=["test"],
+        eval_langs={
+            "ara": ["ara-Arab"],
+            "deu": ["deu-Latn"],
+            "fra": ["fra-Latn"],
+            "ita": ["ita-Latn"],
+            "jpn": ["jpn-Jpan"],
+            "kor": ["kor-Hang"],
+            "rus": ["rus-Cyrl"],
+            "tha": ["tha-Thai"],
+            "vie": ["vie-Latn"],
+        },
+        main_score="ndcg_at_10",
+        date=("2023-01-01", "2024-05-20"),
+        domains=["Scene", "Written"],
+        task_subtypes=["Rendered Texts Understanding"],
+        license="cc-by-nc-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        prompt={"query": "Answer the question about the text in this image."},
+        bibtex_citation=_BIBTEX,
+        is_beta=True,
+    )

--- a/scripts/data/mtvqa_retrieval/create_data.py
+++ b/scripts/data/mtvqa_retrieval/create_data.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Build the MTVQA multilingual image+text retrieval task for MTEB.
+
+Source is `ByteDance/MTVQA` at a pinned revision (Tang et al. 2024), a text-centric visual
+question answering benchmark whose questions are about text appearing inside the image.
+It ships an official `test` split, which is the only split used here.
+
+mteb has thirteen `it2t` tasks and none of them is multilingual, so this is the point of
+the build: a query that is an image plus a question, in nine languages, against the
+answers for that language.
+
+Answers repeat, because different questions about different images can share a short
+answer such as a price or a name. The corpus is therefore deduplicated by answer text and
+every question with that answer points at the single surviving document. Dropping the
+repeats instead would throw away questions that are perfectly well posed.
+
+`qa_pairs` arrives as a Python literal rather than JSON, so it is read with
+`ast.literal_eval`; the answers contain apostrophes, which makes quote substitution
+followed by a JSON parse unsafe.
+
+Examples:
+  # Build the reshaped tables locally.
+  uv run python scripts/data/mtvqa_retrieval/create_data.py --stage build
+
+  # Build and publish.
+  uv run python scripts/data/mtvqa_retrieval/create_data.py --stage all --push
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import io
+import json
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from datasets import Dataset, Image, load_dataset
+from huggingface_hub import HfApi
+
+_SOURCE_REPO = "ByteDance/MTVQA"
+_SOURCE_REV = "7cdca63ec6cd71cdd0b52f79fc3176bb9ce36a9c"
+_TARGET = "vnahata/MTVQA-it2t-retrieval"
+_LICENSE = "cc-by-nc-4.0"
+
+# source `lang` value -> published subset name
+_LANGUAGES = {
+    "AR": "ara",
+    "DE": "deu",
+    "FR": "fra",
+    "IT": "ita",
+    "JA": "jpn",
+    "KR": "kor",
+    "RU": "rus",
+    "TH": "tha",
+    "VI": "vie",
+}
+
+_MIN_ANSWER_CHARS = 1
+
+
+def stage_build(work: Path) -> dict:
+    work.mkdir(parents=True, exist_ok=True)
+    # decode=False keeps the compressed bytes, so a query holds a small dict rather than a
+    # decoded image. Several questions share one image, and decoding each copy exhausts
+    # memory partway through the build.
+    rows = load_dataset(_SOURCE_REPO, split="test", revision=_SOURCE_REV).cast_column(
+        "image", Image(decode=False)
+    )
+
+    counts: dict[str, dict[str, int]] = {}
+    for source_lang, code in _LANGUAGES.items():
+        wanted = [i for i, lang in enumerate(rows["lang"]) if lang == source_lang]
+        if not wanted:
+            continue
+
+        queries, corpus_ids, qrels = [], {}, []
+        corpus_rows = []
+        for n, i in enumerate(wanted):
+            try:
+                pairs = ast.literal_eval(rows[i]["qa_pairs"])
+            except (ValueError, SyntaxError):
+                continue
+            for j, pair in enumerate(pairs):
+                question = (pair.get("question") or "").strip()
+                answer = (pair.get("answer") or "").strip()
+                if not question or len(answer) < _MIN_ANSWER_CHARS:
+                    continue
+                if answer not in corpus_ids:
+                    doc_id = f"{code}-doc-{len(corpus_ids)}"
+                    corpus_ids[answer] = doc_id
+                    corpus_rows.append(
+                        {"id": doc_id, "modality": "text", "text": answer}
+                    )
+                query_id = f"{code}-q-{n}-{j}"
+                queries.append(
+                    {
+                        "id": query_id,
+                        "modality": "image,text",
+                        "image": rows[i]["image"],
+                        "text": question,
+                    }
+                )
+                qrels.append(
+                    {
+                        "query-id": query_id,
+                        "corpus-id": corpus_ids[answer],
+                        "score": 1,
+                    }
+                )
+
+        Dataset.from_list(queries).cast_column("image", Image()).to_parquet(
+            str(work / f"{code}_queries.parquet")
+        )
+        pq.write_table(
+            pa.Table.from_pylist(corpus_rows), work / f"{code}_corpus.parquet"
+        )
+        pq.write_table(pa.Table.from_pylist(qrels), work / f"{code}_qrels.parquet")
+        counts[code] = {
+            "queries": len(queries),
+            "corpus": len(corpus_rows),
+            "images": len(wanted),
+        }
+        print(f"  {code}: {counts[code]}", flush=True)
+
+    (work / "counts.json").write_text(json.dumps(counts, indent=2), encoding="utf-8")
+    print("built", json.dumps(counts))
+    return counts
+
+
+def _card(codes: list[str]) -> str:
+    lines = [
+        "---",
+        f"license: {_LICENSE}",
+        "task_categories:",
+        "  - visual-question-answering",
+        "language:",
+        *[f"  - {c}" for c in codes],
+        "tags:",
+        "  - mteb",
+        "  - retrieval",
+        "  - multilingual",
+        "configs:",
+    ]
+    for c in codes:
+        for kind in ("queries", "corpus", "qrels"):
+            split = "corpus" if kind == "corpus" else "test"
+            lines += [
+                f"  - config_name: {c}-{kind}",
+                "    data_files:",
+                f"      - split: {split}",
+                f"        path: {c}_{kind}.parquet",
+            ]
+    lines += [
+        "---",
+        "",
+        "# MTVQA multilingual image+text retrieval (MTEB)",
+        "",
+        "A query is an image plus a question about the text inside it; the corpus is the",
+        "answers for that language. Nine languages.",
+        "",
+        f"Source: `{_SOURCE_REPO}` at revision `{_SOURCE_REV[:7]}`, {_LICENSE}, official",
+        "`test` split. Answers repeat across questions, so the corpus is deduplicated by",
+        "answer text and every question with that answer points at the surviving document.",
+        "",
+        "Built by `scripts/data/mtvqa_retrieval/create_data.py` in the MTEB repo.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def stage_push(work: Path) -> None:
+    api = HfApi()
+    api.create_repo(_TARGET, repo_type="dataset", exist_ok=True)
+    codes = [c for c in _LANGUAGES.values() if (work / f"{c}_queries.parquet").exists()]
+    for code in codes:
+        for kind in ("queries", "corpus", "qrels"):
+            api.upload_file(
+                path_or_fileobj=str(work / f"{code}_{kind}.parquet"),
+                path_in_repo=f"{code}_{kind}.parquet",
+                repo_id=_TARGET,
+                repo_type="dataset",
+            )
+        print(f"  pushed {code}", flush=True)
+    api.upload_file(
+        path_or_fileobj=io.BytesIO(_card(codes).encode()),
+        path_in_repo="README.md",
+        repo_id=_TARGET,
+        repo_type="dataset",
+    )
+    print(f"pushed {_TARGET}: {len(codes)} languages")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--stage", choices=["build", "push", "all"], default="all")
+    parser.add_argument("--work-dir", type=Path, default=Path("mtvqa_work"))
+    parser.add_argument("--push", action="store_true")
+    args = parser.parse_args()
+
+    print(f"source: {_SOURCE_REPO}@{_SOURCE_REV[:7]} (license {_LICENSE})")
+    if args.stage in ("build", "all"):
+        stage_build(args.work_dir)
+    if args.stage == "push" or (args.push and args.stage == "all"):
+        stage_push(args.work_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_tasks/test_task_quality.py
+++ b/tests/test_tasks/test_task_quality.py
@@ -23,6 +23,7 @@ from mteb.types.statistics import (
 
 KNOWN_ISSUES: dict[str, list[str]] = {
     "short_text": [
+        "MTVQAIT2TRetrieval",  # a complete CJK question or answer can be one or two characters
         "ARCChallenge",
         "AVMemeExamVideoAudioCentricQA",
         "AVMemeExamVideoCentricQA",
@@ -411,6 +412,7 @@ KNOWN_ISSUES: dict[str, list[str]] = {
         "BrightProSustainableLivingRetrieval",
     ],
     "duplicate_text": [
+        "MTVQAIT2TRetrieval",  # the query is an image plus a question, so one question asked of different images is a different query
         "AfriHateClassification",
         "AfriSentiClassification",
         "AllegroReviews",
@@ -830,6 +832,7 @@ KNOWN_ISSUES: dict[str, list[str]] = {
         "YueOpenriceReviewClassification",
     ],
     "duplicate_image": [
+        "MTVQAIT2TRetrieval",  # each image carries several questions by design
         "AROCocoOrder",
         "AROFlickrOrder",
         "AROVisualAttribution",


### PR DESCRIPTION
Adds `MTVQAIT2TRetrieval` over [MTVQA](https://arxiv.org/abs/2405.11985) (Tang et al. 2024): given an image and a question about the text inside it, retrieve the answer, in 9 non-English languages. Part of #4842.

## Gap

mteb has **13 `it2t` tasks and none is multilingual**. This scores whether a model reads text in a picture in a non-English language.

## Construction

Official **test** split, in `scripts/data/mtvqa_retrieval/create_data.py`.

- `qa_pairs` is a Python literal, not JSON, and answers contain apostrophes, so it is read with `ast.literal_eval`.
- **Answers repeat**, since different images share short answers such as a price, so the corpus is deduplicated by answer text and every question with that answer points at the surviving document.

**6,778 queries, 5,973 answers, 2,116 images.** License **CC-BY-NC-4.0**, as the source.

## Candidate sets

Following @isaac-chung suggestion, each question now ranks against **its own answer plus the 10 nearest answers**, chosen by `multilingual-e5-small` comparing question text to answer text, exposed as `top_ranked`. Mean 10.6 candidates.

Selection is **text only, on purpose**: using an image-text model would bake its view of the images into the benchmark.

The selector surfaces the gold answer on its own for only **25% to 64%** of questions, so the negatives are hard rather than trivially separable. The gold is unioned in, so every question stays answerable.

## Results

`main_score` is now **accuracy**. With ~11 candidates nearly everything falls inside a cutoff of 10, putting the nDCG@10 random floor at 0.43; accuracy lands on the theoretical 1/11 floor.

| model | accuracy |
|---|---|
| `mteb/baseline-random-encoder` | 0.0865 |
| `openai/clip-vit-base-patch32` | **0.1087** |

## Checklist

- [x] Outlined why this fills a gap
- [x] Tested that it runs with `mteb`
- [x] Two encoders run, see table
- [x] Size considered, official test split
- [x] `test_task_quality.py` passes, exemptions inline
