### PR TITLE
dataset: add Afri-MCQA multiple choice visual QA (it2t, 16 African languages)

### DIFF
--- a/mteb/descriptive_stats/Image/VisionCentricQA/AfriMCQAVisionCentricQA.json
+++ b/mteb/descriptive_stats/Image/VisionCentricQA/AfriMCQAVisionCentricQA.json
@@ -1,0 +1,837 @@
+{
+    "dev": {
+        "num_samples": 13960,
+        "num_queries": 2792,
+        "num_documents": 11168,
+        "number_of_characters": 269507,
+        "documents_text_statistics": {
+            "total_text_length": 139725,
+            "min_text_length": 1,
+            "average_text_length": 12.511192693409741,
+            "max_text_length": 140,
+            "unique_texts": 8734
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 129782,
+            "min_text_length": 11,
+            "average_text_length": 46.48352435530086,
+            "max_text_length": 142,
+            "unique_texts": 2792
+        },
+        "queries_image_statistics": {
+            "min_image_width": 47,
+            "average_image_width": 1152.7310171919771,
+            "max_image_width": 5760,
+            "min_image_height": 70,
+            "average_image_height": 1140.3424068767908,
+            "max_image_height": 5700,
+            "unique_images": 1986
+        },
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 2792,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 2792,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": {
+            "num_top_ranked": 11168,
+            "min_top_ranked_per_query": 4,
+            "average_top_ranked_per_query": 4.0,
+            "max_top_ranked_per_query": 4
+        },
+        "hf_subset_descriptive_stats": {
+            "twi": {
+                "num_samples": 1050,
+                "num_queries": 210,
+                "num_documents": 840,
+                "number_of_characters": 18399,
+                "documents_text_statistics": {
+                    "total_text_length": 10397,
+                    "min_text_length": 1,
+                    "average_text_length": 12.377380952380953,
+                    "max_text_length": 53,
+                    "unique_texts": 751
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 8002,
+                    "min_text_length": 15,
+                    "average_text_length": 38.10476190476191,
+                    "max_text_length": 74,
+                    "unique_texts": 210
+                },
+                "queries_image_statistics": {
+                    "min_image_width": 169,
+                    "average_image_width": 814.6571428571428,
+                    "max_image_width": 4160,
+                    "min_image_height": 130,
+                    "average_image_height": 746.7809523809524,
+                    "max_image_height": 1872,
+                    "unique_images": 151
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 210,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 210,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": {
+                    "num_top_ranked": 840,
+                    "min_top_ranked_per_query": 4,
+                    "average_top_ranked_per_query": 4.0,
+                    "max_top_ranked_per_query": 4
+                }
+            },
+            "amh": {
+                "num_samples": 865,
+                "num_queries": 173,
+                "num_documents": 692,
+                "number_of_characters": 8804,
+                "documents_text_statistics": {
+                    "total_text_length": 3932,
+                    "min_text_length": 2,
+                    "average_text_length": 5.682080924855492,
+                    "max_text_length": 19,
+                    "unique_texts": 492
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 4872,
+                    "min_text_length": 11,
+                    "average_text_length": 28.161849710982658,
+                    "max_text_length": 65,
+                    "unique_texts": 173
+                },
+                "queries_image_statistics": {
+                    "min_image_width": 262,
+                    "average_image_width": 1697.5144508670521,
+                    "max_image_width": 4288,
+                    "min_image_height": 177,
+                    "average_image_height": 1372.9595375722542,
+                    "max_image_height": 5700,
+                    "unique_images": 122
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 173,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 173,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": {
+                    "num_top_ranked": 692,
+                    "min_top_ranked_per_query": 4,
+                    "average_top_ranked_per_query": 4.0,
+                    "max_top_ranked_per_query": 4
+                }
+            },
+            "nya": {
+                "num_samples": 790,
+                "num_queries": 158,
+                "num_documents": 632,
+                "number_of_characters": 14445,
+                "documents_text_statistics": {
+                    "total_text_length": 7461,
+                    "min_text_length": 2,
+                    "average_text_length": 11.805379746835444,
+                    "max_text_length": 129,
+                    "unique_texts": 457
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 6984,
+                    "min_text_length": 18,
+                    "average_text_length": 44.20253164556962,
+                    "max_text_length": 92,
+                    "unique_texts": 158
+                },
+                "queries_image_statistics": {
+                    "min_image_width": 154,
+                    "average_image_width": 1441.5253164556962,
+                    "max_image_width": 4128,
+                    "min_image_height": 242,
+                    "average_image_height": 1650.746835443038,
+                    "max_image_height": 4128,
+                    "unique_images": 119
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 158,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 158,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": {
+                    "num_top_ranked": 632,
+                    "min_top_ranked_per_query": 4,
+                    "average_top_ranked_per_query": 4.0,
+                    "max_top_ranked_per_query": 4
+                }
+            },
+            "hau": {
+                "num_samples": 860,
+                "num_queries": 172,
+                "num_documents": 688,
+                "number_of_characters": 29510,
+                "documents_text_statistics": {
+                    "total_text_length": 18505,
+                    "min_text_length": 3,
+                    "average_text_length": 26.896802325581394,
+                    "max_text_length": 140,
+                    "unique_texts": 607
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 11005,
+                    "min_text_length": 34,
+                    "average_text_length": 63.98255813953488,
+                    "max_text_length": 111,
+                    "unique_texts": 172
+                },
+                "queries_image_statistics": {
+                    "min_image_width": 330,
+                    "average_image_width": 1235.2790697674418,
+                    "max_image_width": 4316,
+                    "min_image_height": 322,
+                    "average_image_height": 1568.546511627907,
+                    "max_image_height": 4608,
+                    "unique_images": 126
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 172,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 172,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": {
+                    "num_top_ranked": 688,
+                    "min_top_ranked_per_query": 4,
+                    "average_top_ranked_per_query": 4.0,
+                    "max_top_ranked_per_query": 4
+                }
+            },
+            "ibo": {
+                "num_samples": 925,
+                "num_queries": 185,
+                "num_documents": 740,
+                "number_of_characters": 18388,
+                "documents_text_statistics": {
+                    "total_text_length": 9803,
+                    "min_text_length": 2,
+                    "average_text_length": 13.247297297297298,
+                    "max_text_length": 48,
+                    "unique_texts": 645
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 8585,
+                    "min_text_length": 25,
+                    "average_text_length": 46.4054054054054,
+                    "max_text_length": 94,
+                    "unique_texts": 185
+                },
+                "queries_image_statistics": {
+                    "min_image_width": 137,
+                    "average_image_width": 1657.718918918919,
+                    "max_image_width": 4032,
+                    "min_image_height": 108,
+                    "average_image_height": 1796.291891891892,
+                    "max_image_height": 4160,
+                    "unique_images": 126
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 185,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 185,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": {
+                    "num_top_ranked": 740,
+                    "min_top_ranked_per_query": 4,
+                    "average_top_ranked_per_query": 4.0,
+                    "max_top_ranked_per_query": 4
+                }
+            },
+            "kik": {
+                "num_samples": 955,
+                "num_queries": 191,
+                "num_documents": 764,
+                "number_of_characters": 18528,
+                "documents_text_statistics": {
+                    "total_text_length": 8682,
+                    "min_text_length": 1,
+                    "average_text_length": 11.363874345549739,
+                    "max_text_length": 45,
+                    "unique_texts": 656
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 9846,
+                    "min_text_length": 19,
+                    "average_text_length": 51.54973821989529,
+                    "max_text_length": 108,
+                    "unique_texts": 191
+                },
+                "queries_image_statistics": {
+                    "min_image_width": 68,
+                    "average_image_width": 864.4188481675393,
+                    "max_image_width": 1600,
+                    "min_image_height": 101,
+                    "average_image_height": 835.2303664921466,
+                    "max_image_height": 1737,
+                    "unique_images": 133
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 191,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 191,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": {
+                    "num_top_ranked": 764,
+                    "min_top_ranked_per_query": 4,
+                    "average_top_ranked_per_query": 4.0,
+                    "max_top_ranked_per_query": 4
+                }
+            },
+            "kin": {
+                "num_samples": 985,
+                "num_queries": 197,
+                "num_documents": 788,
+                "number_of_characters": 22418,
+                "documents_text_statistics": {
+                    "total_text_length": 13296,
+                    "min_text_length": 1,
+                    "average_text_length": 16.873096446700508,
+                    "max_text_length": 101,
+                    "unique_texts": 738
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 9122,
+                    "min_text_length": 15,
+                    "average_text_length": 46.30456852791878,
+                    "max_text_length": 106,
+                    "unique_texts": 197
+                },
+                "queries_image_statistics": {
+                    "min_image_width": 421,
+                    "average_image_width": 1356.9543147208121,
+                    "max_image_width": 5616,
+                    "min_image_height": 258,
+                    "average_image_height": 1319.791878172589,
+                    "max_image_height": 5184,
+                    "unique_images": 131
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 197,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 197,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": {
+                    "num_top_ranked": 788,
+                    "min_top_ranked_per_query": 4,
+                    "average_top_ranked_per_query": 4.0,
+                    "max_top_ranked_per_query": 4
+                }
+            },
+            "lin": {
+                "num_samples": 955,
+                "num_queries": 191,
+                "num_documents": 764,
+                "number_of_characters": 19043,
+                "documents_text_statistics": {
+                    "total_text_length": 10580,
+                    "min_text_length": 1,
+                    "average_text_length": 13.848167539267015,
+                    "max_text_length": 76,
+                    "unique_texts": 650
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 8463,
+                    "min_text_length": 16,
+                    "average_text_length": 44.30890052356021,
+                    "max_text_length": 98,
+                    "unique_texts": 191
+                },
+                "queries_image_statistics": {
+                    "min_image_width": 280,
+                    "average_image_width": 780.8219895287958,
+                    "max_image_width": 3240,
+                    "min_image_height": 168,
+                    "average_image_height": 782.696335078534,
+                    "max_image_height": 4320,
+                    "unique_images": 140
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 191,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 191,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": {
+                    "num_top_ranked": 764,
+                    "min_top_ranked_per_query": 4,
+                    "average_top_ranked_per_query": 4.0,
+                    "max_top_ranked_per_query": 4
+                }
+            },
+            "lug": {
+                "num_samples": 905,
+                "num_queries": 181,
+                "num_documents": 724,
+                "number_of_characters": 18313,
+                "documents_text_statistics": {
+                    "total_text_length": 8925,
+                    "min_text_length": 3,
+                    "average_text_length": 12.327348066298342,
+                    "max_text_length": 57,
+                    "unique_texts": 568
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 9388,
+                    "min_text_length": 26,
+                    "average_text_length": 51.86740331491713,
+                    "max_text_length": 97,
+                    "unique_texts": 181
+                },
+                "queries_image_statistics": {
+                    "min_image_width": 220,
+                    "average_image_width": 845.8729281767955,
+                    "max_image_width": 3720,
+                    "min_image_height": 147,
+                    "average_image_height": 616.2099447513813,
+                    "max_image_height": 2760,
+                    "unique_images": 121
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 181,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 181,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": {
+                    "num_top_ranked": 724,
+                    "min_top_ranked_per_query": 4,
+                    "average_top_ranked_per_query": 4.0,
+                    "max_top_ranked_per_query": 4
+                }
+            },
+            "orm": {
+                "num_samples": 945,
+                "num_queries": 189,
+                "num_documents": 756,
+                "number_of_characters": 18161,
+                "documents_text_statistics": {
+                    "total_text_length": 9337,
+                    "min_text_length": 1,
+                    "average_text_length": 12.350529100529101,
+                    "max_text_length": 46,
+                    "unique_texts": 596
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 8824,
+                    "min_text_length": 23,
+                    "average_text_length": 46.68783068783069,
+                    "max_text_length": 106,
+                    "unique_texts": 189
+                },
+                "queries_image_statistics": {
+                    "min_image_width": 176,
+                    "average_image_width": 710.4656084656085,
+                    "max_image_width": 3200,
+                    "min_image_height": 140,
+                    "average_image_height": 661.8412698412699,
+                    "max_image_height": 3088,
+                    "unique_images": 121
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 189,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 189,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": {
+                    "num_top_ranked": 756,
+                    "min_top_ranked_per_query": 4,
+                    "average_top_ranked_per_query": 4.0,
+                    "max_top_ranked_per_query": 4
+                }
+            },
+            "sot": {
+                "num_samples": 625,
+                "num_queries": 125,
+                "num_documents": 500,
+                "number_of_characters": 12561,
+                "documents_text_statistics": {
+                    "total_text_length": 4977,
+                    "min_text_length": 1,
+                    "average_text_length": 9.954,
+                    "max_text_length": 51,
+                    "unique_texts": 356
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 7584,
+                    "min_text_length": 22,
+                    "average_text_length": 60.672,
+                    "max_text_length": 142,
+                    "unique_texts": 125
+                },
+                "queries_image_statistics": {
+                    "min_image_width": 405,
+                    "average_image_width": 791.296,
+                    "max_image_width": 2837,
+                    "min_image_height": 324,
+                    "average_image_height": 754.776,
+                    "max_image_height": 4096,
+                    "unique_images": 100
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 125,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 125,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": {
+                    "num_top_ranked": 500,
+                    "min_top_ranked_per_query": 4,
+                    "average_top_ranked_per_query": 4.0,
+                    "max_top_ranked_per_query": 4
+                }
+            },
+            "tsn": {
+                "num_samples": 955,
+                "num_queries": 191,
+                "num_documents": 764,
+                "number_of_characters": 19236,
+                "documents_text_statistics": {
+                    "total_text_length": 9177,
+                    "min_text_length": 3,
+                    "average_text_length": 12.011780104712042,
+                    "max_text_length": 85,
+                    "unique_texts": 646
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 10059,
+                    "min_text_length": 21,
+                    "average_text_length": 52.66492146596859,
+                    "max_text_length": 101,
+                    "unique_texts": 191
+                },
+                "queries_image_statistics": {
+                    "min_image_width": 212,
+                    "average_image_width": 2214.7120418848167,
+                    "max_image_width": 5184,
+                    "min_image_height": 212,
+                    "average_image_height": 2169.565445026178,
+                    "max_image_height": 4608,
+                    "unique_images": 127
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 191,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 191,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": {
+                    "num_top_ranked": 764,
+                    "min_top_ranked_per_query": 4,
+                    "average_top_ranked_per_query": 4.0,
+                    "max_top_ranked_per_query": 4
+                }
+            },
+            "som": {
+                "num_samples": 885,
+                "num_queries": 177,
+                "num_documents": 708,
+                "number_of_characters": 16152,
+                "documents_text_statistics": {
+                    "total_text_length": 8372,
+                    "min_text_length": 2,
+                    "average_text_length": 11.824858757062147,
+                    "max_text_length": 97,
+                    "unique_texts": 542
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 7780,
+                    "min_text_length": 20,
+                    "average_text_length": 43.954802259887,
+                    "max_text_length": 94,
+                    "unique_texts": 177
+                },
+                "queries_image_statistics": {
+                    "min_image_width": 250,
+                    "average_image_width": 782.6723163841808,
+                    "max_image_width": 5760,
+                    "min_image_height": 151,
+                    "average_image_height": 700.2994350282486,
+                    "max_image_height": 3240,
+                    "unique_images": 144
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 177,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 177,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": {
+                    "num_top_ranked": 708,
+                    "min_top_ranked_per_query": 4,
+                    "average_top_ranked_per_query": 4.0,
+                    "max_top_ranked_per_query": 4
+                }
+            },
+            "tir": {
+                "num_samples": 985,
+                "num_queries": 197,
+                "num_documents": 788,
+                "number_of_characters": 13344,
+                "documents_text_statistics": {
+                    "total_text_length": 5527,
+                    "min_text_length": 1,
+                    "average_text_length": 7.0139593908629445,
+                    "max_text_length": 35,
+                    "unique_texts": 555
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 7817,
+                    "min_text_length": 16,
+                    "average_text_length": 39.68020304568528,
+                    "max_text_length": 66,
+                    "unique_texts": 197
+                },
+                "queries_image_statistics": {
+                    "min_image_width": 47,
+                    "average_image_width": 1229.791878172589,
+                    "max_image_width": 4608,
+                    "min_image_height": 70,
+                    "average_image_height": 1116.0152284263959,
+                    "max_image_height": 4928,
+                    "unique_images": 133
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 197,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 197,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": {
+                    "num_top_ranked": 788,
+                    "min_top_ranked_per_query": 4,
+                    "average_top_ranked_per_query": 4.0,
+                    "max_top_ranked_per_query": 4
+                }
+            },
+            "yor": {
+                "num_samples": 855,
+                "num_queries": 171,
+                "num_documents": 684,
+                "number_of_characters": 15289,
+                "documents_text_statistics": {
+                    "total_text_length": 7246,
+                    "min_text_length": 2,
+                    "average_text_length": 10.59356725146199,
+                    "max_text_length": 95,
+                    "unique_texts": 501
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 8043,
+                    "min_text_length": 20,
+                    "average_text_length": 47.03508771929825,
+                    "max_text_length": 103,
+                    "unique_texts": 171
+                },
+                "queries_image_statistics": {
+                    "min_image_width": 192,
+                    "average_image_width": 1047.4444444444443,
+                    "max_image_width": 3456,
+                    "min_image_height": 181,
+                    "average_image_height": 1080.8070175438597,
+                    "max_image_height": 4608,
+                    "unique_images": 119
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 171,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 171,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": {
+                    "num_top_ranked": 684,
+                    "min_top_ranked_per_query": 4,
+                    "average_top_ranked_per_query": 4.0,
+                    "max_top_ranked_per_query": 4
+                }
+            },
+            "zul": {
+                "num_samples": 420,
+                "num_queries": 84,
+                "num_documents": 336,
+                "number_of_characters": 6916,
+                "documents_text_statistics": {
+                    "total_text_length": 3508,
+                    "min_text_length": 2,
+                    "average_text_length": 10.44047619047619,
+                    "max_text_length": 33,
+                    "unique_texts": 302
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 3408,
+                    "min_text_length": 17,
+                    "average_text_length": 40.57142857142857,
+                    "max_text_length": 85,
+                    "unique_texts": 84
+                },
+                "queries_image_statistics": {
+                    "min_image_width": 282,
+                    "average_image_width": 666.5595238095239,
+                    "max_image_width": 720,
+                    "min_image_height": 295,
+                    "average_image_height": 994.797619047619,
+                    "max_image_height": 1600,
+                    "unique_images": 75
+                },
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 84,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 84,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": {
+                    "num_top_ranked": 336,
+                    "min_top_ranked_per_query": 4,
+                    "average_top_ranked_per_query": 4.0,
+                    "max_top_ranked_per_query": 4
+                }
+            }
+        }
+    }
+}

--- a/mteb/tasks/multichoice/__init__.py
+++ b/mteb/tasks/multichoice/__init__.py
@@ -1,1 +1,2 @@
 from .eng import *
+from .multilingual import *

--- a/mteb/tasks/multichoice/multilingual/__init__.py
+++ b/mteb/tasks/multichoice/multilingual/__init__.py
@@ -1,0 +1,5 @@
+from .afri_mcqa_multiple_choice import AfriMCQAVisionCentricQA
+
+__all__ = [
+    "AfriMCQAVisionCentricQA",
+]

--- a/mteb/tasks/multichoice/multilingual/afri_mcqa_multiple_choice.py
+++ b/mteb/tasks/multichoice/multilingual/afri_mcqa_multiple_choice.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from datasets import Dataset, load_dataset
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.retrieval_dataset_loaders import RetrievalSplitData
+from mteb.abstasks.task_metadata import TaskMetadata
+
+_DATASET_PATH = "vnahata/AfriMCQA-multiple-choice"
+_DATASET_REVISION = "3ed9383894a3ff0261af4097d1e4e9d593868f1d"
+
+_LANGUAGES = {
+    "twi": ["twi-Latn"],
+    "amh": ["amh-Ethi"],
+    "nya": ["nya-Latn"],
+    "hau": ["hau-Latn"],
+    "ibo": ["ibo-Latn"],
+    "kik": ["kik-Latn"],
+    "kin": ["kin-Latn"],
+    "lin": ["lin-Latn"],
+    "lug": ["lug-Latn"],
+    # Afri-MCQA's Oromo is the West Central variety, so `gaz` rather than the `orm`
+    # macrolanguage
+    "orm": ["gaz-Latn"],
+    "sot": ["sot-Latn"],
+    "tsn": ["tsn-Latn"],
+    "som": ["som-Latn"],
+    "tir": ["tir-Ethi"],
+    "yor": ["yor-Latn"],
+    "zul": ["zul-Latn"],
+}
+
+
+class AfriMCQAVisionCentricQA(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="AfriMCQAVisionCentricQA",
+        description=(
+            "Culturally grounded multiple choice questions about photographs, written by "
+            "native speakers of 16 African languages. Given a photograph and a question "
+            "about it in the native language, pick the correct answer from that "
+            "question's own options. Every multiple choice task in `mteb` is currently "
+            "English only, so this is the first multilingual one. #5356 added a2i/i2a "
+            "retrieval over the same source; this is the QA formulation. Built from the "
+            "official dev split, the only one where the answer is labelled, since the "
+            "test split ships the four options already shuffled with no key. Options are "
+            "shuffled by a hash of the question, because the source lists the correct "
+            "answer first in every row. Questions with no photograph, questions listing "
+            "their own answer among their distractors, and repeats are dropped. "
+            "Construction script: scripts/data/afri_mcqa_multiple_choice/create_data.py."
+        ),
+        reference="https://arxiv.org/abs/2601.05699",
+        dataset={"path": _DATASET_PATH, "revision": _DATASET_REVISION},
+        type="VisionCentricQA",
+        category="it2t",
+        modalities=["image", "text"],
+        eval_splits=["dev"],
+        eval_langs=_LANGUAGES,
+        main_score="accuracy",
+        date=("2025-01-01", "2026-01-15"),
+        domains=["Scene"],
+        task_subtypes=["Question answering"],
+        license="cc-by-nc-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="created",
+        prompt={"query": "Answer this question about the image."},
+        bibtex_citation=r"""
+@inproceedings{tonja2026afrimcqa,
+  author = {Tonja, Atnafu Lambebo and Anand, Srija and Villa-Cueva, Emilio and Azime, Israel Abebe and Alabi, Jesujoba Oluwadara and Mohamed, Muhidin A. and Yadeta, Debela Desalegn and Abadi, Negasi Haile and Oppong, Abigail and Obiefuna, Nnaemeka Casmir and Abdulmumin, Idris and Etori, Naome A},
+  title = {{Afri-MCQA}: Multimodal Cultural Question Answering for {African} Languages},
+  year = {2026},
+}
+""",
+        is_beta=True,
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+        if self.data_loaded:
+            return
+
+        split = self.metadata.eval_splits[0]
+        self.dataset = {}
+        for lang in _LANGUAGES:
+            rows = load_dataset(
+                _DATASET_PATH, lang, revision=_DATASET_REVISION, split=split
+            )
+            queries = rows.select_columns(["id", "text", "image"])
+
+            corpus_rows: list[dict] = []
+            relevant_docs: dict[str, dict[str, int]] = {}
+            top_ranked: dict[str, list[str]] = {}
+            # Candidates are read without the image column so that scanning the options
+            # does not decode a photograph for every row.
+            for row in rows.select_columns(["id", "candidates", "answer"]):
+                qid = row["id"]
+                top_ranked[qid] = []
+                for j, candidate in enumerate(row["candidates"]):
+                    doc_id = f"{qid}_c{j}"
+                    corpus_rows.append({"id": doc_id, "text": candidate})
+                    top_ranked[qid].append(doc_id)
+                    if candidate == row["answer"]:
+                        relevant_docs[qid] = {doc_id: 1}
+
+            self.dataset[lang] = {
+                split: RetrievalSplitData(
+                    queries=queries,
+                    corpus=Dataset.from_list(corpus_rows),
+                    relevant_docs=relevant_docs,
+                    top_ranked=top_ranked,
+                )
+            }
+        self.data_loaded = True

--- a/scripts/data/afri_mcqa_multiple_choice/create_data.py
+++ b/scripts/data/afri_mcqa_multiple_choice/create_data.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Build the Afri-MCQA multiple choice visual QA task for MTEB.
+
+Source is [Afri-MCQA](https://arxiv.org/abs/2601.05699), culturally grounded multiple
+choice questions about photographs, in 16 African languages. #5356 added the a2i/i2a
+retrieval directions over the same source; this is the QA formulation asked for in that
+thread, where the question and its photograph together select the correct answer.
+
+The answer key is the constraint that shapes the build. The per-language `*_test`
+configs ship the four options already shuffled into `native_option_1..4` with no label,
+so they cannot be scored. The `*_dev` configs keep `correct_native` separate from
+`wrong_native_o1..o3`, so `dev` is the only split where the correct answer is known and
+is what this task evaluates on.
+
+Each row keeps its own options, which is what lets the task be scored the way mteb
+scores its other multiple choice sets: the candidates become `top_ranked` so a question
+is ranked against its own four options rather than a pooled corpus, and the metric is
+accuracy. Because the source lists the correct answer first in every row, the options
+are shuffled by a hash of the question, which keeps the order fixed across rebuilds
+without leaving the answer at index 0 every time.
+
+Examples:
+  # Build the reshaped tables locally.
+  uv run python scripts/data/afri_mcqa_multiple_choice/create_data.py --stage build
+
+  # Build and publish.
+  uv run python scripts/data/afri_mcqa_multiple_choice/create_data.py --stage all --push
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+from pathlib import Path
+
+import pyarrow.parquet as pq
+from datasets import Dataset, Image, load_dataset
+from huggingface_hub import HfApi
+
+_SOURCE_REPO = "Atnafu/Afri-MCQA"
+_SOURCE_REV = "8b8c53df57b0c2cf9d9798c53515ba1dd14df669"
+_TARGET = "vnahata/AfriMCQA-multiple-choice"
+_LICENSE = "cc-by-nc-4.0"
+
+_LANGS = {
+    "Akan_Twi": "twi",
+    "Amharic": "amh",
+    "Chichewa": "nya",
+    "Hausa": "hau",
+    "Igbo": "ibo",
+    "Kikuyu": "kik",
+    "Kinyarwanda": "kin",
+    "Lingala": "lin",
+    "Luganda": "lug",
+    "Oromo": "orm",
+    "Sesotho": "sot",
+    "Setswana": "tsn",
+    "Somali": "som",
+    "Tigrinya": "tir",
+    "Yoruba": "yor",
+    "Zulu": "zul",
+}
+
+_QUESTION = "native_question"
+_CORRECT = "correct_native"
+_WRONG = ["wrong_native_o1", "wrong_native_o2", "wrong_native_o3"]
+
+
+# A few cells survive the source's export as the string a null becomes rather than as
+# an empty cell, so they have to be caught by value and not just by emptiness.
+_NULLISH = {"", "nan", "none", "null", "n/a", "na"}
+
+
+def _clean(value: object) -> str:
+    if not isinstance(value, str):
+        return ""
+    text = value.strip()
+    return "" if text.casefold() in _NULLISH else text
+
+
+def stage_build(work: Path) -> dict:
+    work.mkdir(parents=True, exist_ok=True)
+    counts: dict[str, dict[str, int]] = {}
+
+    for name, code in _LANGS.items():
+        q_path = work / f"{code}.parquet"
+        if q_path.exists():
+            counts[code] = {"questions": pq.read_metadata(q_path).num_rows}
+            print(f"  {code}: cached {counts[code]}", flush=True)
+            continue
+
+        ds = load_dataset(
+            _SOURCE_REPO, f"{name}_dev", revision=_SOURCE_REV, split="dev"
+        )
+        text_cols = [c for c in [_QUESTION, _CORRECT, *_WRONG] if c in ds.column_names]
+        text = ds.select_columns(text_cols).to_dict()
+
+        # Read the photographs undecoded: decoding every image only to check that it is
+        # present would cost far more memory than the build needs.
+        raw = ds.select_columns(["image"]).cast_column("image", Image(decode=False))
+        blobs = [rec["image"].get("bytes") if rec["image"] else None for rec in raw]
+
+        rows, seen_q = [], set()
+        for i in range(len(blobs)):
+            question = _clean(text.get(_QUESTION, [None] * len(blobs))[i])
+            correct = _clean(text.get(_CORRECT, [None] * len(blobs))[i])
+            wrong = [_clean(text.get(w, [None] * len(blobs))[i]) for w in _WRONG]
+            wrong = [w for w in wrong if w]
+
+            # A question with no photograph, no text, or no answer cannot be scored, one
+            # whose correct answer is also listed as its own distractor is ambiguous, and
+            # one left with no distractor is not a choice at all.
+            if not (blobs[i] and question and correct):
+                continue
+            if correct in wrong or not wrong:
+                continue
+            # An identical question asked twice about the same language would be
+            # relevant to whichever copy came first, so the repeat is dropped.
+            if question in seen_q:
+                continue
+            seen_q.add(question)
+
+            # The source always lists the answer first, so leaving source order would
+            # put the correct option at index 0 for every single question. Shuffled by a
+            # hash of the question so the order is fixed across rebuilds.
+            options = [correct, *wrong]
+            digest = hashlib.md5(question.encode("utf-8")).digest()
+            options.sort(key=lambda o: hashlib.md5(digest + o.encode("utf-8")).digest())
+
+            rows.append(
+                {
+                    "id": f"{code}-q-{len(rows)}",
+                    "text": question,
+                    "image": {"bytes": blobs[i], "path": None},
+                    "candidates": options,
+                    "answer": correct,
+                }
+            )
+
+        if len(rows) < 20:
+            print(f"  {code}: skipped, only {len(rows)} questions", flush=True)
+            continue
+
+        Dataset.from_list(rows).cast_column("image", Image()).to_parquet(str(q_path))
+        n_opts = sum(len(r["candidates"]) for r in rows)
+        counts[code] = {"questions": len(rows), "options": n_opts}
+        print(f"  {code}: {counts[code]}", flush=True)
+
+    (work / "counts.json").write_text(json.dumps(counts, indent=2), encoding="utf-8")
+    print("built", json.dumps(counts))
+    return counts
+
+
+def _card(codes: list[str]) -> str:
+    lines = [
+        "---",
+        f"license: {_LICENSE}",
+        "task_categories:",
+        "  - visual-question-answering",
+        "language:",
+        *[f"  - {c}" for c in codes],
+        "tags:",
+        "  - mteb",
+        "  - retrieval",
+        "  - multilingual",
+        "configs:",
+    ]
+    for c in codes:
+        lines += [
+            f"  - config_name: {c}",
+            "    data_files:",
+            "      - split: dev",
+            f"        path: {c}.parquet",
+        ]
+    lines += [
+        "---",
+        "",
+        "# Afri-MCQA multiple choice visual QA (MTEB)",
+        "",
+        "Culturally grounded multiple choice questions about photographs, in 16 African",
+        "languages. Each row is a question, the photograph it asks about, its answer",
+        "options, and which of them is correct. Options are shuffled by a hash of the",
+        "question, because the source always lists the answer first.",
+        "",
+        f"Built from `{_SOURCE_REPO}` at revision `{_SOURCE_REV[:7]}`, {_LICENSE}, using",
+        "the official `dev` split, the only one where the correct answer is labelled.",
+        "",
+        "Built by `scripts/data/afri_mcqa_multiple_choice/create_data.py` in the MTEB repo.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def stage_push(work: Path) -> None:
+    api = HfApi()
+    api.create_repo(_TARGET, repo_type="dataset", exist_ok=True)
+    codes = sorted(p.stem for p in work.glob("*.parquet"))
+    for code in codes:
+        api.upload_file(
+            path_or_fileobj=str(work / f"{code}.parquet"),
+            path_in_repo=f"{code}.parquet",
+            repo_id=_TARGET,
+            repo_type="dataset",
+        )
+        print(f"  pushed {code}", flush=True)
+    api.upload_file(
+        path_or_fileobj=io.BytesIO(_card(codes).encode()),
+        path_in_repo="README.md",
+        repo_id=_TARGET,
+        repo_type="dataset",
+    )
+    print(f"pushed {_TARGET}: {len(codes)} languages")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--stage", choices=["build", "push", "all"], default="all")
+    parser.add_argument("--work-dir", type=Path, default=Path("afri_qa_work"))
+    parser.add_argument("--push", action="store_true")
+    args = parser.parse_args()
+
+    print(f"source: {_SOURCE_REPO}@{_SOURCE_REV[:7]} (license {_LICENSE})")
+    if args.stage in ("build", "all"):
+        stage_build(args.work_dir)
+    if args.stage == "push" or (args.push and args.stage == "all"):
+        stage_push(args.work_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_tasks/test_task_quality.py
+++ b/tests/test_tasks/test_task_quality.py
@@ -23,6 +23,7 @@ from mteb.types.statistics import (
 
 KNOWN_ISSUES: dict[str, list[str]] = {
     "short_text": [
+        "AfriMCQAVisionCentricQA",  # a correct answer can be one character, such as a count
         "ARCChallenge",
         "AVMemeExamVideoAudioCentricQA",
         "AVMemeExamVideoCentricQA",
@@ -411,6 +412,7 @@ KNOWN_ISSUES: dict[str, list[str]] = {
         "BrightProSustainableLivingRetrieval",
     ],
     "duplicate_text": [
+        "AfriMCQAVisionCentricQA",  # each question carries its own copy of its options, and top_ranked scopes it to them
         "AfriHateClassification",
         "AfriSentiClassification",
         "AllegroReviews",
@@ -830,6 +832,7 @@ KNOWN_ISSUES: dict[str, list[str]] = {
         "YueOpenriceReviewClassification",
     ],
     "duplicate_image": [
+        "AfriMCQAVisionCentricQA",  # several questions are asked about one photograph by design
         "AROCocoOrder",
         "AROFlickrOrder",
         "AROVisualAttribution",


### PR DESCRIPTION
Adds `AfriMCQAVisionCentricQA`: given a photograph and a question about it in the native language, pick the correct answer from that question own four options, in 16 African languages. The QA formulation asked for in #5356. Part of #4842.
## Gap
`mteb` has **35 multiple choice tasks and every one is English only**, so this is the first multilingual one. #5356 added a2i/i2a over the same source, where image and audio sit on opposite sides of a pair.
## Construction
Script: `scripts/data/afri_mcqa_multiple_choice/create_data.py`
**Only `dev` can be scored.** The `*_test` configs ship the four options already shuffled into `native_option_1..4` with no key; `*_dev` keeps `correct_native` apart from `wrong_native_o1..o3`.
**Options are shuffled by a hash of the question.** The source lists the correct answer first in every row, so source order would leave it at index 0 every time. Hashing keeps order stable across rebuilds without leaking position.
Scored as `mteb` scores its other multiple choice sets: each question candidates become its `top_ranked`, so it ranks against its own four options, and the metric is accuracy.

**2,792 questions, 11,168 options.** License **CC-BY-NC-4.0**, as in the source.
## Results
Accuracy over the 16 subsets; a four way choice puts the floor at 0.25.
| model | mean |
|---|---|
| `mteb/baseline-random-encoder` | 0.2543 |
| `openai/clip-vit-base-patch32` | 0.2796 |
| `jina-embeddings-v5-omni-nano` | 0.2641 |
Both sit near the floor, which looks like the format rather than this dataset. As a control, the already merged `BLINKIT2TMultiChoice` is also `it2t`, also accuracy, and English: CLIP scores **0.3985 against its 0.3871 floor**, a ratio of 1.03 against 1.04 here.
## Checklist
- [x] Outlined why this fills a gap
- [x] Tested that it runs with `mteb`
- [x] Three encoders run, see table
- [x] Size considered, full official dev split
- [x] `test_task_quality.py` passes, three exemptions noted inline
