### PR TITLE
ci: skip redundant uv sync in leaderboard model generation workflow

### DIFF
--- a/.github/workflows/update_leaderboard_models.yml
+++ b/.github/workflows/update_leaderboard_models.yml
@@ -40,7 +40,7 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Generate model list
-        run: uv run python scripts/generate_leaderboard_models.py > models.py
+        run: uv run --no-sync python scripts/generate_leaderboard_models.py > models.py
 
       - name: Check if models.py changed in HF Space
         id: diff


### PR DESCRIPTION
Follow-up to #5385.

`uv sync --frozen` already runs as a dedicated step before the script, so the default `uv run` behaviour of re-checking the environment is redundant. Adding `--no-sync` skips that step and avoids unnecessary overhead on the runner.