### PR TITLE
fix: break ties by doc id when skipping the first retrieval result

### DIFF
--- a/mteb/_evaluators/retrieval_metrics.py
+++ b/mteb/_evaluators/retrieval_metrics.py
@@ -584,8 +584,12 @@ def calculate_retrieval_scores(  # noqa: PLR0914
     skip_first_result: bool = False,
 ) -> RetrievalEvaluationResult:
     if skip_first_result:
+        # tie-break by doc id descending, like every other ranking in this module (#5092);
+        # a score-only sort is stable, so which doc got dropped followed dict insertion order
         results = {
-            qid: dict(sorted(doc_scores.items(), key=lambda x: x[1], reverse=True)[1:])
+            qid: dict(
+                sorted(doc_scores.items(), key=lambda x: (x[1], x[0]), reverse=True)[1:]
+            )
             for qid, doc_scores in results.items()
         }
 

--- a/tests/test_evaluators/test_evaluation_metrics.py
+++ b/tests/test_evaluators/test_evaluation_metrics.py
@@ -1,6 +1,11 @@
 import pytrec_eval
 
-from mteb._evaluators.retrieval_metrics import calculate_pmrr, mrr, recall_cap
+from mteb._evaluators.retrieval_metrics import (
+    calculate_pmrr,
+    calculate_retrieval_scores,
+    mrr,
+    recall_cap,
+)
 
 
 def test_recall_cap_no_relevant_docs_yields_none():
@@ -61,6 +66,22 @@ def test_p_mrr_tiebreak_independent_of_insertion_order():
 
     score = calculate_pmrr(original_run, new_run, changed_qrels)
     assert score == 0.0
+
+
+def test_skip_first_result_tiebreak_independent_of_insertion_order():
+    # regression for the same #5092 tie-break bug in skip_first_result: the top hit is
+    # dropped with a score-only stable sort, so when the top two scores tie it was dict
+    # insertion order that decided which doc got discarded. Both runs below carry
+    # identical scores, so they must score identically.
+    qrels = {"q1": {"d_dup": 1, "d_other": 1}}
+    tied_self_first = {"q1": {"d_self": 1.0, "d_dup": 1.0, "d_other": 0.5}}
+    tied_dup_first = {"q1": {"d_dup": 1.0, "d_self": 1.0, "d_other": 0.5}}
+
+    self_first = calculate_retrieval_scores(tied_self_first, qrels, [1, 2], True)
+    dup_first = calculate_retrieval_scores(tied_dup_first, qrels, [1, 2], True)
+
+    assert self_first.ndcg == dup_first.ndcg
+    assert self_first.recall == dup_first.recall
 
 
 def test_p_mrr():


### PR DESCRIPTION
Same #5092 tie-break bug, fourth site. `calculate_retrieval_scores` drops the top hit for `skip_first_result` tasks with a score-only sort, and Python's sort is stable — so when the top two scores tie, it's dict insertion order that decides which document gets discarded. The rest of the module has been breaking ties by `(score, doc_id)` since #5136 and #5241; this call was missed.

It affects the seven tasks that set `skip_first_result = True` (Covers80, SHS100K, and the i2i ones — CUB200, MET, RP2K, SOP, StanfordCars). Those are exactly the setups where the query also sits in the corpus, so an exact duplicate scoring 1.0 next to the self-match is the tie you'd expect. Feeding identical scores in two different orders on main:

```
self listed first        NDCG@1 1.0   Recall@3 1.0
duplicate listed first   NDCG@1 0.0   Recall@3 0.5
```

Same data, different dict order. With the tie-break both orders agree.

I haven't measured how often this fires on the real datasets — it needs an exact float tie at rank 1, so in practice duplicate items. And since it can move numbers on those seven tasks, it carries the same results-repo caveat as #5136.

Regression test sits next to the existing tie-break ones and fails on main.
