### PR TITLE
model: improve MIRACL query prompt for voyage-4-large

### DIFF
--- a/mteb/models/model_implementations/voyage_models.py
+++ b/mteb/models/model_implementations/voyage_models.py
@@ -326,7 +326,7 @@ QUERY_PROMPTS = {
     "LegalQuAD": "Locate enforceable legal rules for: {text}",
     "LegalSummarization": "Seek clarity in legal information: {text}",
     "MBPPRetrieval": "Programming task: {text}",
-    "MIRACLRetrievalHardNegatives": "Uncover comprehensive background: {text}",
+    "MIRACLRetrievalHardNegatives": "Represent this question for retrieving one whole, self-contained encyclopedic reference paragraph, not a passing reference: {text}",
     "WikiSQLRetrieval": "Unveil the SQL instruction to fulfill: {text}",
 }
 


### PR DESCRIPTION
Evolutionary prompt search on `MIRACLRetrievalHardNegatives`, optimising the 18-language macro.

nDCG@10 **0.65193 → 0.67583**. Better than the current prompt on all 18 languages.

Corpus prompt unchanged.

Results PR: [embeddings-benchmark/results](https://github.com/embeddings-benchmark/results/pull/701)