### PR TITLE
dataset: add Lingua Libre spoken-word retrieval (a2t, t2a, 36 new languages)

### DIFF
--- a/mteb/descriptive_stats/Image/Any2AnyMultilingualRetrieval/LinguaLibreA2TRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyMultilingualRetrieval/LinguaLibreA2TRetrieval.json
@@ -1,0 +1,1484 @@
+{
+    "test": {
+        "num_samples": 6300,
+        "num_queries": 3150,
+        "num_documents": 3150,
+        "number_of_characters": 19646,
+        "documents_text_statistics": {
+            "total_text_length": 19646,
+            "min_text_length": 2,
+            "average_text_length": 6.236825396825397,
+            "max_text_length": 28,
+            "unique_texts": 3103
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": null,
+        "queries_audio_statistics": {
+            "total_duration_seconds": 3570.673375,
+            "min_duration_seconds": 0.2954375,
+            "average_duration_seconds": 1.1335471031746032,
+            "max_duration_seconds": 5.253375,
+            "unique_audios": 3150,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 3150
+            }
+        },
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 3150,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 3150,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null,
+        "hf_subset_descriptive_stats": {
+            "abl": {
+                "num_samples": 198,
+                "num_queries": 99,
+                "num_documents": 99,
+                "number_of_characters": 540,
+                "documents_text_statistics": {
+                    "total_text_length": 540,
+                    "min_text_length": 3,
+                    "average_text_length": 5.454545454545454,
+                    "max_text_length": 8,
+                    "unique_texts": 99
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 113.2868125,
+                    "min_duration_seconds": 0.656,
+                    "average_duration_seconds": 1.1443112373737374,
+                    "max_duration_seconds": 1.453375,
+                    "unique_audios": 99,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 99
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 99,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 99,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "ace": {
+                "num_samples": 182,
+                "num_queries": 91,
+                "num_documents": 91,
+                "number_of_characters": 459,
+                "documents_text_statistics": {
+                    "total_text_length": 459,
+                    "min_text_length": 2,
+                    "average_text_length": 5.043956043956044,
+                    "max_text_length": 11,
+                    "unique_texts": 91
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 89.9799375,
+                    "min_duration_seconds": 0.6005625,
+                    "average_duration_seconds": 0.9887905219780221,
+                    "max_duration_seconds": 2.228875,
+                    "unique_audios": 91,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 91
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 91,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 91,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "ajp": {
+                "num_samples": 198,
+                "num_queries": 99,
+                "num_documents": 99,
+                "number_of_characters": 572,
+                "documents_text_statistics": {
+                    "total_text_length": 572,
+                    "min_text_length": 3,
+                    "average_text_length": 5.777777777777778,
+                    "max_text_length": 13,
+                    "unique_texts": 99
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 94.0795,
+                    "min_duration_seconds": 0.6,
+                    "average_duration_seconds": 0.9502979797979798,
+                    "max_duration_seconds": 1.376,
+                    "unique_audios": 99,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 99
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 99,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 99,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "ary": {
+                "num_samples": 186,
+                "num_queries": 93,
+                "num_documents": 93,
+                "number_of_characters": 402,
+                "documents_text_statistics": {
+                    "total_text_length": 402,
+                    "min_text_length": 2,
+                    "average_text_length": 4.32258064516129,
+                    "max_text_length": 13,
+                    "unique_texts": 93
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 78.9955625,
+                    "min_duration_seconds": 0.621375,
+                    "average_duration_seconds": 0.8494146505376344,
+                    "max_duration_seconds": 1.2586875,
+                    "unique_audios": 93,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 93
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 93,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 93,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "atj": {
+                "num_samples": 188,
+                "num_queries": 94,
+                "num_documents": 94,
+                "number_of_characters": 709,
+                "documents_text_statistics": {
+                    "total_text_length": 709,
+                    "min_text_length": 3,
+                    "average_text_length": 7.542553191489362,
+                    "max_text_length": 14,
+                    "unique_texts": 94
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 108.145875,
+                    "min_duration_seconds": 0.504,
+                    "average_duration_seconds": 1.1504880319148936,
+                    "max_duration_seconds": 1.7306875,
+                    "unique_audios": 94,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 94
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 94,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 94,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "ban": {
+                "num_samples": 186,
+                "num_queries": 93,
+                "num_documents": 93,
+                "number_of_characters": 482,
+                "documents_text_statistics": {
+                    "total_text_length": 482,
+                    "min_text_length": 3,
+                    "average_text_length": 5.182795698924731,
+                    "max_text_length": 11,
+                    "unique_texts": 93
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 109.0640625,
+                    "min_duration_seconds": 0.7546875,
+                    "average_duration_seconds": 1.1727318548387098,
+                    "max_duration_seconds": 2.536,
+                    "unique_audios": 93,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 93
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 93,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 93,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "bar": {
+                "num_samples": 178,
+                "num_queries": 89,
+                "num_documents": 89,
+                "number_of_characters": 528,
+                "documents_text_statistics": {
+                    "total_text_length": 528,
+                    "min_text_length": 3,
+                    "average_text_length": 5.932584269662922,
+                    "max_text_length": 12,
+                    "unique_texts": 89
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 81.17525,
+                    "min_duration_seconds": 0.501375,
+                    "average_duration_seconds": 0.9120814606741574,
+                    "max_duration_seconds": 1.295375,
+                    "unique_audios": 89,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 89
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 89,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 89,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "bci": {
+                "num_samples": 188,
+                "num_queries": 94,
+                "num_documents": 94,
+                "number_of_characters": 524,
+                "documents_text_statistics": {
+                    "total_text_length": 524,
+                    "min_text_length": 3,
+                    "average_text_length": 5.574468085106383,
+                    "max_text_length": 12,
+                    "unique_texts": 94
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 108.0785625,
+                    "min_duration_seconds": 0.669375,
+                    "average_duration_seconds": 1.1497719414893617,
+                    "max_duration_seconds": 2.1866875,
+                    "unique_audios": 94,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 94
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 94,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 94,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "bcl": {
+                "num_samples": 180,
+                "num_queries": 90,
+                "num_documents": 90,
+                "number_of_characters": 693,
+                "documents_text_statistics": {
+                    "total_text_length": 693,
+                    "min_text_length": 4,
+                    "average_text_length": 7.7,
+                    "max_text_length": 16,
+                    "unique_texts": 90
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 97.095875,
+                    "min_duration_seconds": 0.712,
+                    "average_duration_seconds": 1.0788430555555557,
+                    "max_duration_seconds": 1.549375,
+                    "unique_audios": 90,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 90
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 90,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 90,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "bew": {
+                "num_samples": 178,
+                "num_queries": 89,
+                "num_documents": 89,
+                "number_of_characters": 495,
+                "documents_text_statistics": {
+                    "total_text_length": 495,
+                    "min_text_length": 3,
+                    "average_text_length": 5.561797752808989,
+                    "max_text_length": 12,
+                    "unique_texts": 89
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 87.4113125,
+                    "min_duration_seconds": 0.5386875,
+                    "average_duration_seconds": 0.9821495786516853,
+                    "max_duration_seconds": 2.2566875,
+                    "unique_audios": 89,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 89
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 89,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 89,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "bik": {
+                "num_samples": 174,
+                "num_queries": 87,
+                "num_documents": 87,
+                "number_of_characters": 582,
+                "documents_text_statistics": {
+                    "total_text_length": 582,
+                    "min_text_length": 3,
+                    "average_text_length": 6.689655172413793,
+                    "max_text_length": 13,
+                    "unique_texts": 87
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 98.909625,
+                    "min_duration_seconds": 0.2954375,
+                    "average_duration_seconds": 1.1368922413793103,
+                    "max_duration_seconds": 2.4186875,
+                    "unique_audios": 87,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 87
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 87,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 87,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "bjn": {
+                "num_samples": 176,
+                "num_queries": 88,
+                "num_documents": 88,
+                "number_of_characters": 506,
+                "documents_text_statistics": {
+                    "total_text_length": 506,
+                    "min_text_length": 4,
+                    "average_text_length": 5.75,
+                    "max_text_length": 11,
+                    "unique_texts": 88
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 89.274375,
+                    "min_duration_seconds": 0.3046875,
+                    "average_duration_seconds": 1.0144815340909092,
+                    "max_duration_seconds": 1.574,
+                    "unique_audios": 88,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 88
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 88,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 88,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "bkr": {
+                "num_samples": 170,
+                "num_queries": 85,
+                "num_documents": 85,
+                "number_of_characters": 428,
+                "documents_text_statistics": {
+                    "total_text_length": 428,
+                    "min_text_length": 3,
+                    "average_text_length": 5.035294117647059,
+                    "max_text_length": 9,
+                    "unique_texts": 85
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 87.6664375,
+                    "min_duration_seconds": 0.597375,
+                    "average_duration_seconds": 1.0313698529411766,
+                    "max_duration_seconds": 2.341375,
+                    "unique_audios": 85,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 85
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 85,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 85,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "blk": {
+                "num_samples": 182,
+                "num_queries": 91,
+                "num_documents": 91,
+                "number_of_characters": 819,
+                "documents_text_statistics": {
+                    "total_text_length": 819,
+                    "min_text_length": 2,
+                    "average_text_length": 9.0,
+                    "max_text_length": 24,
+                    "unique_texts": 91
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 97.063125,
+                    "min_duration_seconds": 0.624,
+                    "average_duration_seconds": 1.0666277472527472,
+                    "max_duration_seconds": 1.9066875,
+                    "unique_audios": 91,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 91
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 91,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 91,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "bqr": {
+                "num_samples": 172,
+                "num_queries": 86,
+                "num_documents": 86,
+                "number_of_characters": 499,
+                "documents_text_statistics": {
+                    "total_text_length": 499,
+                    "min_text_length": 2,
+                    "average_text_length": 5.8023255813953485,
+                    "max_text_length": 11,
+                    "unique_texts": 86
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 123.5024375,
+                    "min_duration_seconds": 0.531375,
+                    "average_duration_seconds": 1.4360748546511628,
+                    "max_duration_seconds": 4.6086875,
+                    "unique_audios": 86,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 86
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 86,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 86,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "btm": {
+                "num_samples": 174,
+                "num_queries": 87,
+                "num_documents": 87,
+                "number_of_characters": 518,
+                "documents_text_statistics": {
+                    "total_text_length": 518,
+                    "min_text_length": 3,
+                    "average_text_length": 5.954022988505747,
+                    "max_text_length": 10,
+                    "unique_texts": 87
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 98.9386875,
+                    "min_duration_seconds": 0.5546875,
+                    "average_duration_seconds": 1.1372262931034482,
+                    "max_duration_seconds": 3.7381875,
+                    "unique_audios": 87,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 87
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 87,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 87,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "bug": {
+                "num_samples": 170,
+                "num_queries": 85,
+                "num_documents": 85,
+                "number_of_characters": 527,
+                "documents_text_statistics": {
+                    "total_text_length": 527,
+                    "min_text_length": 3,
+                    "average_text_length": 6.2,
+                    "max_text_length": 14,
+                    "unique_texts": 85
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 103.8013125,
+                    "min_duration_seconds": 0.806,
+                    "average_duration_seconds": 1.2211919117647059,
+                    "max_duration_seconds": 2.2826875,
+                    "unique_audios": 85,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 85
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 85,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 85,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "cor": {
+                "num_samples": 180,
+                "num_queries": 90,
+                "num_documents": 90,
+                "number_of_characters": 679,
+                "documents_text_statistics": {
+                    "total_text_length": 679,
+                    "min_text_length": 3,
+                    "average_text_length": 7.544444444444444,
+                    "max_text_length": 13,
+                    "unique_texts": 90
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 97.201625,
+                    "min_duration_seconds": 0.736,
+                    "average_duration_seconds": 1.0800180555555556,
+                    "max_duration_seconds": 1.5066875,
+                    "unique_audios": 90,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 90
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 90,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 90,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "dtp": {
+                "num_samples": 170,
+                "num_queries": 85,
+                "num_documents": 85,
+                "number_of_characters": 548,
+                "documents_text_statistics": {
+                    "total_text_length": 548,
+                    "min_text_length": 3,
+                    "average_text_length": 6.447058823529412,
+                    "max_text_length": 10,
+                    "unique_texts": 85
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 113.2296875,
+                    "min_duration_seconds": 0.5706875,
+                    "average_duration_seconds": 1.3321139705882352,
+                    "max_duration_seconds": 5.253375,
+                    "unique_audios": 85,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 85
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 85,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 85,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "ext": {
+                "num_samples": 168,
+                "num_queries": 84,
+                "num_documents": 84,
+                "number_of_characters": 475,
+                "documents_text_statistics": {
+                    "total_text_length": 475,
+                    "min_text_length": 3,
+                    "average_text_length": 5.654761904761905,
+                    "max_text_length": 9,
+                    "unique_texts": 84
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 84.199125,
+                    "min_duration_seconds": 0.741375,
+                    "average_duration_seconds": 1.0023705357142856,
+                    "max_duration_seconds": 1.3866875,
+                    "unique_audios": 84,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 84
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 84,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 84,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "fon": {
+                "num_samples": 176,
+                "num_queries": 88,
+                "num_documents": 88,
+                "number_of_characters": 531,
+                "documents_text_statistics": {
+                    "total_text_length": 531,
+                    "min_text_length": 2,
+                    "average_text_length": 6.034090909090909,
+                    "max_text_length": 13,
+                    "unique_texts": 88
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 99.2851875,
+                    "min_duration_seconds": 0.629375,
+                    "average_duration_seconds": 1.1282407670454546,
+                    "max_duration_seconds": 1.813375,
+                    "unique_audios": 88,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 88
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 88,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 88,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "gcf": {
+                "num_samples": 184,
+                "num_queries": 92,
+                "num_documents": 92,
+                "number_of_characters": 597,
+                "documents_text_statistics": {
+                    "total_text_length": 597,
+                    "min_text_length": 2,
+                    "average_text_length": 6.489130434782608,
+                    "max_text_length": 13,
+                    "unique_texts": 92
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 117.691125,
+                    "min_duration_seconds": 0.8501875,
+                    "average_duration_seconds": 1.2792513586956522,
+                    "max_duration_seconds": 1.779,
+                    "unique_audios": 92,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 92
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 92,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 92,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "gcr": {
+                "num_samples": 172,
+                "num_queries": 86,
+                "num_documents": 86,
+                "number_of_characters": 369,
+                "documents_text_statistics": {
+                    "total_text_length": 369,
+                    "min_text_length": 2,
+                    "average_text_length": 4.290697674418604,
+                    "max_text_length": 8,
+                    "unique_texts": 86
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 98.3536875,
+                    "min_duration_seconds": 0.797375,
+                    "average_duration_seconds": 1.1436475290697674,
+                    "max_duration_seconds": 1.6506875,
+                    "unique_audios": 86,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 86
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 86,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 86,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "gsw": {
+                "num_samples": 176,
+                "num_queries": 88,
+                "num_documents": 88,
+                "number_of_characters": 1008,
+                "documents_text_statistics": {
+                    "total_text_length": 1008,
+                    "min_text_length": 3,
+                    "average_text_length": 11.454545454545455,
+                    "max_text_length": 28,
+                    "unique_texts": 88
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 123.94775,
+                    "min_duration_seconds": 0.9430625,
+                    "average_duration_seconds": 1.408497159090909,
+                    "max_duration_seconds": 2.243375,
+                    "unique_audios": 88,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 88
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 88,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 88,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "hat": {
+                "num_samples": 172,
+                "num_queries": 86,
+                "num_documents": 86,
+                "number_of_characters": 502,
+                "documents_text_statistics": {
+                    "total_text_length": 502,
+                    "min_text_length": 2,
+                    "average_text_length": 5.837209302325581,
+                    "max_text_length": 13,
+                    "unique_texts": 86
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 99.45224999999999,
+                    "min_duration_seconds": 0.76,
+                    "average_duration_seconds": 1.1564215116279069,
+                    "max_duration_seconds": 1.9066875,
+                    "unique_audios": 86,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 86
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 86,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 86,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "jax": {
+                "num_samples": 174,
+                "num_queries": 87,
+                "num_documents": 87,
+                "number_of_characters": 510,
+                "documents_text_statistics": {
+                    "total_text_length": 510,
+                    "min_text_length": 2,
+                    "average_text_length": 5.862068965517241,
+                    "max_text_length": 10,
+                    "unique_texts": 87
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 97.5771875,
+                    "min_duration_seconds": 0.536,
+                    "average_duration_seconds": 1.1215768678160918,
+                    "max_duration_seconds": 4.248,
+                    "unique_audios": 87,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 87
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 87,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 87,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "kaa": {
+                "num_samples": 174,
+                "num_queries": 87,
+                "num_documents": 87,
+                "number_of_characters": 668,
+                "documents_text_statistics": {
+                    "total_text_length": 668,
+                    "min_text_length": 3,
+                    "average_text_length": 7.67816091954023,
+                    "max_text_length": 20,
+                    "unique_texts": 87
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 104.6685,
+                    "min_duration_seconds": 0.749375,
+                    "average_duration_seconds": 1.2030862068965518,
+                    "max_duration_seconds": 2.0426875,
+                    "unique_audios": 87,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 87
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 87,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 87,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "ken": {
+                "num_samples": 90,
+                "num_queries": 45,
+                "num_documents": 45,
+                "number_of_characters": 326,
+                "documents_text_statistics": {
+                    "total_text_length": 326,
+                    "min_text_length": 2,
+                    "average_text_length": 7.2444444444444445,
+                    "max_text_length": 21,
+                    "unique_texts": 45
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 51.8185625,
+                    "min_duration_seconds": 0.8501875,
+                    "average_duration_seconds": 1.1515236111111111,
+                    "max_duration_seconds": 1.96475,
+                    "unique_audios": 45,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 45
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 45,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 45,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "kok": {
+                "num_samples": 160,
+                "num_queries": 80,
+                "num_documents": 80,
+                "number_of_characters": 557,
+                "documents_text_statistics": {
+                    "total_text_length": 557,
+                    "min_text_length": 4,
+                    "average_text_length": 6.9625,
+                    "max_text_length": 14,
+                    "unique_texts": 80
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 90.2576875,
+                    "min_duration_seconds": 0.576,
+                    "average_duration_seconds": 1.1282210937500001,
+                    "max_duration_seconds": 1.59325,
+                    "unique_audios": 80,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 80
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 80,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 80,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "kur": {
+                "num_samples": 170,
+                "num_queries": 85,
+                "num_documents": 85,
+                "number_of_characters": 478,
+                "documents_text_statistics": {
+                    "total_text_length": 478,
+                    "min_text_length": 2,
+                    "average_text_length": 5.623529411764705,
+                    "max_text_length": 14,
+                    "unique_texts": 85
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 91.1331875,
+                    "min_duration_seconds": 0.712,
+                    "average_duration_seconds": 1.0721551470588235,
+                    "max_duration_seconds": 1.48,
+                    "unique_audios": 85,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 85
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 85,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 85,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "kvb": {
+                "num_samples": 174,
+                "num_queries": 87,
+                "num_documents": 87,
+                "number_of_characters": 498,
+                "documents_text_statistics": {
+                    "total_text_length": 498,
+                    "min_text_length": 3,
+                    "average_text_length": 5.724137931034483,
+                    "max_text_length": 10,
+                    "unique_texts": 87
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 116.257,
+                    "min_duration_seconds": 0.632,
+                    "average_duration_seconds": 1.3362873563218391,
+                    "max_duration_seconds": 2.189375,
+                    "unique_audios": 87,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 87
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 87,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 87,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "lbx": {
+                "num_samples": 182,
+                "num_queries": 91,
+                "num_documents": 91,
+                "number_of_characters": 512,
+                "documents_text_statistics": {
+                    "total_text_length": 512,
+                    "min_text_length": 3,
+                    "average_text_length": 5.626373626373627,
+                    "max_text_length": 12,
+                    "unique_texts": 91
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 94.7225625,
+                    "min_duration_seconds": 0.672,
+                    "average_duration_seconds": 1.04090728021978,
+                    "max_duration_seconds": 1.789375,
+                    "unique_audios": 91,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 91
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 91,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 91,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "ljp": {
+                "num_samples": 174,
+                "num_queries": 87,
+                "num_documents": 87,
+                "number_of_characters": 451,
+                "documents_text_statistics": {
+                    "total_text_length": 451,
+                    "min_text_length": 3,
+                    "average_text_length": 5.183908045977011,
+                    "max_text_length": 9,
+                    "unique_texts": 87
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 96.75750000000001,
+                    "min_duration_seconds": 0.6346875,
+                    "average_duration_seconds": 1.1121551724137932,
+                    "max_duration_seconds": 2.1526875,
+                    "unique_audios": 87,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 87
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 87,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 87,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "mad": {
+                "num_samples": 178,
+                "num_queries": 89,
+                "num_documents": 89,
+                "number_of_characters": 550,
+                "documents_text_statistics": {
+                    "total_text_length": 550,
+                    "min_text_length": 2,
+                    "average_text_length": 6.179775280898877,
+                    "max_text_length": 12,
+                    "unique_texts": 89
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 114.7146875,
+                    "min_duration_seconds": 0.8186875,
+                    "average_duration_seconds": 1.2889290730337077,
+                    "max_duration_seconds": 2.032,
+                    "unique_audios": 89,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 89
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 89,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 89,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "mak": {
+                "num_samples": 166,
+                "num_queries": 83,
+                "num_documents": 83,
+                "number_of_characters": 596,
+                "documents_text_statistics": {
+                    "total_text_length": 596,
+                    "min_text_length": 4,
+                    "average_text_length": 7.180722891566265,
+                    "max_text_length": 15,
+                    "unique_texts": 83
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 95.6984375,
+                    "min_duration_seconds": 0.5226875,
+                    "average_duration_seconds": 1.1529932228915662,
+                    "max_duration_seconds": 2.7946875,
+                    "unique_audios": 83,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 83
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 83,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 83,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "min": {
+                "num_samples": 180,
+                "num_queries": 90,
+                "num_documents": 90,
+                "number_of_characters": 508,
+                "documents_text_statistics": {
+                    "total_text_length": 508,
+                    "min_text_length": 3,
+                    "average_text_length": 5.644444444444445,
+                    "max_text_length": 13,
+                    "unique_texts": 90
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": null,
+                "queries_image_statistics": null,
+                "queries_audio_statistics": {
+                    "total_duration_seconds": 117.238875,
+                    "min_duration_seconds": 0.568,
+                    "average_duration_seconds": 1.3026541666666667,
+                    "max_duration_seconds": 3.229375,
+                    "unique_audios": 90,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 90
+                    }
+                },
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 90,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 90,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            }
+        }
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyMultilingualRetrieval/LinguaLibreT2ARetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyMultilingualRetrieval/LinguaLibreT2ARetrieval.json
@@ -1,0 +1,1484 @@
+{
+    "test": {
+        "num_samples": 6300,
+        "num_queries": 3150,
+        "num_documents": 3150,
+        "number_of_characters": 19646,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": {
+            "total_duration_seconds": 3570.673375,
+            "min_duration_seconds": 0.2954375,
+            "average_duration_seconds": 1.1335471031746032,
+            "max_duration_seconds": 5.253375,
+            "unique_audios": 3150,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 3150
+            }
+        },
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 19646,
+            "min_text_length": 2,
+            "average_text_length": 6.236825396825397,
+            "max_text_length": 28,
+            "unique_texts": 3103
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 3150,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 3150,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null,
+        "hf_subset_descriptive_stats": {
+            "abl": {
+                "num_samples": 198,
+                "num_queries": 99,
+                "num_documents": 99,
+                "number_of_characters": 540,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 113.2868125,
+                    "min_duration_seconds": 0.656,
+                    "average_duration_seconds": 1.1443112373737374,
+                    "max_duration_seconds": 1.453375,
+                    "unique_audios": 99,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 99
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 540,
+                    "min_text_length": 3,
+                    "average_text_length": 5.454545454545454,
+                    "max_text_length": 8,
+                    "unique_texts": 99
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 99,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 99,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "ace": {
+                "num_samples": 182,
+                "num_queries": 91,
+                "num_documents": 91,
+                "number_of_characters": 459,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 89.9799375,
+                    "min_duration_seconds": 0.6005625,
+                    "average_duration_seconds": 0.9887905219780221,
+                    "max_duration_seconds": 2.228875,
+                    "unique_audios": 91,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 91
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 459,
+                    "min_text_length": 2,
+                    "average_text_length": 5.043956043956044,
+                    "max_text_length": 11,
+                    "unique_texts": 91
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 91,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 91,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "ajp": {
+                "num_samples": 198,
+                "num_queries": 99,
+                "num_documents": 99,
+                "number_of_characters": 572,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 94.0795,
+                    "min_duration_seconds": 0.6,
+                    "average_duration_seconds": 0.9502979797979798,
+                    "max_duration_seconds": 1.376,
+                    "unique_audios": 99,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 99
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 572,
+                    "min_text_length": 3,
+                    "average_text_length": 5.777777777777778,
+                    "max_text_length": 13,
+                    "unique_texts": 99
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 99,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 99,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "ary": {
+                "num_samples": 186,
+                "num_queries": 93,
+                "num_documents": 93,
+                "number_of_characters": 402,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 78.9955625,
+                    "min_duration_seconds": 0.621375,
+                    "average_duration_seconds": 0.8494146505376344,
+                    "max_duration_seconds": 1.2586875,
+                    "unique_audios": 93,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 93
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 402,
+                    "min_text_length": 2,
+                    "average_text_length": 4.32258064516129,
+                    "max_text_length": 13,
+                    "unique_texts": 93
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 93,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 93,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "atj": {
+                "num_samples": 188,
+                "num_queries": 94,
+                "num_documents": 94,
+                "number_of_characters": 709,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 108.145875,
+                    "min_duration_seconds": 0.504,
+                    "average_duration_seconds": 1.1504880319148936,
+                    "max_duration_seconds": 1.7306875,
+                    "unique_audios": 94,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 94
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 709,
+                    "min_text_length": 3,
+                    "average_text_length": 7.542553191489362,
+                    "max_text_length": 14,
+                    "unique_texts": 94
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 94,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 94,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "ban": {
+                "num_samples": 186,
+                "num_queries": 93,
+                "num_documents": 93,
+                "number_of_characters": 482,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 109.0640625,
+                    "min_duration_seconds": 0.7546875,
+                    "average_duration_seconds": 1.1727318548387098,
+                    "max_duration_seconds": 2.536,
+                    "unique_audios": 93,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 93
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 482,
+                    "min_text_length": 3,
+                    "average_text_length": 5.182795698924731,
+                    "max_text_length": 11,
+                    "unique_texts": 93
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 93,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 93,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "bar": {
+                "num_samples": 178,
+                "num_queries": 89,
+                "num_documents": 89,
+                "number_of_characters": 528,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 81.17525,
+                    "min_duration_seconds": 0.501375,
+                    "average_duration_seconds": 0.9120814606741574,
+                    "max_duration_seconds": 1.295375,
+                    "unique_audios": 89,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 89
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 528,
+                    "min_text_length": 3,
+                    "average_text_length": 5.932584269662922,
+                    "max_text_length": 12,
+                    "unique_texts": 89
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 89,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 89,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "bci": {
+                "num_samples": 188,
+                "num_queries": 94,
+                "num_documents": 94,
+                "number_of_characters": 524,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 108.0785625,
+                    "min_duration_seconds": 0.669375,
+                    "average_duration_seconds": 1.1497719414893617,
+                    "max_duration_seconds": 2.1866875,
+                    "unique_audios": 94,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 94
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 524,
+                    "min_text_length": 3,
+                    "average_text_length": 5.574468085106383,
+                    "max_text_length": 12,
+                    "unique_texts": 94
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 94,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 94,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "bcl": {
+                "num_samples": 180,
+                "num_queries": 90,
+                "num_documents": 90,
+                "number_of_characters": 693,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 97.095875,
+                    "min_duration_seconds": 0.712,
+                    "average_duration_seconds": 1.0788430555555557,
+                    "max_duration_seconds": 1.549375,
+                    "unique_audios": 90,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 90
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 693,
+                    "min_text_length": 4,
+                    "average_text_length": 7.7,
+                    "max_text_length": 16,
+                    "unique_texts": 90
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 90,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 90,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "bew": {
+                "num_samples": 178,
+                "num_queries": 89,
+                "num_documents": 89,
+                "number_of_characters": 495,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 87.4113125,
+                    "min_duration_seconds": 0.5386875,
+                    "average_duration_seconds": 0.9821495786516853,
+                    "max_duration_seconds": 2.2566875,
+                    "unique_audios": 89,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 89
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 495,
+                    "min_text_length": 3,
+                    "average_text_length": 5.561797752808989,
+                    "max_text_length": 12,
+                    "unique_texts": 89
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 89,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 89,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "bik": {
+                "num_samples": 174,
+                "num_queries": 87,
+                "num_documents": 87,
+                "number_of_characters": 582,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 98.909625,
+                    "min_duration_seconds": 0.2954375,
+                    "average_duration_seconds": 1.1368922413793103,
+                    "max_duration_seconds": 2.4186875,
+                    "unique_audios": 87,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 87
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 582,
+                    "min_text_length": 3,
+                    "average_text_length": 6.689655172413793,
+                    "max_text_length": 13,
+                    "unique_texts": 87
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 87,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 87,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "bjn": {
+                "num_samples": 176,
+                "num_queries": 88,
+                "num_documents": 88,
+                "number_of_characters": 506,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 89.274375,
+                    "min_duration_seconds": 0.3046875,
+                    "average_duration_seconds": 1.0144815340909092,
+                    "max_duration_seconds": 1.574,
+                    "unique_audios": 88,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 88
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 506,
+                    "min_text_length": 4,
+                    "average_text_length": 5.75,
+                    "max_text_length": 11,
+                    "unique_texts": 88
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 88,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 88,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "bkr": {
+                "num_samples": 170,
+                "num_queries": 85,
+                "num_documents": 85,
+                "number_of_characters": 428,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 87.6664375,
+                    "min_duration_seconds": 0.597375,
+                    "average_duration_seconds": 1.0313698529411766,
+                    "max_duration_seconds": 2.341375,
+                    "unique_audios": 85,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 85
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 428,
+                    "min_text_length": 3,
+                    "average_text_length": 5.035294117647059,
+                    "max_text_length": 9,
+                    "unique_texts": 85
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 85,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 85,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "blk": {
+                "num_samples": 182,
+                "num_queries": 91,
+                "num_documents": 91,
+                "number_of_characters": 819,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 97.063125,
+                    "min_duration_seconds": 0.624,
+                    "average_duration_seconds": 1.0666277472527472,
+                    "max_duration_seconds": 1.9066875,
+                    "unique_audios": 91,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 91
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 819,
+                    "min_text_length": 2,
+                    "average_text_length": 9.0,
+                    "max_text_length": 24,
+                    "unique_texts": 91
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 91,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 91,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "bqr": {
+                "num_samples": 172,
+                "num_queries": 86,
+                "num_documents": 86,
+                "number_of_characters": 499,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 123.5024375,
+                    "min_duration_seconds": 0.531375,
+                    "average_duration_seconds": 1.4360748546511628,
+                    "max_duration_seconds": 4.6086875,
+                    "unique_audios": 86,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 86
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 499,
+                    "min_text_length": 2,
+                    "average_text_length": 5.8023255813953485,
+                    "max_text_length": 11,
+                    "unique_texts": 86
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 86,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 86,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "btm": {
+                "num_samples": 174,
+                "num_queries": 87,
+                "num_documents": 87,
+                "number_of_characters": 518,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 98.9386875,
+                    "min_duration_seconds": 0.5546875,
+                    "average_duration_seconds": 1.1372262931034482,
+                    "max_duration_seconds": 3.7381875,
+                    "unique_audios": 87,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 87
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 518,
+                    "min_text_length": 3,
+                    "average_text_length": 5.954022988505747,
+                    "max_text_length": 10,
+                    "unique_texts": 87
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 87,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 87,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "bug": {
+                "num_samples": 170,
+                "num_queries": 85,
+                "num_documents": 85,
+                "number_of_characters": 527,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 103.8013125,
+                    "min_duration_seconds": 0.806,
+                    "average_duration_seconds": 1.2211919117647059,
+                    "max_duration_seconds": 2.2826875,
+                    "unique_audios": 85,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 85
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 527,
+                    "min_text_length": 3,
+                    "average_text_length": 6.2,
+                    "max_text_length": 14,
+                    "unique_texts": 85
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 85,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 85,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "cor": {
+                "num_samples": 180,
+                "num_queries": 90,
+                "num_documents": 90,
+                "number_of_characters": 679,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 97.201625,
+                    "min_duration_seconds": 0.736,
+                    "average_duration_seconds": 1.0800180555555556,
+                    "max_duration_seconds": 1.5066875,
+                    "unique_audios": 90,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 90
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 679,
+                    "min_text_length": 3,
+                    "average_text_length": 7.544444444444444,
+                    "max_text_length": 13,
+                    "unique_texts": 90
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 90,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 90,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "dtp": {
+                "num_samples": 170,
+                "num_queries": 85,
+                "num_documents": 85,
+                "number_of_characters": 548,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 113.2296875,
+                    "min_duration_seconds": 0.5706875,
+                    "average_duration_seconds": 1.3321139705882352,
+                    "max_duration_seconds": 5.253375,
+                    "unique_audios": 85,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 85
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 548,
+                    "min_text_length": 3,
+                    "average_text_length": 6.447058823529412,
+                    "max_text_length": 10,
+                    "unique_texts": 85
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 85,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 85,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "ext": {
+                "num_samples": 168,
+                "num_queries": 84,
+                "num_documents": 84,
+                "number_of_characters": 475,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 84.199125,
+                    "min_duration_seconds": 0.741375,
+                    "average_duration_seconds": 1.0023705357142856,
+                    "max_duration_seconds": 1.3866875,
+                    "unique_audios": 84,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 84
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 475,
+                    "min_text_length": 3,
+                    "average_text_length": 5.654761904761905,
+                    "max_text_length": 9,
+                    "unique_texts": 84
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 84,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 84,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "fon": {
+                "num_samples": 176,
+                "num_queries": 88,
+                "num_documents": 88,
+                "number_of_characters": 531,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 99.2851875,
+                    "min_duration_seconds": 0.629375,
+                    "average_duration_seconds": 1.1282407670454546,
+                    "max_duration_seconds": 1.813375,
+                    "unique_audios": 88,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 88
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 531,
+                    "min_text_length": 2,
+                    "average_text_length": 6.034090909090909,
+                    "max_text_length": 13,
+                    "unique_texts": 88
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 88,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 88,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "gcf": {
+                "num_samples": 184,
+                "num_queries": 92,
+                "num_documents": 92,
+                "number_of_characters": 597,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 117.691125,
+                    "min_duration_seconds": 0.8501875,
+                    "average_duration_seconds": 1.2792513586956522,
+                    "max_duration_seconds": 1.779,
+                    "unique_audios": 92,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 92
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 597,
+                    "min_text_length": 2,
+                    "average_text_length": 6.489130434782608,
+                    "max_text_length": 13,
+                    "unique_texts": 92
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 92,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 92,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "gcr": {
+                "num_samples": 172,
+                "num_queries": 86,
+                "num_documents": 86,
+                "number_of_characters": 369,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 98.3536875,
+                    "min_duration_seconds": 0.797375,
+                    "average_duration_seconds": 1.1436475290697674,
+                    "max_duration_seconds": 1.6506875,
+                    "unique_audios": 86,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 86
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 369,
+                    "min_text_length": 2,
+                    "average_text_length": 4.290697674418604,
+                    "max_text_length": 8,
+                    "unique_texts": 86
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 86,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 86,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "gsw": {
+                "num_samples": 176,
+                "num_queries": 88,
+                "num_documents": 88,
+                "number_of_characters": 1008,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 123.94775,
+                    "min_duration_seconds": 0.9430625,
+                    "average_duration_seconds": 1.408497159090909,
+                    "max_duration_seconds": 2.243375,
+                    "unique_audios": 88,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 88
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 1008,
+                    "min_text_length": 3,
+                    "average_text_length": 11.454545454545455,
+                    "max_text_length": 28,
+                    "unique_texts": 88
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 88,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 88,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "hat": {
+                "num_samples": 172,
+                "num_queries": 86,
+                "num_documents": 86,
+                "number_of_characters": 502,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 99.45224999999999,
+                    "min_duration_seconds": 0.76,
+                    "average_duration_seconds": 1.1564215116279069,
+                    "max_duration_seconds": 1.9066875,
+                    "unique_audios": 86,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 86
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 502,
+                    "min_text_length": 2,
+                    "average_text_length": 5.837209302325581,
+                    "max_text_length": 13,
+                    "unique_texts": 86
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 86,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 86,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "jax": {
+                "num_samples": 174,
+                "num_queries": 87,
+                "num_documents": 87,
+                "number_of_characters": 510,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 97.5771875,
+                    "min_duration_seconds": 0.536,
+                    "average_duration_seconds": 1.1215768678160918,
+                    "max_duration_seconds": 4.248,
+                    "unique_audios": 87,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 87
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 510,
+                    "min_text_length": 2,
+                    "average_text_length": 5.862068965517241,
+                    "max_text_length": 10,
+                    "unique_texts": 87
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 87,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 87,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "kaa": {
+                "num_samples": 174,
+                "num_queries": 87,
+                "num_documents": 87,
+                "number_of_characters": 668,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 104.6685,
+                    "min_duration_seconds": 0.749375,
+                    "average_duration_seconds": 1.2030862068965518,
+                    "max_duration_seconds": 2.0426875,
+                    "unique_audios": 87,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 87
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 668,
+                    "min_text_length": 3,
+                    "average_text_length": 7.67816091954023,
+                    "max_text_length": 20,
+                    "unique_texts": 87
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 87,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 87,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "ken": {
+                "num_samples": 90,
+                "num_queries": 45,
+                "num_documents": 45,
+                "number_of_characters": 326,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 51.8185625,
+                    "min_duration_seconds": 0.8501875,
+                    "average_duration_seconds": 1.1515236111111111,
+                    "max_duration_seconds": 1.96475,
+                    "unique_audios": 45,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 45
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 326,
+                    "min_text_length": 2,
+                    "average_text_length": 7.2444444444444445,
+                    "max_text_length": 21,
+                    "unique_texts": 45
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 45,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 45,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "kok": {
+                "num_samples": 160,
+                "num_queries": 80,
+                "num_documents": 80,
+                "number_of_characters": 557,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 90.2576875,
+                    "min_duration_seconds": 0.576,
+                    "average_duration_seconds": 1.1282210937500001,
+                    "max_duration_seconds": 1.59325,
+                    "unique_audios": 80,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 80
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 557,
+                    "min_text_length": 4,
+                    "average_text_length": 6.9625,
+                    "max_text_length": 14,
+                    "unique_texts": 80
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 80,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 80,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "kur": {
+                "num_samples": 170,
+                "num_queries": 85,
+                "num_documents": 85,
+                "number_of_characters": 478,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 91.1331875,
+                    "min_duration_seconds": 0.712,
+                    "average_duration_seconds": 1.0721551470588235,
+                    "max_duration_seconds": 1.48,
+                    "unique_audios": 85,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 85
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 478,
+                    "min_text_length": 2,
+                    "average_text_length": 5.623529411764705,
+                    "max_text_length": 14,
+                    "unique_texts": 85
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 85,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 85,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "kvb": {
+                "num_samples": 174,
+                "num_queries": 87,
+                "num_documents": 87,
+                "number_of_characters": 498,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 116.257,
+                    "min_duration_seconds": 0.632,
+                    "average_duration_seconds": 1.3362873563218391,
+                    "max_duration_seconds": 2.189375,
+                    "unique_audios": 87,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 87
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 498,
+                    "min_text_length": 3,
+                    "average_text_length": 5.724137931034483,
+                    "max_text_length": 10,
+                    "unique_texts": 87
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 87,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 87,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "lbx": {
+                "num_samples": 182,
+                "num_queries": 91,
+                "num_documents": 91,
+                "number_of_characters": 512,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 94.7225625,
+                    "min_duration_seconds": 0.672,
+                    "average_duration_seconds": 1.04090728021978,
+                    "max_duration_seconds": 1.789375,
+                    "unique_audios": 91,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 91
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 512,
+                    "min_text_length": 3,
+                    "average_text_length": 5.626373626373627,
+                    "max_text_length": 12,
+                    "unique_texts": 91
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 91,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 91,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "ljp": {
+                "num_samples": 174,
+                "num_queries": 87,
+                "num_documents": 87,
+                "number_of_characters": 451,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 96.75750000000001,
+                    "min_duration_seconds": 0.6346875,
+                    "average_duration_seconds": 1.1121551724137932,
+                    "max_duration_seconds": 2.1526875,
+                    "unique_audios": 87,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 87
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 451,
+                    "min_text_length": 3,
+                    "average_text_length": 5.183908045977011,
+                    "max_text_length": 9,
+                    "unique_texts": 87
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 87,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 87,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "mad": {
+                "num_samples": 178,
+                "num_queries": 89,
+                "num_documents": 89,
+                "number_of_characters": 550,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 114.7146875,
+                    "min_duration_seconds": 0.8186875,
+                    "average_duration_seconds": 1.2889290730337077,
+                    "max_duration_seconds": 2.032,
+                    "unique_audios": 89,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 89
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 550,
+                    "min_text_length": 2,
+                    "average_text_length": 6.179775280898877,
+                    "max_text_length": 12,
+                    "unique_texts": 89
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 89,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 89,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "mak": {
+                "num_samples": 166,
+                "num_queries": 83,
+                "num_documents": 83,
+                "number_of_characters": 596,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 95.6984375,
+                    "min_duration_seconds": 0.5226875,
+                    "average_duration_seconds": 1.1529932228915662,
+                    "max_duration_seconds": 2.7946875,
+                    "unique_audios": 83,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 83
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 596,
+                    "min_text_length": 4,
+                    "average_text_length": 7.180722891566265,
+                    "max_text_length": 15,
+                    "unique_texts": 83
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 83,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 83,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            },
+            "min": {
+                "num_samples": 180,
+                "num_queries": 90,
+                "num_documents": 90,
+                "number_of_characters": 508,
+                "documents_text_statistics": null,
+                "documents_image_statistics": null,
+                "documents_audio_statistics": {
+                    "total_duration_seconds": 117.238875,
+                    "min_duration_seconds": 0.568,
+                    "average_duration_seconds": 1.3026541666666667,
+                    "max_duration_seconds": 3.229375,
+                    "unique_audios": 90,
+                    "average_sampling_rate": 16000.0,
+                    "sampling_rates": {
+                        "16000": 90
+                    }
+                },
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 508,
+                    "min_text_length": 3,
+                    "average_text_length": 5.644444444444445,
+                    "max_text_length": 13,
+                    "unique_texts": 90
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 90,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 90,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": null
+            }
+        }
+    }
+}

--- a/mteb/tasks/retrieval/multilingual/__init__.py
+++ b/mteb/tasks/retrieval/multilingual/__init__.py
@@ -72,6 +72,10 @@ from .jina_vdr_bench_retrieval import (
     JinaVDRWikimediaCommonsDocumentsRetrieval,
     JinaVDRWikimediaCommonsMapsRetrieval,
 )
+from .lingua_libre_retrieval import (
+    LinguaLibreA2TRetrieval,
+    LinguaLibreT2ARetrieval,
+)
 from .mintaka_retrieval import MintakaRetrieval
 from .miracl_retrieval import (
     MIRACLRetrieval,
@@ -219,6 +223,8 @@ __all__ = [
     "JinaVDRTweetStockSyntheticsRetrieval",
     "JinaVDRWikimediaCommonsDocumentsRetrieval",
     "JinaVDRWikimediaCommonsMapsRetrieval",
+    "LinguaLibreA2TRetrieval",
+    "LinguaLibreT2ARetrieval",
     "MIRACLRetrieval",
     "MIRACLRetrievalHardNegatives",
     "MIRACLRetrievalHardNegativesV2",

--- a/mteb/tasks/retrieval/multilingual/lingua_libre_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/lingua_libre_retrieval.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from datasets import load_dataset
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.retrieval_dataset_loaders import RetrievalSplitData
+from mteb.abstasks.task_metadata import TaskMetadata
+
+_DATASET_PATH = "vnahata/LinguaLibre-word-retrieval"
+_DATASET_REVISION = "92576496cdf11e39315ec3c79e69da634177e13a"
+
+# Scripts are taken from the recordings themselves rather than assumed from the language.
+# South Levantine Arabic is romanised in this collection, while Moroccan Arabic is not.
+_LANGUAGES = {
+    "abl": ["abl-Latn"],
+    "ace": ["ace-Latn"],
+    "ajp": ["ajp-Latn"],
+    "ary": ["ary-Arab"],
+    "atj": ["atj-Latn"],
+    "ban": ["ban-Latn"],
+    "bar": ["bar-Latn"],
+    "bci": ["bci-Latn"],
+    "bcl": ["bcl-Latn"],
+    "bew": ["bew-Latn"],
+    "bik": ["bik-Latn"],
+    "bjn": ["bjn-Latn"],
+    "bkr": ["bkr-Latn"],
+    "blk": ["blk-Mymr"],
+    "bqr": ["bqr-Latn"],
+    "btm": ["btm-Latn"],
+    "bug": ["bug-Latn"],
+    "cor": ["cor-Latn"],
+    "dtp": ["dtp-Latn"],
+    "ext": ["ext-Latn"],
+    "fon": ["fon-Latn"],
+    "gcf": ["gcf-Latn"],
+    "gcr": ["gcr-Latn"],
+    "gsw": ["gsw-Latn"],
+    "hat": ["hat-Latn"],
+    "jax": ["jax-Latn"],
+    "kaa": ["kaa-Latn"],
+    "ken": ["ken-Latn"],
+    "kok": ["kok-Deva"],
+    "kur": ["kur-Latn"],
+    "kvb": ["kvb-Latn"],
+    "lbx": ["lbx-Latn"],
+    "ljp": ["ljp-Latn"],
+    "mad": ["mad-Latn"],
+    "mak": ["mak-Latn"],
+    "min": ["min-Latn"],
+}
+
+_BIBTEX = r"""
+@misc{lingualibre,
+  author = {{Lingua Libre contributors}},
+  howpublished = {\url{https://lingualibre.org}},
+  title = {Lingua Libre},
+  year = {2026},
+}
+"""
+
+_DESCRIPTION = (
+    "Single words read aloud by volunteers, paired with the written word, in 36 languages "
+    "that no other audio task in mteb reaches. Lingua Libre is a Wikimedia project and the "
+    "recordings are hosted on Wikimedia Commons."
+)
+
+_CONSTRUCTION = (
+    "Commons files these under one category per language keyed by ISO 639-3, and the word "
+    "and speaker both sit in the filename, so the label needs no annotation. Entries "
+    "beginning with a non-letter are dropped, which removes affixes such as -able and "
+    "recordings of bare punctuation, as are entries containing whitespace, which are read "
+    "sentences rather than words. Each word is kept once, since the same word read by two "
+    "speakers would otherwise be relevant to only one of its recordings. Files are listed "
+    "newest first because alphabetical order puts thousands of digits and symbols before "
+    "the first real word. Construction script: scripts/data/lingua_libre/create_data.py."
+)
+
+_COMMON = {
+    "reference": "https://commons.wikimedia.org/wiki/Category:Lingua_Libre_pronunciation",
+    "dataset": {"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+    "type": "Any2AnyMultilingualRetrieval",
+    "eval_splits": ["test"],
+    "eval_langs": _LANGUAGES,
+    "main_score": "ndcg_at_10",
+    "date": ("2018-01-01", "2026-09-02"),
+    "domains": ["Spoken"],
+    "task_subtypes": ["Cross-Modal Retrieval"],
+    "license": "cc-by-sa-4.0",
+    "annotations_creators": "derived",
+    "dialect": [],
+    "sample_creation": "found",
+    "bibtex_citation": _BIBTEX,
+    "is_beta": True,
+}
+
+
+def _load(task: AbsTaskRetrieval, to_text: bool) -> None:
+    """Load one direction. `to_text` selects recording->word, otherwise the reverse."""
+    if task.data_loaded:
+        return
+
+    split = task.metadata.eval_splits[0]
+    task.dataset = {}
+    for lang in _LANGUAGES:
+        rows = load_dataset(
+            _DATASET_PATH, lang, revision=_DATASET_REVISION, split=split
+        )
+        audio = rows.select_columns(["id", "audio"])
+        text = rows.select_columns(["id", "text"])
+        qrels = {i: {i: 1} for i in rows["id"]}
+
+        task.dataset[lang] = {
+            split: RetrievalSplitData(
+                queries=audio if to_text else text,
+                corpus=text if to_text else audio,
+                relevant_docs=qrels,
+                top_ranked=None,
+            )
+        }
+    task.data_loaded = True
+
+
+class LinguaLibreA2TRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="LinguaLibreA2TRetrieval",
+        description=f"{_DESCRIPTION} Retrieve the written form of a spoken word. {_CONSTRUCTION}",
+        category="a2t",
+        modalities=["audio", "text"],
+        prompt={"query": "Find the written form of this spoken word."},
+        **_COMMON,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load(self, to_text=True)
+
+
+class LinguaLibreT2ARetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="LinguaLibreT2ARetrieval",
+        description=f"{_DESCRIPTION} Retrieve the recording of a written word. {_CONSTRUCTION}",
+        category="t2a",
+        modalities=["text", "audio"],
+        prompt={"query": "Find the recording of this written word."},
+        **_COMMON,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        _load(self, to_text=False)

--- a/scripts/data/lingua_libre/create_data.py
+++ b/scripts/data/lingua_libre/create_data.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""Build the Lingua Libre spoken-word retrieval tasks for MTEB.
+
+Source is Lingua Libre, a Wikimedia project where volunteers record individual words, with
+the recordings hosted on Wikimedia Commons. Commons is free by site policy and every file
+sampled here is CC-BY-SA 4.0 or CC0, so the published set is CC-BY-SA 4.0.
+
+Commons files it under `Category:Lingua Libre pronunciation-<iso 639-3>`, one category per
+language, which is what makes a wide multilingual build tractable: the language code comes
+straight from the category name rather than having to be inferred. There are over 340 such
+categories. Languages are chosen by a fixed rule, described in `select_languages`.
+
+The word and the speaker both sit in the filename, `LL-Q150 (fra)-Speaker-word.wav`, so the
+label needs no annotation. Three filters apply, because the categories hold more than
+single words:
+
+- entries with no letters are dropped, which removes recordings of bare punctuation such
+  as `!` or `$`;
+- entries containing whitespace are dropped, which removes the read sentences that some
+  contributors upload alongside words;
+- a word is kept once, since the same word read by two speakers would otherwise be
+  relevant to only one of its recordings.
+
+Examples:
+  # Build the reshaped tables locally.
+  uv run python scripts/data/lingua_libre/create_data.py --stage build
+
+  # Build and publish.
+  uv run python scripts/data/lingua_libre/create_data.py --stage all --push
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import re
+import time
+from math import gcd
+from pathlib import Path
+
+import pyarrow.parquet as pq
+import requests
+import soundfile as sf
+from datasets import Audio, Dataset
+from huggingface_hub import HfApi
+from scipy.signal import resample_poly
+
+_TARGET = "vnahata/LinguaLibre-word-retrieval"
+_LICENSE = "cc-by-sa-4.0"
+_UA = "mteb-dataset-builder/1.0 (https://github.com/embeddings-benchmark/mteb)"
+_COMMONS = "https://commons.wikimedia.org/w/api.php"
+
+_N_LANGUAGES = 40
+_MIN_FILES = 300  # probed per category, so a language has enough words to rank
+_PER_LANGUAGE = 150
+_MIN_WORD_CHARS = 2
+_MAX_WORD_CHARS = 30
+_TARGET_RATE = 16000
+
+_FILENAME = re.compile(r"^LL-Q\d+\s*\(([a-z]{2,3})\)-(.+?)-(.+)$")
+
+
+def _get(params: dict) -> dict:
+    for attempt in range(4):
+        try:
+            r = requests.get(
+                _COMMONS,
+                params={**params, "format": "json"},
+                headers={"User-Agent": _UA},
+                timeout=60,
+            )
+            r.raise_for_status()
+            return r.json()
+        except Exception:
+            if attempt == 3:
+                raise
+            time.sleep(2 * (attempt + 1))
+    return {}
+
+
+def _language_categories() -> list[str]:
+    out, cont = [], {}
+    while True:
+        d = _get(
+            {
+                "action": "query",
+                "list": "categorymembers",
+                "cmtitle": "Category:Lingua Libre pronunciation",
+                "cmtype": "subcat",
+                "cmlimit": 500,
+                **cont,
+            }
+        )
+        for m in d.get("query", {}).get("categorymembers", []):
+            name = m["title"].replace("Category:", "")
+            if re.fullmatch(r"Lingua Libre pronunciation-[a-z]{3}", name):
+                out.append(name)
+        if "continue" not in d:
+            return sorted(out)
+        cont = {"cmcontinue": d["continue"]["cmcontinue"]}
+
+
+def _category_files(category: str, pages: int = 1) -> list[str]:
+    """Listed newest first. Alphabetical order puts thousands of digits and symbols
+    before the first real word, so sorting by upload time is what makes a page usable."""
+    out, cont = [], {}
+    for _ in range(pages):
+        d = _get(
+            {
+                "action": "query",
+                "list": "categorymembers",
+                "cmtitle": f"Category:{category}",
+                "cmtype": "file",
+                "cmlimit": 500,
+                "cmsort": "timestamp",
+                "cmdir": "desc",
+                **cont,
+            }
+        )
+        out += [m["title"] for m in d.get("query", {}).get("categorymembers", [])]
+        if "continue" not in d:
+            break
+        cont = {"cmcontinue": d["continue"]["cmcontinue"]}
+        time.sleep(0.2)
+    return out
+
+
+def _covered_languages() -> set[str]:
+    """ISO codes already reachable through some mteb audio task."""
+    import mteb
+
+    covered = set()
+    for task in mteb.get_tasks():
+        if "audio" not in (task.metadata.modalities or []):
+            continue
+        langs = task.metadata.eval_langs
+        values = (
+            [v for vs in langs.values() for v in vs]
+            if isinstance(langs, dict)
+            else list(langs)
+        )
+        covered.update(v.split("-")[0] for v in values)
+    return covered
+
+
+def select_languages() -> list[str]:
+    """Languages absent from every existing mteb audio task, with enough recordings.
+
+    Half of Lingua Libre's larger categories are languages the benchmark already reaches,
+    so taking them in plain ISO order spends most of the slots on coverage that exists.
+    """
+    covered = _covered_languages()
+    chosen = []
+    for category in _language_categories():
+        code = category.rsplit("-", 1)[1]
+        if code in covered:
+            continue
+        files = _category_files(category)
+        if len(files) >= _MIN_FILES:
+            chosen.append(code)
+            print(f"    {code}: {len(files)}+ files", flush=True)
+        if len(chosen) >= _N_LANGUAGES:
+            break
+        time.sleep(0.2)
+    return chosen
+
+
+def _words(files: list[str]) -> dict[str, str]:
+    """Filename -> word, keeping one recording per word."""
+    out, seen = {}, set()
+    for f in files:
+        stem = re.sub(
+            r"\.(wav|ogg|oga|mp3|flac)$", "", f.replace("File:", ""), flags=re.I
+        )
+        m = _FILENAME.match(stem)
+        if not m:
+            continue
+        word = m.group(3).strip()
+        if not (_MIN_WORD_CHARS <= len(word) <= _MAX_WORD_CHARS):
+            continue
+        # A leading hyphen marks an affix such as "-able" rather than a word, whitespace
+        # marks a read sentence, and an entry with no letters is bare punctuation.
+        if not word[0].isalpha() or any(ch.isspace() for ch in word):
+            continue
+        key = word.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        out[f] = word
+    return out
+
+
+def _to_opus(raw: bytes) -> bytes | None:
+    data, rate = sf.read(io.BytesIO(raw), dtype="float32")
+    if data.ndim > 1:
+        data = data[:, 0]
+    if len(data) < rate * 0.2:
+        return None
+    if rate != _TARGET_RATE:
+        factor = gcd(int(rate), _TARGET_RATE)
+        data = resample_poly(data, _TARGET_RATE // factor, int(rate) // factor)
+    buf = io.BytesIO()
+    sf.write(buf, data, _TARGET_RATE, format="OGG", subtype="OPUS")
+    return buf.getvalue()
+
+
+def stage_build(work: Path) -> dict:
+    work.mkdir(parents=True, exist_ok=True)
+    codes_path = work / "languages.json"
+    if codes_path.exists():
+        codes = json.loads(codes_path.read_text(encoding="utf-8"))
+    else:
+        codes = select_languages()
+        codes_path.write_text(json.dumps(codes), encoding="utf-8")
+    print(f"selected {len(codes)} languages", flush=True)
+
+    counts: dict[str, int] = {}
+    for code in codes:
+        out_path = work / f"{code}.parquet"
+        if out_path.exists():
+            counts[code] = pq.read_metadata(out_path).num_rows
+            print(f"  {code}: cached {counts[code]}", flush=True)
+            continue
+
+        files = _category_files(f"Lingua Libre pronunciation-{code}", pages=2)
+        mapping = dict(list(_words(files).items())[:_PER_LANGUAGE])
+
+        # one imageinfo request per file would be thousands of round trips
+        urls: dict[str, str] = {}
+        titles = list(mapping)
+        for i in range(0, len(titles), 40):
+            d = _get(
+                {
+                    "action": "query",
+                    "titles": "|".join(titles[i : i + 40]),
+                    "prop": "imageinfo",
+                    "iiprop": "url",
+                }
+            )
+            for page in (d.get("query") or {}).get("pages", {}).values():
+                url = ((page.get("imageinfo") or [{}])[0]).get("url")
+                if url:
+                    urls[page["title"]] = url
+            time.sleep(0.2)
+
+        rows = []
+        for f, word in mapping.items():
+            url = urls.get(f)
+            if not url:
+                continue
+            # Commons throttles sustained downloads, and a throttled response decodes
+            # as garbage rather than raising, so the status is checked and the loop paced.
+            try:
+                r = requests.get(url, headers={"User-Agent": _UA}, timeout=90)
+                if r.status_code != 200:
+                    time.sleep(2)
+                    continue
+                audio = _to_opus(r.content)
+            except Exception:
+                continue
+            finally:
+                time.sleep(0.15)
+            if audio is None:
+                continue
+            rows.append(
+                {
+                    "id": f"{code}-{len(rows)}",
+                    "audio": {"bytes": audio, "path": None},
+                    "text": word,
+                }
+            )
+
+        if len(rows) < 40:
+            print(f"  {code}: skipped, only {len(rows)} words", flush=True)
+            continue
+        Dataset.from_list(rows).cast_column(
+            "audio", Audio(sampling_rate=_TARGET_RATE)
+        ).to_parquet(str(out_path))
+        counts[code] = len(rows)
+        print(f"  {code}: {len(rows)} words", flush=True)
+
+    (work / "counts.json").write_text(json.dumps(counts, indent=2), encoding="utf-8")
+    print("built", json.dumps(counts))
+    return counts
+
+
+def _card(codes: list[str]) -> str:
+    lines = [
+        "---",
+        f"license: {_LICENSE}",
+        "task_categories:",
+        "  - automatic-speech-recognition",
+        "language:",
+        *[f"  - {c}" for c in codes],
+        "tags:",
+        "  - mteb",
+        "  - retrieval",
+        "  - multilingual",
+        "configs:",
+    ]
+    for c in codes:
+        lines += [
+            f"  - config_name: {c}",
+            "    data_files:",
+            "      - split: test",
+            f"        path: {c}.parquet",
+        ]
+    lines += [
+        "---",
+        "",
+        "# Lingua Libre spoken-word retrieval (MTEB)",
+        "",
+        "Single words read aloud by volunteers, paired with the written word, across many",
+        "languages.",
+        "",
+        "Recordings come from Lingua Libre, a Wikimedia project, hosted on Wikimedia",
+        f"Commons, which is free by site policy. Published as {_LICENSE}. Audio is 16 kHz",
+        "Opus. Bare punctuation and read sentences are excluded, and each word is kept once.",
+        "",
+        "Built by `scripts/data/lingua_libre/create_data.py` in the MTEB repo.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def stage_push(work: Path) -> None:
+    api = HfApi()
+    api.create_repo(_TARGET, repo_type="dataset", exist_ok=True)
+    codes = sorted(p.stem for p in work.glob("*.parquet"))
+    for code in codes:
+        api.upload_file(
+            path_or_fileobj=str(work / f"{code}.parquet"),
+            path_in_repo=f"{code}.parquet",
+            repo_id=_TARGET,
+            repo_type="dataset",
+        )
+        print(f"  pushed {code}", flush=True)
+    api.upload_file(
+        path_or_fileobj=io.BytesIO(_card(codes).encode()),
+        path_in_repo="README.md",
+        repo_id=_TARGET,
+        repo_type="dataset",
+    )
+    print(f"pushed {_TARGET}: {len(codes)} languages")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--stage", choices=["build", "push", "all"], default="all")
+    parser.add_argument("--work-dir", type=Path, default=Path("lingualibre_work"))
+    parser.add_argument("--push", action="store_true")
+    args = parser.parse_args()
+
+    print(f"source: Wikimedia Commons, Lingua Libre (license {_LICENSE})")
+    if args.stage in ("build", "all"):
+        stage_build(args.work_dir)
+    if args.stage == "push" or (args.push and args.stage == "all"):
+        stage_push(args.work_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_tasks/test_task_quality.py
+++ b/tests/test_tasks/test_task_quality.py
@@ -23,6 +23,8 @@ from mteb.types.statistics import (
 
 KNOWN_ISSUES: dict[str, list[str]] = {
     "short_text": [
+        "LinguaLibreA2TRetrieval",  # single words, so two characters is a whole word
+        "LinguaLibreT2ARetrieval",
         "ARCChallenge",
         "AVMemeExamVideoAudioCentricQA",
         "AVMemeExamVideoCentricQA",
@@ -411,6 +413,8 @@ KNOWN_ISSUES: dict[str, list[str]] = {
         "BrightProSustainableLivingRetrieval",
     ],
     "duplicate_text": [
+        "LinguaLibreA2TRetrieval",  # no repeats within a language; related languages share cognates and each subset is ranked on its own
+        "LinguaLibreT2ARetrieval",
         "AfriHateClassification",
         "AfriSentiClassification",
         "AllegroReviews",


### PR DESCRIPTION
Adds `LinguaLibreA2TRetrieval` and `LinguaLibreT2ARetrieval`: single words read aloud paired with the written word, in **36 languages no existing mteb audio task reaches**. Part of #4842, and a second piece of the audio side of #5254.

## Gap

The audio tasks in mteb reach 165 languages between them. All 36 here were picked by excluding every one of those, among them Acehnese, Atikamekw, Balinese, Betawi, Buginese, Cornish, Fon, Haitian Creole, Karakalpak and Madurese.

Lingua Libre is a Wikimedia project hosted on Commons, free by site policy, so this is also a slice of the audio work #5254 asks for.

## Construction

Built from the Commons API, in `scripts/data/lingua_libre/create_data.py`.

- Commons files these under one category per language keyed by **ISO 639-3**, and the word sits in the filename, so the label needs no annotation.
- Entries beginning with a non-letter are dropped, removing affixes and punctuation; entries with whitespace are read sentences.
- **Each word is kept once**, since one word read twice would be relevant to only one recording.
- Files are listed **newest first**: alphabetical order puts thousands of digits and symbols ahead of the first real word.

Scripts are read off the recordings, not assumed: South Levantine Arabic is romanised here while Moroccan Arabic is not.

Result: **3,150 words over 36 languages**, median 88 each, 16 kHz Opus. License **CC-BY-SA-4.0**.

## Checklist

- [x] Outlined why this fills a gap
- [x] Tested that it runs with `mteb`
- [x] `mteb/baseline-random-encoder` nDCG@10: a2t 0.0518, t2a 0.0556
- [x] `jina-embeddings-v5-omni-nano` nDCG@10: a2t **0.7449**, t2a **0.7686**, 14x the floor. CLAP and VoiceCLAP sit at chance, both being English-only caption models rather than speech ones
- [x] Size considered, one recording per word
- [x] `test_task_quality.py` passes with two exemptions: words are short by nature, and there are **no repeats within a language**, only cognates across related ones

