### PR TITLE
fix(openai): add %s placeholder so retry logging does not raise TypeError

### DIFF
--- a/mteb/models/model_implementations/openai_models.py
+++ b/mteb/models/model_implementations/openai_models.py
@@ -130,7 +130,7 @@ class OpenAIModel(AbsEncoder):
                 )
             except Exception as e:
                 # Sleep due to too many requests
-                logger.info("Sleeping for 10 seconds due to error", e)  # noqa: PLE1205
+                logger.info("Sleeping for 10 seconds due to error: %s", e)
                 import time
 
                 time.sleep(10)
@@ -139,7 +139,7 @@ class OpenAIModel(AbsEncoder):
                         input=sublist, **default_kwargs
                     )
                 except Exception as e:
-                    logger.info("Sleeping for 60 seconds due to error", e)  # noqa: PLE1205
+                    logger.info("Sleeping for 60 seconds due to error: %s", e)
                     time.sleep(60)
                     response = self._client.embeddings.create(
                         input=sublist, **default_kwargs


### PR DESCRIPTION
## Problem

Both OpenAI retry handlers pass the caught exception positionally while the format string has no `%` placeholder, so `LogRecord.getMessage()` evaluates `msg % (e,)` and raises `TypeError: not all arguments converted during string formatting`.

This hits the default CLI path: `main()` installs `RichHandler` (`build_cli.py:608`) and `--verbosity` defaults to `2`, putting the `mteb` logger at INFO (`build_cli.py:37`, `:214`). `RichHandler.emit()` calls `self.format(record)` without the `try/except` stdlib `StreamHandler` has, so the `TypeError` escapes `logger.info()` **and the `except` block** — `time.sleep()` and the retry never run. One transient 429 kills the run and hides the real API error.

Ruff flags this as `PLE1205`; #4317 suppressed it instead of fixing it.

## Change

Two lines: add `%s`, drop the now-unused `# noqa` (`RUF100` is enabled, so it must go). Matches `google_text_embedding.py:115`, already `logger.info("Retrying once after error: %s", e)`.

## Verification

Same try/except shape under mteb's own handler config (RichHandler + `mteb` logger at INFO), raising `RuntimeError("Error code: 429 ...")`:

before
```
>>> ESCAPED FROM except BLOCK: TypeError - not all arguments converted during string formatting
```
after
```
INFO  Sleeping for 10 seconds due to error: Error code: 429 - Rate limit reached
>>> RETRY BRANCH REACHED
```

Lint (ruff 0.16.6, repo config):
```
$ ruff check --ignore-noqa <file>   # before
logging-too-many-args ... :133:17
logging-too-many-args ... :142:21
$ ruff check .           -> All checks passed!
$ ruff format --check .  -> 1970 files already formatted
```

## Limitations

`make install/test/typecheck` not run locally: `pyproject.toml` sets uv `required-version = ">=0.10.0"`, my uv is 0.9.29, so lint used a standalone ruff (repo pins 0.16.0). No existing test references `OpenAIModel`, so none was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
