### PR TITLE
Enables ANN (flake8-simplify) Ruff Rule

### DIFF
--- a/mteb/leaderboard/benchmark_selector.py
+++ b/mteb/leaderboard/benchmark_selector.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import gradio as gr
 
@@ -18,7 +18,7 @@ def _create_button(
     benchmark: Benchmark,
     state: gr.State,
     label_to_value: dict[str, str],
-    **kwargs,
+    **kwargs: Any,
 ):
     val = benchmark.name
     label = (

--- a/mteb/leaderboard/event_logger/logger.py
+++ b/mteb/leaderboard/event_logger/logger.py
@@ -139,7 +139,7 @@ class EventLogger:
         benchmark: str | None = None,
         filters: dict[str, Any] | None = None,
         properties: dict[str, Any] | None = None,
-        **kwargs,
+        **kwargs: Any,
     ):
         """Log raw event (generic method)
 
@@ -163,7 +163,9 @@ class EventLogger:
 
     # ============ Convenience Methods ============
 
-    def log_page_view(self, session_id: str, benchmark: str | None = None, **kwargs):
+    def log_page_view(
+        self, session_id: str, benchmark: str | None = None, **kwargs: Any
+    ):
         """Log page view event
 
         Args:
@@ -175,7 +177,11 @@ class EventLogger:
         self.log(event)
 
     def log_benchmark_change(
-        self, session_id: str, new_value: str, old_value: str | None = None, **kwargs
+        self,
+        session_id: str,
+        new_value: str,
+        old_value: str | None = None,
+        **kwargs: Any,
     ):
         """Log benchmark change event
 
@@ -199,7 +205,7 @@ class EventLogger:
         old_value: Any = None,
         benchmark: str | None = None,
         filters: dict[str, Any] | None = None,
-        **kwargs,
+        **kwargs: Any,
     ):
         """Log filter change event
 
@@ -229,7 +235,7 @@ class EventLogger:
         new_table: str,
         old_table: str | None = None,
         benchmark: str | None = None,
-        **kwargs,
+        **kwargs: Any,
     ):
         """Log table switch event
 
@@ -255,7 +261,7 @@ class EventLogger:
         benchmark: str | None = None,
         file_format: str = "csv",
         row_count: int | None = None,
-        **kwargs,
+        **kwargs: Any,
     ):
         """Log table download event
 

--- a/mteb/leaderboard/event_logger/models/events.py
+++ b/mteb/leaderboard/event_logger/models/events.py
@@ -53,7 +53,7 @@ class BenchmarkChangeEvent(BaseEvent):
         old_value: str | None,
         new_value: str,
         properties: dict[str, Any] | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> BenchmarkChangeEvent:
         """Convenience creation method"""
         merged = {"old_value": old_value, "new_value": new_value}
@@ -90,7 +90,7 @@ class FilterChangeEvent(BaseEvent):
         benchmark: str | None = None,
         filters: dict[str, Any] | None = None,
         properties: dict[str, Any] | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> FilterChangeEvent:
         """Convenience creation method"""
         merged = {
@@ -129,7 +129,7 @@ class TableSwitchEvent(BaseEvent):
         new_table: str,
         benchmark: str | None = None,
         properties: dict[str, Any] | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> TableSwitchEvent:
         """Convenience creation method"""
         merged = {"old_table": old_table, "new_table": new_table}
@@ -163,7 +163,7 @@ class TableDownloadEvent(BaseEvent):
         file_format: str = "csv",
         row_count: int | None = None,
         properties: dict[str, Any] | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> TableDownloadEvent:
         """Convenience creation method"""
         merged = {"format": file_format}

--- a/mteb/leaderboard/figures.py
+++ b/mteb/leaderboard/figures.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from typing import get_args
+from typing import Any, get_args
 
 import numpy as np
 import pandas as pd
@@ -29,7 +29,7 @@ def _failsafe_plot(fun):
          A text plot with the error message if an exception occurs.
     """
 
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: Any, **kwargs: Any):
         t0 = time.time()
         try:
             result = fun(*args, **kwargs)

--- a/mteb/mocks/mock_tasks/bitext_mining.py
+++ b/mteb/mocks/mock_tasks/bitext_mining.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import Dataset, DatasetDict
 
 from mteb.abstasks.task_metadata import TaskMetadata
@@ -62,7 +64,7 @@ class MockBitextMiningTask(AbsTaskBitextMining):
         **general_args,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         sentence1 = ["This is a test sentence", "This is another test sentence"]
         sentence2 = [
             "dette er en test sætning",
@@ -153,7 +155,7 @@ class MockMultilingualBitextMiningTask(AbsTaskBitextMining):
     )
     metadata.eval_langs = multilingual_eval_langs
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         sentence1 = ["This is a test sentence", "This is another test sentence"]
         sentence2 = [
             "dette er en test sætning",
@@ -251,7 +253,7 @@ class MockMultilingualParallelBitextMiningTask(AbsTaskBitextMining):
         "fra_Latn-eng_Latn": ["eng-Latn", "fra-Latn"],
     }
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         sentence1 = ["This is a test sentence", "This is another test sentence"]
         sentence2 = [
             "dette er en test sætning",

--- a/mteb/mocks/mock_tasks/classification.py
+++ b/mteb/mocks/mock_tasks/classification.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import Audio, Dataset, DatasetDict
 from sklearn.linear_model import LogisticRegression
 
@@ -97,7 +99,7 @@ class MockClassificationTask(AbsTaskClassification):
         **general_args,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         train_texts = ["This is a test sentence", "This is another train sentence"]
         test_texts = ["This is a test sentence", "This is another test sentence"]
 
@@ -266,7 +268,7 @@ class MockMultilingualClassificationTask(AbsTaskClassification):
     )
     metadata.eval_langs = multilingual_eval_langs
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         train_texts = ["This is a test sentence", "This is another train sentence"]
         test_texts = ["This is a test sentence", "This is another test sentence"]
         labels = [0, 1]
@@ -347,7 +349,7 @@ class MockMultilabelClassification(AbsTaskMultilabelClassification):
         **general_args,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         train_texts = ["This is a test sentence", "This is another train sentence"] * 3
         test_texts = ["This is a test sentence", "This is another test sentence"] * 3
         labels = [[0, 1], [1, 0]] * 3
@@ -513,7 +515,7 @@ class MockMultilingualMultilabelClassification(AbsTaskMultilabelClassification):
     )
     metadata.eval_langs = multilingual_eval_langs
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         train_texts = ["This is a test sentence", "This is another train sentence"] * 3
         test_texts = ["This is a test sentence", "This is another test sentence"] * 3
         labels = [[0, 1], [1, 0]] * 3
@@ -604,7 +606,7 @@ class MockImageClassificationTask(AbsTaskClassification):
     samples_per_label = 5
     input_column_name = "image"
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         images = create_mock_images(self.np_rng)
         labels = [1, 0]
 
@@ -786,7 +788,7 @@ class MockMultilingualImageClassificationTask(AbsTaskClassification):
     metadata.eval_langs = multilingual_eval_langs
     input_column_name = "image"
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         images = create_mock_images(self.np_rng)
         labels = [1, 0]
         data = {
@@ -885,7 +887,7 @@ class MockImageMultilabelClassificationTask(AbsTaskMultilabelClassification):
     samples_per_label = 3
     input_column_name = "image"
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         images = create_mock_images(self.np_rng)
         labels = [["0", "3"], ["1", "2"]]
 
@@ -967,7 +969,7 @@ class MockAudioMultilabelClassificationTask(AbsTaskMultilabelClassification):
     metadata.modalities = ["audio"]
     input_column_name = "audio"
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         mock_audio = create_mock_audio(self.np_rng)
         labels = [[0], [1]]
 
@@ -1041,7 +1043,7 @@ class MockAudioClassification(AbsTaskClassification):
         },
     }
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         sampling_rates = [16000, 8000]
         mock_audio = [
             {
@@ -1109,7 +1111,7 @@ class MockAudioClassificationCrossVal(AbsTaskClassification):
         }
     }
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         mock_audio = create_mock_audio(self.np_rng)
 
         self.dataset = DatasetDict(
@@ -1208,7 +1210,7 @@ class MockVideoClassification(AbsTaskClassification):
         },
     }
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         from datasets import Video
 
         mock_videos = create_mock_video_bytes(self.np_rng)
@@ -1331,7 +1333,7 @@ class MockVideoAudioClassification(AbsTaskClassification):
         },
     }
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         from datasets import Video
 
         mock_videos = create_mock_video_bytes(self.np_rng)
@@ -1442,7 +1444,7 @@ class MockVideoMultilabelClassificationTask(AbsTaskMultilabelClassification):
     metadata.category = "v2c"
     input_column_name = "video"
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         from datasets import Video
 
         mock_videos = create_mock_video_bytes(self.np_rng)
@@ -1559,7 +1561,7 @@ class MockVideoAudioMultilabelClassificationTask(AbsTaskMultilabelClassification
     metadata.category = "va2c"
     input_column_name = ("video", "audio")
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         from datasets import Video
 
         mock_videos = create_mock_video_bytes(self.np_rng)

--- a/mteb/mocks/mock_tasks/clustering.py
+++ b/mteb/mocks/mock_tasks/clustering.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import Audio, Dataset, DatasetDict
 
 from mteb.abstasks.clustering import AbsTaskClustering
@@ -70,7 +72,7 @@ class MockClusteringTask(AbsTaskClusteringLegacy):
         **general_args,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         sentences = [
             [
                 "This is a test sentence",
@@ -175,7 +177,7 @@ class MockMultilingualClusteringTask(AbsTaskClusteringLegacy):
     )
     metadata.eval_langs = multilingual_eval_langs
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         sentences = [
             [
                 "This is a test sentence",
@@ -237,7 +239,7 @@ class LegacyMockClusteringFastTask(AbsTaskClustering):
         **general_args,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         sentences = [
             "This is a test sentence",
             "This is another test sentence",
@@ -343,7 +345,7 @@ class MockMultilingualClusteringFastTask(AbsTaskClustering):
     )
     metadata.eval_langs = multilingual_eval_langs
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         sentences = [
             "This is a test sentence",
             "This is another test sentence",
@@ -404,7 +406,7 @@ class MockImageClusteringTask(AbsTaskClusteringLegacy):
     input_column_name = "image"
     label_column_name = "label"
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         images = create_mock_images(self.np_rng)
         labels = [1, 0]
 
@@ -459,7 +461,7 @@ class MockImageClusteringFastTask(AbsTaskClustering):
     max_fraction_of_documents_to_embed = None
     max_document_to_embed = 2
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         images = create_mock_images(self.np_rng)
         labels = [1, 0]
 
@@ -514,7 +516,7 @@ class MockAudioClusteringTask(AbsTaskClustering):
     )
     metadata.modalities = ["audio"]
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         mock_audio = create_mock_audio(self.np_rng, n=3)
 
         labels = [0, 1, 2]
@@ -583,7 +585,7 @@ class MockVideoClusteringTask(AbsTaskClustering):
     metadata.modalities = ["video"]
     metadata.category = "v2c"
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         from datasets import Video
 
         mock_videos = create_mock_video_bytes(self.np_rng, n=3)
@@ -661,7 +663,7 @@ class MockVideoAudioClusteringTask(AbsTaskClustering):
     metadata.modalities = ["video", "audio"]
     metadata.category = "va2c"
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         from datasets import Video
 
         mock_videos = create_mock_video_bytes(self.np_rng, n=3)

--- a/mteb/mocks/mock_tasks/pair_classification.py
+++ b/mteb/mocks/mock_tasks/pair_classification.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import Audio, Dataset, DatasetDict
 
 from mteb.abstasks.image.image_text_pair_classification import (
@@ -85,7 +87,7 @@ class MockPairClassificationTask(AbsTaskPairClassification):
         **general_args,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         sentence1 = ["This is a test sentence", "This is another test sentence"]
         sentence2 = [
             "dette er en test sætning",
@@ -217,7 +219,7 @@ class MockMultilingualPairClassificationTask(AbsTaskPairClassification):
     )
     metadata.eval_langs = multilingual_eval_langs
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         sentence1 = ["This is a test sentence", "This is another test sentence"]
         sentence2 = [
             "dette er en test sætning",
@@ -296,7 +298,7 @@ class MockPairImageClassificationTask(AbsTaskPairClassification):
     input1_column_name = "image1"
     input2_column_name = "image2"
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         images1 = create_mock_images(self.np_rng)
         images2 = create_mock_images(self.np_rng)
 
@@ -348,7 +350,7 @@ class MockImageTextPairClassificationTask(AbsTaskImageTextPairClassification):
     metadata.modalities = ["image", "text"]
     metadata.category = "i2t"
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         images = create_mock_images(self.np_rng)
         texts = ["This is a test sentence", "This is another test sentence"]
 
@@ -441,7 +443,7 @@ class MockMultilingualImageTextPairClassificationTask(
 
     metadata.eval_langs = multilingual_eval_langs
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         images = create_mock_images(self.np_rng)
         texts = ["This is a test sentence", "This is another test sentence"]
         data = {
@@ -515,7 +517,7 @@ class MockAudioPairClassification(AbsTaskPairClassification):
     input2_column_name = "audio1"
     label_column_name = "label"
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         mock_audio = create_mock_audio(self.np_rng)
 
         self.dataset = DatasetDict(
@@ -609,7 +611,7 @@ class MockVideoPairClassificationTask(AbsTaskPairClassification):
     input2_column_name = "video2"
     label_column_name = "label"
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         from datasets import Video
 
         mock_videos = create_mock_video_bytes(self.np_rng)
@@ -721,7 +723,7 @@ class MockVideoAudioPairClassificationTask(AbsTaskPairClassification):
         }
     }
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         from datasets import Video
 
         mock_videos = create_mock_video_bytes(self.np_rng)
@@ -816,7 +818,7 @@ class MockAsymVideoAudioPairClassificationTask(AbsTaskPairClassification):
         }
     }
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         from datasets import Video
 
         mock_videos = create_mock_video_bytes(self.np_rng)
@@ -907,7 +909,7 @@ class MockAsymVideoAudioPairClassificationTaskV2(AbsTaskPairClassification):
         }
     }
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         from datasets import Video
 
         mock_videos = create_mock_video_bytes(self.np_rng)
@@ -998,7 +1000,7 @@ class MockSymCustomVideoAudioPairClassificationTaskV2(AbsTaskPairClassification)
         }
     }
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         from datasets import Video
 
         mock_videos = create_mock_video_bytes(self.np_rng)
@@ -1072,7 +1074,7 @@ class MockAsymCustomTextImagePairClassificationTaskV2(AbsTaskPairClassification)
         }
     }
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         from datasets import Image
 
         mock_text = ["text 1", "text 2"]

--- a/mteb/mocks/mock_tasks/regression.py
+++ b/mteb/mocks/mock_tasks/regression.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import Dataset, DatasetDict
 
 from mteb.abstasks.regression import AbsTaskRegression
@@ -72,7 +74,7 @@ class MockRegressionTask(AbsTaskRegression):
         **general_args,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         train_texts = ["This is a test sentence", "This is another train sentence"]
         test_texts = ["This is a test sentence", "This is another test sentence"]
         train_values = [1.0, 0.0]
@@ -145,7 +147,7 @@ class MockImageRegressionTask(AbsTaskRegression):
     metadata.category = "i2c"
     input_column_name = "image"
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         train_images = create_mock_images(self.np_rng)
         test_images = create_mock_images(self.np_rng)
 

--- a/mteb/mocks/mock_tasks/reranking.py
+++ b/mteb/mocks/mock_tasks/reranking.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import Audio, Dataset
 
 from mteb.abstasks.aggregate_task_metadata import AggregateTaskMetadata
@@ -96,7 +98,7 @@ class MockRerankingTask(AbsTaskRetrieval):
         **general_args,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         base_datasplit = base_retrieval_datasplit()
 
         self.dataset = {"default": {"test": base_datasplit}}
@@ -240,7 +242,7 @@ class MockMultilingualRerankingTask(AbsTaskRetrieval):
     )
     metadata.eval_langs = multilingual_eval_langs
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         base_datasplit = base_retrieval_datasplit()
         self.dataset = {
             "eng": {"test": base_datasplit},
@@ -301,7 +303,7 @@ class MockInstructionReranking(AbsTaskRetrieval):
         **general_args,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         base_datasplit = instruction_retrieval_datasplit()
         self.dataset = {"default": {"test": base_datasplit}}
         self.data_loaded = True
@@ -444,7 +446,7 @@ class MockMultilingualInstructionReranking(AbsTaskRetrieval):
     )
     metadata.eval_langs = multilingual_eval_langs
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         base_datasplit = instruction_retrieval_datasplit()
         self.dataset = {
             "eng": {"test": base_datasplit, "val": base_datasplit},
@@ -511,7 +513,7 @@ class MockAudioReranking(AbsTaskRetrieval):
         }
     }
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         mock_audio = create_mock_audio(self.np_rng)
 
         queries = Dataset.from_dict(

--- a/mteb/mocks/mock_tasks/retrieval.py
+++ b/mteb/mocks/mock_tasks/retrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import Audio, Dataset, DatasetDict
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -186,7 +188,7 @@ class MockRetrievalTask(AbsTaskRetrieval):
         **dict(general_args | {"eval_splits": ["val", "test"]}),
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         base_datasplit = base_retrieval_datasplit()
 
         base_datasplit["top_ranked"] = None
@@ -277,7 +279,7 @@ class MockRetrievalDialogTask(AbsTaskRetrieval):
         **dict(general_args | {"eval_splits": ["val", "test"]}),
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         base_datasplit = base_retrieval_datasplit()
 
         base_datasplit["top_ranked"] = None
@@ -535,7 +537,7 @@ class MockMultilingualRetrievalTask(AbsTaskRetrieval):
     )
     metadata.eval_langs = multilingual_eval_langs
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         base_datasplit = base_retrieval_datasplit()
 
         base_datasplit["top_ranked"] = None
@@ -593,7 +595,7 @@ class MockInstructionRetrieval(AbsTaskRetrieval):
         **general_args,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         base_datasplit = instruction_retrieval_datasplit()
         base_datasplit["top_ranked"] = None
 
@@ -723,7 +725,7 @@ class MockMultilingualInstructionRetrieval(AbsTaskRetrieval):
     )
     metadata.eval_langs = multilingual_eval_langs
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         base_datasplit = instruction_retrieval_datasplit()
         base_datasplit["top_ranked"] = None
         self.dataset = {
@@ -797,7 +799,7 @@ class MockMultiChoiceTask(AbsTaskRetrieval):
     metadata.modalities = ["image", "text"]
     metadata.category = "it2i"
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         images = create_mock_images(self.np_rng)
         retrieval_split_data = RetrievalSplitData(
             queries=Dataset.from_dict(
@@ -997,7 +999,7 @@ class MockMultilingualMultiChoiceTask(AbsTaskRetrieval):
     metadata.modalities = ["image", "text"]
     metadata.category = "it2i"
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         images = create_mock_images(self.np_rng)
 
         split_data = RetrievalSplitData(
@@ -1089,7 +1091,7 @@ class MockAny2AnyRetrievalI2TTask(AbsTaskRetrieval):
     metadata.modalities = ["image", "text"]
     metadata.category = "i2t"
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         images = create_mock_images(self.np_rng)
 
         retrieval_split_data = RetrievalSplitData(
@@ -1168,7 +1170,7 @@ class MockAny2AnyRetrievalT2ITask(AbsTaskRetrieval):
     metadata.modalities = ["image", "text"]
     metadata.category = "t2i"
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         images = create_mock_images(self.np_rng)
 
         retrieval_split_data = RetrievalSplitData(
@@ -1247,7 +1249,7 @@ class MockAny2AnyRetrievalT2ATask(AbsTaskRetrieval):
         }
     }
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         mock_audio = create_mock_audio(self.np_rng)
 
         self.queries = DatasetDict(
@@ -1337,7 +1339,7 @@ class MockAny2AnyRetrievalA2TTask(AbsTaskRetrieval):
         }
     }
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         mock_audio = create_mock_audio(self.np_rng)
 
         self.queries = DatasetDict(
@@ -1428,7 +1430,7 @@ class MockAny2AnyRetrievalA2ATask(AbsTaskRetrieval):
         }
     }
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         mock_audio = create_mock_audio(self.np_rng)
 
         self.queries = DatasetDict(
@@ -1530,7 +1532,7 @@ class MockVideoRetrievalV2T(AbsTaskRetrieval):
         }
     }
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         from datasets import Video
 
         mock_videos = create_mock_video_bytes(self.np_rng)
@@ -1633,7 +1635,7 @@ class MockVideoRetrievalT2V(AbsTaskRetrieval):
         }
     }
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         from datasets import Video
 
         mock_videos = create_mock_video_bytes(self.np_rng)
@@ -1744,7 +1746,7 @@ class MockVideoAudioRetrievalVA2T(AbsTaskRetrieval):
         }
     }
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         from datasets import Video
 
         mock_videos = create_mock_video_bytes(self.np_rng)
@@ -1858,7 +1860,7 @@ class MockVideoAudioRetrievalT2VA(AbsTaskRetrieval):
         }
     }
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         from datasets import Video
 
         mock_videos = create_mock_video_bytes(self.np_rng)
@@ -1978,7 +1980,7 @@ class MockVideoAudioTextRetrievalVAT2T(AbsTaskRetrieval):
         }
     }
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         from datasets import Video
 
         mock_videos = create_mock_video_bytes(self.np_rng)

--- a/mteb/mocks/mock_tasks/sts.py
+++ b/mteb/mocks/mock_tasks/sts.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import datasets
 from datasets import Audio, Dataset, DatasetDict
 
@@ -77,7 +79,7 @@ class MockSTSTask(AbsTaskSTS):
         **general_args,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         sentence1 = ["This is a test sentence", "This is another test sentence"]
         sentence2 = [
             "dette er en test sætning",
@@ -202,7 +204,7 @@ class MockMultilingualSTSTask(AbsTaskSTS):
     )
     metadata.eval_langs = multilingual_eval_langs
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         sentence1 = ["This is a test sentence", "This is another test sentence"]
         sentence2 = [
             "dette er en test sætning",
@@ -272,7 +274,7 @@ class MockVisualSTSTask(AbsTaskSTS):
     metadata.modalities = ["image"]
     metadata.category = "i2i"
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         images = create_mock_images(self.np_rng)
         scores = [0.5, 0.5]
 
@@ -377,7 +379,7 @@ class MockVideoAudioSTSTask(AbsTaskSTS):
         }
     }
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         from datasets import Video
 
         mock_videos = create_mock_video_bytes(self.np_rng)
@@ -467,7 +469,7 @@ class MockSymCustomVideoAudiSTSTask(AbsTaskSTS):
         }
     }
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         from datasets import Video
 
         mock_videos = create_mock_video_bytes(self.np_rng)

--- a/mteb/mocks/mock_tasks/summarization.py
+++ b/mteb/mocks/mock_tasks/summarization.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import Dataset, DatasetDict
 
 from mteb.abstasks.task_metadata import TaskMetadata
@@ -69,7 +71,7 @@ class MockSummarizationTask(AbsTaskSummarization):
         **general_args,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         texts = ["This is a test sentence", "This is another test sentence"]
         human_summaries = [
             ["This is a summary", "This is another summary"],
@@ -199,7 +201,7 @@ class MockMultilingualSummarizationTask(AbsTaskSummarization):
     )
     metadata.eval_langs = multilingual_eval_langs
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         texts = ["This is a test sentence", "This is another test sentence"]
         human_summaries = [
             ["This is a summary", "This is another summary"],

--- a/mteb/mocks/mock_tasks/zeroshot_classification.py
+++ b/mteb/mocks/mock_tasks/zeroshot_classification.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 from datasets import Audio, Dataset, DatasetDict
 
@@ -78,7 +80,7 @@ class MockZeroShotClassificationTask(AbsTaskZeroShotClassification):
     metadata.modalities = ["image", "text"]
     metadata.category = "i2t"
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         images = create_mock_images(self.np_rng)
         labels = [0, 1]
 
@@ -142,7 +144,7 @@ class MockTextZeroShotClassificationTask(AbsTaskZeroShotClassification):
     metadata.category = "t2t"
     input_column_name = "text"
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         texts = ["This is a test sentence", "This is another test sentence"]
         # String labels matching `get_candidate_labels` cover the string-label
         # code path; they are mapped to candidate indices during evaluation.
@@ -208,7 +210,7 @@ class MockAudioZeroshotClassificationTask(AbsTaskZeroShotClassification):
     )
     metadata.modalities = ["audio", "text"]
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         mock_audio = create_mock_audio(self.np_rng)
         labels = np.array([0, 1])  # Convert labels to numpy array
 
@@ -286,7 +288,7 @@ class MockVideoZeroshotClassificationTask(AbsTaskZeroShotClassification):
     metadata.modalities = ["video", "text"]
     metadata.category = "v2c"
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         from datasets import Video
 
         mock_videos = create_mock_video_bytes(self.np_rng)
@@ -373,7 +375,7 @@ class MockVideoAudioZeroshotClassificationTask(AbsTaskZeroShotClassification):
     metadata.modalities = ["video", "audio", "text"]
     metadata.category = "va2c"
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         from datasets import Video
 
         mock_videos = create_mock_video_bytes(self.np_rng)

--- a/mteb/models/model_implementations/align_models.py
+++ b/mteb/models/model_implementations/align_models.py
@@ -35,7 +35,7 @@ class ALIGNModel(AbsEncoder):
         self,
         texts: DataLoader[BatchedInput],
         show_progress_bar: bool = True,
-        **kwargs,
+        **kwargs: Any,
     ):
         all_text_embeddings = []
 
@@ -62,7 +62,7 @@ class ALIGNModel(AbsEncoder):
         self,
         images: DataLoader[BatchedInput],
         show_progress_bar: bool = True,
-        **kwargs,
+        **kwargs: Any,
     ):
         all_image_embeddings = []
         with torch.no_grad():

--- a/mteb/models/model_implementations/bb25.py
+++ b/mteb/models/model_implementations/bb25.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -52,7 +52,7 @@ def _composite_prior(
     return np.clip(prior, 0.1, 0.9)
 
 
-def bb25_loader(model_name, **kwargs) -> SearchProtocol:
+def bb25_loader(model_name, **kwargs: Any) -> SearchProtocol:
     import bm25s
     import Stemmer
 
@@ -93,7 +93,7 @@ def bb25_loader(model_name, **kwargs) -> SearchProtocol:
             b: float = 0.75,
             alpha: float = 1.0,
             prior_weight: float = 0.0,
-            **kwargs,
+            **kwargs: Any,
         ):
             self.k1 = k1
             self.b = b

--- a/mteb/models/model_implementations/bedrock_models.py
+++ b/mteb/models/model_implementations/bedrock_models.py
@@ -65,7 +65,7 @@ class BedrockModel(AbsEncoder):
         provider: str,
         max_tokens: int,
         model_prompts: dict[str, str] | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         self._client = get_bedrock_runtime_client()
 

--- a/mteb/models/model_implementations/blip2_models.py
+++ b/mteb/models/model_implementations/blip2_models.py
@@ -22,7 +22,7 @@ BLIP2_CITATION = """@inproceedings{li2023blip2,
 }"""
 
 
-def blip2_loader(model_name, **kwargs):
+def blip2_loader(model_name, **kwargs: Any):
     from lavis.models.blip2_models.blip2_image_text_matching import (
         Blip2ITM,
     )

--- a/mteb/models/model_implementations/bm25.py
+++ b/mteb/models/model_implementations/bm25.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import unicodedata
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from mteb._create_dataloaders import _combine_queries_with_instruction_text
 from mteb.models.model_meta import ModelMeta
@@ -333,7 +333,7 @@ class BM25Search:
         b: float = 0.75,
         delta: float = 0.5,
         method: Literal["robertson", "lucene", "atire"] = "lucene",
-        **kwargs,
+        **kwargs: Any,
     ):
         """
         Args:
@@ -475,7 +475,7 @@ class BM25Search:
         return results
 
 
-def bm25_loader(model_name, **kwargs) -> SearchProtocol:
+def bm25_loader(model_name, **kwargs: Any) -> SearchProtocol:
     return BM25Search(**kwargs)
 
 

--- a/mteb/models/model_implementations/cde_models.py
+++ b/mteb/models/model_implementations/cde_models.py
@@ -58,7 +58,7 @@ class CDEWrapper(SentenceTransformerEncoderWrapper):
         model: str,
         revision: str | None = None,
         device: str | None = None,
-        *args,
+        *args: Any,
         **kwargs: Any,
     ) -> None:
         from transformers import AutoConfig

--- a/mteb/models/model_implementations/cohere_models.py
+++ b/mteb/models/model_implementations/cohere_models.py
@@ -175,7 +175,7 @@ def retry_with_rate_limit(
 
     def decorator(func):
         @wraps(func)
-        def wrapper(self, *args, **kwargs):
+        def wrapper(self, *args: Any, **kwargs: Any):
             import cohere
 
             nonlocal previous_call_ts
@@ -230,7 +230,7 @@ class CohereTextEmbeddingModel(AbsEncoder):
         model_prompts: dict[str, str] | None = None,
         embedding_type: EmbeddingType = "float",
         output_dimension: int | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         import cohere
 
@@ -247,7 +247,7 @@ class CohereTextEmbeddingModel(AbsEncoder):
         self._client = cohere.Client()
 
     @retry_with_rate_limit(max_retries=5, max_rpm=300)
-    def _embed_func(self, **kwargs):
+    def _embed_func(self, **kwargs: Any):
         """Call Cohere embed API with retry and rate limiting."""
         return self._client.embed(**kwargs)
 

--- a/mteb/models/model_implementations/cohere_v.py
+++ b/mteb/models/model_implementations/cohere_v.py
@@ -179,7 +179,7 @@ OUTPUT_TYPES = [
 ]
 
 
-def cohere_v_loader(model_name, **kwargs):
+def cohere_v_loader(model_name, **kwargs: Any):
     import cohere
 
     class CohereMultiModalModelWrapper(AbsEncoder):
@@ -213,7 +213,7 @@ def cohere_v_loader(model_name, **kwargs):
             self.transform = transforms.Compose([transforms.PILToTensor()])
 
         @retry_with_rate_limit(max_retries=5, max_rpm=300)
-        def _embed_func(self, **kwargs):
+        def _embed_func(self, **kwargs: Any):
             """Call Cohere embed API with retry and rate limiting."""
             return self.client.embed(**kwargs)
 

--- a/mteb/models/model_implementations/colpali_models.py
+++ b/mteb/models/model_implementations/colpali_models.py
@@ -35,7 +35,7 @@ class ColPaliEngineWrapper(AbsEncoder):
         revision: str | None = None,
         device: str | None = None,
         query_prefix: str | None = None,
-        **kwargs,
+        **kwargs: Any,
     ):
         self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
 
@@ -90,7 +90,7 @@ class ColPaliEngineWrapper(AbsEncoder):
         self,
         images,
         batch_size: int = 32,
-        **kwargs,
+        **kwargs: Any,
     ):
         import torchvision.transforms.functional as F
         from PIL import Image
@@ -120,7 +120,7 @@ class ColPaliEngineWrapper(AbsEncoder):
         self,
         texts,
         batch_size: int = 32,
-        **kwargs,
+        **kwargs: Any,
     ):
         all_embeds = []
         with torch.no_grad():
@@ -169,7 +169,7 @@ class ColPaliWrapper(ColPaliEngineWrapper):
         revision: str | None = None,
         device: str | None = None,
         query_prefix: str = "Query: ",
-        **kwargs,
+        **kwargs: Any,
     ):
         from colpali_engine.models import ColPali, ColPaliProcessor
 

--- a/mteb/models/model_implementations/colqwen_models.py
+++ b/mteb/models/model_implementations/colqwen_models.py
@@ -34,7 +34,7 @@ class ColQwen2Wrapper(ColPaliEngineWrapper):
         revision: str | None = None,
         device: str | None = None,
         query_prefix: str = "Query: ",
-        **kwargs,
+        **kwargs: Any,
     ):
         from colpali_engine.models import ColQwen2, ColQwen2Processor
 
@@ -59,7 +59,7 @@ class ColQwen2_5Wrapper(ColPaliEngineWrapper):  # noqa: N801
         device: str | None = None,
         attn_implementation: str | None = None,
         query_prefix: str = "Query: ",
-        **kwargs,
+        **kwargs: Any,
     ):
         from colpali_engine.models import ColQwen2_5, ColQwen2_5_Processor
         from transformers.utils.import_utils import is_flash_attn_2_available
@@ -88,7 +88,7 @@ class ColQwen3_5Wrapper(AbsEncoder):  # noqa: N801
         model_name: str = "athrael-soju/colqwen3.5-4.5B-v3",
         revision: str | None = None,
         device: str | None = None,
-        **kwargs,
+        **kwargs: Any,
     ):
         from colpali_engine.models import ColQwen3_5, ColQwen3_5Processor
 
@@ -332,7 +332,7 @@ class ColQwen2_5OmniWrapper(ColPaliEngineWrapper):  # noqa: N801
         max_frames: int | None = 64,
         num_frames: int | None = None,
         max_audio_length: int | None = None,
-        **kwargs,
+        **kwargs: Any,
     ):
         from colpali_engine.models import ColQwen2_5Omni, ColQwen2_5OmniProcessor
 
@@ -411,7 +411,7 @@ class ColQwen2_5OmniWrapper(ColPaliEngineWrapper):  # noqa: N801
             all_embeds, batch_first=True, padding_value=0
         )
 
-    def get_audio_embeddings(self, audios, batch_size: int = 32, **kwargs):
+    def get_audio_embeddings(self, audios, batch_size: int = 32, **kwargs: Any):
         def _process(audio):
             arr = audio["array"] if isinstance(audio, dict) else audio
             if isinstance(arr, torch.Tensor):
@@ -420,7 +420,7 @@ class ColQwen2_5OmniWrapper(ColPaliEngineWrapper):  # noqa: N801
 
         return self._encode_batches(audios, "audio", _process, "Encoding audio")
 
-    def get_video_embeddings(self, videos, batch_size: int = 32, **kwargs):
+    def get_video_embeddings(self, videos, batch_size: int = 32, **kwargs: Any):
         def _process(clip):
             return self.processor.process_videos([clip])
 
@@ -754,7 +754,7 @@ class ColQwen3EngineWrapper(ColPaliEngineWrapper):
         model_name: str = "Verm1ion/ColTurk-VDR-Qwen3VL-4B-v1.0",
         revision: str | None = None,
         device: str | None = None,
-        **kwargs,
+        **kwargs: Any,
     ):
         from colpali_engine.models import ColQwen3, ColQwen3Processor
 

--- a/mteb/models/model_implementations/colsmol_models.py
+++ b/mteb/models/model_implementations/colsmol_models.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 import torch
 
@@ -23,7 +24,7 @@ class ColSmolWrapper(ColPaliEngineWrapper):
         device: str | None = None,
         attn_implementation: str | None = None,
         query_prefix: str = "Query: ",
-        **kwargs,
+        **kwargs: Any,
     ):
         from colpali_engine.models import ColIdefics3, ColIdefics3Processor
         from transformers.utils.import_utils import is_flash_attn_2_available

--- a/mteb/models/model_implementations/conan_models.py
+++ b/mteb/models/model_implementations/conan_models.py
@@ -59,7 +59,7 @@ class RateLimiter:
             time.sleep(sleep_time)
         self.last_request_time = time.time()
 
-    def execute_with_retry(self, func, *args, **kwargs):
+    def execute_with_retry(self, func, *args: Any, **kwargs: Any):
         """Execute a function with retry logic
 
         Args:
@@ -159,7 +159,7 @@ class ConanWrapper(AbsEncoder):
         model_name: str,
         revision: str | None = None,
         api_model_name: str | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         ak = os.getenv("CONAN_AK")
         sk = os.getenv("CONAN_SK")

--- a/mteb/models/model_implementations/eagerworks_models.py
+++ b/mteb/models/model_implementations/eagerworks_models.py
@@ -25,7 +25,7 @@ class EagerEmbedV1Wrapper(AbsEncoder):
         revision: str | None = None,
         device: str | None = None,
         image_size: int = 784,
-        **kwargs,
+        **kwargs: Any,
     ):
         from transformers import AutoProcessor, Qwen3VLForConditionalGeneration
 

--- a/mteb/models/model_implementations/evaclip_models.py
+++ b/mteb/models/model_implementations/evaclip_models.py
@@ -23,7 +23,7 @@ EVA_CLIP_CITATION = """@article{EVA-CLIP,
 }"""
 
 
-def evaclip_loader(model_name, **kwargs):
+def evaclip_loader(model_name, **kwargs: Any):
     try:
         import sys
 

--- a/mteb/models/model_implementations/geevec_models.py
+++ b/mteb/models/model_implementations/geevec_models.py
@@ -272,7 +272,14 @@ PROMPTS_DICT = {
 
 class GeeVecLiteModel(InstructSentenceTransformerModel):
     def encode(
-        self, inputs, *, task_metadata, hf_split, hf_subset, prompt_type=None, **kwargs
+        self,
+        inputs,
+        *,
+        task_metadata,
+        hf_split,
+        hf_subset,
+        prompt_type=None,
+        **kwargs: Any,
     ):
         sentences = [text for batch in inputs for text in batch["text"]]
         domain = _resolve_geevec_domain(task_metadata, hf_subset, kwargs.get("domain"))
@@ -320,7 +327,7 @@ class GeeVecAPIModel(AbsEncoder):
         base_url: str | None = None,
         api_key: str | None = None,
         session: Any | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         import requests
 

--- a/mteb/models/model_implementations/gme_v_models.py
+++ b/mteb/models/model_implementations/gme_v_models.py
@@ -60,7 +60,7 @@ class Encoder(torch.nn.Module):
         image_grid_thw: torch.LongTensor | None = None,
         # video_grid_thw: torch.LongTensor | None = None,
         pooling_mask: torch.LongTensor | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> torch.Tensor:
         if inputs_embeds is None:
             inputs_embeds = self.base.model.embed_tokens(input_ids)
@@ -108,7 +108,7 @@ class Encoder(torch.nn.Module):
         images: list[Image.Image],
         device,
         instruction=None,
-        **kwargs,
+        **kwargs: Any,
     ):
         instruction = instruction or self.default_instruction
         # Inputs must be batched
@@ -149,7 +149,7 @@ class GmeQwen2VL(AbsEncoder):
         min_image_tokens=4,
         max_image_tokens=1280,
         max_length=1800,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         from transformers import AutoModelForVision2Seq, AutoProcessor
 

--- a/mteb/models/model_implementations/google_gemini.py
+++ b/mteb/models/model_implementations/google_gemini.py
@@ -322,7 +322,7 @@ class GoogleGeminiEmbeddingModel(AbsEncoder):
         model_name: str,
         model_prompts: dict[str, str] | None = None,
         embed_dim: int | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         from google import genai
 

--- a/mteb/models/model_implementations/google_text_embedding.py
+++ b/mteb/models/model_implementations/google_text_embedding.py
@@ -64,7 +64,7 @@ class GoogleTextEmbeddingModel(AbsEncoder):
         model_name: str,
         sep: str = " ",
         model_prompts: dict[str, str] | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         self.model_name = model_name
         self.model_prompts = self.validate_task_to_prompt_name(model_prompts)

--- a/mteb/models/model_implementations/granite_vision_embedding_models.py
+++ b/mteb/models/model_implementations/granite_vision_embedding_models.py
@@ -25,7 +25,7 @@ class GraniteVisionEmbeddingWrapper:
         revision: str | None = None,
         device: str | None = None,
         attn_implementation: str | None = None,
-        **kwargs,
+        **kwargs: Any,
     ):
         from transformers import AutoModel, AutoProcessor
         from transformers.utils.import_utils import is_flash_attn_2_available
@@ -60,7 +60,7 @@ class GraniteVisionEmbeddingWrapper:
         images,
         batch_size: int = 16,
         show_progress_bar: bool = True,
-        **kwargs,
+        **kwargs: Any,
     ):
         all_embeds = []
         with torch.no_grad():
@@ -81,7 +81,7 @@ class GraniteVisionEmbeddingWrapper:
         self,
         texts: DataLoader[BatchedInput],
         show_progress_bar: bool = True,
-        **kwargs,
+        **kwargs: Any,
     ):
         all_embeds = []
 

--- a/mteb/models/model_implementations/hybrid_models.py
+++ b/mteb/models/model_implementations/hybrid_models.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import mteb
 from mteb.models.hybrid_wrappers import HybridSearch
 from mteb.models.model_meta import ModelMeta, ScoringFunction
@@ -12,7 +14,7 @@ from .e5_models import (
 from .facebookai import XLMR_LANGUAGES
 
 
-def hybrid_bm25s_e5_loader(model_name: str, **kwargs) -> HybridSearch:
+def hybrid_bm25s_e5_loader(model_name: str, **kwargs: Any) -> HybridSearch:
     bm25 = mteb.get_model("mteb/baseline-bm25s")
     dense = mteb.get_model("intfloat/multilingual-e5-small")
     return HybridSearch(
@@ -47,7 +49,7 @@ hybrid_bm25s_e5_rrf = ModelMeta(
 )
 
 
-def hybrid_bm25s_e5_dbsf_loader(model_name: str, **kwargs) -> HybridSearch:
+def hybrid_bm25s_e5_dbsf_loader(model_name: str, **kwargs: Any) -> HybridSearch:
     bm25 = mteb.get_model("mteb/baseline-bm25s")
     dense = mteb.get_model("intfloat/multilingual-e5-small")
     return HybridSearch(
@@ -82,7 +84,7 @@ hybrid_bm25s_e5_dbsf = ModelMeta(
 )
 
 
-def hybrid_bm25s_e5_rsf_loader(model_name: str, **kwargs) -> HybridSearch:
+def hybrid_bm25s_e5_rsf_loader(model_name: str, **kwargs: Any) -> HybridSearch:
     bm25 = mteb.get_model("mteb/baseline-bm25s")
     dense = mteb.get_model("intfloat/multilingual-e5-small")
     return HybridSearch(

--- a/mteb/models/model_implementations/jina_models.py
+++ b/mteb/models/model_implementations/jina_models.py
@@ -334,7 +334,7 @@ class JinaWrapper(SentenceTransformerEncoderWrapper):
         revision: str,
         device: str | None = None,
         model_prompts: dict[str, str] | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         super().__init__(
             model, revision, device=device, model_prompts=model_prompts, **kwargs
@@ -416,7 +416,7 @@ class JinaV4Wrapper(AbsEncoder):
         trust_remote_code: bool = True,
         model_prompts: dict[str, str] | None = None,
         vector_type: Literal[SUPPORTED_VECTOR_TYPES] = "single_vector",
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         device = device_map or device
 
@@ -754,7 +754,7 @@ class JinaV5TextWrapper(SentenceTransformerEncoderWrapper):
         revision: str,
         device: str | None = None,
         model_prompts: dict[str, str] | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         super().__init__(
             model, revision, device=device, model_prompts=model_prompts, **kwargs

--- a/mteb/models/model_implementations/listconranker.py
+++ b/mteb/models/model_implementations/listconranker.py
@@ -23,7 +23,7 @@ LISTCONRANKER_CITATION = """@article{liu2025listconranker,
 
 
 class ListConRanker(RerankerWrapper):
-    def __init__(self, model_name_or_path: str, **kwargs) -> None:
+    def __init__(self, model_name_or_path: str, **kwargs: Any) -> None:
         from transformers import AutoModelForSequenceClassification, AutoTokenizer
 
         super().__init__(model_name_or_path, **kwargs)

--- a/mteb/models/model_implementations/llm2clip_models.py
+++ b/mteb/models/model_implementations/llm2clip_models.py
@@ -32,7 +32,7 @@ MODEL2PROCESSOR = {
 }
 
 
-def llm2clip_loader(model_name, **kwargs):
+def llm2clip_loader(model_name, **kwargs: Any):
     from llm2vec import LLM2Vec
     from transformers import AutoConfig, AutoModel, AutoTokenizer, CLIPImageProcessor
     from transformers.modeling_outputs import BaseModelOutputWithPooling

--- a/mteb/models/model_implementations/llm2vec_models.py
+++ b/mteb/models/model_implementations/llm2vec_models.py
@@ -61,8 +61,8 @@ class LLM2VecModel(AbsEncoder):
         self,
         model_prompts: dict[str, str] | None = None,
         device: str | None = None,
-        *args,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ):
         model_name = kwargs.get("model_name", "LLM2Vec")
         from llm2vec import LLM2Vec
@@ -107,7 +107,9 @@ class LLM2VecModel(AbsEncoder):
         return self.model.encode(sentences, **kwargs)
 
 
-def _loader(wrapper: type[LLM2VecModel], **kwargs) -> Callable[..., EncoderProtocol]:
+def _loader(
+    wrapper: type[LLM2VecModel], **kwargs: Any
+) -> Callable[..., EncoderProtocol]:
     _kwargs = kwargs
 
     def loader_inner(**kwargs: Any) -> EncoderProtocol:

--- a/mteb/models/model_implementations/moco_models.py
+++ b/mteb/models/model_implementations/moco_models.py
@@ -22,7 +22,7 @@ MOCOV3_CITATION = """@Article{chen2021mocov3,
 }"""
 
 
-def mocov3_loader(model_name, **kwargs):
+def mocov3_loader(model_name, **kwargs: Any):
     import timm
 
     class MOCOv3Model(AbsEncoder):

--- a/mteb/models/model_implementations/model2vec_models.py
+++ b/mteb/models/model_implementations/model2vec_models.py
@@ -140,7 +140,7 @@ class Model2VecModel(AbsEncoder):
     def __init__(
         self,
         model_name: str,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """Wrapper for Model2Vec models.
 

--- a/mteb/models/model_implementations/nomic_multimodal.py
+++ b/mteb/models/model_implementations/nomic_multimodal.py
@@ -50,7 +50,7 @@ class BiQwen2_5Wrapper(AbsEncoder):  # noqa: N801
         revision: str | None = None,
         device: str | None = None,
         base_revision: str | None = None,
-        **kwargs,
+        **kwargs: Any,
     ):
         from colpali_engine.models import BiQwen2_5, BiQwen2_5_Processor
 
@@ -102,7 +102,7 @@ class BiQwen2_5Wrapper(AbsEncoder):  # noqa: N801
         self,
         images,
         batch_size: int = 32,
-        **kwargs,
+        **kwargs: Any,
     ):
         all_embeds = []
 
@@ -122,7 +122,7 @@ class BiQwen2_5Wrapper(AbsEncoder):  # noqa: N801
         self,
         texts,
         batch_size: int = 32,
-        **kwargs,
+        **kwargs: Any,
     ):
         all_embeds = []
         with torch.no_grad():

--- a/mteb/models/model_implementations/nvidia_models.py
+++ b/mteb/models/model_implementations/nvidia_models.py
@@ -748,7 +748,9 @@ nemotron_3_embed_8b_bf16 = ModelMeta(
 )
 
 
-def _nemotron_rerank_model(model: str, revision: str, **kwargs) -> CrossEncoderWrapper:
+def _nemotron_rerank_model(
+    model: str, revision: str, **kwargs: Any
+) -> CrossEncoderWrapper:
     return CrossEncoderWrapper(
         model=model,
         revision=revision,

--- a/mteb/models/model_implementations/nvidia_nemotron_vl_models.py
+++ b/mteb/models/model_implementations/nvidia_nemotron_vl_models.py
@@ -56,7 +56,7 @@ class NemotronColEmbedVL(AbsEncoder):
         device_map="cuda",
         torch_dtype=torch.bfloat16,
         attn_implementation="flash_attention_2",
-        **kwargs,
+        **kwargs: Any,
     ):
         from transformers import AutoModel
 
@@ -69,14 +69,14 @@ class NemotronColEmbedVL(AbsEncoder):
             attn_implementation=attn_implementation,
         ).eval()
 
-    def get_text_embeddings(self, texts, batch_size: int = 32, **kwargs):
+    def get_text_embeddings(self, texts, batch_size: int = 32, **kwargs: Any):
         return self.model.forward_queries(texts, batch_size=batch_size)
 
     def get_image_embeddings(
         self,
         images,
         batch_size: int = 32,
-        **kwargs,
+        **kwargs: Any,
     ):
         import torchvision.transforms.functional as F
         from PIL import Image
@@ -103,8 +103,8 @@ class NemotronColEmbedVL(AbsEncoder):
 
     def get_fused_embeddings(
         self,
-        *args,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ):
         raise NotImplementedError(
             "Fused embeddings are not supported yet. Please use get_text_embeddings or get_image_embeddings."
@@ -331,7 +331,7 @@ class LlamaNemotronEmbedVL(AbsEncoder):
         attn_implementation="flash_attention_2",
         use_image_modality: bool = True,
         use_text_modality: bool = True,
-        **kwargs,
+        **kwargs: Any,
     ):
         self.use_image_modality = use_image_modality
         self.use_text_modality = use_text_modality

--- a/mteb/models/model_implementations/octen_models.py
+++ b/mteb/models/model_implementations/octen_models.py
@@ -361,7 +361,7 @@ class OctenVLEmbeddingModel(AbsEncoder):
         model_name: str,
         model_prompts: dict[str, str] | None = None,
         embed_dim: int | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         from octen import Octen
 

--- a/mteb/models/model_implementations/openai_models.py
+++ b/mteb/models/model_implementations/openai_models.py
@@ -33,7 +33,7 @@ class OpenAIModel(AbsEncoder):
         tokenizer_name: str = "cl100k_base",
         embed_dim: int | None = None,
         client: Any | None = None,  # OpenAI
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """Wrapper for OpenAIs embedding API.
 

--- a/mteb/models/model_implementations/openclip_models.py
+++ b/mteb/models/model_implementations/openclip_models.py
@@ -23,7 +23,7 @@ OPENCLIP_CITATION = """@inproceedings{cherti2023reproducible,
 }"""
 
 
-def openclip_loader(model_name, **kwargs):
+def openclip_loader(model_name, **kwargs: Any):
     import open_clip
 
     class OpenCLIPModel(AbsEncoder):

--- a/mteb/models/model_implementations/ops_colqwen3_models.py
+++ b/mteb/models/model_implementations/ops_colqwen3_models.py
@@ -26,7 +26,7 @@ class OpsColQwen3Wrapper(AbsEncoder):
         device: str | None = None,
         attn_implementation: str | None = None,
         trust_remote_code: bool = True,
-        **kwargs,
+        **kwargs: Any,
     ):
         from transformers.utils.import_utils import is_flash_attn_2_available
 
@@ -90,7 +90,7 @@ class OpsColQwen3Wrapper(AbsEncoder):
         self,
         images: DataLoader,
         batch_size: int = 32,
-        **kwargs,
+        **kwargs: Any,
     ) -> torch.Tensor:
         import torchvision.transforms.functional as F
         from PIL import Image
@@ -120,7 +120,7 @@ class OpsColQwen3Wrapper(AbsEncoder):
         self,
         texts: DataLoader,
         batch_size: int = 32,
-        **kwargs,
+        **kwargs: Any,
     ) -> torch.Tensor:
         all_embeds = []
 

--- a/mteb/models/model_implementations/ops_moa_models.py
+++ b/mteb/models/model_implementations/ops_moa_models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from mteb.models.abs_encoder import AbsEncoder
 from mteb.models.model_meta import ModelMeta
@@ -20,7 +20,7 @@ class OPSWrapper(AbsEncoder):
         )
         self.output_dim = 1536
 
-    def encode(self, sentences: list[str], **kwargs) -> Array:
+    def encode(self, sentences: list[str], **kwargs: Any) -> Array:
         embeddings = self.model.encode(sentences, **kwargs)
         return embeddings[:, : self.output_dim]
 

--- a/mteb/models/model_implementations/promptriever_models.py
+++ b/mteb/models/model_implementations/promptriever_models.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 
 class PromptrieverModel(RepLLaMAModel, AbsEncoder):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
 
     def encode(
@@ -48,7 +48,7 @@ class PromptrieverModel(RepLLaMAModel, AbsEncoder):
 
 
 def _loader(
-    wrapper: type[PromptrieverModel], **kwargs
+    wrapper: type[PromptrieverModel], **kwargs: Any
 ) -> Callable[..., EncoderProtocol]:
     _kwargs = kwargs
 

--- a/mteb/models/model_implementations/pylate_models.py
+++ b/mteb/models/model_implementations/pylate_models.py
@@ -294,7 +294,7 @@ class MultiVectorModel(PylateSearchEncoder):
         index_name: str | None = None,
         index_autodelete: bool = True,
         index_kwargs: dict[str, Any] | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """Wrapper for MultiVector/ColBERT models (via PyLate)."""
         from pylate.models import ColBERT  # type: ignore[import]

--- a/mteb/models/model_implementations/qwen3_models.py
+++ b/mteb/models/model_implementations/qwen3_models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from mteb.models.instruct_wrapper import InstructSentenceTransformerModel
 from mteb.models.model_meta import ModelMeta
@@ -122,7 +122,7 @@ training_data = {
 
 
 def q3e_instruct_loader(
-    model_name_or_path: str, revision: str, **kwargs
+    model_name_or_path: str, revision: str, **kwargs: Any
 ) -> EncoderProtocol:
     model = InstructSentenceTransformerModel(
         model_name_or_path,

--- a/mteb/models/model_implementations/qwen3_reranker.py
+++ b/mteb/models/model_implementations/qwen3_reranker.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import torch
@@ -30,7 +30,7 @@ class Qwen3RerankerWrapper:
         model_name_or_path: str,
         device: str | None = None,
         max_length: int = 8192,
-        **kwargs,
+        **kwargs: Any,
     ):
         self.model_name_or_path = model_name_or_path
         self.device = device or (

--- a/mteb/models/model_implementations/repllama_models.py
+++ b/mteb/models/model_implementations/repllama_models.py
@@ -36,7 +36,7 @@ class RepLLaMAModel(AbsEncoder):
         torch_dtype: torch.dtype,
         device_map: str,
         model_prompts: dict[str, str] | None = None,
-        **kwargs,
+        **kwargs: Any,
     ):
         from peft import PeftModel
         from transformers import AutoModel, AutoTokenizer
@@ -131,7 +131,9 @@ class RepLLaMAModel(AbsEncoder):
         return np.concatenate(all_embeddings, axis=0)
 
 
-def _loader(wrapper: type[RepLLaMAModel], **kwargs) -> Callable[..., EncoderProtocol]:
+def _loader(
+    wrapper: type[RepLLaMAModel], **kwargs: Any
+) -> Callable[..., EncoderProtocol]:
     _kwargs = kwargs
 
     def loader_inner(**kwargs: Any) -> EncoderProtocol:

--- a/mteb/models/model_implementations/rerankers_custom.py
+++ b/mteb/models/model_implementations/rerankers_custom.py
@@ -27,7 +27,7 @@ class RerankerWrapper:
         batch_size: int = 4,
         fp_options: bool | None = None,
         silent: bool = False,
-        **kwargs,
+        **kwargs: Any,
     ):
         self.model_name_or_path = model_name_or_path
         self.batch_size = batch_size
@@ -53,7 +53,7 @@ class BGEReranker(RerankerWrapper):
         self,
         model_name_or_path="BAAI/bge-reranker-v2-m3",
         torch_compile=False,
-        **kwargs,
+        **kwargs: Any,
     ):
         super().__init__(model_name_or_path, **kwargs)
         if not self.device:
@@ -109,7 +109,7 @@ class JinaReranker(RerankerWrapper):
         self,
         model_name_or_path="jinaai/jina-reranker-v2-base-multilingual",
         torch_compile=False,
-        **kwargs,
+        **kwargs: Any,
     ):
         from sentence_transformers import CrossEncoder
 

--- a/mteb/models/model_implementations/rerankers_monot5_based.py
+++ b/mteb/models/model_implementations/rerankers_monot5_based.py
@@ -49,7 +49,7 @@ class MonoT5Reranker(RerankerWrapper):
     def __init__(
         self,
         model_name_or_path="castorini/monot5-base-msmarco-10k",
-        **kwargs,
+        **kwargs: Any,
     ):
         super().__init__(model_name_or_path, **kwargs)
         from transformers import (
@@ -161,7 +161,7 @@ class LlamaReranker(RerankerWrapper):
     name: str = "LLAMA-Based"
 
     def __init__(
-        self, model_name_or_path: str, is_classification: bool = False, **kwargs
+        self, model_name_or_path: str, is_classification: bool = False, **kwargs: Any
     ):
         from transformers import AutoModelForCausalLM, AutoTokenizer
 
@@ -281,7 +281,7 @@ Relevant: """
 class MistralReranker(LlamaReranker):
     name: str = "Mistral"
 
-    def __init__(self, model_name_or_path: str, **kwargs):
+    def __init__(self, model_name_or_path: str, **kwargs: Any):
         # use the base class for everything except template
         super().__init__(model_name_or_path, **kwargs)
         self.template = """<s>[INST] You are an expert Google searcher, whose job is to determine if the following document is relevant to the query (true/false).
@@ -296,7 +296,7 @@ Relevant (either "true" or "false"): [/INST]"""
 class FollowIRReranker(LlamaReranker):
     name: str = "FollowIR"
 
-    def __init__(self, model_name_or_path: str, **kwargs):
+    def __init__(self, model_name_or_path: str, **kwargs: Any):
         # use the base class for everything except template
         super().__init__(model_name_or_path, **kwargs)
         self.template = """<s> [INST] You are an expert Google searcher, whose job is to determine if the following document is relevant to the query (true/false). Answer using only one word, one of those two choices.
@@ -314,7 +314,7 @@ class FLANT5Reranker(MonoT5Reranker):
 Query: {query}
 Passage: {text}"""
 
-    def get_prediction_tokens(self, *args, **kwargs):
+    def get_prediction_tokens(self, *args: Any, **kwargs: Any):
         yes_token_id, *_ = self.tokenizer.encode("yes")
         no_token_id, *_ = self.tokenizer.encode("no")
         return no_token_id, yes_token_id

--- a/mteb/models/model_implementations/samilpwc_models.py
+++ b/mteb/models/model_implementations/samilpwc_models.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.models.instruct_wrapper import InstructSentenceTransformerModel
 from mteb.models.model_implementations.e5_models import ME5_TRAINING_DATA
 from mteb.models.model_meta import ModelMeta
@@ -28,7 +30,7 @@ def instruction_template(
     return INSTRUCTION.format(instruction=instruction)
 
 
-def instruct_loader(*args, **kwargs):
+def instruct_loader(*args: Any, **kwargs: Any):
     model = InstructSentenceTransformerModel(*args, **kwargs)
     encoder = model.model._first_module()
     if encoder.auto_model.config._attn_implementation == "flash_attention_2":

--- a/mteb/models/model_implementations/seed_1_6_embedding_models.py
+++ b/mteb/models/model_implementations/seed_1_6_embedding_models.py
@@ -159,7 +159,7 @@ class Seed16EmbeddingWrapper(AbsEncoder):
         tokenizer_name: str = "cl100k_base",
         embed_dim: int | None = None,
         available_embed_dims: Sequence[int | None] = (None,),
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """Wrapper for Seed embedding API."""
         import tiktoken

--- a/mteb/models/model_implementations/seed_1_6_embedding_models_1215.py
+++ b/mteb/models/model_implementations/seed_1_6_embedding_models_1215.py
@@ -52,7 +52,7 @@ class Seed16EmbeddingWrapper(AbsEncoder):
         revision: str,
         tokenizer_name: str = "cl100k_base",
         embed_dim: int | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """Wrapper for Seed embedding API."""
         self._model_name = model_name

--- a/mteb/models/model_implementations/seed_models.py
+++ b/mteb/models/model_implementations/seed_models.py
@@ -45,7 +45,7 @@ class SeedTextEmbeddingModel(AbsEncoder):
         tokenizer_name: str = "cl100k_base",
         embed_dim: int | None = None,
         available_embed_dims: Sequence[int | None] = (None,),
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """Wrapper for Seed embedding API."""
         import tiktoken

--- a/mteb/models/model_implementations/slm_models.py
+++ b/mteb/models/model_implementations/slm_models.py
@@ -61,14 +61,16 @@ class SLMBaseWrapper(AbsEncoder):
         revision: str | None = None,
         device: str | None = None,
         use_flash_attn: bool = True,
-        **kwargs,
+        **kwargs: Any,
     ):
         self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
         self._load_model_and_processor(model_name, revision, use_flash_attn, **kwargs)
         self.mdl = self.mdl.to(self.device)
         self.mdl.eval()
 
-    def _load_model_and_processor(self, model_name, revision, use_flash_attn, **kwargs):
+    def _load_model_and_processor(
+        self, model_name, revision, use_flash_attn, **kwargs: Any
+    ):
         """Override in subclasses to load specific model/processor."""
         raise NotImplementedError
 
@@ -121,7 +123,7 @@ class SLMBaseWrapper(AbsEncoder):
         self,
         images: DataLoader,
         batch_size: int = 32,
-        **kwargs,
+        **kwargs: Any,
     ) -> torch.Tensor:
         import torchvision.transforms.functional as F
 
@@ -149,7 +151,7 @@ class SLMBaseWrapper(AbsEncoder):
         self,
         texts: DataLoader,
         batch_size: int = 32,
-        **kwargs,
+        **kwargs: Any,
     ) -> torch.Tensor:
         all_embeds = []
 
@@ -176,7 +178,9 @@ class SLMBaseWrapper(AbsEncoder):
 class SLMColQwen3Wrapper(SLMBaseWrapper):
     """Wrapper for SLM-ColQwen3 models (Qwen3-VL backbone)."""
 
-    def _load_model_and_processor(self, model_name, revision, use_flash_attn, **kwargs):
+    def _load_model_and_processor(
+        self, model_name, revision, use_flash_attn, **kwargs: Any
+    ):
         from sauerkrautlm_colpali.models.qwen3.colqwen3 import (
             ColQwen3,
             ColQwen3Processor,
@@ -201,7 +205,9 @@ class SLMColQwen3Wrapper(SLMBaseWrapper):
 class SLMColLFM2Wrapper(SLMBaseWrapper):
     """Wrapper for SLM-ColLFM2 models (LFM2 backbone)."""
 
-    def _load_model_and_processor(self, model_name, revision, use_flash_attn, **kwargs):
+    def _load_model_and_processor(
+        self, model_name, revision, use_flash_attn, **kwargs: Any
+    ):
         from sauerkrautlm_colpali.models.lfm2.collfm2 import ColLFM2, ColLFM2Processor
 
         self.mdl = ColLFM2.from_pretrained(
@@ -222,7 +228,9 @@ class SLMColLFM2Wrapper(SLMBaseWrapper):
 class SLMColMinistral3Wrapper(SLMBaseWrapper):
     """Wrapper for SLM-ColMinistral3 models (Ministral3 backbone)."""
 
-    def _load_model_and_processor(self, model_name, revision, use_flash_attn, **kwargs):
+    def _load_model_and_processor(
+        self, model_name, revision, use_flash_attn, **kwargs: Any
+    ):
         from sauerkrautlm_colpali.models.ministral3.colministral3 import (
             ColMinistral3,
             ColMinistral3Processor,

--- a/mteb/models/model_implementations/ume_r1.py
+++ b/mteb/models/model_implementations/ume_r1.py
@@ -35,7 +35,7 @@ class UMER1Wrapper(AbsEncoder):
         fps: float | None = 2.0,
         max_frames: int | None = 64,
         num_frames: int | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         from transformers import AutoProcessor, Qwen2VLForConditionalGeneration
         from transformers.utils.import_utils import is_flash_attn_2_available

--- a/mteb/models/model_implementations/unite_models.py
+++ b/mteb/models/model_implementations/unite_models.py
@@ -31,7 +31,7 @@ UNITE_CITATION = """@article{kong2025modality,
 # Qwen2VL refactor; each is marked inline.
 
 
-def _build_unite_model(model_name: str, revision: str | None, **kwargs):
+def _build_unite_model(model_name: str, revision: str | None, **kwargs: Any):
     from transformers import Qwen2VLForConditionalGeneration
 
     class UniteQwen2VL(Qwen2VLForConditionalGeneration):
@@ -51,7 +51,7 @@ def _build_unite_model(model_name: str, revision: str | None, **kwargs):
             image_grid_thw=None,
             video_grid_thw=None,
             pooling_mask=None,
-            **unused,
+            **unused: Any,
         ) -> torch.Tensor:
             if inputs_embeds is None:
                 # Upstream: self.model.embed_tokens(input_ids).

--- a/mteb/models/model_implementations/vggish_models.py
+++ b/mteb/models/model_implementations/vggish_models.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def vggish_loader(*args, **kwargs):
+def vggish_loader(*args: Any, **kwargs: Any):
     """Factory function to create a VGGish model wrapper."""
     import torchaudio
     from torch_vggish_yamnet import vggish
@@ -111,7 +111,7 @@ def vggish_loader(*args, **kwargs):
             self,
             inputs: DataLoader[AudioInput],
             show_progress_bar=True,
-            **kwargs,
+            **kwargs: Any,
         ):
             """Generate embeddings for audio inputs."""
             all_embeddings = []

--- a/mteb/models/model_implementations/virtue_models.py
+++ b/mteb/models/model_implementations/virtue_models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import torch
 from tqdm.auto import tqdm
@@ -44,7 +44,7 @@ class VirtueWrapper(AbsEncoder):
         revision: str | None = None,
         *,
         device: str | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         from transformers import AutoProcessor, Qwen2VLForConditionalGeneration
 

--- a/mteb/models/model_implementations/vista_models.py
+++ b/mteb/models/model_implementations/vista_models.py
@@ -22,7 +22,7 @@ VISTA_CITATION = """@article{zhou2024vista,
 }"""
 
 
-def vista_loader(model_name, **kwargs):
+def vista_loader(model_name, **kwargs: Any):
     try:  # a temporal fix for the dependency issues of vista models.
         from visual_bge.modeling import Visualized_BGE
     except ImportError:

--- a/mteb/models/model_implementations/vlm2vec_models.py
+++ b/mteb/models/model_implementations/vlm2vec_models.py
@@ -38,7 +38,7 @@ class VLM2VecWrapper(AbsEncoder):
         self,
         model_name: str = "TIGER-Lab/VLM2Vec-LoRA",
         device: str = "cuda" if torch.cuda.is_available() else "cpu",
-        **kwargs,
+        **kwargs: Any,
     ):
         if suggest_package(
             self,
@@ -398,7 +398,7 @@ class VLM2VEC2Wrapper(AbsEncoder):
         fps: float | None = 2.0,
         max_frames: int | None = 64,
         num_frames: int | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         from peft import PeftModel
         from transformers import AutoProcessor, Qwen2VLForConditionalGeneration

--- a/mteb/models/model_implementations/voyage_models.py
+++ b/mteb/models/model_implementations/voyage_models.py
@@ -141,7 +141,7 @@ def token_limit(max_tpm: int, interval: int = 60):
 
     def decorator(func):
         @wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: Any, **kwargs: Any):
             nonlocal limit_interval_start_ts, used_tokens
 
             result = func(*args, **kwargs)
@@ -168,7 +168,7 @@ def rate_limit(max_rpm: int, interval: int = 60):
 
     def decorator(func):
         @wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: Any, **kwargs: Any):
             current_time = time.time()
             nonlocal previous_call_ts
             if (
@@ -198,7 +198,7 @@ class VoyageModel(AbsEncoder):
         output_dtype: str | None = None,
         api_model_name: str | None = None,
         evolved_prompts: bool = False,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         import voyageai
 

--- a/mteb/models/model_implementations/voyage_v.py
+++ b/mteb/models/model_implementations/voyage_v.py
@@ -56,7 +56,7 @@ def _downsample_image(
     return image
 
 
-def voyage_v_loader(model_name, **kwargs):
+def voyage_v_loader(model_name, **kwargs: Any):
     import voyageai
     from tenacity import retry, stop_after_attempt, wait_exponential
 

--- a/mteb/models/model_implementations/webai_models.py
+++ b/mteb/models/model_implementations/webai_models.py
@@ -32,7 +32,7 @@ class ColVec1Wrapper(AbsEncoder):
         device: str | None = None,
         trust_remote_code: bool = True,
         torch_dtype: torch.dtype | None = torch.bfloat16,
-        **kwargs,
+        **kwargs: Any,
     ):
         self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
 
@@ -90,7 +90,7 @@ class ColVec1Wrapper(AbsEncoder):
         return self.model(**encoded_inputs)
 
     def get_image_embeddings(
-        self, images, batch_size=32, show_progress_bar=True, **kwargs
+        self, images, batch_size=32, show_progress_bar=True, **kwargs: Any
     ):
         import torchvision.transforms.functional as F
         from PIL import Image
@@ -116,7 +116,7 @@ class ColVec1Wrapper(AbsEncoder):
         )
 
     def get_text_embeddings(
-        self, texts, batch_size=32, show_progress_bar=True, **kwargs
+        self, texts, batch_size=32, show_progress_bar=True, **kwargs: Any
     ):
         all_embeds = []
         with torch.no_grad():
@@ -153,7 +153,7 @@ class ColVec11Wrapper(ColVec1Wrapper):
         trust_remote_code: bool = True,
         torch_dtype: torch.dtype | None = torch.bfloat16,
         processor_kwargs: dict[str, Any] | None = None,
-        **model_kwargs,
+        **model_kwargs: Any,
     ):
         self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
         processor_kwargs = dict(processor_kwargs or {})
@@ -175,7 +175,7 @@ class ColVec11Wrapper(ColVec1Wrapper):
         )
 
     def get_image_embeddings(
-        self, images, batch_size=32, show_progress_bar=True, **kwargs
+        self, images, batch_size=32, show_progress_bar=True, **kwargs: Any
     ):
         import torchvision.transforms.functional as F
         from PIL import Image

--- a/mteb/models/model_implementations/yamnet_models.py
+++ b/mteb/models/model_implementations/yamnet_models.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def yamnet_loader(*args, **kwargs):
+def yamnet_loader(*args: Any, **kwargs: Any):
     """Factory function to create a YAMNet model wrapper."""
     from torch_vggish_yamnet import yamnet
     from torch_vggish_yamnet.input_proc import WaveformToInput
@@ -116,7 +116,7 @@ def yamnet_loader(*args, **kwargs):
             self,
             inputs: DataLoader[AudioInput],
             show_progress_bar=True,
-            **kwargs,
+            **kwargs: Any,
         ):
             """Generate embeddings for audio inputs."""
             all_embeddings = []

--- a/mteb/tasks/bitext_mining/kat/tbilisi_city_hall_bitext_mining.py
+++ b/mteb/tasks/bitext_mining/kat/tbilisi_city_hall_bitext_mining.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from datasets import DatasetDict, load_dataset
 
 from mteb.abstasks.task_metadata import TaskMetadata
@@ -40,7 +42,7 @@ class TbilisiCityHallBitextMining(AbsTaskBitextMining):
         bibtex_citation="",
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = {}

--- a/mteb/tasks/bitext_mining/multilingual/bible_nlp_bitext_mining.py
+++ b/mteb/tasks/bitext_mining/multilingual/bible_nlp_bitext_mining.py
@@ -914,7 +914,7 @@ class BibleNLPBitextMining(AbsTaskBitextMining):
         self.dataset_transform()
         self.data_loaded = True
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         # Convert to standard format
         for lang in self.hf_subsets:
             l1, l2 = (l.split("_")[0] for l in lang.split("-"))

--- a/mteb/tasks/bitext_mining/multilingual/flores_bitext_mining.py
+++ b/mteb/tasks/bitext_mining/multilingual/flores_bitext_mining.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.task_metadata import TaskMetadata
@@ -265,7 +267,7 @@ class FloresBitextMining(AbsTaskBitextMining):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/bitext_mining/multilingual/in22_conv_bitext_mining.py
+++ b/mteb/tasks/bitext_mining/multilingual/in22_conv_bitext_mining.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.task_metadata import TaskMetadata
@@ -98,7 +100,7 @@ class IN22ConvBitextMining(AbsTaskBitextMining):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/bitext_mining/multilingual/in22_gen_bitext_mining.py
+++ b/mteb/tasks/bitext_mining/multilingual/in22_gen_bitext_mining.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.task_metadata import TaskMetadata
@@ -93,7 +95,7 @@ class IN22GenBitextMining(AbsTaskBitextMining):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/bitext_mining/multilingual/ntrex_bitext_mining.py
+++ b/mteb/tasks/bitext_mining/multilingual/ntrex_bitext_mining.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.task_metadata import TaskMetadata
@@ -279,7 +281,7 @@ class NTREXBitextMining(AbsTaskBitextMining):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/bitext_mining/multilingual/roma_tales_bitext_mining.py
+++ b/mteb/tasks/bitext_mining/multilingual/roma_tales_bitext_mining.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.task_metadata import TaskMetadata
@@ -32,7 +34,7 @@ class RomaTalesBitextMining(AbsTaskBitextMining):
         bibtex_citation="",
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """Load dataset from HuggingFace hub and convert it to the standard format."""
         if self.data_loaded:
             return

--- a/mteb/tasks/bitext_mining/slk/opus_slovak_english_bitext_mining.py
+++ b/mteb/tasks/bitext_mining/slk/opus_slovak_english_bitext_mining.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.task_metadata import TaskMetadata
 from mteb.abstasks.text.bitext_mining import AbsTaskBitextMining
 
@@ -45,7 +47,7 @@ Sennrich, Rico},
         prompt="Retrieve parallel sentences.",
     )
 
-    def dataset_transform(self, **kwargs) -> None:
+    def dataset_transform(self, **kwargs: Any) -> None:
         # Convert from OPUS-100 format to standard bitext format
         # OPUS-100 has structure: {"translation": {"en": "...", "sk": "..."}}
         # We need: {"sentence1": "...", "sentence2": "..."}

--- a/mteb/tasks/classification/ben/bengali_document_classification.py
+++ b/mteb/tasks/classification/ben/bengali_document_classification.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.classification import AbsTaskClassification
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -43,7 +45,7 @@ Islam, Tanvir},
         superseded_by="BengaliDocumentClassification.v2",
     )
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         self.dataset = self.dataset.rename_columns(
             {"article": "text", "category": "label"}
         )
@@ -92,7 +94,7 @@ Islam, Tanvir},
 """,
     )
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         self.dataset = self.stratified_subsampling(
             self.dataset, seed=self.seed, splits=["test"]
         )

--- a/mteb/tasks/classification/ces/czech_so_me_sentiment_classification.py
+++ b/mteb/tasks/classification/ces/czech_so_me_sentiment_classification.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.classification import AbsTaskClassification
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -46,7 +48,7 @@ Montoyo, Andres},
     )
     samples_per_label = 16
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         self.dataset = self.dataset.rename_columns(
             {"comment": "text", "sentiment_int": "label"}
         )

--- a/mteb/tasks/classification/eng/ave_dataset_classification.py
+++ b/mteb/tasks/classification/eng/ave_dataset_classification.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from mteb.abstasks.classification import AbsTaskClassification
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -41,7 +43,7 @@ class AVEDatasetClassification(AbsTaskClassification):
     label_column_name: str = "label"
     is_cross_validation: bool = False
 
-    def dataset_transform(self, num_proc=None, **kwargs) -> None:
+    def dataset_transform(self, num_proc=None, **kwargs: Any) -> None:
         self.dataset["train"] = self.dataset["train"].select(range(2048))
 
 
@@ -82,5 +84,5 @@ class AVEDatasetVideoClassification(AbsTaskClassification):
     label_column_name: str = "label"
     is_cross_validation: bool = False
 
-    def dataset_transform(self, num_proc=None, **kwargs) -> None:
+    def dataset_transform(self, num_proc=None, **kwargs: Any) -> None:
         self.dataset["train"] = self.dataset["train"].select(range(2048))

--- a/mteb/tasks/classification/eng/common_language_age_detection.py
+++ b/mteb/tasks/classification/eng/common_language_age_detection.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.classification import AbsTaskClassification
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -44,7 +46,7 @@ Mirco Ravanelli},
     input_column_name: str = "audio"
     label_column_name: str = "age"
 
-    def dataset_transform(self, **kwargs):
+    def dataset_transform(self, **kwargs: Any):
         # remove rows where age is "not_defined" or "eighties" <- only 1 label so messes up stratified subsampling
         for split in self.dataset:
             self.dataset[split] = self.dataset[split].filter(

--- a/mteb/tasks/classification/eng/common_language_gender_detection.py
+++ b/mteb/tasks/classification/eng/common_language_gender_detection.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.classification import AbsTaskClassification
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -44,7 +46,7 @@ Mirco Ravanelli},
     input_column_name: str = "audio"
     label_column_name: str = "gender"
 
-    def dataset_transform(self, **kwargs):
+    def dataset_transform(self, **kwargs: Any):
         self.dataset = self.stratified_subsampling(
             self.dataset, seed=self.seed, splits=["test"], label=self.label_column_name
         )

--- a/mteb/tasks/classification/eng/common_language_language_classification.py
+++ b/mteb/tasks/classification/eng/common_language_language_classification.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.classification import AbsTaskClassification
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -44,7 +46,7 @@ Mirco Ravanelli},
     input_column_name: str = "audio"
     label_column_name: str = "language"
 
-    def dataset_transform(self, **kwargs):
+    def dataset_transform(self, **kwargs: Any):
         self.dataset = self.stratified_subsampling(
             self.dataset, seed=self.seed, splits=["test"], label=self.label_column_name
         )

--- a/mteb/tasks/classification/eng/iemocap_emotion.py
+++ b/mteb/tasks/classification/eng/iemocap_emotion.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.classification import AbsTaskClassification
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -43,7 +45,7 @@ class IEMOCAPEmotionClassification(AbsTaskClassification):
 
     is_cross_validation: bool = True
 
-    def dataset_transform(self, **kwargs):
+    def dataset_transform(self, **kwargs: Any):
         # Define emotion labels and their mapping to indices
         labels = [
             "angry",  # 0

--- a/mteb/tasks/classification/eng/iemocap_gender.py
+++ b/mteb/tasks/classification/eng/iemocap_gender.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 from mteb.abstasks.classification import AbsTaskClassification
 from mteb.abstasks.task_metadata import TaskMetadata
@@ -47,7 +48,7 @@ class IEMOCAPGenderClassification(AbsTaskClassification):
 
     is_cross_validation: bool = True
 
-    def dataset_transform(self, **kwargs):
+    def dataset_transform(self, **kwargs: Any):
         # Define label mapping
         label2id = {"Female": 0, "Male": 1}
 

--- a/mteb/tasks/classification/eng/meld_classification.py
+++ b/mteb/tasks/classification/eng/meld_classification.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from mteb.abstasks.classification import AbsTaskClassification
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -42,7 +44,7 @@ class MELDAudioVideoClassification(AbsTaskClassification):
     is_cross_validation: bool = True
     train_split: str = "test"
 
-    def dataset_transform(self, num_proc=None, **kwargs) -> None:
+    def dataset_transform(self, num_proc=None, **kwargs: Any) -> None:
         self.dataset = self.stratified_subsampling(
             self.dataset,
             seed=self.seed,
@@ -90,7 +92,7 @@ class MELDVideoClassification(AbsTaskClassification):
     is_cross_validation: bool = True
     train_split: str = "test"
 
-    def dataset_transform(self, num_proc=None, **kwargs) -> None:
+    def dataset_transform(self, num_proc=None, **kwargs: Any) -> None:
         self.dataset = self.stratified_subsampling(
             self.dataset,
             seed=self.seed,

--- a/mteb/tasks/classification/eng/spoken_q_afor_ic.py
+++ b/mteb/tasks/classification/eng/spoken_q_afor_ic.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.classification import AbsTaskClassification
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -42,5 +44,5 @@ class SpokenQAForIC(AbsTaskClassification):
 
     is_cross_validation: bool = True
 
-    def dataset_transform(self, **kwargs):
+    def dataset_transform(self, **kwargs: Any):
         self.dataset["train"] = self.dataset.pop("test")

--- a/mteb/tasks/classification/eng/ucf101_classification.py
+++ b/mteb/tasks/classification/eng/ucf101_classification.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks import AbsTaskClassification
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -88,7 +90,7 @@ class UCF101VideoAudioClassification(AbsTaskClassification):
     input_column_name = ("video", "audio")
     label_column_name: str = "label"
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         for split in self.metadata.eval_splits:
             self.dataset[split] = self.dataset[split].select_columns(
                 ["video", "audio", "label"],
@@ -138,7 +140,7 @@ class UCF101VideoClassification(AbsTaskClassification):
     input_column_name = "video"
     label_column_name: str = "label"
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         for split in self.metadata.eval_splits:
             self.dataset[split] = self.dataset[split].select_columns(
                 ["video", "label"],

--- a/mteb/tasks/classification/eng/vocal_sound.py
+++ b/mteb/tasks/classification/eng/vocal_sound.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.classification import AbsTaskClassification
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -41,5 +43,5 @@ class VocalSoundClassification(AbsTaskClassification):
     input_column_name: str = "audio"
     label_column_name: str = "answer"
 
-    def dataset_transform(self, **kwargs):
+    def dataset_transform(self, **kwargs: Any):
         self.dataset["train"] = self.dataset["val"]

--- a/mteb/tasks/classification/eng/vox_celeb_sa.py
+++ b/mteb/tasks/classification/eng/vox_celeb_sa.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.classification import AbsTaskClassification
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -42,7 +44,7 @@ class VoxCelebSA(AbsTaskClassification):
 
     is_cross_validation: bool = True
 
-    def dataset_transform(self, **kwargs):
+    def dataset_transform(self, **kwargs: Any):
         # remove disagreement data
         self.dataset = self.dataset.filter(lambda x: x["label"] != "Disagreement")
         self.dataset["train"] = self.dataset.pop("test")

--- a/mteb/tasks/classification/eng/vox_populi_accent_id.py
+++ b/mteb/tasks/classification/eng/vox_populi_accent_id.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.classification import AbsTaskClassification
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -53,7 +55,7 @@ Dupoux, Emmanuel},
 
     is_cross_validation: bool = True
 
-    def dataset_transform(self, **kwargs):
+    def dataset_transform(self, **kwargs: Any):
         import numpy as np
         from datasets import DatasetDict
 

--- a/mteb/tasks/classification/multilingual/hin_dialect_classification.py
+++ b/mteb/tasks/classification/multilingual/hin_dialect_classification.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.classification import AbsTaskClassification
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -60,7 +62,7 @@ class HinDialectClassification(AbsTaskClassification):
 """,
     )
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         self.dataset = self.dataset.rename_columns(
             {"folksong": "text", "language": "label"}
         )

--- a/mteb/tasks/classification/multilingual/indic_sentiment_classification.py
+++ b/mteb/tasks/classification/multilingual/indic_sentiment_classification.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.classification import AbsTaskClassification
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -52,7 +54,7 @@ class IndicSentimentClassification(AbsTaskClassification):
 """,
     )
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         label_map = {"Negative": 0, "Positive": 1}
         # Convert to standard format
         for lang in self.hf_subsets:

--- a/mteb/tasks/classification/multilingual/injongo_intent.py
+++ b/mteb/tasks/classification/multilingual/injongo_intent.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from mteb.abstasks.classification import AbsTaskClassification
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -62,7 +64,7 @@ class InjongoIntent(AbsTaskClassification):
 """,
     )
 
-    def dataset_transform(self, **kwargs):
+    def dataset_transform(self, **kwargs: Any):
         """Convert HuggingFace splits to the lists of dicts expected by AbsTaskClassification."""
         transformed = {}
 

--- a/mteb/tasks/classification/multilingual/language_classification.py
+++ b/mteb/tasks/classification/multilingual/language_classification.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.classification import AbsTaskClassification
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -66,7 +68,7 @@ in Natural Language Processing},
 """,
     )
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         self.dataset = self.dataset.rename_columns({"labels": "label"})
         self.dataset = self.stratified_subsampling(
             self.dataset, seed=self.seed, splits=["test"]

--- a/mteb/tasks/classification/multilingual/sib200_classification.py
+++ b/mteb/tasks/classification/multilingual/sib200_classification.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.classification import AbsTaskClassification
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -305,7 +307,7 @@ class SIB200ClassificationV2(AbsTaskClassification):
 """,
     )
 
-    def dataset_transform(self, **kwargs) -> None:
+    def dataset_transform(self, **kwargs: Any) -> None:
         """
         Convert each split to the MTEB format:
         * text: str

--- a/mteb/tasks/classification/multilingual/south_african_lang_classification.py
+++ b/mteb/tasks/classification/multilingual/south_african_lang_classification.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.classification import AbsTaskClassification
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -49,7 +51,7 @@ class SouthAfricanLangClassification(AbsTaskClassification):
 """,
     )
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         self.dataset = self.dataset.rename_columns(
             {" text": "text", "lang_id": "label"}
         )

--- a/mteb/tasks/classification/multilingual/turkic_classification.py
+++ b/mteb/tasks/classification/multilingual/turkic_classification.py
@@ -1,4 +1,5 @@
 from collections import Counter
+from typing import Any
 
 import datasets
 from datasets import DatasetDict
@@ -50,7 +51,7 @@ class TurkicClassification(AbsTaskClassification):
         )
         return dataset_lang["train"]
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """Load dataset from HuggingFace hub"""
         if self.data_loaded:
             return

--- a/mteb/tasks/classification/multilingual/vox_populi_gender_id.py
+++ b/mteb/tasks/classification/multilingual/vox_populi_gender_id.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.classification import AbsTaskClassification
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -58,7 +60,7 @@ Dupoux, Emmanuel},
     label_column_name: str = "gender_id"
     is_cross_validation: bool = True
 
-    def dataset_transform(self, **kwargs):
+    def dataset_transform(self, **kwargs: Any):
         # Define label mapping
         label2id = {"female": 0, "male": 1}
 

--- a/mteb/tasks/classification/multilingual/vox_populi_language_id.py
+++ b/mteb/tasks/classification/multilingual/vox_populi_language_id.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.classification import AbsTaskClassification
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -58,7 +60,7 @@ Dupoux, Emmanuel},
     label_column_name: str = "language"
     is_cross_validation: bool = True
 
-    def dataset_transform(self, **kwargs):
+    def dataset_transform(self, **kwargs: Any):
         import numpy as np
         from datasets import DatasetDict
 

--- a/mteb/tasks/classification/slk/csfdsk_movie_review_sentiment_classification.py
+++ b/mteb/tasks/classification/slk/csfdsk_movie_review_sentiment_classification.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.classification import AbsTaskClassification
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -81,7 +83,7 @@ class CSFDSKMovieReviewSentimentClassificationV2(AbsTaskClassification):
     # Increase the samples_per_label in order to improve baseline performance
     samples_per_label = 20
 
-    def dataset_transform(self, **kwargs) -> None:
+    def dataset_transform(self, **kwargs: Any) -> None:
         self.dataset = self.stratified_subsampling(
             self.dataset, seed=self.seed, splits=["test"], n_samples=N_SAMPLES
         )

--- a/mteb/tasks/classification/slk/slovak_movie_review_sentiment_classification.py
+++ b/mteb/tasks/classification/slk/slovak_movie_review_sentiment_classification.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.classification import AbsTaskClassification
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -73,7 +75,7 @@ class SlovakMovieReviewSentimentClassificationV2(AbsTaskClassification):
         adapted_from=["SlovakMovieReviewSentimentClassification"],
     )
 
-    def dataset_transform(self, **kwargs) -> None:
+    def dataset_transform(self, **kwargs: Any) -> None:
         self.dataset = self.stratified_subsampling(
             self.dataset, seed=self.seed, splits=["test"]
         )

--- a/mteb/tasks/classification/slk/slovak_parla_sent_classification.py
+++ b/mteb/tasks/classification/slk/slovak_parla_sent_classification.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.classification import AbsTaskClassification
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -36,7 +38,7 @@ class SlovakParlaSentClassification(AbsTaskClassification):
         prompt="Classify the sentiment expressed in the given text as negative, neutral or positive",
     )
 
-    def dataset_transform(self, **kwargs) -> None:
+    def dataset_transform(self, **kwargs: Any) -> None:
         """Transform the ParlaSent dataset for classification.
 
         Note: MTEB classification requires both train and test splits.

--- a/mteb/tasks/classification/swa/swahili_news_classification.py
+++ b/mteb/tasks/classification/swa/swahili_news_classification.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.classification import AbsTaskClassification
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -73,7 +75,7 @@ class SwahiliNewsClassificationV2(AbsTaskClassification):
         adapted_from=["SwahiliNewsClassification"],
     )
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         self.dataset = self.stratified_subsampling(
             self.dataset, seed=self.seed, splits=["train"]
         )

--- a/mteb/tasks/classification/zxx/urban_sound8k.py
+++ b/mteb/tasks/classification/zxx/urban_sound8k.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.classification import AbsTaskClassification
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -41,7 +43,7 @@ class UrbanSound8kClassification(AbsTaskClassification):
     is_cross_validation: bool = True
 
 
-def dataset_transform(self, **kwargs):
+def dataset_transform(self, **kwargs: Any):
     self.dataset = self.stratified_subsampling(
         self.dataset, seed=self.seed, splits=["train"], label=self.label_column_name
     )

--- a/mteb/tasks/clustering/deu/ten_k_gnad_clustering_p2p.py
+++ b/mteb/tasks/clustering/deu/ten_k_gnad_clustering_p2p.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.clustering import AbsTaskClustering, _convert_to_fast
 from mteb.abstasks.clustering_legacy import AbsTaskClusteringLegacy
 from mteb.abstasks.task_metadata import TaskMetadata
@@ -65,7 +67,7 @@ class TenKGnadClusteringP2PFast(AbsTaskClustering):
         adapted_from=["TenKGnadClusteringP2P"],
     )
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         ds = _convert_to_fast(
             self.dataset, self.input_column_name, self.label_column_name, self.seed
         )

--- a/mteb/tasks/clustering/deu/ten_k_gnad_clustering_s2s.py
+++ b/mteb/tasks/clustering/deu/ten_k_gnad_clustering_s2s.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.clustering import AbsTaskClustering, _convert_to_fast
 from mteb.abstasks.clustering_legacy import AbsTaskClusteringLegacy
 from mteb.abstasks.task_metadata import TaskMetadata
@@ -65,7 +67,7 @@ class TenKGnadClusteringS2SFast(AbsTaskClustering):
         adapted_from=["TenKGnadClusteringS2S"],
     )
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         ds = _convert_to_fast(
             self.dataset, self.input_column_name, self.label_column_name, self.seed
         )

--- a/mteb/tasks/clustering/eng/ave_dataset_clustering.py
+++ b/mteb/tasks/clustering/eng/ave_dataset_clustering.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from mteb.abstasks import AbsTaskClustering
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -52,7 +54,7 @@ class AVEDatasetAudioVideoClustering(AbsTaskClustering):
     input_column_name = ("video", "audio")
     label_column_name: str = "label"
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         for split in self.metadata.eval_splits:
             self.dataset[split] = self.dataset[split].select_columns(
                 ["video", "audio", "label"],
@@ -86,7 +88,7 @@ class AVEDatasetVideoClustering(AbsTaskClustering):
     input_column_name: str = "video"
     label_column_name: str = "label"
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         for split in self.metadata.eval_splits:
             self.dataset[split] = self.dataset[split].select_columns(
                 ["video", "label"],

--- a/mteb/tasks/clustering/eng/breakfast_clustering.py
+++ b/mteb/tasks/clustering/eng/breakfast_clustering.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from mteb.abstasks import AbsTaskClustering
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -46,7 +48,7 @@ class BreakfastClustering(AbsTaskClustering):
     input_column_name: str = "video"
     label_column_name: str = "label"
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         for split in self.metadata.eval_splits:
             self.dataset[split] = self.dataset[split].select_columns(
                 ["video", "label"],

--- a/mteb/tasks/clustering/eng/crema_d_clustering.py
+++ b/mteb/tasks/clustering/eng/crema_d_clustering.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks import AbsTaskClustering
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -47,7 +49,7 @@ voice expression},
     max_fraction_of_documents_to_embed = None
     input_column_name: str = "audio"
 
-    def dataset_transform(self, **kwargs):
+    def dataset_transform(self, **kwargs: Any):
         self.dataset = self.stratified_subsampling(
             self.dataset, seed=self.seed, splits=["train"], label=self.label_column_name
         )

--- a/mteb/tasks/clustering/eng/hmdb51_clustering.py
+++ b/mteb/tasks/clustering/eng/hmdb51_clustering.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from mteb.abstasks import AbsTaskClustering
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -46,7 +48,7 @@ class HMDB51Clustering(AbsTaskClustering):
     input_column_name: str = "video"
     label_column_name: str = "label"
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         for split in self.metadata.eval_splits:
             self.dataset[split] = self.dataset[split].select_columns(
                 ["video", "label"],

--- a/mteb/tasks/clustering/eng/human_concepts_clustering.py
+++ b/mteb/tasks/clustering/eng/human_concepts_clustering.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import DatasetDict
 
 from mteb.abstasks.clustering import AbsTaskClustering
@@ -54,7 +56,7 @@ class HumanConceptsClustering(AbsTaskClustering):
     input_column_name = "item"
     label_column_name = "category"
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         self.dataset = DatasetDict(
             {
                 sub: self.dataset["train"].filter(

--- a/mteb/tasks/clustering/eng/meld_clustering.py
+++ b/mteb/tasks/clustering/eng/meld_clustering.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from mteb.abstasks import AbsTaskClustering
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -63,7 +65,7 @@ class MELDEmotionAudioVideoClustering(AbsTaskClustering):
     input_column_name = ("video", "audio")
     label_column_name: str = "emotion"
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         for split in self.metadata.eval_splits:
             ds = self.dataset[split]
             neutral_id = ds.features["emotion"].str2int("neutral")
@@ -99,7 +101,7 @@ class MELDEmotionVideoClustering(AbsTaskClustering):
     input_column_name: str = "video"
     label_column_name: str = "emotion"
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         for split in self.metadata.eval_splits:
             ds = self.dataset[split]
             neutral_id = ds.features["emotion"].str2int("neutral")
@@ -134,7 +136,7 @@ class MELDSpeakerAudioVideoClustering(AbsTaskClustering):
     input_column_name = ("video", "audio")
     label_column_name: str = "speaker"
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         for split in self.metadata.eval_splits:
             self.dataset[split] = self.dataset[split].select_columns(
                 ["video", "audio", "speaker"],
@@ -168,7 +170,7 @@ class MELDSpeakerVideoClustering(AbsTaskClustering):
     input_column_name: str = "video"
     label_column_name: str = "speaker"
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         for split in self.metadata.eval_splits:
             self.dataset[split] = self.dataset[split].select_columns(
                 ["video", "speaker"],

--- a/mteb/tasks/clustering/eng/music_avqa_clustering.py
+++ b/mteb/tasks/clustering/eng/music_avqa_clustering.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from mteb.abstasks import AbsTaskClustering
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -50,7 +52,7 @@ class MusicAVQACLSAudioVideoClustering(AbsTaskClustering):
     input_column_name = ("video", "audio")
     label_column_name: str = "label"
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         for split in self.metadata.eval_splits:
             self.dataset[split] = self.dataset[split].select_columns(
                 ["video", "audio", "label"],
@@ -84,7 +86,7 @@ class MusicAVQACLSVideoClustering(AbsTaskClustering):
     input_column_name: str = "video"
     label_column_name: str = "label"
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         for split in self.metadata.eval_splits:
             self.dataset[split] = self.dataset[split].select_columns(
                 ["video", "label"],

--- a/mteb/tasks/clustering/eng/ucf101_clustering.py
+++ b/mteb/tasks/clustering/eng/ucf101_clustering.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from mteb.abstasks import AbsTaskClustering
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -52,7 +54,7 @@ class UCF101AudioVideoClustering(AbsTaskClustering):
     input_column_name = ("video", "audio")
     label_column_name: str = "label"
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         for split in self.metadata.eval_splits:
             self.dataset[split] = self.dataset[split].select_columns(
                 ["video", "audio", "label"],
@@ -86,7 +88,7 @@ class UCF101VideoClustering(AbsTaskClustering):
     input_column_name: str = "video"
     label_column_name: str = "label"
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         for split in self.metadata.eval_splits:
             self.dataset[split] = self.dataset[split].select_columns(
                 ["video", "label"],

--- a/mteb/tasks/clustering/eng/vox_celeb_clustering.py
+++ b/mteb/tasks/clustering/eng/vox_celeb_clustering.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks import AbsTaskClustering
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -40,7 +42,7 @@ class VoxCelebClustering(AbsTaskClustering):
     max_fraction_of_documents_to_embed = None
     input_column_name: str = "audio"
 
-    def dataset_transform(self, **kwargs):
+    def dataset_transform(self, **kwargs: Any):
         ds = self.dataset
         # Remove 'Disagreement' samples and '<mixed>' samples
         ds = ds.filter(lambda x: x["label"] not in ["Disagreement", "<mixed>"])  # noqa: PLR6201

--- a/mteb/tasks/clustering/eng/worldsense_1min_domain_clustering.py
+++ b/mteb/tasks/clustering/eng/worldsense_1min_domain_clustering.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from mteb.abstasks import AbsTaskClustering
 from mteb.abstasks.task_metadata import TaskMetadata
@@ -70,7 +70,7 @@ class WorldSense1MinDomainAudioVideoClustering(AbsTaskClustering):
     input_column_name = ("video", "audio")
     label_column_name: str = "domain"
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         for split in self.metadata.eval_splits:
             ds = self.dataset[split]
             ds = _dedupe_one_per_video_id(ds)
@@ -106,7 +106,7 @@ class WorldSense1MinDomainVideoClustering(AbsTaskClustering):
     input_column_name: str = "video"
     label_column_name: str = "domain"
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         for split in self.metadata.eval_splits:
             ds = self.dataset[split]
             ds = _dedupe_one_per_video_id(ds)

--- a/mteb/tasks/clustering/multilingual/mlsum_clustering_p2p.py
+++ b/mteb/tasks/clustering/multilingual/mlsum_clustering_p2p.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 import numpy as np
 from datasets import Dataset, DatasetDict
@@ -51,7 +53,7 @@ class MLSUMClusteringP2P(AbsTaskClusteringLegacy):
         superseded_by="MLSUMClusteringP2P.v2",
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """Load dataset from HuggingFace hub and convert it to the standard format."""
         if self.data_loaded:
             return
@@ -124,7 +126,7 @@ class MLSUMClusteringP2PFast(AbsTaskClustering):
         adapted_from=["MLSUMClusteringP2P"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """Load dataset from HuggingFace hub and convert it to the standard format."""
         if self.data_loaded:
             return

--- a/mteb/tasks/clustering/multilingual/mlsum_clustering_s2s.py
+++ b/mteb/tasks/clustering/multilingual/mlsum_clustering_s2s.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 import numpy as np
 from datasets import Dataset, DatasetDict
@@ -51,7 +53,7 @@ class MLSUMClusteringS2S(AbsTaskClusteringLegacy):
         superseded_by="MLSUMClusteringS2S.v2",
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """Load dataset from HuggingFace hub and convert it to the standard format."""
         if self.data_loaded:
             return
@@ -119,7 +121,7 @@ class MLSUMClusteringS2SFast(AbsTaskClustering):
         adapted_from=["MLSUMClusteringS2S"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """Load dataset from HuggingFace hub and convert it to the standard format."""
         if self.data_loaded:
             return

--- a/mteb/tasks/clustering/multilingual/vox_populi_gender_clustering.py
+++ b/mteb/tasks/clustering/multilingual/vox_populi_gender_clustering.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks import AbsTaskClustering
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -59,7 +61,7 @@ Dupoux, Emmanuel},
     max_fraction_of_documents_to_embed = None
     input_column_name: str = "audio"
 
-    def dataset_transform(self, **kwargs):
+    def dataset_transform(self, **kwargs: Any):
         # Define label mapping
         label2id = {"female": 0, "male": 1}
 

--- a/mteb/tasks/clustering/nob/vg_hierarchical_clustering.py
+++ b/mteb/tasks/clustering/nob/vg_hierarchical_clustering.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.clustering import AbsTaskClustering
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -45,7 +47,7 @@ class VGHierarchicalClusteringP2P(AbsTaskClustering):
         prompt="Identify the categories (e.g. sports) of given articles in Norwegian",
     )
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         self.dataset = self.dataset.rename_columns(
             {"article": "sentences", "classes": "labels"}
         )
@@ -92,7 +94,7 @@ class VGHierarchicalClusteringS2S(AbsTaskClustering):
         prompt="Identify the categories (e.g. sports) of given articles in Norwegian",
     )
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         self.dataset = self.dataset.rename_columns(
             {"ingress": "sentences", "classes": "labels"}
         )

--- a/mteb/tasks/clustering/slk/pravda_sk_clustering.py
+++ b/mteb/tasks/clustering/slk/pravda_sk_clustering.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from datasets import Dataset, DatasetDict
 
 from mteb.abstasks.clustering import AbsTaskClustering
@@ -35,7 +37,7 @@ class PravdaSKTagClustering(AbsTaskClustering):
         prompt="Identify the topic or theme of the given text.",
     )
 
-    def dataset_transform(self, **kwargs) -> None:
+    def dataset_transform(self, **kwargs: Any) -> None:
         """Transform the dataset to create sentences (title + summary) and labels (assigned_label)."""
         ds = {}
         for split in self.metadata.eval_splits:
@@ -84,7 +86,7 @@ class PravdaSKURLClustering(AbsTaskClustering):
         prompt="Identify the topic or theme of the given text.",
     )
 
-    def dataset_transform(self, **kwargs) -> None:
+    def dataset_transform(self, **kwargs: Any) -> None:
         """Transform the dataset to create sentences (title + summary) and labels (url_category)."""
         ds = {}
         for split in self.metadata.eval_splits:

--- a/mteb/tasks/clustering/slk/sme_sum_category_clustering.py
+++ b/mteb/tasks/clustering/slk/sme_sum_category_clustering.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from datasets import Dataset, DatasetDict
 
 from mteb.abstasks.clustering import AbsTaskClustering
@@ -45,7 +47,7 @@ class SMESumCategoryClustering(AbsTaskClustering):
         prompt="Identify the topic or theme of the given text.",
     )
 
-    def dataset_transform(self, **kwargs) -> None:
+    def dataset_transform(self, **kwargs: Any) -> None:
         """Transform the dataset to create sentences (title + introduction) and labels (category).
 
         Filters out articles with 'none' category as they don't represent meaningful clusters.

--- a/mteb/tasks/image_text_pair_classification/eng/image_co_de.py
+++ b/mteb/tasks/image_text_pair_classification/eng/image_co_de.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import numpy as np
 from datasets import DatasetDict, load_dataset
 
@@ -53,7 +55,7 @@ class ImageCoDe(AbsTaskImageTextPairClassification):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/image_text_pair_classification/eng/sugar_crepe.py
+++ b/mteb/tasks/image_text_pair_classification/eng/sugar_crepe.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.image.image_text_pair_classification import (
@@ -53,7 +55,7 @@ class SugarCrepe(AbsTaskImageTextPairClassification):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """Load dataset from HuggingFace hub"""
         if self.data_loaded:
             return

--- a/mteb/tasks/instruction_reranking/multilingual/m_follow_ir.py
+++ b/mteb/tasks/instruction_reranking/multilingual/m_follow_ir.py
@@ -1,4 +1,5 @@
 from logging import getLogger
+from typing import Any
 
 import datasets
 
@@ -175,7 +176,7 @@ class mFollowIRCrossLingual(AbsTaskRetrieval):  # noqa: N801
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 
@@ -243,7 +244,7 @@ class mFollowIR(AbsTaskRetrieval):  # noqa: N801
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/multichoice/eng/av_speaker_bench.py
+++ b/mteb/tasks/multichoice/eng/av_speaker_bench.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import Dataset, load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -40,7 +42,7 @@ class AVSpeakerBenchVideoCentricQA(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = {"default": {}}
@@ -113,7 +115,7 @@ class AVSpeakerBenchVideoAudioCentricQA(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = {"default": {}}

--- a/mteb/tasks/multichoice/eng/avmeme_exam.py
+++ b/mteb/tasks/multichoice/eng/avmeme_exam.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import Dataset, load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -40,7 +42,7 @@ class AVMemeExamVideoCentricQA(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = {"default": {}}
@@ -113,7 +115,7 @@ class AVMemeExamVideoAudioCentricQA(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = {"default": {}}

--- a/mteb/tasks/multichoice/eng/avqa.py
+++ b/mteb/tasks/multichoice/eng/avqa.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import Dataset, load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -40,7 +42,7 @@ class AVQAVideoCentricQA(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = {"default": {}}
@@ -113,7 +115,7 @@ class AVQAVideoAudioCentricQA(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = {"default": {}}

--- a/mteb/tasks/multichoice/eng/blink_it2i_multi_choice.py
+++ b/mteb/tasks/multichoice/eng/blink_it2i_multi_choice.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from typing import Any
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
@@ -36,7 +37,7 @@ class BLINKIT2IMultiChoice(AbsTaskRetrieval):
 """,
     )
 
-    def dataset_transform(self, **kwargs):
+    def dataset_transform(self, **kwargs: Any):
         for split_data in self.dataset.values():
             for dataset in split_data.values():
                 top_ranked = defaultdict(list)

--- a/mteb/tasks/multichoice/eng/blink_it2t_multi_choice.py
+++ b/mteb/tasks/multichoice/eng/blink_it2t_multi_choice.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from typing import Any
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
@@ -36,7 +37,7 @@ class BLINKIT2TMultiChoice(AbsTaskRetrieval):
 """,
     )
 
-    def dataset_transform(self, **kwargs):
+    def dataset_transform(self, **kwargs: Any):
         for split_data in self.dataset.values():
             for dataset in split_data.values():
                 top_ranked = defaultdict(list)

--- a/mteb/tasks/multichoice/eng/cv_bench.py
+++ b/mteb/tasks/multichoice/eng/cv_bench.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from typing import Any
 
 from datasets import Dataset, load_dataset
 
@@ -123,7 +124,7 @@ class CVBenchCount(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         self.corpus, self.queries, self.relevant_docs, self.top_ranked = _load_data(
             path=self.metadata.dataset["path"],
             splits=self.metadata.eval_splits,
@@ -165,7 +166,7 @@ class CVBenchRelation(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         self.corpus, self.queries, self.relevant_docs, self.top_ranked = _load_data(
             path=self.metadata.dataset["path"],
             splits=self.metadata.eval_splits,
@@ -207,7 +208,7 @@ class CVBenchDepth(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         self.corpus, self.queries, self.relevant_docs, self.top_ranked = _load_data(
             path=self.metadata.dataset["path"],
             splits=self.metadata.eval_splits,
@@ -249,7 +250,7 @@ class CVBenchDistance(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         self.corpus, self.queries, self.relevant_docs, self.top_ranked = _load_data(
             path=self.metadata.dataset["path"],
             splits=self.metadata.eval_splits,

--- a/mteb/tasks/multichoice/eng/daily_omni.py
+++ b/mteb/tasks/multichoice/eng/daily_omni.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import Dataset, load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -40,7 +42,7 @@ class DailyOmniVideoCentricQA(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = {"default": {}}
@@ -113,7 +115,7 @@ class DailyOmniVideoAudioCentricQA(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = {"default": {}}

--- a/mteb/tasks/multichoice/eng/egoschema.py
+++ b/mteb/tasks/multichoice/eng/egoschema.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import Dataset, load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -40,7 +42,7 @@ class EgoSchemaVideoCentricQA(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = {"default": {}}

--- a/mteb/tasks/multichoice/eng/nextqa.py
+++ b/mteb/tasks/multichoice/eng/nextqa.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import Dataset, load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -41,7 +43,7 @@ class NExTQAVideoCentricQA(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = {"default": {}}

--- a/mteb/tasks/multichoice/eng/omni_video_bench.py
+++ b/mteb/tasks/multichoice/eng/omni_video_bench.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import Dataset, load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -40,7 +42,7 @@ class OmniVideoBenchVideoCentricQA(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = {"default": {}}
@@ -113,7 +115,7 @@ class OmniVideoBenchVideoAudioCentricQA(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = {"default": {}}

--- a/mteb/tasks/multichoice/eng/perception_test.py
+++ b/mteb/tasks/multichoice/eng/perception_test.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import Dataset, load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -40,7 +42,7 @@ class PerceptionTestVideoCentricQA(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = {"default": {}}
@@ -113,7 +115,7 @@ class PerceptionTestVideoAudioCentricQA(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = {"default": {}}

--- a/mteb/tasks/multichoice/eng/star_bench.py
+++ b/mteb/tasks/multichoice/eng/star_bench.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import Dataset, load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -78,7 +80,7 @@ class STARBenchFeasibilityVideoCentricQA(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = {"default": {}}
@@ -116,7 +118,7 @@ class STARBenchFeasibilityVideoAudioCentricQA(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = {"default": {}}
@@ -154,7 +156,7 @@ class STARBenchInteractionVideoCentricQA(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = {"default": {}}
@@ -192,7 +194,7 @@ class STARBenchInteractionVideoAudioCentricQA(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = {"default": {}}
@@ -230,7 +232,7 @@ class STARBenchPredictionVideoCentricQA(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = {"default": {}}
@@ -268,7 +270,7 @@ class STARBenchPredictionVideoAudioCentricQA(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = {"default": {}}
@@ -306,7 +308,7 @@ class STARBenchSequenceVideoCentricQA(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = {"default": {}}
@@ -344,7 +346,7 @@ class STARBenchSequenceVideoAudioCentricQA(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = {"default": {}}

--- a/mteb/tasks/multichoice/eng/video_mme.py
+++ b/mteb/tasks/multichoice/eng/video_mme.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import Dataset, load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -40,7 +42,7 @@ class VideoMMEShortVideoCentricQA(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = {"default": {}}
@@ -113,7 +115,7 @@ class VideoMMEShortVideoAudioCentricQA(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = {"default": {}}

--- a/mteb/tasks/multichoice/eng/worldqa.py
+++ b/mteb/tasks/multichoice/eng/worldqa.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import Dataset, load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -40,7 +42,7 @@ class WorldQAVideoCentricQA(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = {"default": {}}
@@ -113,7 +115,7 @@ class WorldQAVideoAudioCentricQA(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = {"default": {}}

--- a/mteb/tasks/multichoice/eng/worldsense.py
+++ b/mteb/tasks/multichoice/eng/worldsense.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import Dataset, load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -40,7 +42,7 @@ class WorldSense1MinVideoCentricQA(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = {"default": {}}
@@ -113,7 +115,7 @@ class WorldSense1MinVideoAudioCentricQA(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = {"default": {}}

--- a/mteb/tasks/multilabel_classification/eng/fsd2019_kaggle.py
+++ b/mteb/tasks/multilabel_classification/eng/fsd2019_kaggle.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 from sklearn.linear_model import LogisticRegression
 from sklearn.multioutput import MultiOutputClassifier
@@ -54,7 +56,7 @@ Xavier Serra},
     label_column_name: str = "sound"
     samples_per_label: int = 8
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         """Load dataset from HuggingFace hub and convert it to the standard format."""
         if self.data_loaded:
             return

--- a/mteb/tasks/multilabel_classification/nld/covid_disinformation_nl_multi_label_classification.py
+++ b/mteb/tasks/multilabel_classification/nld/covid_disinformation_nl_multi_label_classification.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.multilabel_classification import (
     AbsTaskMultilabelClassification,
 )
@@ -64,7 +66,7 @@ Yih, Scott Wen-tau},
         prompt="Classificeer COVID-19-gerelateerde sociale media-berichten in alle toepasselijke desinformatiecategorieën",
     )
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         labels = [
             "q2_label",
             "q3_label",

--- a/mteb/tasks/multilabel_classification/zxx/bird_set.py
+++ b/mteb/tasks/multilabel_classification/zxx/bird_set.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from datasets import Audio, DatasetDict
 from sklearn.linear_model import LogisticRegression
 from sklearn.multioutput import MultiOutputClassifier
@@ -47,7 +49,7 @@ class BirdSetMultilabelClassification(AbsTaskMultilabelClassification):
     label_column_name: str = "labels"
     samples_per_label: int = 21
 
-    def dataset_transform(self, **kwargs):
+    def dataset_transform(self, **kwargs: Any):
         if "ebird_code_multilabel" in self.dataset.column_names[self.eval_splits[0]]:
             self.dataset = self.dataset.rename_column(
                 original_column_name="ebird_code_multilabel",

--- a/mteb/tasks/pair_classification/eng/velociti.py
+++ b/mteb/tasks/pair_classification/eng/velociti.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from datasets import concatenate_datasets, load_dataset
 
@@ -56,7 +56,7 @@ class VELOCITIPairClassification(AbsTaskPairClassification):
     input2_column_name: ClassVar[Mapping[str, str]] = {"text": "text"}
     label_column_name: str = "label"
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         path = self.metadata.dataset["path"]

--- a/mteb/tasks/pair_classification/multilingual/pub_chem_wiki_pair_classification.py
+++ b/mteb/tasks/pair_classification/multilingual/pub_chem_wiki_pair_classification.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.pair_classification import AbsTaskPairClassification
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -60,7 +62,7 @@ class PubChemWikiPairClassification(AbsTaskPairClassification):
 """,
     )
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _dataset = {}
         for lang in self.hf_subsets:
             _dataset[lang] = {}

--- a/mteb/tasks/pair_classification/slk/demagog_sknli.py
+++ b/mteb/tasks/pair_classification/slk/demagog_sknli.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from datasets import DatasetDict
 
 from mteb.abstasks.pair_classification import AbsTaskPairClassification
@@ -36,7 +38,7 @@ class DemagogSKNLI(AbsTaskPairClassification):
         prompt="Given a fact-checker's analysis (evidence), determine if it supports or refutes the political claim",
     )
 
-    def dataset_transform(self, **kwargs):
+    def dataset_transform(self, **kwargs: Any):
         """Transform DemagogSK into evidence-claim NLI pairs."""
         _dataset = {}
 

--- a/mteb/tasks/pair_classification/slk/slovak_nli.py
+++ b/mteb/tasks/pair_classification/slk/slovak_nli.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from datasets import DatasetDict
 
 from mteb.abstasks.pair_classification import AbsTaskPairClassification
@@ -35,7 +37,7 @@ class SlovakNLI(AbsTaskPairClassification):
         bibtex_citation="",
     )
 
-    def dataset_transform(self, **kwargs):
+    def dataset_transform(self, **kwargs: Any):
         _dataset = {}
 
         for split in self.metadata.eval_splits:

--- a/mteb/tasks/pair_classification/slk/slovak_rte.py
+++ b/mteb/tasks/pair_classification/slk/slovak_rte.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from datasets import DatasetDict
 
 from mteb.abstasks.pair_classification import AbsTaskPairClassification
@@ -50,7 +52,7 @@ class SlovakRTE(AbsTaskPairClassification):
         prompt="Given a premise, retrieve a hypothesis that is entailed by the premise",
     )
 
-    def dataset_transform(self, **kwargs):
+    def dataset_transform(self, **kwargs: Any):
         _dataset = {}
 
         for split in self.dataset:

--- a/mteb/tasks/retrieval/ara/sadeem_question_retrieval.py
+++ b/mteb/tasks/retrieval/ara/sadeem_question_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -37,7 +39,7 @@ class SadeemQuestionRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/code/code_edit_search_retrieval.py
+++ b/mteb/tasks/retrieval/code/code_edit_search_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -53,7 +55,7 @@ class CodeEditSearchRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/code/code_rag.py
+++ b/mteb/tasks/retrieval/code/code_rag.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -51,7 +53,7 @@ class CodeRAGProgrammingSolutionsRetrieval(AbsTaskRetrieval):
         **common_args,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """Load dataset from HuggingFace hub"""
         if self.data_loaded:
             return
@@ -59,7 +61,7 @@ class CodeRAGProgrammingSolutionsRetrieval(AbsTaskRetrieval):
         self.dataset_transform()
         self.data_loaded = True
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """And transform to a retrieval dataset, which have the following attributes
 
         self.corpus = Dict[doc_id, Dict[str, str]] #id => dict with document data like title and text
@@ -108,7 +110,7 @@ class CodeRAGOnlineTutorialsRetrieval(AbsTaskRetrieval):
         **common_args,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """Load dataset from HuggingFace hub"""
         if self.data_loaded:
             return
@@ -116,7 +118,7 @@ class CodeRAGOnlineTutorialsRetrieval(AbsTaskRetrieval):
         self.dataset_transform()
         self.data_loaded = True
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """And transform to a retrieval dataset, which have the following attributes
 
         self.corpus = Dict[doc_id, Dict[str, str]] #id => dict with document data like title and text
@@ -167,7 +169,7 @@ class CodeRAGLibraryDocumentationSolutionsRetrieval(AbsTaskRetrieval):
         **common_args,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """Load dataset from HuggingFace hub"""
         if self.data_loaded:
             return
@@ -175,7 +177,7 @@ class CodeRAGLibraryDocumentationSolutionsRetrieval(AbsTaskRetrieval):
         self.dataset_transform()
         self.data_loaded = True
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """And transform to a retrieval dataset, which have the following attributes
 
         self.corpus = Dict[doc_id, Dict[str, str]] #id => dict with document data like title and text
@@ -224,7 +226,7 @@ class CodeRAGStackoverflowPostsRetrieval(AbsTaskRetrieval):
         **common_args,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """Load dataset from HuggingFace hub"""
         if self.data_loaded:
             return
@@ -232,7 +234,7 @@ class CodeRAGStackoverflowPostsRetrieval(AbsTaskRetrieval):
         self.dataset_transform()
         self.data_loaded = True
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """And transform to a retrieval dataset, which have the following attributes
 
         self.corpus = Dict[doc_id, Dict[str, str]] #id => dict with document data like title and text

--- a/mteb/tasks/retrieval/code/code_search_net_cc_retrieval.py
+++ b/mteb/tasks/retrieval/code/code_search_net_cc_retrieval.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 import datasets
 
@@ -99,7 +100,7 @@ class CodeSearchNetCCRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/code/coir_code_search_net_retrieval.py
+++ b/mteb/tasks/retrieval/code/coir_code_search_net_retrieval.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 import datasets
 
@@ -97,7 +98,7 @@ class COIRCodeSearchNetRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/code/ds1000_retrieval.py
+++ b/mteb/tasks/retrieval/code/ds1000_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -34,7 +36,7 @@ class DS1000Retrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/code/fresh_stack_retrieval.py
+++ b/mteb/tasks/retrieval/code/fresh_stack_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -37,7 +39,7 @@ class FreshStackRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/code/human_eval_retrieval.py
+++ b/mteb/tasks/retrieval/code/human_eval_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -34,7 +36,7 @@ class HumanEvalRetrieval(AbsTaskRetrieval):
 }""",
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/code/mbpp_retrieval.py
+++ b/mteb/tasks/retrieval/code/mbpp_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -34,7 +36,7 @@ class MBPPRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/code/wiki_sql_retrieval.py
+++ b/mteb/tasks/retrieval/code/wiki_sql_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -36,7 +38,7 @@ class WikiSQLRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/dan/dan_fever_retrieval.py
+++ b/mteb/tasks/retrieval/dan/dan_fever_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -47,7 +49,7 @@ Derczynski, Leon},
         task_subtypes=["Claim verification"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """Load dataset from HuggingFace hub"""
         if self.data_loaded:
             return
@@ -55,7 +57,7 @@ Derczynski, Leon},
         self.dataset_transform()
         self.data_loaded = True
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """And transform to a retrieval dataset, which have the following attributes
 
         self.corpus = dict[doc_id, dict[str, str]] #id => dict with document data like title and text

--- a/mteb/tasks/retrieval/dan/tv2_nordretrieval.py
+++ b/mteb/tasks/retrieval/dan/tv2_nordretrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -60,7 +62,7 @@ Piperidis, Stelios},
         task_subtypes=["Article retrieval"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """Load dataset from HuggingFace hub"""
         if self.data_loaded:
             return
@@ -68,7 +70,7 @@ Piperidis, Stelios},
         self.dataset_transform()
         self.data_loaded = True
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """And transform to a retrieval dataset, which have the following attributes
 
         self.corpus = dict[doc_id, dict[str, str]] #id => dict with document data like title and text

--- a/mteb/tasks/retrieval/deu/german_qu_ad_retrieval.py
+++ b/mteb/tasks/retrieval/deu/german_qu_ad_retrieval.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from typing import Any
 
 from datasets import DatasetDict, load_dataset
 
@@ -58,7 +59,7 @@ class GermanQuADRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/ell/greek_civics_qa.py
+++ b/mteb/tasks/retrieval/ell/greek_civics_qa.py
@@ -1,4 +1,5 @@
 from hashlib import sha256
+from typing import Any
 
 import datasets
 
@@ -31,7 +32,7 @@ class GreekCivicsQA(AbsTaskRetrieval):
         bibtex_citation="",
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         # fetch both subsets of the dataset

--- a/mteb/tasks/retrieval/eng/activitynet_captions_retrieval.py
+++ b/mteb/tasks/retrieval/eng/activitynet_captions_retrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -80,7 +82,7 @@ class ActivityNetCaptionsV2TRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_activitynet(self, query_columns=["video"], corpus_columns=["caption"])
 
 
@@ -113,5 +115,5 @@ class ActivityNetCaptionsT2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_activitynet(self, query_columns=["caption"], corpus_columns=["video"])

--- a/mteb/tasks/retrieval/eng/audiocaps_av_retrieval.py
+++ b/mteb/tasks/retrieval/eng/audiocaps_av_retrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -81,7 +83,7 @@ class AudioCapsAVV2TRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_audiocaps_av(self, query_columns=["video"], corpus_columns=["caption"])
 
 
@@ -114,7 +116,7 @@ class AudioCapsAVT2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_audiocaps_av(self, query_columns=["caption"], corpus_columns=["video"])
 
 
@@ -147,7 +149,7 @@ class AudioCapsAVVA2TRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_audiocaps_av(
             self, query_columns=["video", "audio"], corpus_columns=["caption"]
         )
@@ -182,7 +184,7 @@ class AudioCapsAVT2VARetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_audiocaps_av(
             self, query_columns=["caption"], corpus_columns=["video", "audio"]
         )
@@ -218,7 +220,7 @@ class AudioCapsAVV2ARetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_audiocaps_av(self, query_columns=["video"], corpus_columns=["audio"])
 
 
@@ -252,7 +254,7 @@ class AudioCapsAVA2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_audiocaps_av(self, query_columns=["audio"], corpus_columns=["video"])
 
 
@@ -287,7 +289,7 @@ class AudioCapsAVVT2ARetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_audiocaps_av(
             self, query_columns=["video", "caption"], corpus_columns=["audio"]
         )
@@ -324,7 +326,7 @@ class AudioCapsAVAT2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_audiocaps_av(
             self, query_columns=["audio", "caption"], corpus_columns=["video"]
         )

--- a/mteb/tasks/retrieval/eng/avcaps_retrieval.py
+++ b/mteb/tasks/retrieval/eng/avcaps_retrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -109,7 +111,7 @@ class AVCapsA2TRetrieval(AbsTaskRetrieval):
         **_COMMON,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_avcaps(self, "audio_captions", to_text=True)
 
 
@@ -123,7 +125,7 @@ class AVCapsT2ARetrieval(AbsTaskRetrieval):
         **_COMMON,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_avcaps(self, "audio_captions", to_text=False)
 
 
@@ -137,7 +139,7 @@ class AVCapsV2TRetrieval(AbsTaskRetrieval):
         **_COMMON,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_avcaps(self, "visual_captions", to_text=True)
 
 
@@ -151,7 +153,7 @@ class AVCapsT2VRetrieval(AbsTaskRetrieval):
         **_COMMON,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_avcaps(self, "visual_captions", to_text=False)
 
 
@@ -167,7 +169,7 @@ class AVCapsVA2TRetrieval(AbsTaskRetrieval):
         **_COMMON,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_avcaps(self, "av_captions", to_text=True)
 
 
@@ -185,5 +187,5 @@ class AVCapsT2VARetrieval(AbsTaskRetrieval):
         **_COMMON,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_avcaps(self, "av_captions", to_text=False)

--- a/mteb/tasks/retrieval/eng/avmeme_exam_retrieval.py
+++ b/mteb/tasks/retrieval/eng/avmeme_exam_retrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -80,7 +82,7 @@ class AVMemeExamV2TRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_avmeme_exam(self, query_columns=["video"], corpus_columns=["summary"])
 
 
@@ -113,7 +115,7 @@ class AVMemeExamT2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_avmeme_exam(self, query_columns=["summary"], corpus_columns=["video"])
 
 
@@ -146,7 +148,7 @@ class AVMemeExamVA2TRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_avmeme_exam(
             self, query_columns=["video", "audio"], corpus_columns=["summary"]
         )
@@ -181,7 +183,7 @@ class AVMemeExamT2VARetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_avmeme_exam(
             self, query_columns=["summary"], corpus_columns=["video", "audio"]
         )
@@ -218,7 +220,7 @@ class AVMemeExamV2ARetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_avmeme_exam(self, query_columns=["video"], corpus_columns=["audio"])
 
 
@@ -253,7 +255,7 @@ class AVMemeExamA2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_avmeme_exam(self, query_columns=["audio"], corpus_columns=["video"])
 
 
@@ -288,7 +290,7 @@ class AVMemeExamVT2ARetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_avmeme_exam(
             self, query_columns=["video", "summary"], corpus_columns=["audio"]
         )
@@ -325,7 +327,7 @@ class AVMemeExamAT2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_avmeme_exam(
             self, query_columns=["audio", "summary"], corpus_columns=["video"]
         )

--- a/mteb/tasks/retrieval/eng/bright_retrieval.py
+++ b/mteb/tasks/retrieval/eng/bright_retrieval.py
@@ -1,5 +1,6 @@
 import warnings
 from collections import defaultdict
+from typing import Any
 
 import datasets
 
@@ -83,7 +84,7 @@ def load_bright_data(
     return corpus, queries, relevant_docs
 
 
-def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
     if self.data_loaded:
         return
 

--- a/mteb/tasks/retrieval/eng/bright_v1_1_retrieval.py
+++ b/mteb/tasks/retrieval/eng/bright_v1_1_retrieval.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from typing import Any
 
 import datasets
 
@@ -113,7 +114,7 @@ class BrightBiologyRetrieval(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX_CITATION,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
 
@@ -157,7 +158,7 @@ class BrightEarthScienceRetrieval(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX_CITATION,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
 
@@ -201,7 +202,7 @@ class BrightEconomicsRetrieval(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX_CITATION,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
 
@@ -245,7 +246,7 @@ class BrightPsychologyRetrieval(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX_CITATION,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
 
@@ -289,7 +290,7 @@ class BrightRoboticsRetrieval(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX_CITATION,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
 
@@ -333,7 +334,7 @@ class BrightStackoverflowRetrieval(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX_CITATION,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
 
@@ -377,7 +378,7 @@ class BrightSustainableLivingRetrieval(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX_CITATION,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
 
@@ -421,7 +422,7 @@ class BrightPonyRetrieval(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX_CITATION,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
 
@@ -465,7 +466,7 @@ class BrightLeetcodeRetrieval(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX_CITATION,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
 
@@ -509,7 +510,7 @@ class BrightAopsRetrieval(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX_CITATION,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
 
@@ -553,7 +554,7 @@ class BrightTheoremQATheoremsRetrieval(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX_CITATION,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
 
@@ -597,7 +598,7 @@ class BrightTheoremQAQuestionsRetrieval(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX_CITATION,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
 
@@ -641,7 +642,7 @@ class BrightBiologyLongRetrieval(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX_CITATION,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
 
@@ -685,7 +686,7 @@ class BrightEarthScienceLongRetrieval(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX_CITATION,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
 
@@ -729,7 +730,7 @@ class BrightEconomicsLongRetrieval(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX_CITATION,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
 
@@ -773,7 +774,7 @@ class BrightPsychologyLongRetrieval(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX_CITATION,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
 
@@ -817,7 +818,7 @@ class BrightRoboticsLongRetrieval(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX_CITATION,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
 
@@ -861,7 +862,7 @@ class BrightStackoverflowLongRetrieval(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX_CITATION,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
 
@@ -905,7 +906,7 @@ class BrightSustainableLivingLongRetrieval(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX_CITATION,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
 
@@ -949,7 +950,7 @@ class BrightPonyLongRetrieval(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX_CITATION,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/carebench_retrieval.py
+++ b/mteb/tasks/retrieval/eng/carebench_retrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -81,7 +83,7 @@ class CaReBenchT2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_carebench(self, query_columns=["caption"], corpus_columns=["video"])
 
 
@@ -115,5 +117,5 @@ class CaReBenchV2TRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_carebench(self, query_columns=["video"], corpus_columns=["caption"])

--- a/mteb/tasks/retrieval/eng/chat_doctor_retrieval.py
+++ b/mteb/tasks/retrieval/eng/chat_doctor_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -36,7 +38,7 @@ class ChatDoctorRetrieval(AbsTaskRetrieval):
         },
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/clotho.py
+++ b/mteb/tasks/retrieval/eng/clotho.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from typing import Any
 
 from datasets import Dataset, DatasetDict, load_dataset
 from tqdm.auto import tqdm
@@ -43,7 +44,7 @@ class ClothoA2TRetrieval(AbsTaskRetrieval):
         superseded_by="ClothoA2TRetrieval.v2",
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
 
@@ -148,7 +149,7 @@ class ClothoT2ARetrieval(AbsTaskRetrieval):
         superseded_by="ClothoT2ARetrieval.v2",
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/dapfam_patent_retrieval.py
+++ b/mteb/tasks/retrieval/eng/dapfam_patent_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -59,7 +61,7 @@ class _DAPFAMMixin:
     query_fields: list[str] = []  # noqa: RUF012
     corpus_fields: list[str] = []  # noqa: RUF012
 
-    def load_data(self, **kwargs) -> tuple[dict, dict, dict]:
+    def load_data(self, **kwargs: Any) -> tuple[dict, dict, dict]:
         ds_c = load_dataset(
             self.metadata.dataset["path"],
             "corpus",

--- a/mteb/tasks/retrieval/eng/didemo_retrieval.py
+++ b/mteb/tasks/retrieval/eng/didemo_retrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -80,7 +82,7 @@ class DiDeMoV2TRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_didemo(self, query_columns=["video"], corpus_columns=["caption"])
 
 
@@ -113,7 +115,7 @@ class DiDeMoT2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_didemo(self, query_columns=["caption"], corpus_columns=["video"])
 
 
@@ -146,7 +148,7 @@ class DiDeMoVA2TRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_didemo(self, query_columns=["video", "audio"], corpus_columns=["caption"])
 
 
@@ -179,7 +181,7 @@ class DiDeMoT2VARetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_didemo(self, query_columns=["caption"], corpus_columns=["video", "audio"])
 
 
@@ -211,7 +213,7 @@ class DiDeMoV2ARetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_didemo(self, query_columns=["video"], corpus_columns=["audio"])
 
 
@@ -243,7 +245,7 @@ class DiDeMoA2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_didemo(self, query_columns=["audio"], corpus_columns=["video"])
 
 
@@ -278,7 +280,7 @@ class DiDeMoVT2ARetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_didemo(self, query_columns=["video", "caption"], corpus_columns=["audio"])
 
 
@@ -313,5 +315,5 @@ class DiDeMoAT2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_didemo(self, query_columns=["audio", "caption"], corpus_columns=["video"])

--- a/mteb/tasks/retrieval/eng/fgmcaps_retrieval.py
+++ b/mteb/tasks/retrieval/eng/fgmcaps_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -82,7 +84,7 @@ class FGMCapsT2ARetrieval(AbsTaskRetrieval):
         prompt={"query": "Retrieve the music clip described by this caption."},
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 
@@ -127,7 +129,7 @@ class FGMCapsA2TRetrieval(AbsTaskRetrieval):
         prompt={"query": "Retrieve the caption that describes this music clip."},
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/fin_qa_retrieval.py
+++ b/mteb/tasks/retrieval/eng/fin_qa_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -37,7 +39,7 @@ class FinQARetrieval(AbsTaskRetrieval):
         },
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/finance_bench_retrieval.py
+++ b/mteb/tasks/retrieval/eng/finance_bench_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -37,7 +39,7 @@ class FinanceBenchRetrieval(AbsTaskRetrieval):
         },
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/flickr_audio_image_retrieval.py
+++ b/mteb/tasks/retrieval/eng/flickr_audio_image_retrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -43,7 +45,7 @@ class FlickrAudioToImageRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
 
@@ -108,7 +110,7 @@ class FlickrImageToAudioRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/hateful_memes_i2t_retrieval.py
+++ b/mteb/tasks/retrieval/eng/hateful_memes_i2t_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import polars as pl
 from datasets import concatenate_datasets, load_dataset
 
@@ -90,7 +92,7 @@ class HatefulMemesI2TRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.corpus, self.queries, self.relevant_docs = _load_data(

--- a/mteb/tasks/retrieval/eng/hateful_memes_t2i_retrieval.py
+++ b/mteb/tasks/retrieval/eng/hateful_memes_t2i_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import polars as pl
 from datasets import concatenate_datasets, load_dataset
 
@@ -90,7 +92,7 @@ class HatefulMemesT2IRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.corpus, self.queries, self.relevant_docs = _load_data(

--- a/mteb/tasks/retrieval/eng/hc3_finance_retrieval.py
+++ b/mteb/tasks/retrieval/eng/hc3_finance_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -37,7 +39,7 @@ class HC3FinanceRetrieval(AbsTaskRetrieval):
         },
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/incompe_bench_retrieval.py
+++ b/mteb/tasks/retrieval/eng/incompe_bench_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -100,7 +102,7 @@ class IncompeBenchStrictRetrieval(AbsTaskRetrieval):
         prompt={"query": "Retrieve music that matches the user's search query."},
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 
@@ -156,7 +158,7 @@ class IncompeBenchLenientRetrieval(AbsTaskRetrieval):
         prompt={"query": "Retrieve music that matches the user's search query."},
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/irpapers_t2i_retrieval.py
+++ b/mteb/tasks/retrieval/eng/irpapers_t2i_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -37,7 +39,7 @@ class IRPapersT2IRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         self.dataset["default"]["train"]["corpus"] = self.dataset["default"]["train"][
             "corpus"
         ].remove_columns("transcription")

--- a/mteb/tasks/retrieval/eng/irpapers_t2it_retrieval.py
+++ b/mteb/tasks/retrieval/eng/irpapers_t2it_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -37,7 +39,7 @@ class IRPapersT2ITRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         self.dataset["default"]["train"]["corpus"] = self.dataset["default"]["train"][
             "corpus"
         ].rename_column("transcription", "text")

--- a/mteb/tasks/retrieval/eng/lemb_narrative_qa_retrieval.py
+++ b/mteb/tasks/retrieval/eng/lemb_narrative_qa_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -55,7 +57,7 @@ Roark, Brian},
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/lemb_needle_retrieval.py
+++ b/mteb/tasks/retrieval/eng/lemb_needle_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -46,7 +48,7 @@ class LEMBNeedleRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/lemb_summ_screen_fd_retrieval.py
+++ b/mteb/tasks/retrieval/eng/lemb_summ_screen_fd_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -51,7 +53,7 @@ Villavicencio, Aline},
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/lemb_wikim_qa_retrieval.py
+++ b/mteb/tasks/retrieval/eng/lemb_wikim_qa_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -40,7 +42,7 @@ class LEMBWikimQARetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/lembqm_sum_retrieval.py
+++ b/mteb/tasks/retrieval/eng/lembqm_sum_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -64,7 +66,7 @@ Zhou, Yichao},
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/lit_search_retrieval.py
+++ b/mteb/tasks/retrieval/eng/lit_search_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -35,7 +37,7 @@ class LitSearchRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.corpus, self.queries, self.relevant_docs = {}, {}, {}

--- a/mteb/tasks/retrieval/eng/lombard_grid_retrieval.py
+++ b/mteb/tasks/retrieval/eng/lombard_grid_retrieval.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from datasets import concatenate_datasets, load_dataset
 
@@ -174,7 +174,7 @@ class LombardGridA2VRetrieval(AbsTaskRetrieval):
         **_COMMON,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_lombard_grid(self, "a2v")
 
 
@@ -193,7 +193,7 @@ class LombardGridV2ARetrieval(AbsTaskRetrieval):
         **_COMMON,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_lombard_grid(self, "v2a")
 
 
@@ -214,7 +214,7 @@ class LombardGridV2VRetrieval(AbsTaskRetrieval):
         **_COMMON,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_lombard_grid(self, "v2v")
 
 
@@ -240,5 +240,5 @@ class LombardGridVA2VARetrieval(AbsTaskRetrieval):
         **_COMMON,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_lombard_grid(self, "va2va")

--- a/mteb/tasks/retrieval/eng/mars_vl_pairs.py
+++ b/mteb/tasks/retrieval/eng/mars_vl_pairs.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal
 
 from datasets import load_dataset
 
@@ -106,7 +106,7 @@ class MarsVLPairsT2IRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_mars_vl_pairs(self, "t2i", num_proc)
 
 
@@ -140,5 +140,5 @@ class MarsVLPairsI2TRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_mars_vl_pairs(self, "i2t", num_proc)

--- a/mteb/tasks/retrieval/eng/memotion_i2t_retrieval.py
+++ b/mteb/tasks/retrieval/eng/memotion_i2t_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from datasets import concatenate_datasets, load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -113,7 +115,7 @@ class MemotionI2TRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.corpus, self.queries, self.relevant_docs = _load_data(

--- a/mteb/tasks/retrieval/eng/memotion_t2i_retrieval.py
+++ b/mteb/tasks/retrieval/eng/memotion_t2i_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from datasets import concatenate_datasets, load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -112,7 +114,7 @@ class MemotionT2IRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.corpus, self.queries, self.relevant_docs = _load_data(

--- a/mteb/tasks/retrieval/eng/ml_questions.py
+++ b/mteb/tasks/retrieval/eng/ml_questions.py
@@ -1,5 +1,6 @@
 import csv
 from pathlib import Path
+from typing import Any
 
 from huggingface_hub import snapshot_download
 
@@ -55,7 +56,7 @@ Reddy, Siva},
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.corpus, self.queries, self.relevant_docs = {}, {}, {}

--- a/mteb/tasks/retrieval/eng/mm_long_bench_doc_retrieval.py
+++ b/mteb/tasks/retrieval/eng/mm_long_bench_doc_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -98,7 +100,7 @@ class MMLongBenchDocRetrieval(AbsTaskRetrieval):
         prompt={"query": "Find a document image that matches the given query."},
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/mmdocir_t2i_retrieval.py
+++ b/mteb/tasks/retrieval/eng/mmdocir_t2i_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -50,7 +52,7 @@ class MMDocIRT2IRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         for subset in self.dataset:
             for split in self.dataset[subset]:
                 if "corpus" in self.dataset[subset][split]:

--- a/mteb/tasks/retrieval/eng/moment_seeker.py
+++ b/mteb/tasks/retrieval/eng/moment_seeker.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -82,7 +84,7 @@ class MomentSeekerTI2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_momentseeker(self, "ti2v")
 
 
@@ -114,5 +116,5 @@ class MomentSeekerTV2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_momentseeker(self, "tv2v")

--- a/mteb/tasks/retrieval/eng/msr_vtt.py
+++ b/mteb/tasks/retrieval/eng/msr_vtt.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -75,7 +77,7 @@ class MSRVTTV2T(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_msr_vtt(self, query_columns=["video"], corpus_columns=["caption"])
 
 
@@ -103,7 +105,7 @@ class MSRVTTT2V(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_msr_vtt(self, query_columns=["caption"], corpus_columns=["video"])
 
 
@@ -131,7 +133,7 @@ class MSRVTTVA2T(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_msr_vtt(
             self, query_columns=["video", "audio"], corpus_columns=["caption"]
         )
@@ -161,7 +163,7 @@ class MSRVTTT2VA(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_msr_vtt(
             self, query_columns=["caption"], corpus_columns=["video", "audio"]
         )
@@ -195,7 +197,7 @@ class MSRVTTV2A(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_msr_vtt(self, query_columns=["video"], corpus_columns=["audio"])
 
 
@@ -227,7 +229,7 @@ class MSRVTTA2V(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_msr_vtt(self, query_columns=["audio"], corpus_columns=["video"])
 
 
@@ -257,7 +259,7 @@ class MSRVTTVT2A(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_msr_vtt(
             self, query_columns=["video", "caption"], corpus_columns=["audio"]
         )
@@ -289,7 +291,7 @@ class MSRVTTAT2V(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_msr_vtt(
             self, query_columns=["audio", "caption"], corpus_columns=["video"]
         )

--- a/mteb/tasks/retrieval/eng/msvd_t2v_retrieval.py
+++ b/mteb/tasks/retrieval/eng/msvd_t2v_retrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -47,7 +49,7 @@ class MSVDT2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """Load the MSVD dataset for text-to-video retrieval.
 
         TODO: Reupload dataset in standard format and remove this custom load_data.

--- a/mteb/tasks/retrieval/eng/msvd_v2t_retrieval.py
+++ b/mteb/tasks/retrieval/eng/msvd_v2t_retrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -47,7 +49,7 @@ class MSVDV2TRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """Load the MSVD dataset.
 
         TODO: Reupload dataset in standard format and remove this custom load_data.

--- a/mteb/tasks/retrieval/eng/nano_argu_ana_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_argu_ana_retrieval.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from typing import Any
 
 from datasets import load_dataset
 
@@ -40,7 +41,7 @@ class NanoArguAnaRetrieval(AbsTaskRetrieval):
         adapted_from=["ArguAna"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/nano_climate_fever_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_climate_fever_retrieval.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from typing import Any
 
 from datasets import load_dataset
 
@@ -44,7 +45,7 @@ class NanoClimateFeverRetrieval(AbsTaskRetrieval):
         adapted_from=["ClimateFEVER"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/nano_db_pedia_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_db_pedia_retrieval.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from typing import Any
 
 from datasets import load_dataset
 
@@ -42,7 +43,7 @@ class NanoDBPediaRetrieval(AbsTaskRetrieval):
         adapted_from=["DBPedia"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/nano_fever_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_fever_retrieval.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from typing import Any
 
 from datasets import load_dataset
 
@@ -57,7 +58,7 @@ Stent, Amanda},
         adapted_from=["FEVER"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/nano_fi_qa2018_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_fi_qa2018_retrieval.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from typing import Any
 
 from datasets import load_dataset
 
@@ -43,7 +44,7 @@ class NanoFiQA2018Retrieval(AbsTaskRetrieval):
         adapted_from=["FiQA2018"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/nano_hotpot_qa_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_hotpot_qa_retrieval.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from typing import Any
 
 from datasets import load_dataset
 
@@ -60,7 +61,7 @@ Tsujii, Jun{'}ichi},
         adapted_from=["HotpotQA"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/nano_msmarco_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_msmarco_retrieval.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from typing import Any
 
 from datasets import load_dataset
 
@@ -55,7 +56,7 @@ Li Deng},
         adapted_from=["MSMARCO"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/nano_nf_corpus_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_nf_corpus_retrieval.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from typing import Any
 
 from datasets import load_dataset
 
@@ -46,7 +47,7 @@ class NanoNFCorpusRetrieval(AbsTaskRetrieval):
         adapted_from=["NFCorpus"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/nano_nq_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_nq_retrieval.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from typing import Any
 
 from datasets import load_dataset
 
@@ -46,7 +47,7 @@ Linguistics},
         adapted_from=["NQ"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/nano_quora_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_quora_retrieval.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from typing import Any
 
 from datasets import load_dataset
 
@@ -45,7 +46,7 @@ class NanoQuoraRetrieval(AbsTaskRetrieval):
         adapted_from=["QuoraRetrieval"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/nano_sci_fact_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_sci_fact_retrieval.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from typing import Any
 
 from datasets import load_dataset
 
@@ -42,7 +43,7 @@ class NanoSciFactRetrieval(AbsTaskRetrieval):
         adapted_from=["SciFact"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/nano_scidocs_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_scidocs_retrieval.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from typing import Any
 
 from datasets import load_dataset
 
@@ -44,7 +45,7 @@ class NanoSCIDOCSRetrieval(AbsTaskRetrieval):
         adapted_from=["SCIDOCS"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/nano_touche2020_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_touche2020_retrieval.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from typing import Any
 
 from datasets import load_dataset
 
@@ -53,7 +54,7 @@ Questions}},
         adapted_from=["Touche2020"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/narrative_qa_retrieval.py
+++ b/mteb/tasks/retrieval/eng/narrative_qa_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -57,7 +59,7 @@ Roark, Brian},
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/panda70m_retrieval.py
+++ b/mteb/tasks/retrieval/eng/panda70m_retrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -80,7 +82,7 @@ class Panda70MV2TRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_panda70m(self, query_columns=["video"], corpus_columns=["caption"])
 
 
@@ -113,7 +115,7 @@ class Panda70MT2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_panda70m(self, query_columns=["caption"], corpus_columns=["video"])
 
 
@@ -145,7 +147,7 @@ class Panda70MVA2TRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_panda70m(
             self, query_columns=["video", "audio"], corpus_columns=["caption"]
         )
@@ -179,7 +181,7 @@ class Panda70MT2VARetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_panda70m(
             self, query_columns=["caption"], corpus_columns=["video", "audio"]
         )

--- a/mteb/tasks/retrieval/eng/r2_med_retrieval.py
+++ b/mteb/tasks/retrieval/eng/r2_med_retrieval.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from typing import Any
 
 import datasets
 
@@ -70,7 +71,7 @@ class R2MEDBiologyRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 
@@ -114,7 +115,7 @@ class R2MEDBioinformaticsRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 
@@ -158,7 +159,7 @@ class R2MEDMedicalSciencesRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 
@@ -202,7 +203,7 @@ class R2MEDMedXpertQAExamRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 
@@ -246,7 +247,7 @@ class R2MEDMedQADiagRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 
@@ -290,7 +291,7 @@ class R2MEDPMCTreatmentRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 
@@ -334,7 +335,7 @@ class R2MEDPMCClinicalRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 
@@ -378,7 +379,7 @@ class R2MEDIIYiClinicalRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/ravenea.py
+++ b/mteb/tasks/retrieval/eng/ravenea.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
@@ -146,7 +146,7 @@ class RAVENEAI2TRetrieval(AbsTaskRetrieval):
         },
     )
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         split_data = self.dataset["default"]["test"]
         query_metadata = [
             column

--- a/mteb/tasks/retrieval/eng/real_mm_rag_retrieval.py
+++ b/mteb/tasks/retrieval/eng/real_mm_rag_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from datasets import Features, Value, load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -115,7 +117,7 @@ class RealMMRAGFinReportRetrieval(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX_CITATION,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = _load_data(
@@ -152,7 +154,7 @@ class RealMMRAGFinSlidesRetrieval(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX_CITATION,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = _load_data(
@@ -189,7 +191,7 @@ class RealMMRAGTechReportRetrieval(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX_CITATION,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = _load_data(
@@ -226,7 +228,7 @@ class RealMMRAGTechSlidesRetrieval(AbsTaskRetrieval):
         bibtex_citation=_BIBTEX_CITATION,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.dataset = _load_data(

--- a/mteb/tasks/retrieval/eng/sci_mmir_i2t_retrieval.py
+++ b/mteb/tasks/retrieval/eng/sci_mmir_i2t_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -91,7 +93,7 @@ class SciMMIRI2TRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.corpus, self.queries, self.relevant_docs = _load_data(

--- a/mteb/tasks/retrieval/eng/sci_mmir_t2i_retrieval.py
+++ b/mteb/tasks/retrieval/eng/sci_mmir_t2i_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -91,7 +93,7 @@ class SciMMIRT2IRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.corpus, self.queries, self.relevant_docs = _load_data(

--- a/mteb/tasks/retrieval/eng/shot2story_retrieval.py
+++ b/mteb/tasks/retrieval/eng/shot2story_retrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -79,7 +81,7 @@ class Shot2Story20KV2TRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_shot2story(self, query_columns=["video"], corpus_columns=["caption"])
 
 
@@ -111,7 +113,7 @@ class Shot2Story20KT2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_shot2story(self, query_columns=["caption"], corpus_columns=["video"])
 
 
@@ -143,7 +145,7 @@ class Shot2Story20KVA2TRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_shot2story(
             self, query_columns=["video", "audio"], corpus_columns=["caption"]
         )
@@ -177,7 +179,7 @@ class Shot2Story20KT2VARetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_shot2story(
             self, query_columns=["caption"], corpus_columns=["video", "audio"]
         )
@@ -212,7 +214,7 @@ class Shot2Story20KV2ARetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_shot2story(self, query_columns=["video"], corpus_columns=["audio"])
 
 
@@ -245,7 +247,7 @@ class Shot2Story20KA2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_shot2story(self, query_columns=["audio"], corpus_columns=["video"])
 
 
@@ -279,7 +281,7 @@ class Shot2Story20KVT2ARetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_shot2story(
             self, query_columns=["video", "caption"], corpus_columns=["audio"]
         )
@@ -315,7 +317,7 @@ class Shot2Story20KAT2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_shot2story(
             self, query_columns=["audio", "caption"], corpus_columns=["video"]
         )

--- a/mteb/tasks/retrieval/eng/ssw60.py
+++ b/mteb/tasks/retrieval/eng/ssw60.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import concatenate_datasets, load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -58,7 +60,7 @@ class SSW60A2IRetrieval(AbsTaskRetrieval):
         },
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 
@@ -134,7 +136,7 @@ class SSW60I2ARetrieval(AbsTaskRetrieval):
         },
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/eng/tuna_bench_t2v_retrieval.py
+++ b/mteb/tasks/retrieval/eng/tuna_bench_t2v_retrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -48,7 +50,7 @@ class TUNABenchT2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """Load the TUNA-Bench dataset for text-to-video retrieval.
 
         TODO: Reupload dataset in standard format and remove this custom load_data.

--- a/mteb/tasks/retrieval/eng/tuna_bench_v2t_retrieval.py
+++ b/mteb/tasks/retrieval/eng/tuna_bench_v2t_retrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -48,7 +50,7 @@ class TUNABenchV2TRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """Load the TUNA-Bench dataset for video-to-text retrieval.
 
         TODO: Reupload dataset in standard format and remove this custom load_data.

--- a/mteb/tasks/retrieval/eng/valor_32k_retrieval.py
+++ b/mteb/tasks/retrieval/eng/valor_32k_retrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -79,7 +81,7 @@ class VALOR32KV2TRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_valor(self, query_columns=["video"], corpus_columns=["description"])
 
 
@@ -111,7 +113,7 @@ class VALOR32KT2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_valor(self, query_columns=["description"], corpus_columns=["video"])
 
 
@@ -143,7 +145,7 @@ class VALOR32KVA2TRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_valor(
             self, query_columns=["video", "audio"], corpus_columns=["description"]
         )
@@ -177,7 +179,7 @@ class VALOR32KT2VARetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_valor(
             self, query_columns=["description"], corpus_columns=["video", "audio"]
         )
@@ -212,7 +214,7 @@ class VALOR32KV2ARetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_valor(self, query_columns=["video"], corpus_columns=["audio"])
 
 
@@ -245,7 +247,7 @@ class VALOR32KA2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_valor(self, query_columns=["audio"], corpus_columns=["video"])
 
 
@@ -280,7 +282,7 @@ class VALOR32KVT2ARetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_valor(
             self, query_columns=["video", "description"], corpus_columns=["audio"]
         )
@@ -317,7 +319,7 @@ class VALOR32KAT2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_valor(
             self, query_columns=["audio", "description"], corpus_columns=["video"]
         )

--- a/mteb/tasks/retrieval/eng/vatex_retrieval.py
+++ b/mteb/tasks/retrieval/eng/vatex_retrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -79,7 +81,7 @@ class VATEXV2TRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_vatex(self, query_columns=["video"], corpus_columns=["caption"])
 
 
@@ -111,7 +113,7 @@ class VATEXT2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_vatex(self, query_columns=["caption"], corpus_columns=["video"])
 
 
@@ -143,7 +145,7 @@ class VATEXVA2TRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_vatex(self, query_columns=["video", "audio"], corpus_columns=["caption"])
 
 
@@ -175,7 +177,7 @@ class VATEXT2VARetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_vatex(self, query_columns=["caption"], corpus_columns=["video", "audio"])
 
 
@@ -207,7 +209,7 @@ class VATEXV2ARetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_vatex(self, query_columns=["video"], corpus_columns=["audio"])
 
 
@@ -239,7 +241,7 @@ class VATEXA2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_vatex(self, query_columns=["audio"], corpus_columns=["video"])
 
 
@@ -273,7 +275,7 @@ class VATEXVT2ARetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_vatex(self, query_columns=["video", "caption"], corpus_columns=["audio"])
 
 
@@ -307,5 +309,5 @@ class VATEXAT2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_vatex(self, query_columns=["audio", "caption"], corpus_columns=["video"])

--- a/mteb/tasks/retrieval/eng/vggsound_av_retrieval.py
+++ b/mteb/tasks/retrieval/eng/vggsound_av_retrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -93,7 +95,7 @@ class VGGSoundAVV2TRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_vggsound_av(
             self, query_columns=["video"], corpus_columns=["video_caption"]
         )
@@ -128,7 +130,7 @@ class VGGSoundAVT2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_vggsound_av(
             self, query_columns=["video_caption"], corpus_columns=["video"]
         )
@@ -165,7 +167,7 @@ class VGGSoundAVVA2TRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_vggsound_av(
             self, query_columns=["video", "audio"], corpus_columns=["av_caption"]
         )
@@ -202,7 +204,7 @@ class VGGSoundAVT2VARetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_vggsound_av(
             self, query_columns=["av_caption"], corpus_columns=["video", "audio"]
         )
@@ -237,7 +239,7 @@ class VGGSoundAVV2ARetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_vggsound_av(self, query_columns=["video"], corpus_columns=["audio"])
 
 
@@ -270,7 +272,7 @@ class VGGSoundAVA2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_vggsound_av(self, query_columns=["audio"], corpus_columns=["video"])
 
 
@@ -305,7 +307,7 @@ class VGGSoundAVVT2ARetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_vggsound_av(
             self, query_columns=["video", "av_caption"], corpus_columns=["audio"]
         )
@@ -342,7 +344,7 @@ class VGGSoundAVAT2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_vggsound_av(
             self, query_columns=["audio", "av_caption"], corpus_columns=["video"]
         )

--- a/mteb/tasks/retrieval/eng/vidore_bench_retrieval.py
+++ b/mteb/tasks/retrieval/eng/vidore_bench_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -95,7 +97,7 @@ class VidoreArxivQARetrieval(AbsTaskRetrieval):
         prompt={"query": "Find a screenshot that relevant to the user's question."},
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         self.corpus, self.queries, self.relevant_docs = _load_data(
             path=self.metadata.dataset["path"],
             splits=self.metadata.eval_splits,
@@ -138,7 +140,7 @@ class VidoreDocVQARetrieval(AbsTaskRetrieval):
         prompt={"query": "Find a screenshot that relevant to the user's question."},
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         self.corpus, self.queries, self.relevant_docs = _load_data(
             path=self.metadata.dataset["path"],
             splits=self.metadata.eval_splits,
@@ -181,7 +183,7 @@ class VidoreInfoVQARetrieval(AbsTaskRetrieval):
         prompt={"query": "Find a screenshot that relevant to the user's question."},
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         self.corpus, self.queries, self.relevant_docs = _load_data(
             path=self.metadata.dataset["path"],
             splits=self.metadata.eval_splits,
@@ -224,7 +226,7 @@ class VidoreTabfquadRetrieval(AbsTaskRetrieval):
         prompt={"query": "Find a screenshot that relevant to the user's question."},
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         self.corpus, self.queries, self.relevant_docs = _load_data(
             path=self.metadata.dataset["path"],
             splits=self.metadata.eval_splits,
@@ -267,7 +269,7 @@ class VidoreTatdqaRetrieval(AbsTaskRetrieval):
         prompt={"query": "Find a screenshot that relevant to the user's question."},
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         self.corpus, self.queries, self.relevant_docs = _load_data(
             path=self.metadata.dataset["path"],
             splits=self.metadata.eval_splits,
@@ -310,7 +312,7 @@ class VidoreShiftProjectRetrieval(AbsTaskRetrieval):
         prompt={"query": "Find a screenshot that relevant to the user's question."},
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         self.corpus, self.queries, self.relevant_docs = _load_data(
             path=self.metadata.dataset["path"],
             splits=self.metadata.eval_splits,
@@ -354,7 +356,7 @@ class VidoreSyntheticDocQAAIRetrieval(AbsTaskRetrieval):
         adapted_from=["VidoreDocVQARetrieval"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         self.corpus, self.queries, self.relevant_docs = _load_data(
             path=self.metadata.dataset["path"],
             splits=self.metadata.eval_splits,
@@ -398,7 +400,7 @@ class VidoreSyntheticDocQAEnergyRetrieval(AbsTaskRetrieval):
         adapted_from=["VidoreDocVQARetrieval"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         self.corpus, self.queries, self.relevant_docs = _load_data(
             path=self.metadata.dataset["path"],
             splits=self.metadata.eval_splits,
@@ -442,7 +444,7 @@ class VidoreSyntheticDocQAGovernmentReportsRetrieval(AbsTaskRetrieval):
         adapted_from=["VidoreDocVQARetrieval"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         self.corpus, self.queries, self.relevant_docs = _load_data(
             path=self.metadata.dataset["path"],
             splits=self.metadata.eval_splits,
@@ -486,7 +488,7 @@ class VidoreSyntheticDocQAHealthcareIndustryRetrieval(AbsTaskRetrieval):
         adapted_from=["VidoreDocVQARetrieval"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         self.corpus, self.queries, self.relevant_docs = _load_data(
             path=self.metadata.dataset["path"],
             splits=self.metadata.eval_splits,

--- a/mteb/tasks/retrieval/eng/webvid_covr_retrieval.py
+++ b/mteb/tasks/retrieval/eng/webvid_covr_retrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -47,7 +49,7 @@ class WebVidCoVRIT2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         path = self.metadata.dataset["path"]

--- a/mteb/tasks/retrieval/eng/youcook2_retrieval.py
+++ b/mteb/tasks/retrieval/eng/youcook2_retrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -80,7 +82,7 @@ class YouCook2V2TRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_youcook2(self, query_columns=["video"], corpus_columns=["sentence"])
 
 
@@ -113,7 +115,7 @@ class YouCook2T2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_youcook2(self, query_columns=["sentence"], corpus_columns=["video"])
 
 
@@ -145,7 +147,7 @@ class YouCook2VA2TRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_youcook2(
             self, query_columns=["video", "audio"], corpus_columns=["sentence"]
         )
@@ -179,7 +181,7 @@ class YouCook2T2VARetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_youcook2(
             self, query_columns=["sentence"], corpus_columns=["video", "audio"]
         )
@@ -214,7 +216,7 @@ class YouCook2V2ARetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_youcook2(self, query_columns=["video"], corpus_columns=["audio"])
 
 
@@ -247,7 +249,7 @@ class YouCook2A2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_youcook2(self, query_columns=["audio"], corpus_columns=["video"])
 
 
@@ -282,7 +284,7 @@ class YouCook2VT2ARetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_youcook2(
             self, query_columns=["video", "sentence"], corpus_columns=["audio"]
         )
@@ -319,7 +321,7 @@ class YouCook2AT2VRetrieval(AbsTaskRetrieval):
         is_beta=True,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_youcook2(
             self, query_columns=["audio", "sentence"], corpus_columns=["video"]
         )

--- a/mteb/tasks/retrieval/fra/f_qu_ad_retrieval.py
+++ b/mteb/tasks/retrieval/fra/f_qu_ad_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -49,7 +51,7 @@ Liu, Yang},
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         dataset_raw = datasets.load_dataset(

--- a/mteb/tasks/retrieval/fra/syntec_retrieval.py
+++ b/mteb/tasks/retrieval/fra/syntec_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -38,7 +40,7 @@ class SyntecRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         # fetch both subsets of the dataset

--- a/mteb/tasks/retrieval/hun/hun_sum2.py
+++ b/mteb/tasks/retrieval/hun/hun_sum2.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -43,7 +45,7 @@ class HunSum2AbstractiveRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.corpus, self.queries, self.relevant_docs = {}, {}, {}

--- a/mteb/tasks/retrieval/kat/georgian_faq_retrieval.py
+++ b/mteb/tasks/retrieval/kat/georgian_faq_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from datasets import DatasetDict, load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -33,7 +35,7 @@ class GeorgianFAQRetrieval(AbsTaskRetrieval):
         bibtex_citation="",
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/multilingual/afri_mcqa_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/afri_mcqa_retrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -123,7 +125,7 @@ class AfriMCQAA2IRetrieval(AbsTaskRetrieval):
         **_COMMON,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_afri_mcqa(self, to_image=True)
 
 
@@ -137,5 +139,5 @@ class AfriMCQAI2ARetrieval(AbsTaskRetrieval):
         **_COMMON,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load_afri_mcqa(self, to_image=False)

--- a/mteb/tasks/retrieval/multilingual/belebele_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/belebele_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -209,7 +211,7 @@ class BelebeleRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/multilingual/common_voice.py
+++ b/mteb/tasks/retrieval/multilingual/common_voice.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from typing import Any
 
 import datasets
 from datasets import DatasetDict
@@ -214,7 +215,7 @@ class CommonVoiceMini17A2TRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         """Load dataset from HuggingFace hub"""
         if self.data_loaded:
             return
@@ -291,7 +292,7 @@ class CommonVoiceMini17T2ARetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         """Load dataset from HuggingFace hub"""
         if self.data_loaded:
             return
@@ -365,7 +366,7 @@ class CommonVoiceMini21A2TRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         """Load dataset from HuggingFace hub"""
         if self.data_loaded:
             return
@@ -442,7 +443,7 @@ class CommonVoiceMini21T2ARetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         """Load dataset from HuggingFace hub"""
         if self.data_loaded:
             return

--- a/mteb/tasks/retrieval/multilingual/cross_lingual_semantic_discrimination_wmt19.py
+++ b/mteb/tasks/retrieval/multilingual/cross_lingual_semantic_discrimination_wmt19.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -53,7 +55,7 @@ class CrossLingualSemanticDiscriminationWMT19(AbsTaskRetrieval):
     )
     num_of_distractors = 4
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """Generic data loader function for original clsd datasets with the format shown in "hf_dataset_link".
         Loading the hf dataset, it populates the following three variables to be used for retrieval evaluation.
 

--- a/mteb/tasks/retrieval/multilingual/cross_lingual_semantic_discrimination_wmt21.py
+++ b/mteb/tasks/retrieval/multilingual/cross_lingual_semantic_discrimination_wmt21.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -54,7 +56,7 @@ class CrossLingualSemanticDiscriminationWMT21(AbsTaskRetrieval):
 
     num_of_distractors = 4
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """Generic data loader function for original clsd datasets with the format shown in "hf_dataset_link".
         Loading the hf dataset, it populates the following three variables to be used for retrieval evaluation.
 

--- a/mteb/tasks/retrieval/multilingual/cur_ev1_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/cur_ev1_retrieval.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Any
 
 from datasets import DatasetDict, load_dataset
 
@@ -111,7 +112,7 @@ class CUREv1Retrieval(AbsTaskRetrieval):
 
         return queries
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/multilingual/fleurs.py
+++ b/mteb/tasks/retrieval/multilingual/fleurs.py
@@ -210,7 +210,7 @@ class FleursA2TRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
         self.corpus = defaultdict(DatasetDict)
@@ -283,7 +283,7 @@ class FleursT2ARetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
         self.corpus = defaultdict(DatasetDict)
@@ -364,7 +364,7 @@ class FleursA2TRetrievalV2(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
         self.corpus = defaultdict(DatasetDict)
@@ -432,7 +432,7 @@ class FleursT2ARetrievalV2(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
         self.corpus = defaultdict(DatasetDict)

--- a/mteb/tasks/retrieval/multilingual/glami_1m_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/glami_1m_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -55,7 +57,7 @@ class GLAMI1MT2IRetrieval(AbsTaskRetrieval):
         prompt={"query": "Find the fashion product image matching this description."},
     )
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         for subset in self.hf_subsets:
             for split in self.eval_splits:
                 queries = self.dataset[subset][split]["queries"]
@@ -98,7 +100,7 @@ class GLAMI1MI2TRetrieval(AbsTaskRetrieval):
         prompt={"query": "Find the fashion product matching this image."},
     )
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         for subset in self.hf_subsets:
             for split in self.eval_splits:
                 data = self.dataset[subset][split]

--- a/mteb/tasks/retrieval/multilingual/google_svq.py
+++ b/mteb/tasks/retrieval/multilingual/google_svq.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from typing import Any
 
 import datasets
 from datasets import Audio, DatasetDict
@@ -71,7 +72,7 @@ class GoogleSVQA2TRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if getattr(self, "data_loaded", False):
             return
         self.corpus = defaultdict(DatasetDict)
@@ -163,7 +164,7 @@ class GoogleSVQT2ARetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if getattr(self, "data_loaded", False):
             return
         self.corpus = defaultdict(DatasetDict)

--- a/mteb/tasks/retrieval/multilingual/jam_alt.py
+++ b/mteb/tasks/retrieval/multilingual/jam_alt.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from datasets import Audio, DatasetDict, load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -18,7 +20,7 @@ def _load_jam_alt_data(
     query_column: str,
     corpus_column: str,
     qrels_column: str,
-    **kwargs,
+    **kwargs: Any,
 ):
     corpus = {lang: dict.fromkeys(splits) for lang in langs}
     queries = {lang: dict.fromkeys(splits) for lang in langs}
@@ -143,7 +145,7 @@ Music Information Retrieval Conference},
         },
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
 
@@ -201,7 +203,7 @@ Music Information Retrieval Conference},
         prompt={"query": "Retrieve audio clip for the lyrics: {query}"},
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
 
@@ -261,7 +263,7 @@ Music Information Retrieval Conference},
         },
     )
 
-    def load_data(self, **kwargs):
+    def load_data(self, **kwargs: Any):
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/multilingual/jina_vdr_bench_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/jina_vdr_bench_retrieval.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from typing import Any
 
 from datasets import load_dataset
 
@@ -148,7 +149,7 @@ def _load_data(
     return corpus, queries, relevant_docs
 
 
-def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
     if self.data_loaded:
         return
 

--- a/mteb/tasks/retrieval/multilingual/miracl_vision_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/miracl_vision_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -143,7 +145,7 @@ class MIRACLVisionRetrieval(AbsTaskRetrieval):
         prompt={"query": "Find a screenshot that is relevant to the user's query."},
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/multilingual/mr_tidy_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/mr_tidy_retrieval.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 import datasets
 
@@ -108,7 +109,7 @@ class MrTidyRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/multilingual/omnilingual_asr_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/omnilingual_asr_retrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -144,7 +146,7 @@ class OmnilingualASRA2TRetrieval(AbsTaskRetrieval):
         **_COMMON,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load(self, to_text=True)
 
 
@@ -158,5 +160,5 @@ class OmnilingualASRT2ARetrieval(AbsTaskRetrieval):
         **_COMMON,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load(self, to_text=False)

--- a/mteb/tasks/retrieval/multilingual/public_health_qa_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/public_health_qa_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -97,7 +99,7 @@ class PublicHealthQARetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/multilingual/ru_sci_bench_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/ru_sci_bench_retrieval.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import cast
+from typing import Any, cast
 
 import datasets
 
@@ -103,7 +103,7 @@ class RuSciBenchCiteRetrieval(AbsTaskRetrieval):
         },
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 
@@ -161,7 +161,7 @@ class RuSciBenchCociteRetrieval(AbsTaskRetrieval):
         },
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/multilingual/vdr_multilingual_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/vdr_multilingual_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 from datasets import Dataset, DatasetDict
 
@@ -126,7 +128,7 @@ class VDRMultilingualRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/multilingual/vidore2_bench_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/vidore2_bench_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -133,7 +135,7 @@ class Vidore2ESGReportsRetrieval(AbsTaskRetrieval):
         prompt={"query": "Find a screenshot that relevant to the user's question."},
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 
@@ -181,7 +183,7 @@ class Vidore2EconomicsReportsRetrieval(AbsTaskRetrieval):
         prompt={"query": "Find a screenshot that relevant to the user's question."},
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 
@@ -229,7 +231,7 @@ class Vidore2BioMedicalLecturesRetrieval(AbsTaskRetrieval):
         prompt={"query": "Find a screenshot that relevant to the user's question."},
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 
@@ -277,7 +279,7 @@ class Vidore2ESGReportsHLRetrieval(AbsTaskRetrieval):
         prompt={"query": "Find a screenshot that relevant to the user's question."},
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/multilingual/wit_t2i_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/wit_t2i_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from datasets import Dataset, DatasetDict, load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -167,7 +169,7 @@ class WITT2IRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 
@@ -217,7 +219,7 @@ class WITI2TRetrieval(AbsTaskRetrieval):
         prompt={"query": "Find a caption describing the following image."},
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/multilingual/x_flickr30k_co_t2i_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/x_flickr30k_co_t2i_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from datasets import DatasetDict, Image, load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -146,7 +148,7 @@ class XFlickr30kCoT2IRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 
@@ -196,7 +198,7 @@ class XFlickr30kCoI2TRetrieval(AbsTaskRetrieval):
         prompt={"query": "Find a caption describing the following image."},
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/multilingual/x_qu_ad_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/x_qu_ad_retrieval.py
@@ -1,4 +1,5 @@
 from hashlib import sha256
+from typing import Any
 
 import datasets
 
@@ -64,7 +65,7 @@ class XQuADRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/multilingual/xm3600_t2i_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/xm3600_t2i_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from datasets import Dataset, DatasetDict, Image, load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -190,7 +192,7 @@ class XM3600T2IRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 
@@ -239,7 +241,7 @@ class XM3600I2TRetrieval(AbsTaskRetrieval):
         prompt={"query": "Find a caption describing the following image."},
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/nld/cqa_dupstack_android_nl_retrieval.py
+++ b/mteb/tasks/retrieval/nld/cqa_dupstack_android_nl_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -42,7 +44,7 @@ class CQADupstackAndroidNLRetrieval(AbsTaskRetrieval):
         adapted_from=["CQADupstackAndroid"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/nld/cqa_dupstack_english_nl_retrieval.py
+++ b/mteb/tasks/retrieval/nld/cqa_dupstack_english_nl_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -42,7 +44,7 @@ class CQADupstackEnglishNLRetrieval(AbsTaskRetrieval):
         adapted_from=["CQADupstackEnglish"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/nld/cqa_dupstack_gaming_nl_retrieval.py
+++ b/mteb/tasks/retrieval/nld/cqa_dupstack_gaming_nl_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -42,7 +44,7 @@ class CQADupstackGamingNLRetrieval(AbsTaskRetrieval):
         adapted_from=["CQADupstackGamingRetrieval"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/nld/cqa_dupstack_gis_nl_retrieval.py
+++ b/mteb/tasks/retrieval/nld/cqa_dupstack_gis_nl_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -42,7 +44,7 @@ class CQADupstackGisNLRetrieval(AbsTaskRetrieval):
         adapted_from=["CQADupstackGisRetrieval"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/nld/cqa_dupstack_mathematica_nl_retrieval.py
+++ b/mteb/tasks/retrieval/nld/cqa_dupstack_mathematica_nl_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -42,7 +44,7 @@ class CQADupstackMathematicaNLRetrieval(AbsTaskRetrieval):
         adapted_from=["CQADupstackMathematicaRetrieval"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/nld/cqa_dupstack_physics_nl_retrieval.py
+++ b/mteb/tasks/retrieval/nld/cqa_dupstack_physics_nl_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -42,7 +44,7 @@ class CQADupstackPhysicsNLRetrieval(AbsTaskRetrieval):
         adapted_from=["CQADupstackPhysicsRetrieval"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/nld/cqa_dupstack_programmers_nl_retrieval.py
+++ b/mteb/tasks/retrieval/nld/cqa_dupstack_programmers_nl_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -42,7 +44,7 @@ class CQADupstackProgrammersNLRetrieval(AbsTaskRetrieval):
         adapted_from=["CQADupstackProgrammersRetrieval"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/nld/cqa_dupstack_stats_nl_retrieval.py
+++ b/mteb/tasks/retrieval/nld/cqa_dupstack_stats_nl_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -42,7 +44,7 @@ class CQADupstackStatsNLRetrieval(AbsTaskRetrieval):
         adapted_from=["CQADupstackStatsRetrieval"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/nld/cqa_dupstack_tex_nl_retrieval.py
+++ b/mteb/tasks/retrieval/nld/cqa_dupstack_tex_nl_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -42,7 +44,7 @@ class CQADupstackTexNLRetrieval(AbsTaskRetrieval):
         adapted_from=["CQADupstackTexRetrieval"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/nld/cqa_dupstack_unix_nl_retrieval.py
+++ b/mteb/tasks/retrieval/nld/cqa_dupstack_unix_nl_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -42,7 +44,7 @@ class CQADupstackUnixNLRetrieval(AbsTaskRetrieval):
         adapted_from=["CQADupstackUnixRetrieval"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/nld/cqa_dupstack_webmasters_nl_retrieval.py
+++ b/mteb/tasks/retrieval/nld/cqa_dupstack_webmasters_nl_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -42,7 +44,7 @@ class CQADupstackWebmastersNLRetrieval(AbsTaskRetrieval):
         adapted_from=["CQADupstackWebmastersRetrieval"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/nld/cqa_dupstack_wordpress_nl_retrieval.py
+++ b/mteb/tasks/retrieval/nld/cqa_dupstack_wordpress_nl_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -42,7 +44,7 @@ class CQADupstackWordpressNLRetrieval(AbsTaskRetrieval):
         adapted_from=["CQADupstackWordpressRetrieval"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/retrieval/nob/norquad.py
+++ b/mteb/tasks/retrieval/nob/norquad.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -50,7 +52,7 @@ Fishel, Mark},
         },
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """Load dataset from HuggingFace hub"""
         if self.data_loaded:
             return
@@ -58,7 +60,7 @@ Fishel, Mark},
         self.dataset_transform()
         self.data_loaded = True
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """And transform to a retrieval dataset, which have the following attributes
 
         self.corpus = dict[doc_id, dict[str, str]] #id => dict with document data like title and text

--- a/mteb/tasks/retrieval/nob/snl_retrieval.py
+++ b/mteb/tasks/retrieval/nob/snl_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -37,7 +39,7 @@ class SNLRetrieval(AbsTaskRetrieval):
         task_subtypes=["Article retrieval"],
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """Load dataset from HuggingFace hub"""
         if self.data_loaded:
             return
@@ -45,7 +47,7 @@ class SNLRetrieval(AbsTaskRetrieval):
         self.dataset_transform()
         self.data_loaded = True
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """And transform to a retrieval dataset, which have the following attributes
 
         self.corpus = dict[doc_id, dict[str, str]] #id => dict with document data like title and text

--- a/mteb/tasks/retrieval/slk/sk_quad_retrieval.py
+++ b/mteb/tasks/retrieval/slk/sk_quad_retrieval.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 from datasets import load_dataset
 
@@ -38,7 +39,7 @@ class SKQuadRetrieval(AbsTaskRetrieval):
         bibtex_citation="",
     )
 
-    def load_data(self, eval_splits=None, **kwargs) -> None:
+    def load_data(self, eval_splits=None, **kwargs: Any) -> None:
         """Load and preprocess datasets for retrieval task."""
         eval_splits = eval_splits or ["test"]
 

--- a/mteb/tasks/retrieval/slk/slovak_sum_retrieval.py
+++ b/mteb/tasks/retrieval/slk/slovak_sum_retrieval.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -42,7 +44,7 @@ class SlovakSumRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         if self.data_loaded:
             return
         self.corpus, self.queries, self.relevant_docs = {}, {}, {}

--- a/mteb/tasks/retrieval/tur/tur_hist_quad.py
+++ b/mteb/tasks/retrieval/tur/tur_hist_quad.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datasets
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -41,7 +43,7 @@ class TurHistQuadRetrieval(AbsTaskRetrieval):
 """,
     )
 
-    def load_data(self, **kwargs) -> None:
+    def load_data(self, **kwargs: Any) -> None:
         """And transform to a retrieval dataset, which have the following attributes
 
         self.corpus = dict[doc_id, dict[str, str]] #id => dict with document data like title and text

--- a/mteb/tasks/retrieval/vie/vie_qu_ad_retrieval.py
+++ b/mteb/tasks/retrieval/vie/vie_qu_ad_retrieval.py
@@ -1,4 +1,5 @@
 import random
+from typing import Any
 
 from datasets import load_dataset
 
@@ -52,7 +53,7 @@ Zong, Chengqing},
 """,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         if self.data_loaded:
             return
 

--- a/mteb/tasks/sts/multilingual/sts_benchmark_multilingual_sts.py
+++ b/mteb/tasks/sts/multilingual/sts_benchmark_multilingual_sts.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.sts import AbsTaskSTS
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -56,6 +58,6 @@ class STSBenchmarkMultilingualSTS(AbsTaskSTS):
     min_score = 0
     max_score = 5
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         for lang, subset in self.dataset.items():
             self.dataset[lang] = subset.rename_column("similarity_score", "score")

--- a/mteb/tasks/sts/por/assin2_sts.py
+++ b/mteb/tasks/sts/por/assin2_sts.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.sts import AbsTaskSTS
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -39,7 +41,7 @@ class Assin2STS(AbsTaskSTS):
     min_score = 1
     max_score = 5
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         self.dataset = self.dataset.rename_columns(
             {
                 "premise": "sentence1",

--- a/mteb/tasks/sts/slk/slovak_sum_sts.py
+++ b/mteb/tasks/sts/slk/slovak_sum_sts.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.sts import AbsTaskSTS
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -30,7 +32,7 @@ class SlovakSumSTS(AbsTaskSTS):
     min_score = 0
     max_score = 5
 
-    def dataset_transform(self, **kwargs):
+    def dataset_transform(self, **kwargs: Any):
         _dataset = self.dataset.rename_columns({"similarity_score": "score"})
 
         # ensure numeric value

--- a/mteb/tasks/zeroshot_classification/eng/meld_classification.py
+++ b/mteb/tasks/zeroshot_classification/eng/meld_classification.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from mteb.abstasks.task_metadata import TaskMetadata
 from mteb.abstasks.zeroshot_classification import AbsTaskZeroShotClassification
 
@@ -42,7 +44,7 @@ class MELDAudioVideoZeroShotClassification(AbsTaskZeroShotClassification):
     input_column_name = ("video", "audio")
     label_column_name: str = "emotion"
 
-    def dataset_transform(self, num_proc=None, **kwargs) -> None:
+    def dataset_transform(self, num_proc=None, **kwargs: Any) -> None:
         self.dataset = self.stratified_subsampling(
             self.dataset,
             seed=self.seed,
@@ -83,7 +85,7 @@ class MELDVideoZeroShotClassification(AbsTaskZeroShotClassification):
     input_column_name = "video"
     label_column_name: str = "emotion"
 
-    def dataset_transform(self, num_proc=None, **kwargs) -> None:
+    def dataset_transform(self, num_proc=None, **kwargs: Any) -> None:
         self.dataset = self.stratified_subsampling(
             self.dataset,
             seed=self.seed,

--- a/mteb/tasks/zeroshot_classification/eng/ucf101.py
+++ b/mteb/tasks/zeroshot_classification/eng/ucf101.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks.task_metadata import TaskMetadata
 from mteb.abstasks.zeroshot_classification import AbsTaskZeroShotClassification
 
@@ -90,7 +92,7 @@ class UCF101VideoAudioZeroShotClassification(AbsTaskZeroShotClassification):
     input_column_name = ("video", "audio")
     label_column_name: str = "label"
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         for split in self.metadata.eval_splits:
             self.dataset[split] = self.dataset[split].select_columns(
                 ["video", "audio", "label"],
@@ -146,7 +148,7 @@ class UCF101VideoZeroShotClassification(AbsTaskZeroShotClassification):
     input_column_name = "video"
     label_column_name: str = "label"
 
-    def dataset_transform(self, num_proc: int | None = None, **kwargs) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         for split in self.metadata.eval_splits:
             self.dataset[split] = self.dataset[split].select_columns(
                 ["video", "label"],

--- a/mteb/tasks/zeroshot_classification/zxx/urban_sound8k.py
+++ b/mteb/tasks/zeroshot_classification/zxx/urban_sound8k.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mteb.abstasks import AbsTaskZeroShotClassification
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -54,7 +56,7 @@ class UrbanSound8kZeroshotClassification(AbsTaskZeroShotClassification):
             "This is a sound of street music",
         ]
 
-    def dataset_transform(self, **kwargs):
+    def dataset_transform(self, **kwargs: Any):
         self.dataset = self.stratified_subsampling(
             self.dataset, seed=self.seed, splits=["train"], label=self.label_column_name
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -337,6 +337,7 @@ select = [
     "A",       # flake8-builtins, don't shadow builtins
     "RET",     # flake8-return
     "SIM",     # flake8-simplify
+    "ANN",     # flake8-annotations
 ]
 
 ignore = [
@@ -362,6 +363,13 @@ ignore = [
     "PT018",    # composite assertions; splitting `assert a and b` is not always clearer
     "RET504",   # unnecessary-assign; named intermediate results often aid readability
     "SIM108",   # ternary over if/else is a style preference, and displaces inline comments
+    # TODO: burn down in follow-ups. These need a type inferred per call site (ruff can fix
+    # only 5 of 733), and all of them sit in modules mypy currently exempts.
+    "ANN001",   # missing-type-function-argument
+    "ANN201",   # missing-return-type-undocumented-public-function
+    "ANN202",   # missing-return-type-private-function
+    "ANN205",   # missing-return-type-static-method
+    "ANN401",   # any-type
 ]
 future-annotations = true  # For TC rules
 typing-modules = ["typing_extensions", "mteb.types", "collections.abc"]
@@ -433,6 +441,9 @@ convention = "google"
 [tool.ruff.lint.flake8-annotations]
 mypy-init-return = true
 suppress-none-returning = true
+# ANN003 requires `**kwargs` to be annotated; ANN401 rejects `Any`. `**kwargs` here is a
+# pass-through for arbitrary model/task options, so `Any` is the only correct annotation.
+allow-star-arg-any = true
 
 [tool.ruff.lint.flake8-type-checking]
 strict = true
@@ -623,6 +634,7 @@ extend-ignore-re = [
     "editor.*",  # ignore authors in citations
     "FIne-Grained Music retrievAl",  # stylised paper title (FIGMA)
     "@\\w+\\{[^,\n]+,",  # bibtex entry keys are arbitrary identifiers
+    '"[a-z]{3}": \["[a-z]{3}-[A-Z][a-z]{3}"\]',  # ISO 639-3 language-map entries are codes, not prose
 ]
 
 [tool.typos.files]

--- a/tests/mock_models.py
+++ b/tests/mock_models.py
@@ -52,7 +52,7 @@ class MockSentenceTransformer(SentenceTransformer):
         truncate_dim: int | None = None,
         pool: dict[Literal["input", "output", "processes"], Any] | None = None,
         chunk_size: int | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> (
         list[Tensor] | np.ndarray | Tensor | dict[str, Tensor] | list[dict[str, Tensor]]
     ):
@@ -93,7 +93,7 @@ class MockSentenceTransformersbf16Encoder(MockSentenceTransformer):
         truncate_dim: int | None = None,
         pool: dict[Literal["input", "output", "processes"], Any] | None = None,
         chunk_size: int | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> (
         list[Tensor] | np.ndarray | Tensor | dict[str, Tensor] | list[dict[str, Tensor]]
     ):
@@ -106,7 +106,7 @@ class MockSentenceTransformerWrapper(SentenceTransformerEncoderWrapper):
         model: str | SentenceTransformer | CrossEncoder,
         revision: str | None = None,
         model_prompts: dict[str, str] | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """Wrapper for SentenceTransformer models.
 

--- a/tests/test_abstasks/test_task_metadata.py
+++ b/tests/test_abstasks/test_task_metadata.py
@@ -160,7 +160,9 @@ def test_given_missing_revision_path_then_it_throws():
         )
 
 
-def test_given_none_revision_path_then_it_logs_warning(caplog):
+def test_given_none_revision_path_then_it_logs_warning(
+    caplog: pytest.LogCaptureFixture,
+):
     with pytest.raises(ValidationError):
         TaskMetadata(
             name="MyTask",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,7 @@ from mteb.cli.build_cli import (
 )
 
 
-def test_available_tasks(capsys):
+def test_available_tasks(capsys: pytest.CaptureFixture[str]):
     args = Namespace(
         categories=None,
         task_types=None,
@@ -35,7 +35,7 @@ def test_available_tasks(capsys):
     )
 
 
-def test_available_benchmarks(capsys):
+def test_available_benchmarks(capsys: pytest.CaptureFixture[str]):
     args = Namespace(benchmarks=None)
     _available_benchmarks(args=args)
 
@@ -96,7 +96,7 @@ def test_run_task(
     )
 
 
-def test_create_meta(tmp_path):
+def test_create_meta(tmp_path: Path):
     """Test create_meta function directly as well as through the command line interface"""
     test_folder = Path(__file__).parent
     model_name = "sentence-transformers/all-MiniLM-L6-v2"
@@ -315,7 +315,7 @@ def test_leaderboard_cli_integration():
     assert "leaderboard" in result.stdout, "Leaderboard command not found in main help"
 
 
-def test_mock_run_cli(tmp_path):
+def test_mock_run_cli(tmp_path: Path):
     """Test the mock-run subcommand."""
 
     args = Namespace(

--- a/tests/test_deprecated/test_MTEB_splits.py
+++ b/tests/test_deprecated/test_MTEB_splits.py
@@ -28,7 +28,7 @@ def multilingual_tasks():
     return [MockMultilingualRetrievalTask()]
 
 
-def test_all_splits_evaluated(model, tasks, tmp_path):
+def test_all_splits_evaluated(model, tasks, tmp_path: Path):
     evaluation = MTEB(tasks=tasks)
     results = evaluation.run(
         model,
@@ -44,7 +44,7 @@ def test_all_splits_evaluated(model, tasks, tmp_path):
     assert results[0].scores.keys() == {"val", "test"}
 
 
-def test_one_missing_split(model, tasks, tmp_path):
+def test_one_missing_split(model, tasks, tmp_path: Path):
     evaluation = MTEB(tasks=tasks)
     results = evaluation.run(
         model,
@@ -73,7 +73,7 @@ def test_one_missing_split(model, tasks, tmp_path):
     assert results2[0].scores.keys() == {"test", "val"}
 
 
-def test_no_missing_splits(model, tasks, tmp_path):
+def test_no_missing_splits(model, tasks, tmp_path: Path):
     evaluation = MTEB(tasks=tasks)
     results = evaluation.run(
         model,
@@ -100,7 +100,7 @@ def test_no_missing_splits(model, tasks, tmp_path):
     assert results[0].scores.keys() == {"test", "val"}
 
 
-def test_all_languages_evaluated(model, multilingual_tasks, tmp_path):
+def test_all_languages_evaluated(model, multilingual_tasks, tmp_path: Path):
     evaluation = MTEB(tasks=multilingual_tasks)
     results = evaluation.run(
         model,
@@ -118,7 +118,7 @@ def test_all_languages_evaluated(model, multilingual_tasks, tmp_path):
     assert len(results[0].scores["test"]) == 2
 
 
-def test_missing_language(model, multilingual_tasks, tmp_path):
+def test_missing_language(model, multilingual_tasks, tmp_path: Path):
     evaluation = MTEB(tasks=multilingual_tasks)
     results = evaluation.run(
         model,
@@ -152,7 +152,7 @@ def test_missing_language(model, multilingual_tasks, tmp_path):
     assert len(results[0].scores["test"]) == 2
 
 
-def test_no_missing_languages(model, multilingual_tasks, tmp_path):
+def test_no_missing_languages(model, multilingual_tasks, tmp_path: Path):
     evaluation = MTEB(tasks=multilingual_tasks)
     results = evaluation.run(
         model,
@@ -183,7 +183,7 @@ def test_no_missing_languages(model, multilingual_tasks, tmp_path):
     assert sorted(results[0].languages) == ["eng", "fra"]
 
 
-def test_partial_languages(model, multilingual_tasks, tmp_path):
+def test_partial_languages(model, multilingual_tasks, tmp_path: Path):
     evaluation = MTEB(tasks=multilingual_tasks)
     results = evaluation.run(
         model,
@@ -215,7 +215,7 @@ def test_partial_languages(model, multilingual_tasks, tmp_path):
 
 
 def test_multilingual_one_missing_split_no_missing_lang(
-    model, multilingual_tasks, tmp_path
+    model, multilingual_tasks, tmp_path: Path
 ):
     evaluation = MTEB(tasks=multilingual_tasks)
     results = evaluation.run(
@@ -250,7 +250,7 @@ def test_multilingual_one_missing_split_no_missing_lang(
 
 
 def test_multilingual_one_missing_lang_in_one_split(
-    model, multilingual_tasks, tmp_path
+    model, multilingual_tasks, tmp_path: Path
 ):
     evaluation = MTEB(tasks=multilingual_tasks)
     results = evaluation.run(
@@ -298,7 +298,7 @@ def test_multilingual_one_missing_lang_in_one_split(
     assert len(results[0].scores["test"]) == 2
 
 
-def test_all_splits_evaluated_with_overwrite(model, tasks, tmp_path):
+def test_all_splits_evaluated_with_overwrite(model, tasks, tmp_path: Path):
     evaluation = MTEB(tasks=tasks)
     results = evaluation.run(
         model,
@@ -328,7 +328,7 @@ def test_all_splits_evaluated_with_overwrite(model, tasks, tmp_path):
 
 
 def test_all_splits_subsets_evaluated_with_overwrite(
-    model, multilingual_tasks, tmp_path
+    model, multilingual_tasks, tmp_path: Path
 ):
     evaluation = MTEB(tasks=multilingual_tasks)
     results = evaluation.run(

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -288,7 +288,7 @@ def test_evaluate_aggregated_task():
     mteb.evaluate(model, task, cache=None)
 
 
-def test_evaluate_aggregated_task_with_cache(tmp_path):
+def test_evaluate_aggregated_task_with_cache(tmp_path: Path):
     """Test evaluating an aggregate task with caching.
 
     Verifies both that:
@@ -333,7 +333,7 @@ def test_evaluate_aggregated_task_with_cache(tmp_path):
     assert cached_results.task_results[0].get_score() == pytest.approx(score1)
 
 
-def test_run_private_task_warning(caplog):
+def test_run_private_task_warning(caplog: pytest.LogCaptureFixture):
     """Test that a warning is correctly logged in an attempt run a private dataset is made"""
     task = mteb.get_task("Code1Retrieval")
     from mteb.timing import TimingStack
@@ -423,7 +423,7 @@ def test_evaluate_preserves_preloaded_data_across_multiple_calls():
     _ = task.dataset["test"]  # Verify dataset persists across multiple calls
 
 
-def test_evaluate_experiment(tmp_path):
+def test_evaluate_experiment(tmp_path: Path):
     """Test that evaluate() can be used in an experiment context."""
     model = mteb.get_model(
         "mteb/baseline-random-encoder", test_param=123, test_param2="abc"
@@ -445,7 +445,7 @@ def test_evaluate_experiment(tmp_path):
 
 
 @pytest.mark.parametrize("embed_dim", [None, 10])
-def test_evaluate_mrl(tmp_path, embed_dim):
+def test_evaluate_mrl(tmp_path: Path, embed_dim):
     """Test that evaluate() can be used in an experiment context."""
     model = mteb.get_model(
         "mteb/baseline-random-encoder",
@@ -524,7 +524,7 @@ def test_mock_mmeb_tasks(task: AbsTask):
 
 
 class MockCrashTask(MockMultilingualClassificationTask):
-    def _evaluate_subset(self, model, data_split, hf_split, hf_subset, **kwargs):
+    def _evaluate_subset(self, model, data_split, hf_split, hf_subset, **kwargs: Any):
         if hf_subset == "fra":
             raise RuntimeError("Crash on fra")
         return {"accuracy": 0.8}

--- a/tests/test_evaluators/test_ClusteringEvaluator.py
+++ b/tests/test_evaluators/test_ClusteringEvaluator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from datasets import Dataset
@@ -26,7 +26,7 @@ class TestClusteringEvaluator:
                 hf_subset,
                 task_name: str | None = None,
                 batch_size=32,
-                **kwargs,
+                **kwargs: Any,
             ) -> NDArray[np.floating]:
                 return np.eye(len(sentences.dataset))
 

--- a/tests/test_integrations/test_encode_args_passed.py
+++ b/tests/test_integrations/test_encode_args_passed.py
@@ -30,7 +30,9 @@ def test_encode_kwargs_passed_to_all_encodes(task: AbsTask, tmp_path: Path):
     my_encode_kwargs = {"no_one_uses_this_args": "but_its_here"}
 
     class MockEncoderWithKwargs(AbsEncoder):
-        def encode(self, sentences: DataLoader, task_name: str | None = None, **kwargs):
+        def encode(
+            self, sentences: DataLoader, task_name: str | None = None, **kwargs: Any
+        ):
             assert "no_one_uses_this_args" in kwargs
             assert (
                 my_encode_kwargs["no_one_uses_this_args"]

--- a/tests/test_integrations/test_modality.py
+++ b/tests/test_integrations/test_modality.py
@@ -49,7 +49,9 @@ def test_task_modality_filtering(task, modalities):
 
 
 @pytest.mark.parametrize("task", [MockMultiChoiceTask()])
-def test_task_modality_filtering_model_modalities_only_one_of_modalities(task, caplog):
+def test_task_modality_filtering_model_modalities_only_one_of_modalities(
+    task, caplog: pytest.LogCaptureFixture
+):
     """Task have it2i, model only image."""
     with caplog.at_level(logging.WARNING):
         model = mteb.get_model("mteb/baseline-random-encoder")

--- a/tests/test_integrations/test_prompts.py
+++ b/tests/test_integrations/test_prompts.py
@@ -2,6 +2,7 @@
 
 import logging
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pytest
@@ -44,7 +45,7 @@ def test_prompt_name_passed_to_all_encodes_with_prompts(
         prompts = {}
 
         def encode(
-            self, sentences: DataLoader, prompt_name: str | None = None, **kwargs
+            self, sentences: DataLoader, prompt_name: str | None = None, **kwargs: Any
         ):
             assert prompt_name == to_compare
             return np.zeros((len(sentences.dataset), 10))
@@ -63,7 +64,7 @@ def test_prompt_name_passed_to_all_encodes_with_prompts(
         prompts = {to_compare: to_compare}
 
         def encode(
-            self, sentences: DataLoader, prompt_name: str | None = None, **kwargs
+            self, sentences: DataLoader, prompt_name: str | None = None, **kwargs: Any
         ):
             assert prompt_name == to_compare
             return np.zeros((len(sentences.dataset), 10))
@@ -118,7 +119,7 @@ def test_model_query_passage_prompts_task_type(
         is_query = True
 
         def encode(
-            self, sentences: DataLoader, prompt_name: str | None = None, **kwargs
+            self, sentences: DataLoader, prompt_name: str | None = None, **kwargs: Any
         ):
             check_prompt(prompt_name, self.is_query)
             self.is_query = not self.is_query
@@ -128,7 +129,7 @@ def test_model_query_passage_prompts_task_type(
         is_query = True
 
         def encode(
-            self, sentences: DataLoader, prompt_name: str | None = None, **kwargs
+            self, sentences: DataLoader, prompt_name: str | None = None, **kwargs: Any
         ):
             check_prompt(prompt_name, self.is_query)
             self.is_query = not self.is_query

--- a/tests/test_models/test_cached_embedding_wrapper.py
+++ b/tests/test_models/test_cached_embedding_wrapper.py
@@ -62,7 +62,7 @@ class DummyModel(RandomEncoderBaseline):
 
 class TestCachedEmbeddingWrapper:
     @pytest.fixture
-    def cache_dir(self, tmp_path):
+    def cache_dir(self, tmp_path: Path):
         cache_path = tmp_path / "test_cache"
         yield cache_path
         # Cleanup after test

--- a/tests/test_models/test_get_task_instruction.py
+++ b/tests/test_models/test_get_task_instruction.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from typing import Any
 
 import pytest
 
@@ -20,7 +21,7 @@ class _FakeEncoder(AbsEncoder):
     ) -> None:
         self.instruction_template = instruction_template
 
-    def encode(self, *args, **kwargs):
+    def encode(self, *args: Any, **kwargs: Any):
         raise NotImplementedError
 
 

--- a/tests/test_models/test_jina_v5_omni_wrapper.py
+++ b/tests/test_models/test_jina_v5_omni_wrapper.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import typing
+from typing import Any
 
 import numpy as np
 import pytest
@@ -35,7 +36,7 @@ class CapturingModel(MockSentenceTransformer):
         super().__init__()
         self.captured: list[dict] = []
 
-    def encode(self, inputs, **kwargs):
+    def encode(self, inputs, **kwargs: Any):
         self.captured.append(
             {
                 "inputs": inputs,

--- a/tests/test_models/test_model_meta.py
+++ b/tests/test_models/test_model_meta.py
@@ -1,5 +1,6 @@
 import json
 import re
+from typing import Any
 
 import pytest
 
@@ -171,7 +172,7 @@ def test_similar_tasks_superseded_by():
     assert "Banking77Classification.v2" in model_meta.get_training_datasets()
 
 
-def _openness_meta(**overwrites) -> ModelMeta:
+def _openness_meta(**overwrites: Any) -> ModelMeta:
     return ModelMeta.create_empty(
         overwrites={"name": "test/openness", "revision": "test", **overwrites}
     )
@@ -525,7 +526,7 @@ def test_model_meta_dependencies_not_installed_group():
         model_meta._check_requirements()
 
 
-def test_model_meta_auto_install_extras(monkeypatch):
+def test_model_meta_auto_install_extras(monkeypatch: pytest.MonkeyPatch):
     """When MTEB_AUTO_INSTALL_EXTRAS is set, missing deps trigger an install attempt."""
     model_meta = mteb.get_model_meta("google/vggish").model_copy(
         update={
@@ -552,7 +553,7 @@ def test_model_meta_auto_install_extras(monkeypatch):
     assert "torch-vggish-yamnet" in groups
 
 
-def test_model_meta_no_auto_install_by_default(monkeypatch):
+def test_model_meta_no_auto_install_by_default(monkeypatch: pytest.MonkeyPatch):
     """Without the env var, no install is attempted and the error is raised directly."""
     model_meta = mteb.get_model_meta("google/vggish").model_copy(
         update={

--- a/tests/test_models/test_openai_api_wrapper.py
+++ b/tests/test_models/test_openai_api_wrapper.py
@@ -3,6 +3,7 @@
 All tests are fully mocked and do not require a running vLLM server.
 """
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -16,7 +17,7 @@ class TestOpenAIAPIEncodeWrapper:
     """Test OpenAIAPIEncodeWrapper functionality."""
 
     @patch("requests.get")
-    def test_initialization(self, mock_get):
+    def test_initialization(self, mock_get: MagicMock):
         """Test that wrapper initializes and connects to server."""
         # Mock the /v1/models endpoint
         mock_response = MagicMock()
@@ -52,7 +53,7 @@ class TestOpenAIAPIEncodeWrapper:
                 )
 
     @patch("requests.get")
-    def test_instruction_template_validation(self, mock_get):
+    def test_instruction_template_validation(self, mock_get: MagicMock):
         """Test instruction template validation."""
         # Mock server response
         mock_response = MagicMock()
@@ -79,7 +80,7 @@ class TestOpenAIAPIEncodeWrapper:
 
     @patch("requests.post")
     @patch("requests.get")
-    def test_basic_encoding(self, mock_get, mock_post):
+    def test_basic_encoding(self, mock_get: MagicMock, mock_post: MagicMock):
         """Test basic text encoding functionality with mocked responses."""
         from mteb.abstasks.task_metadata import TaskMetadata
         from mteb.types import PromptType
@@ -130,7 +131,7 @@ class TestOpenAIAPIEncodeWrapper:
         assert embeddings.dtype == np.float32
 
     @patch("requests.get")
-    def test_ssl_verification(self, mock_get):
+    def test_ssl_verification(self, mock_get: MagicMock):
         """Test SSL verification can be disabled."""
         # Mock successful response when SSL verification is disabled
         mock_response = MagicMock()
@@ -154,7 +155,7 @@ class TestOpenAIAPIEncodeWrapper:
         assert call_kwargs["verify"] is False
 
     @patch("requests.get")
-    def test_api_key_header(self, mock_get):
+    def test_api_key_header(self, mock_get: MagicMock):
         """Test that API key is stored correctly."""
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -170,7 +171,7 @@ class TestOpenAIAPIEncodeWrapper:
 
     @patch("requests.post")
     @patch("requests.get")
-    def test_encode_with_mock_task(self, mock_get, mock_post):
+    def test_encode_with_mock_task(self, mock_get: MagicMock, mock_post: MagicMock):
         """Test encoding with a mock task and actual data return."""
         # Mock server initialization
         mock_get_response = MagicMock()
@@ -197,7 +198,7 @@ class TestOpenAIAPIEncodeWrapper:
         mock_post_response.status_code = 200
 
         # Return different responses based on input size
-        def mock_post_side_effect(*args, **kwargs):
+        def mock_post_side_effect(*args: Any, **kwargs: Any):
             input_data = kwargs.get("json", {}).get("input", [])
             response = MagicMock()
             response.status_code = 200
@@ -255,7 +256,7 @@ class TestOpenAIAPIEncodeWrapper:
 
     @patch("requests.post")
     @patch("requests.get")
-    def test_batch_size_override(self, mock_get, mock_post):
+    def test_batch_size_override(self, mock_get: MagicMock, mock_post: MagicMock):
         """Test that batch_size can be overridden in encode()."""
         from mteb.abstasks.task_metadata import TaskMetadata
         from mteb.types import PromptType

--- a/tests/test_models/test_openai_rerank_wrapper.py
+++ b/tests/test_models/test_openai_rerank_wrapper.py
@@ -16,7 +16,7 @@ class TestOpenAIAPIRerankWrapper:
     """Test OpenAIAPIRerankWrapper functionality."""
 
     @patch("requests.get")
-    def test_initialization(self, mock_get):
+    def test_initialization(self, mock_get: MagicMock):
         """Test that wrapper initializes and connects to server."""
         # Mock the /v1/models endpoint
         mock_response = MagicMock()
@@ -51,7 +51,7 @@ class TestOpenAIAPIRerankWrapper:
 
     @patch("requests.post")
     @patch("requests.get")
-    def test_basic_reranking(self, mock_get, mock_post):
+    def test_basic_reranking(self, mock_get: MagicMock, mock_post: MagicMock):
         """Test basic reranking functionality with mocked responses."""
         # Mock server initialization
         mock_get_response = MagicMock()
@@ -92,7 +92,7 @@ class TestOpenAIAPIRerankWrapper:
 
     @patch("requests.post")
     @patch("requests.get")
-    def test_predict_pairwise(self, mock_get, mock_post):
+    def test_predict_pairwise(self, mock_get: MagicMock, mock_post: MagicMock):
         """Test predict with pairwise query-document scoring."""
         from mteb.abstasks.task_metadata import TaskMetadata
         from mteb.types import PromptType
@@ -147,7 +147,7 @@ class TestOpenAIAPIRerankWrapper:
 
     @patch("requests.post")
     @patch("requests.get")
-    def test_top_k_parameter(self, mock_get, mock_post):
+    def test_top_k_parameter(self, mock_get: MagicMock, mock_post: MagicMock):
         """Test that top_k parameter can be passed to predict()."""
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -193,7 +193,7 @@ class TestOpenAIAPIRerankWrapper:
 
     @patch("requests.post")
     @patch("requests.get")
-    def test_predict_invalid_sizes(self, mock_get, mock_post):
+    def test_predict_invalid_sizes(self, mock_get: MagicMock, mock_post: MagicMock):
         """Test predict with invalid input sizes raises ValueError."""
         from mteb.abstasks.task_metadata import TaskMetadata
         from mteb.types import PromptType

--- a/tests/test_result_cache.py
+++ b/tests/test_result_cache.py
@@ -2,7 +2,7 @@
 
 import subprocess
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 from unittest.mock import patch
 
 import numpy as np
@@ -266,7 +266,7 @@ def test_cache_load_different_subsets():
     assert result2.model_results[0].task_results[0].get_score() == 0.01035
 
 
-def test_load_experiment_results(tmp_path):
+def test_load_experiment_results(tmp_path: Path):
     """Test that results from an experiment can be loaded correctly."""
     model = mteb.get_model("mteb/baseline-random-encoder")
     task = MockRetrievalTask()
@@ -463,7 +463,7 @@ def _setup_test_model_results(cache_path: Path) -> tuple[ModelMeta, list[str]]:
     return model_meta, result_files
 
 
-def test_submit_results_with_fake_remote(tmp_path):
+def test_submit_results_with_fake_remote(tmp_path: Path):
     """Comprehensive test for submit_results workflow: verifies file copying, commit creation, branch restoration, and pre-flight checks."""
     cache_path, remote_path = _setup_fake_remote(tmp_path)
     test_model, result_files_copied = _setup_test_model_results(cache_path)
@@ -563,7 +563,7 @@ def test_submit_results_with_fake_remote(tmp_path):
         )
 
 
-def test_submit_results(tmp_path):
+def test_submit_results(tmp_path: Path):
     cache_path, remote_path = _setup_fake_remote(tmp_path)
     test_model, result_files_copied = _setup_test_model_results(cache_path)
 
@@ -616,7 +616,7 @@ def test_submit_results(tmp_path):
         )
 
 
-def test_pr_creation_failure_cleans_up_branch(tmp_path):
+def test_pr_creation_failure_cleans_up_branch(tmp_path: Path):
     """Verify that failed PR creation cleans up temporary branch and restores original branch."""
     cache_path, remote_path = _setup_fake_remote(tmp_path)
     test_model, _ = _setup_test_model_results(cache_path)
@@ -675,7 +675,7 @@ def test_pr_creation_failure_cleans_up_branch(tmp_path):
 
 
 def _setup_experiment_model_results(
-    cache_path: Path, **kwargs
+    cache_path: Path, **kwargs: Any
 ) -> tuple[ModelMeta, list[str]]:
     """Generate experiment results by evaluating the baseline random encoder with experiment kwargs."""
     cache = ResultCache(cache_path=cache_path)
@@ -717,7 +717,7 @@ def _committed_files(remote_path: Path) -> str:
     ).stdout
 
 
-def test_submit_results_experiments_only(tmp_path):
+def test_submit_results_experiments_only(tmp_path: Path):
     """Submit results for a model that only has experiment results (no base results)."""
     cache_path, remote_path = _setup_fake_remote(tmp_path)
     test_model, result_files = _setup_experiment_model_results(cache_path, a="test")

--- a/tests/test_result_cache_load_from_cache.py
+++ b/tests/test_result_cache_load_from_cache.py
@@ -1,5 +1,6 @@
 """Test cases for the _load_from_cache and _rebuild_from_full_repository methods."""
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -11,7 +12,7 @@ from mteb.results import BenchmarkResults
 class TestLoadFromCache:
     """Test the _load_from_cache method."""
 
-    def test_rebuild_flag_forces_full_rebuild(self, tmp_path):
+    def test_rebuild_flag_forces_full_rebuild(self, tmp_path: Path):
         """Test rebuild=True bypasses cache and forces rebuild."""
         cache = ResultCache(cache_path=tmp_path)
         cache_filename = "test_cache.json"
@@ -26,7 +27,7 @@ class TestLoadFromCache:
             mock_rebuild.assert_called_once_with(expected_path)
             assert result == mock_result
 
-    def test_loading_strategies_in_order(self, tmp_path):
+    def test_loading_strategies_in_order(self, tmp_path: Path):
         """Test the 3-tier loading strategy: local -> download -> rebuild."""
         cache = ResultCache(cache_path=tmp_path)
         cache_filename = "test_cache.json"
@@ -65,7 +66,7 @@ class TestLoadFromCache:
             mock_rebuild.assert_called_once_with(expected_path)
             assert result == mock_result
 
-    def test_corrupt_cache_triggers_fallback(self, tmp_path):
+    def test_corrupt_cache_triggers_fallback(self, tmp_path: Path):
         """Test that corrupt cache files trigger next strategy."""
         cache = ResultCache(cache_path=tmp_path)
         cache_filename = "test_cache.json"
@@ -90,7 +91,7 @@ class TestLoadFromCache:
 class TestRebuildFromFullRepository:
     """Test the _rebuild_from_full_repository method."""
 
-    def test_full_rebuild_process(self, tmp_path):
+    def test_full_rebuild_process(self, tmp_path: Path):
         """Test rebuild downloads repo, loads results, and saves cache."""
         cache = ResultCache(cache_path=tmp_path)
         quick_cache_path = tmp_path / "cache.json"
@@ -123,7 +124,7 @@ class TestRebuildFromFullRepository:
             mock_results.to_disk.assert_called_once_with(quick_cache_path)
             assert result == mock_results
 
-    def test_rebuild_error_propagation(self, tmp_path):
+    def test_rebuild_error_propagation(self, tmp_path: Path):
         """Test that errors during rebuild are properly propagated."""
         cache = ResultCache(cache_path=tmp_path)
         quick_cache_path = tmp_path / "cache.json"

--- a/tests/test_results/test_task_results.py
+++ b/tests/test_results/test_task_results.py
@@ -1,5 +1,6 @@
 from importlib.metadata import version
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -45,7 +46,7 @@ class DummyTask(AbsTask):
     def evaluate(self, model, split: str = "test"):
         pass
 
-    def _evaluate_subset(self, **kwargs):
+    def _evaluate_subset(self, **kwargs: Any):
         pass
 
     def _calculate_descriptive_statistics_from_split(

--- a/tests/test_run_settings_jsonl.py
+++ b/tests/test_run_settings_jsonl.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import mteb
 from mteb.cache import ResultCache
@@ -12,7 +13,7 @@ def _read_jsonl(path):
         return [json.loads(line) for line in handle if line.strip()]
 
 
-def test_save_to_cache_replaces_existing_run_settings_entry(tmp_path):
+def test_save_to_cache_replaces_existing_run_settings_entry(tmp_path: Path):
     cache = ResultCache(cache_path=tmp_path)
     task_result = TaskResult.from_task_results(
         task=mteb.get_task("STS12"),
@@ -43,7 +44,7 @@ def test_save_to_cache_replaces_existing_run_settings_entry(tmp_path):
     assert entries[0]["encode_kwargs"]["batch_size"] == 32
 
 
-def test_save_to_cache_combines_subsets_with_same_settings(tmp_path):
+def test_save_to_cache_combines_subsets_with_same_settings(tmp_path: Path):
     cache = ResultCache(cache_path=tmp_path)
     for subset in ["en", "de"]:
         cache.save_to_cache(
@@ -84,7 +85,7 @@ def test_save_to_cache_combines_subsets_with_same_settings(tmp_path):
     assert entries[1]["encode_kwargs"]["batch_size"] == 32
 
 
-def test_save_to_cache_combines_splits_evaluated_on_the_same_subsets(tmp_path):
+def test_save_to_cache_combines_splits_evaluated_on_the_same_subsets(tmp_path: Path):
     cache = ResultCache(cache_path=tmp_path)
     scores = {"en": {"main_score": 0.5}, "de": {"main_score": 0.5}}
     cache.save_to_cache(
@@ -125,7 +126,7 @@ def test_save_to_cache_combines_splits_evaluated_on_the_same_subsets(tmp_path):
     assert entries[1]["subsets"] == ["de", "en"]
 
 
-def test_save_to_cache_serializes_non_json_serializable_encode_kwargs(tmp_path):
+def test_save_to_cache_serializes_non_json_serializable_encode_kwargs(tmp_path: Path):
     cache = ResultCache(cache_path=tmp_path)
     task_result = TaskResult.from_task_results(
         task=mteb.get_task("STS13"),

--- a/tests/test_validate_metadata/test_citation_formatting.py
+++ b/tests/test_validate_metadata/test_citation_formatting.py
@@ -25,7 +25,7 @@ def format_bibtex(bibtex_str: str) -> str | None:
 
 
 @pytest.fixture(params=mteb.get_tasks())
-def task(request):
+def task(request: pytest.FixtureRequest):
     return request.param
 
 
@@ -44,7 +44,7 @@ def test_task_bibtex(task: AbsTask):
 
 
 @pytest.fixture(params=mteb.get_benchmarks())
-def benchmark(request):
+def benchmark(request: pytest.FixtureRequest):
     return request.param
 
 

--- a/tests/test_workflow/test_git_actions.py
+++ b/tests/test_workflow/test_git_actions.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -265,7 +266,7 @@ def test_create_pr_action_do_and_undo() -> None:
             self.pr = FakePR()
             self.last_args = None
 
-        def create_pull(self, **kwargs):
+        def create_pull(self, **kwargs: Any):
             self.last_args = kwargs
             return self.pr
 


### PR DESCRIPTION
Enables `ANN` (flake8-annotations), from #2416. Lands the part that can be annotated correctly without per-site inference — 931 annotations — and defers the rest, which need a type worked out by reading each function body.

### Enabled and fixed:

| Rule | n | Fix |
|---|---|---|
| `ANN003` missing-type-kwargs | 617 | `**kwargs` → `**kwargs: Any` |
| `ANN002` missing-type-args | 15 | `*args` → `*args: Any` |
| `ANN001` missing-type-function-argument | 59 | Known pytest fixtures: `tmp_path`, `monkeypatch`, `caplog`, `capsys`, `request`, `mock_get`/`mock_post` |

- `allow-star-arg-any = true`: Required because `ANN003` demands `**kwargs` be annotated and `ANN401` rejects `Any`, so the two are mutually unsatisfiable here. 447 of the 497 `ANN401` hits (90%) are exactly `*args: Any` / `**kwargs: Any`, and annotating the 617 `ANN003` sites would have pushed `ANN401` to ~1064. `**kwargs` in mteb is a pass-through for arbitrary model/task options, so `Any` is the correct annotation.

- Deferred (733), with a TODO in `ignore.`
- `ANN001` (426), `ANN202` (132), `ANN201` (120), `ANN401` (50), `ANN205` (5)