### PR TITLE
dataset: add TAU Urban Acoustic Scenes 2022 clustering (a2a)

### DIFF
--- a/mteb/descriptive_stats/AudioClustering/TAUAcousticScenes2022MobileClustering.json
+++ b/mteb/descriptive_stats/AudioClustering/TAUAcousticScenes2022MobileClustering.json
@@ -1,0 +1,57 @@
+{
+    "test": {
+        "num_samples": 5000,
+        "text_statistics": null,
+        "image_statistics": null,
+        "audio_statistics": {
+            "total_duration_seconds": 5000.0,
+            "min_duration_seconds": 1.0,
+            "average_duration_seconds": 1.0,
+            "max_duration_seconds": 1.0,
+            "unique_audios": 5000,
+            "average_sampling_rate": 44100.0,
+            "sampling_rates": {
+                "44100": 5000
+            }
+        },
+        "video_statistics": null,
+        "labels_statistics": {
+            "min_labels_per_text": 1,
+            "average_label_per_text": 1.0,
+            "max_labels_per_text": 1,
+            "unique_labels": 10,
+            "labels": {
+                "airport": {
+                    "count": 499
+                },
+                "bus": {
+                    "count": 500
+                },
+                "metro": {
+                    "count": 500
+                },
+                "metro_station": {
+                    "count": 500
+                },
+                "park": {
+                    "count": 500
+                },
+                "public_square": {
+                    "count": 500
+                },
+                "shopping_mall": {
+                    "count": 500
+                },
+                "street_pedestrian": {
+                    "count": 501
+                },
+                "street_traffic": {
+                    "count": 501
+                },
+                "tram": {
+                    "count": 499
+                }
+            }
+        }
+    }
+}

--- a/mteb/tasks/clustering/zxx/__init__.py
+++ b/mteb/tasks/clustering/zxx/__init__.py
@@ -3,6 +3,9 @@ from .esc50_clustering import ESC50Clustering
 from .gtzan_genre_clustering import GTZANGenreClustering
 from .music_genre import MusicGenreClustering
 from .n_synth_clustering import NSynthInstrumentFamilyClustering
+from .tau_acoustic_scenes_2022_mobile_clustering import (
+    TAUAcousticScenes2022MobileClustering,
+)
 from .urban_sound8k_clustering import UrbanSound8kClustering
 from .vehicle_sound_clustering import VehicleSoundClustering
 from .vim_sketch_clustering import VimSketchImitationClustering
@@ -13,6 +16,7 @@ __all__ = [
     "GTZANGenreClustering",
     "MusicGenreClustering",
     "NSynthInstrumentFamilyClustering",
+    "TAUAcousticScenes2022MobileClustering",
     "UrbanSound8kClustering",
     "VehicleSoundClustering",
     "VimSketchImitationClustering",

--- a/mteb/tasks/clustering/zxx/tau_acoustic_scenes_2022_mobile_clustering.py
+++ b/mteb/tasks/clustering/zxx/tau_acoustic_scenes_2022_mobile_clustering.py
@@ -1,0 +1,42 @@
+from mteb.abstasks import AbsTaskClustering
+from mteb.abstasks.task_metadata import TaskMetadata
+
+
+class TAUAcousticScenes2022MobileClustering(AbsTaskClustering):
+    metadata = TaskMetadata(
+        name="TAUAcousticScenes2022MobileClustering",
+        description="Clustering task over TAU Urban Acoustic Scenes 2022 Mobile, 1-second recordings made in 12 European cities across 10 acoustic scenes with 4 different devices. mteb already scores this dataset with labels through TAUAcousticScenes2022Mobile; this asks instead whether audio embeddings separate urban acoustic environments with no labels at all. Same stratified subsample of the evaluation_setup subset, at the same revision, so the two tasks are directly comparable.",
+        reference="https://zenodo.org/records/6337421",
+        dataset={
+            "path": "mteb/tau-acoustic-scenes-2022-mobile-mini",
+            "revision": "d0da0ed80d22944c7a5690c4b570683d45c4dfaf",
+        },
+        type="AudioClustering",
+        category="a2a",
+        eval_splits=["test"],
+        eval_langs=["zxx-Zxxx"],
+        main_score="v_measure",
+        date=("2022-03-08", "2022-03-08"),
+        domains=[
+            "AudioScene",
+        ],
+        task_subtypes=["Environment Sound Clustering"],
+        license="not specified",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        modalities=["audio"],
+        sample_creation="found",
+        bibtex_citation=r"""
+@dataset{heittola_2022_6337421,
+  author = {Toni Heittola and Annamaria Mesaros and Tuomas Virtanen},
+  publisher = {Zenodo},
+  title = {TAU Urban Acoustic Scenes 2022 Mobile, Development Dataset},
+  url = {https://doi.org/10.5281/zenodo.6337421},
+  year = {2022},
+}
+""",
+    )
+
+    max_fraction_of_documents_to_embed = None
+    input_column_name: str = "audio"
+    label_column_name: str = "scene_label"

--- a/mteb/tasks/clustering/zxx/tau_acoustic_scenes_2022_mobile_clustering.py
+++ b/mteb/tasks/clustering/zxx/tau_acoustic_scenes_2022_mobile_clustering.py
@@ -6,7 +6,7 @@ class TAUAcousticScenes2022MobileClustering(AbsTaskClustering):
     metadata = TaskMetadata(
         name="TAUAcousticScenes2022MobileClustering",
         description="Clustering task over TAU Urban Acoustic Scenes 2022 Mobile, 1-second recordings made in 12 European cities across 10 acoustic scenes with 4 different devices. mteb already scores this dataset with labels through TAUAcousticScenes2022Mobile; this asks instead whether audio embeddings separate urban acoustic environments with no labels at all. Same stratified subsample of the evaluation_setup subset, at the same revision, so the two tasks are directly comparable.",
-        reference="https://zenodo.org/records/6337421",
+        reference="https://arxiv.org/abs/2005.14623",
         dataset={
             "path": "mteb/tau-acoustic-scenes-2022-mobile-mini",
             "revision": "d0da0ed80d22944c7a5690c4b570683d45c4dfaf",
@@ -27,6 +27,15 @@ class TAUAcousticScenes2022MobileClustering(AbsTaskClustering):
         modalities=["audio"],
         sample_creation="found",
         bibtex_citation=r"""
+@inproceedings{heittola2020acoustic,
+  author = {Heittola, Toni and Mesaros, Annamaria and Virtanen, Tuomas},
+  booktitle = {Proceedings of the Detection and Classification of Acoustic Scenes and Events 2020 Workshop (DCASE2020)},
+  pages = {56--60},
+  title = {Acoustic scene classification in {DCASE} 2020 Challenge: generalization across devices and low complexity solutions},
+  url = {https://arxiv.org/abs/2005.14623},
+  year = {2020},
+}
+
 @dataset{heittola_2022_6337421,
   author = {Toni Heittola and Annamaria Mesaros and Tuomas Virtanen},
   publisher = {Zenodo},


### PR DESCRIPTION
Adds `TAUAcousticScenes2022MobileClustering`, the unsupervised counterpart to the TAU classification task already in `mteb`. Closes #5019. Part of #4842.

## Gap

`mteb` already scores this dataset with labels through `TAUAcousticScenes2022Mobile` (`a2c`, accuracy). This asks whether audio embeddings separate urban acoustic environments **with no labels at all**, which is what the issue proposes to complete coverage.

Same stratified subsample of the `evaluation_setup` subset at the **same pinned revision** as the classification task, so the supervised and unsupervised numbers are directly comparable.

## Dataset

`mteb/tau-acoustic-scenes-2022-mobile-mini` at `d0da0ed8`, already hosted in the `mteb` org, so nothing new is redistributed and no build script is needed.

**On licence:** set to `not specified`, matching the already merged `TAUAcousticScenes2022Mobile` on this same revision. The HF card declares none, and Zenodo lists the source as "Other (Non-Commercial)", which is not one of the values `Licenses` allows. Flagging it rather than leaving it implicit.

1-second recordings from 12 European cities on 4 devices, across 10 scenes: airport, bus, metro, metro station, park, public square, shopping mall, street pedestrian, street traffic, tram.

`eval_langs` is `zxx-Zxxx`: environmental recordings, no linguistic content.

## Results

`v_measure` on the test split, 5,000 samples:

| model | v_measure |
|---|---|
| `mteb/baseline-random-encoder` | 0.0049 |
| `laion/clap-htsat-fused` | **0.1680** |

34x the random floor. CLAP does well here because it is trained on audio paired with captions of environmental sound, exactly this domain; the same checkpoint sits at the random floor on speech-transcript retrieval.

## Checklist

- [x] Outlined why this fills a gap
- [x] Tested that it runs with `mteb`
- [x] Two encoders run, see table
- [x] Size considered, full official test split
- [x] `test_metadata.py` and `test_task_quality.py` pass with no exemptions
