### PR TITLE
Enables ANN205 (missing-return-type-static-method) Ruff Rule

### DIFF
--- a/mteb/models/model_implementations/bm25.py
+++ b/mteb/models/model_implementations/bm25.py
@@ -10,6 +10,8 @@ from mteb.models.model_meta import ModelMeta
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from bm25s.tokenization import Tokenized
+
     from mteb.abstasks.task_metadata import TaskMetadata
     from mteb.models.models_protocols import SearchProtocol
     from mteb.types import (
@@ -289,7 +291,7 @@ class BM25Tokenizer:
         raise ValueError(f"Unknown tokenizer name: {name!r}")
 
     @staticmethod
-    def _to_tokenized(token_lists: list[list[str]]):
+    def _to_tokenized(token_lists: list[list[str]]) -> Tokenized:
         from bm25s.tokenization import Tokenized
 
         vocab: dict[str, int] = {}

--- a/mteb/models/model_implementations/jina_models.py
+++ b/mteb/models/model_implementations/jina_models.py
@@ -617,7 +617,7 @@ class JinaV4Wrapper(AbsEncoder):
         )
 
     @staticmethod
-    def _convert_to_torch_if_needed(embeddings):
+    def _convert_to_torch_if_needed(embeddings: Any) -> torch.Tensor | list[Any] | Any:
         """Convert numpy arrays to torch tensors if needed."""
         if isinstance(embeddings, np.ndarray):
             return torch.from_numpy(embeddings)

--- a/mteb/models/model_implementations/omniretriever_models.py
+++ b/mteb/models/model_implementations/omniretriever_models.py
@@ -116,7 +116,7 @@ class OmniRetrieverWrapper(AbsEncoder):
         )
 
     @staticmethod
-    def _load_processor(base_model_name_or_path: str, revision: str):
+    def _load_processor(base_model_name_or_path: str, revision: str) -> Any:
         """Load WAVE-7B's multimodal processor.
 
         The backbone repo ships no ``processor_config.json``, so

--- a/mteb/tasks/bitext_mining/multilingual/bible_nlp_bitext_mining.py
+++ b/mteb/tasks/bitext_mining/multilingual/bible_nlp_bitext_mining.py
@@ -924,7 +924,7 @@ class BibleNLPBitextMining(AbsTaskBitextMining):
             )
 
     @staticmethod
-    def _transform_lang_name_hf(lang):
+    def _transform_lang_name_hf(lang: str) -> str:
         # Transform language name to match huggingface configuration
         langs = [l.split("_")[0] for l in lang.split("-")]
         if langs[1] == "eng":
@@ -932,7 +932,7 @@ class BibleNLPBitextMining(AbsTaskBitextMining):
         return "-".join(langs)
 
     @staticmethod
-    def _swap_substrings(string):
+    def _swap_substrings(string: str) -> str:
         substring1, substring2 = string.split("-")
         parts = string.split("-")
         if substring1 in parts and substring2 in parts:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -368,7 +368,6 @@ ignore = [
     "ANN001",   # missing-type-function-argument
     "ANN201",   # missing-return-type-undocumented-public-function
     "ANN202",   # missing-return-type-private-function
-    "ANN205",   # missing-return-type-static-method
     "ANN401",   # any-type
 ]
 future-annotations = true  # For TC rules


### PR DESCRIPTION
Enables `ANN205` (`missing-return-type-static-method`) from #2416, burning down the staticmethod return type annotations deferred in #5372.

### Changes:
- Added return type annotations to all 5 remaining staticmethod sites:
  - `mteb/models/model_implementations/bm25.py`: `_to_tokenized` -> `Tokenized` (with `Tokenized` imported under `TYPE_CHECKING`)
  - `mteb/models/model_implementations/jina_models.py`: `_convert_to_torch_if_needed` -> `torch.Tensor | list[Any] | Any`
  - `mteb/models/model_implementations/omniretriever_models.py`: `_load_processor` -> `Any`
  - `mteb/tasks/bitext_mining/multilingual/bible_nlp_bitext_mining.py`: `_transform_lang_name_hf` -> `str` and `_swap_substrings` -> `str`
- Removed `ANN205` from the `ignore` list in `pyproject.toml`.
- Verified with `ruff check .` and `ruff format --check .`.