### PR TITLE
enable ANN for `mteb/model_implementations`

### DIFF
--- a/mteb/models/model_implementations/align_models.py
+++ b/mteb/models/model_implementations/align_models.py
@@ -36,7 +36,7 @@ class ALIGNModel(AbsEncoder):
         texts: DataLoader[BatchedInput],
         show_progress_bar: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_text_embeddings = []
 
         with torch.no_grad():
@@ -63,7 +63,7 @@ class ALIGNModel(AbsEncoder):
         images: DataLoader[BatchedInput],
         show_progress_bar: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_image_embeddings = []
         with torch.no_grad():
             for batch in tqdm(

--- a/mteb/models/model_implementations/argus_qwen35.py
+++ b/mteb/models/model_implementations/argus_qwen35.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from transformers import AutoProcessor
 
@@ -8,6 +8,9 @@ from mteb.models.model_implementations.ops_colqwen3_models import (
     OpsColQwen3Wrapper,
 )
 from mteb.models.model_meta import ModelMeta, ScoringFunction
+
+if TYPE_CHECKING:
+    import torch
 
 
 class ArgusColQwen35Wrapper(OpsColQwen3Wrapper):
@@ -43,7 +46,7 @@ class ArgusColQwen35Wrapper(OpsColQwen3Wrapper):
             max_num_visual_tokens=max_num_visual_tokens,
         )
 
-    def encode_input(self, inputs):
+    def encode_input(self, inputs: dict[str, Any]) -> torch.Tensor:
         # Argus returns ``ArgusOutput(embeddings=...)`` instead of a tensor.
         return self.mdl(**inputs).embeddings
 

--- a/mteb/models/model_implementations/bb25.py
+++ b/mteb/models/model_implementations/bb25.py
@@ -8,6 +8,8 @@ import numpy as np
 from mteb.models.model_meta import ModelMeta
 
 if TYPE_CHECKING:
+    from bm25s.tokenization import Tokenized
+
     from mteb.abstasks.task_metadata import TaskMetadata
     from mteb.models.models_protocols import SearchProtocol
     from mteb.types import (
@@ -51,7 +53,7 @@ def _composite_prior(
     return np.clip(prior, 0.1, 0.9)
 
 
-def bb25_loader(model_name, **kwargs: Any) -> SearchProtocol:
+def bb25_loader(model_name: str, **kwargs: Any) -> SearchProtocol:
     import bm25s
     import Stemmer
 
@@ -103,7 +105,7 @@ def bb25_loader(model_name, **kwargs: Any) -> SearchProtocol:
                 Stemmer.Stemmer(stemmer_language) if stemmer_language else None
             )
 
-        def _encode(self, texts: list[str]):
+        def _encode(self, texts: list[str]) -> Tokenized:
             """Tokenize texts using bm25s. Not to be confused with EncoderProtocol.encode()."""
             return bm25s.tokenize(texts, stopwords=self.stopwords, stemmer=self.stemmer)
 

--- a/mteb/models/model_implementations/bedrock_models.py
+++ b/mteb/models/model_implementations/bedrock_models.py
@@ -41,7 +41,7 @@ CHARS_PER_TOKEN = 4.5
 def get_bedrock_runtime_client(
     region_name: str | None = None,
     config: Any = None,  # noqa: ANN401 -- botocore Config; boto3 is an optional, untyped dep
-):
+) -> Any:  # noqa: ANN401 -- botocore client; boto3 is an optional, untyped dep
     """Create a bedrock-runtime client.
 
     Defaults to the region of the active boto3 session when none is given.
@@ -181,7 +181,7 @@ class BedrockModel(AbsEncoder):
         )
         return self._to_numpy(response)
 
-    def _to_numpy(self, embedding_response) -> Array:
+    def _to_numpy(self, embedding_response: Any) -> Array:  # noqa: ANN401 -- raw botocore response
         response = read_response_body(embedding_response)
         key = "embedding" if self._provider == "amazon" else "embeddings"
         return np.array(response[key])

--- a/mteb/models/model_implementations/blip2_models.py
+++ b/mteb/models/model_implementations/blip2_models.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from torch.utils.data import DataLoader
 
     from mteb.abstasks.task_metadata import TaskMetadata
+    from mteb.models.models_protocols import EncoderProtocol
     from mteb.types import Array, BatchedInput, PromptType
 
 BLIP2_CITATION = """@inproceedings{li2023blip2,
@@ -22,7 +23,7 @@ BLIP2_CITATION = """@inproceedings{li2023blip2,
 }"""
 
 
-def blip2_loader(model_name, **kwargs: Any):
+def blip2_loader(model_name: str, **kwargs: Any) -> EncoderProtocol:
     from lavis.models.blip2_models.blip2_image_text_matching import (
         Blip2ITM,
     )
@@ -54,7 +55,7 @@ def blip2_loader(model_name, **kwargs: Any):
             texts: DataLoader[BatchedInput],
             show_progress_bar: bool = True,
             **kwargs: Any,
-        ):
+        ) -> Array:
             all_text_embeddings = []
 
             with torch.no_grad():
@@ -78,7 +79,7 @@ def blip2_loader(model_name, **kwargs: Any):
             images: DataLoader[BatchedInput],
             show_progress_bar: bool = True,
             **kwargs: Any,
-        ):
+        ) -> Array:
             all_image_embeddings = []
 
             with torch.no_grad():
@@ -102,7 +103,7 @@ def blip2_loader(model_name, **kwargs: Any):
             inputs: DataLoader[BatchedInput],
             show_progress_bar: bool = True,
             **kwargs: Any,
-        ):
+        ) -> Array:
             all_multimodal_embeddings = []
 
             with torch.no_grad():

--- a/mteb/models/model_implementations/blip_models.py
+++ b/mteb/models/model_implementations/blip_models.py
@@ -49,7 +49,7 @@ class BLIPModel(AbsEncoder):
         texts: DataLoader[BatchedInput],
         show_progress_bar: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_text_embeddings = []
 
         with torch.no_grad():
@@ -79,7 +79,7 @@ class BLIPModel(AbsEncoder):
         images: DataLoader[BatchedInput],
         show_progress_bar: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_image_embeddings = []
 
         with torch.no_grad():

--- a/mteb/models/model_implementations/bm25.py
+++ b/mteb/models/model_implementations/bm25.py
@@ -183,7 +183,7 @@ class BM25Tokenizer:
         self.fit_transform(corpus_texts)
         return self
 
-    def fit_transform(self, corpus_texts: list[str]):
+    def fit_transform(self, corpus_texts: list[str]) -> Tokenized:
         """Fit on corpus and return the encoded corpus as a ``Tokenized``."""
         if self._tok_arg is None:
             return self._fit_transform_bm25s(corpus_texts)
@@ -192,13 +192,13 @@ class BM25Tokenizer:
         )
         return self._fit_transform_custom(corpus_texts)
 
-    def transform(self, texts: list[str]):
+    def transform(self, texts: list[str]) -> Tokenized:
         """Tokenize ``texts`` using the stopword set learned during ``fit_transform``."""
         if self._tok_arg is None:
             return self._transform_bm25s(texts)
         return self._transform_custom(texts)
 
-    def _fit_transform_bm25s(self, corpus_texts: list[str]):
+    def _fit_transform_bm25s(self, corpus_texts: list[str]) -> Tokenized:
         import bm25s
         from bm25s.tokenization import Tokenized
 
@@ -241,14 +241,14 @@ class BM25Tokenizer:
         ]
         return Tokenized(ids=filtered_ids, vocab=raw.vocab)
 
-    def _transform_bm25s(self, texts: list[str]):
+    def _transform_bm25s(self, texts: list[str]) -> Tokenized:
         import bm25s
 
         return bm25s.tokenize(
             texts, stopwords=self._combined_list, stemmer=self.stemmer
         )
 
-    def _fit_transform_custom(self, corpus_texts: list[str]):
+    def _fit_transform_custom(self, corpus_texts: list[str]) -> Tokenized:
         raw_token_lists = [self._raw_tok(text) for text in corpus_texts]
 
         freq_stops: frozenset[str] = frozenset()
@@ -276,7 +276,7 @@ class BM25Tokenizer:
         ]
         return self._to_tokenized(filtered)
 
-    def _transform_custom(self, texts: list[str]):
+    def _transform_custom(self, texts: list[str]) -> Tokenized:
         token_lists = [
             [t for t in self._raw_tok(text) if t not in self._combined_stops]
             for text in texts
@@ -478,7 +478,7 @@ class BM25Search:
         return results
 
 
-def bm25_loader(model_name, **kwargs: Any) -> SearchProtocol:
+def bm25_loader(model_name: str, **kwargs: Any) -> SearchProtocol:
     return BM25Search(**kwargs)
 
 

--- a/mteb/models/model_implementations/clip_models.py
+++ b/mteb/models/model_implementations/clip_models.py
@@ -37,7 +37,7 @@ class CLIPModel(AbsEncoder):
         texts: DataLoader[BatchedInput],
         show_progress_bar: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_text_embeddings = []
 
         with torch.no_grad():
@@ -66,7 +66,7 @@ class CLIPModel(AbsEncoder):
         images: DataLoader[BatchedInput],
         show_progress_bar: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_image_embeddings = []
 
         for batch in tqdm(images, disable=not show_progress_bar, desc="Image Encoding"):

--- a/mteb/models/model_implementations/cohere_models.py
+++ b/mteb/models/model_implementations/cohere_models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import time
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Literal, get_args
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, get_args
 
 import numpy as np
 import torch
@@ -13,7 +13,12 @@ from mteb.models.abs_encoder import AbsEncoder
 from mteb.models.model_meta import ModelMeta, ScoringFunction
 from mteb.types import OutputDType, PromptType
 
+T = TypeVar("T")
+
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import cohere
     from torch.utils.data import DataLoader
 
     from mteb.abstasks.task_metadata import TaskMetadata
@@ -157,7 +162,7 @@ def retry_with_rate_limit(
     max_retries: int = 5,
     max_rpm: int = 300,
     initial_delay: float = 1.0,
-):
+) -> Callable[[Callable[..., T]], Callable[..., T | None]]:
     """Combined retry and rate limiting decorator.
 
     This decorator handles both proactive rate limiting (spacing requests)
@@ -173,9 +178,9 @@ def retry_with_rate_limit(
     """
     previous_call_ts: float | None = None
 
-    def decorator(func):
+    def decorator(func: Callable[..., T]) -> Callable[..., T | None]:
         @wraps(func)
-        def wrapper(self, *args: Any, **kwargs: Any):
+        def wrapper(self: AbsEncoder, *args: Any, **kwargs: Any) -> T | None:
             import cohere
 
             nonlocal previous_call_ts
@@ -247,7 +252,7 @@ class CohereTextEmbeddingModel(AbsEncoder):
         self._client = cohere.Client()
 
     @retry_with_rate_limit(max_retries=5, max_rpm=300)
-    def _embed_func(self, **kwargs: Any):
+    def _embed_func(self, **kwargs: Any) -> cohere.EmbedResponse:
         """Call Cohere embed API with retry and rate limiting."""
         return self._client.embed(**kwargs)
 

--- a/mteb/models/model_implementations/cohere_v.py
+++ b/mteb/models/model_implementations/cohere_v.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from torch.utils.data import DataLoader
 
     from mteb.abstasks.task_metadata import TaskMetadata
+    from mteb.models.models_protocols import EncoderProtocol
     from mteb.types import Array, BatchedInput, PromptType
 
 
@@ -179,7 +180,7 @@ OUTPUT_TYPES = [
 ]
 
 
-def cohere_v_loader(model_name, **kwargs: Any):
+def cohere_v_loader(model_name: str, **kwargs: Any) -> EncoderProtocol:
     import cohere
 
     class CohereMultiModalModelWrapper(AbsEncoder):
@@ -213,7 +214,7 @@ def cohere_v_loader(model_name, **kwargs: Any):
             self.transform = transforms.Compose([transforms.PILToTensor()])
 
         @retry_with_rate_limit(max_retries=5, max_rpm=300)
-        def _embed_func(self, **kwargs: Any):
+        def _embed_func(self, **kwargs: Any) -> cohere.EmbedByTypeResponse:
             """Call Cohere embed API with retry and rate limiting."""
             return self.client.embed(**kwargs)
 
@@ -222,7 +223,7 @@ def cohere_v_loader(model_name, **kwargs: Any):
             inputs: DataLoader[BatchedInput],
             show_progress_bar: bool = True,
             **kwargs: Any,
-        ):
+        ) -> Array:
             all_text_embeddings = []
             index = 0
             texts = [text for batch in inputs for text in batch["text"]]
@@ -301,7 +302,7 @@ def cohere_v_loader(model_name, **kwargs: Any):
             images: DataLoader[BatchedInput],
             show_progress_bar: bool = True,
             **kwargs: Any,
-        ):
+        ) -> Array:
             all_image_embeddings = []
             images = [image for batch in images for image in batch["images"]]
 

--- a/mteb/models/model_implementations/colpali_models.py
+++ b/mteb/models/model_implementations/colpali_models.py
@@ -83,15 +83,15 @@ class ColPaliEngineWrapper(AbsEncoder):
             return image_embeddings
         raise ValueError
 
-    def encode_input(self, inputs):
+    def encode_input(self, inputs: dict[str, Any]) -> torch.Tensor:
         return self.mdl(**inputs)
 
     def get_image_embeddings(
         self,
-        images,
+        images: DataLoader[BatchedInput],
         batch_size: int = 32,
         **kwargs: Any,
-    ):
+    ) -> Array:
         import torchvision.transforms.functional as F
         from PIL import Image
 
@@ -118,10 +118,10 @@ class ColPaliEngineWrapper(AbsEncoder):
 
     def get_text_embeddings(
         self,
-        texts,
+        texts: DataLoader[BatchedInput],
         batch_size: int = 32,
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_embeds = []
         with torch.no_grad():
             for batch in tqdm(texts, desc="Encoding texts"):
@@ -149,14 +149,14 @@ class ColPaliEngineWrapper(AbsEncoder):
         task_name: str | None = None,
         prompt_type: PromptType | None = None,
         batch_size: int = 32,
-        fusion_mode="sum",
+        fusion_mode: str = "sum",
         **kwargs: Any,
     ):
         raise NotImplementedError(
             "Fused embeddings are not supported yet. Please use get_text_embeddings or get_image_embeddings."
         )
 
-    def similarity(self, a, b):
+    def similarity(self, a: Array, b: Array) -> Array:
         return self.processor.score(a, b, device=self.device)
 
 

--- a/mteb/models/model_implementations/colqwen_models.py
+++ b/mteb/models/model_implementations/colqwen_models.py
@@ -11,10 +11,13 @@ from mteb.models.modality_collators import AudioCollator, VideoCollator
 from mteb.models.model_meta import ModelMeta, ScoringFunction
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
     from torch.utils.data import DataLoader
 
     from mteb.abstasks.task_metadata import TaskMetadata
     from mteb.types import Array, BatchedInput, PromptType
+    from mteb.types._encoder_io import AudioInputItem
 
 from .colpali_models import (
     COLPALI_CITATION,
@@ -136,7 +139,7 @@ class ColQwen3_5Wrapper(AbsEncoder):  # noqa: N801
         batch_size: int = 32,
         show_progress_bar: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Array:
         import torchvision.transforms.functional as F
         from PIL import Image
 
@@ -192,7 +195,7 @@ class ColQwen3_5Wrapper(AbsEncoder):  # noqa: N801
         )
         return padded
 
-    def similarity(self, a, b):
+    def similarity(self, a: Array, b: Array) -> Array:
         a = [torch.as_tensor(x) for x in a]
         b = [torch.as_tensor(x) for x in b]
         return self.processor.score_multi_vector(a, b, device=self.device)
@@ -265,9 +268,9 @@ class ColQwen3Wrapper(AbsEncoder):
         image_texts_pairs: DataLoader[BatchedInput] | None = None,
         batch_size: int = 32,
         show_progress_bar: bool = True,
-        fusion_mode="concat",
+        fusion_mode: str = "concat",
         **kwargs: Any,
-    ):
+    ) -> Array:
         import torchvision.transforms.functional as F
         from PIL import Image
 
@@ -319,7 +322,7 @@ class ColQwen3Wrapper(AbsEncoder):
         )
         return padded
 
-    def similarity(self, a, b):
+    def similarity(self, a: Array, b: Array) -> Array:
         return self.processor.score_multi_vector(a, b, device=self.device)
 
 
@@ -400,7 +403,13 @@ class ColQwen2_5OmniWrapper(ColPaliEngineWrapper):  # noqa: N801
             raise ValueError("All modalities must have the same number of items")
         return torch.cat(embeddings, dim=1)
 
-    def _encode_batches(self, loader, key, process_fn, desc):
+    def _encode_batches(
+        self,
+        loader: DataLoader[BatchedInput],
+        key: str,
+        process_fn: Callable[[Any], Mapping[str, torch.Tensor]],
+        desc: str,
+    ) -> torch.Tensor:
         all_embeds = []
         with torch.no_grad():
             for batch in tqdm(loader, desc=desc):
@@ -413,8 +422,12 @@ class ColQwen2_5OmniWrapper(ColPaliEngineWrapper):  # noqa: N801
             all_embeds, batch_first=True, padding_value=0
         )
 
-    def get_audio_embeddings(self, audios, batch_size: int = 32, **kwargs: Any):
-        def _process(audio):
+    def get_audio_embeddings(
+        self, audios: DataLoader[BatchedInput], batch_size: int = 32, **kwargs: Any
+    ) -> Array:
+        def _process(
+            audio: AudioInputItem | torch.Tensor,
+        ) -> Mapping[str, torch.Tensor]:
             arr = audio["array"] if isinstance(audio, dict) else audio
             if isinstance(arr, torch.Tensor):
                 arr = arr.numpy()
@@ -422,8 +435,10 @@ class ColQwen2_5OmniWrapper(ColPaliEngineWrapper):  # noqa: N801
 
         return self._encode_batches(audios, "audio", _process, "Encoding audio")
 
-    def get_video_embeddings(self, videos, batch_size: int = 32, **kwargs: Any):
-        def _process(clip):
+    def get_video_embeddings(
+        self, videos: DataLoader[BatchedInput], batch_size: int = 32, **kwargs: Any
+    ) -> Array:
+        def _process(clip: torch.Tensor) -> Mapping[str, torch.Tensor]:
             return self.processor.process_videos([clip])
 
         return self._encode_batches(videos, "video", _process, "Encoding video")

--- a/mteb/models/model_implementations/conan_models.py
+++ b/mteb/models/model_implementations/conan_models.py
@@ -7,7 +7,7 @@ import os
 import random
 import string
 import time
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import numpy as np
 import requests
@@ -18,7 +18,11 @@ from mteb.models.model_meta import ModelMeta
 from .bge_models import bge_full_data
 from .e5_instruct import E5_MISTRAL_TRAINING_DATA
 
+T = TypeVar("T")
+
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from torch.utils.data import DataLoader
 
     from mteb.abstasks.task_metadata import TaskMetadata
@@ -44,7 +48,7 @@ logger = logging.getLogger(__name__)
 
 
 class RateLimiter:
-    def __init__(self, qps, max_retries=3):
+    def __init__(self, qps: float, max_retries: int = 3) -> None:
         self.qps = qps
         self.min_interval = 1.0 / qps
         self.last_request_time = 0
@@ -59,7 +63,9 @@ class RateLimiter:
             time.sleep(sleep_time)
         self.last_request_time = time.time()
 
-    def execute_with_retry(self, func, *args: Any, **kwargs: Any):
+    def execute_with_retry(
+        self, func: Callable[..., T], *args: Any, **kwargs: Any
+    ) -> T | None:
         """Execute a function with retry logic
 
         Args:
@@ -91,25 +97,25 @@ class RateLimiter:
 
 
 class Client:
-    def __init__(self, ak, sk, url, timeout=30):
+    def __init__(self, ak: str, sk: str, url: str, timeout: int = 30) -> None:
         self.ak = ak
         self.sk = sk
         self.url = url
         self.timeout = timeout
         self.rate_limiter = RateLimiter(qps=5, max_retries=3)
 
-    def _random_password(self, size=40, chars=None):  # noqa: PLR6301
+    def _random_password(self, size: int = 40, chars: str | None = None) -> str:  # noqa: PLR6301
         if chars is None:
             chars = string.ascii_uppercase + string.ascii_lowercase + string.digits
         random_chars = random.SystemRandom().choice
         return "".join(random_chars(chars) for _ in range(size))
 
-    def __signature(self, random_str, time_stamp):
+    def __signature(self, random_str: str, time_stamp: int) -> str:
         params_str = f"{self.ak}:{time_stamp}:{random_str}:{self.sk}"
         encoded_params_str = params_str.encode("utf-8")
         return hashlib.md5(encoded_params_str, usedforsecurity=False).hexdigest()
 
-    def get_signature(self):
+    def get_signature(self) -> dict[str, Any]:
         timestamp = int(time.time())
         random_str = self._random_password(20)
         sig = self.__signature(random_str, timestamp)
@@ -121,7 +127,7 @@ class Client:
         }
         return params
 
-    def _do_request(self, text):
+    def _do_request(self, text: str) -> dict[str, Any]:
         """Execute the actual request without retry logic"""
         params = self.get_signature()
         params["body"] = text
@@ -140,7 +146,7 @@ class Client:
 
         return result
 
-    def embed(self, text):
+    def embed(self, text: str) -> dict[str, Any] | None:
         """Embed text using the server with rate limiting and retry logic
 
         Args:

--- a/mteb/models/model_implementations/dino_models.py
+++ b/mteb/models/model_implementations/dino_models.py
@@ -52,7 +52,7 @@ class DINOModel(AbsEncoder):
         show_progress_bar: bool = True,
         pooling: Literal["cls", "mean"] = "cls",
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_image_embeddings = []
 
         with torch.no_grad():

--- a/mteb/models/model_implementations/e5_v.py
+++ b/mteb/models/model_implementations/e5_v.py
@@ -31,7 +31,7 @@ class E5VModel(AbsEncoder):
         model_name: str,
         revision: str,
         device: str | None = None,
-        composed_prompt=None,
+        composed_prompt: str | None = None,
         **kwargs: Any,
     ):
         from transformers import LlavaNextForConditionalGeneration, LlavaNextProcessor
@@ -65,7 +65,7 @@ class E5VModel(AbsEncoder):
         texts: DataLoader[BatchedInput],
         show_progress_bar: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_text_embeddings = []
 
         with torch.no_grad():
@@ -91,7 +91,7 @@ class E5VModel(AbsEncoder):
         images: DataLoader[BatchedInput],
         show_progress_bar: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_image_embeddings = []
 
         with torch.no_grad():

--- a/mteb/models/model_implementations/evaclip_models.py
+++ b/mteb/models/model_implementations/evaclip_models.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from torch.utils.data import DataLoader
 
     from mteb.abstasks.task_metadata import TaskMetadata
+    from mteb.models.models_protocols import EncoderProtocol
     from mteb.types import Array, BatchedInput, PromptType
 
 EVA_CLIP_CITATION = """@article{EVA-CLIP,
@@ -23,7 +24,7 @@ EVA_CLIP_CITATION = """@article{EVA-CLIP,
 }"""
 
 
-def evaclip_loader(model_name, **kwargs: Any):
+def evaclip_loader(model_name: str, **kwargs: Any) -> EncoderProtocol:
     try:
         import sys
 
@@ -60,7 +61,7 @@ def evaclip_loader(model_name, **kwargs: Any):
             texts: DataLoader[BatchedInput],
             show_progress_bar: bool = True,
             **kwargs: Any,
-        ):
+        ) -> Array:
             all_text_embeddings = []
 
             with torch.no_grad(), torch.cuda.amp.autocast():
@@ -79,7 +80,7 @@ def evaclip_loader(model_name, **kwargs: Any):
             images: DataLoader[BatchedInput],
             show_progress_bar: bool = True,
             **kwargs: Any,
-        ):
+        ) -> Array:
             all_image_embeddings = []
 
             with torch.no_grad(), torch.cuda.amp.autocast():

--- a/mteb/models/model_implementations/geevec_models.py
+++ b/mteb/models/model_implementations/geevec_models.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from torch.utils.data import DataLoader
 
     from mteb.abstasks.task_metadata import TaskMetadata
-    from mteb.types import BatchedInput
+    from mteb.types import Array, BatchedInput
 
 logger = logging.getLogger(__name__)
 
@@ -274,14 +274,14 @@ PROMPTS_DICT = {
 class GeeVecLiteModel(InstructSentenceTransformerModel):
     def encode(
         self,
-        inputs,
+        inputs: DataLoader[BatchedInput],
         *,
-        task_metadata,
-        hf_split,
-        hf_subset,
-        prompt_type=None,
+        task_metadata: TaskMetadata,
+        hf_split: str,
+        hf_subset: str,
+        prompt_type: PromptType | None = None,
         **kwargs: Any,
-    ):
+    ) -> Array:
         sentences = [text for batch in inputs for text in batch["text"]]
         domain = _resolve_geevec_domain(task_metadata, hf_subset, kwargs.get("domain"))
         if domain is not None:
@@ -390,7 +390,7 @@ class GeeVecAPIModel(AbsEncoder):
         hf_subset: str,
         prompt_type: PromptType | None = None,
         **kwargs: Any,
-    ):
+    ) -> Array:
         sentences = [text for batch in inputs for text in batch["text"]]
 
         prompt_name = self.get_prompt_name(task_metadata, prompt_type)

--- a/mteb/models/model_implementations/gme_v_models.py
+++ b/mteb/models/model_implementations/gme_v_models.py
@@ -15,6 +15,7 @@ from mteb.types import PromptType
 if TYPE_CHECKING:
     from PIL import Image
     from torch.utils.data import DataLoader
+    from transformers import PreTrainedModel, ProcessorMixin
 
     from mteb.abstasks.task_metadata import TaskMetadata
     from mteb.types import Array, BatchedInput
@@ -35,10 +36,10 @@ GME_CITATION = """@misc{zhang2024gme,
 class Encoder(torch.nn.Module):
     def __init__(
         self,
-        base,
-        processor,
-        max_length=1800,
-        normalize=True,
+        base: PreTrainedModel,
+        processor: ProcessorMixin,
+        max_length: int = 1800,
+        normalize: bool = True,
     ) -> None:
         super().__init__()
         self.base = base
@@ -106,10 +107,10 @@ class Encoder(torch.nn.Module):
         self,
         texts: list[str],
         images: list[Image.Image],
-        device,
-        instruction=None,
+        device: str,
+        instruction: str | None = None,
         **kwargs: Any,
-    ):
+    ) -> torch.Tensor:
         instruction = instruction or self.default_instruction
         # Inputs must be batched
         input_texts, input_images = [], []
@@ -146,9 +147,9 @@ class GmeQwen2VL(AbsEncoder):
         revision: str,
         model_path: str | None = None,
         device: str = "cuda" if torch.cuda.is_available() else "cpu",
-        min_image_tokens=4,
-        max_image_tokens=1280,
-        max_length=1800,
+        min_image_tokens: int = 4,
+        max_image_tokens: int = 1280,
+        max_length: int = 1800,
         **kwargs: Any,
     ) -> None:
         from transformers import AutoModelForVision2Seq, AutoProcessor

--- a/mteb/models/model_implementations/granite_vision_embedding_models.py
+++ b/mteb/models/model_implementations/granite_vision_embedding_models.py
@@ -52,16 +52,16 @@ class GraniteVisionEmbeddingWrapper:
             model_name, trust_remote_code=True, revision=revision
         )
 
-    def encode_input(self, inputs):
+    def encode_input(self, inputs: dict[str, Any]) -> torch.Tensor:
         return self.mdl(**inputs)
 
     def get_image_embeddings(
         self,
-        images,
+        images: DataLoader[BatchedInput],
         batch_size: int = 16,
         show_progress_bar: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_embeds = []
         with torch.no_grad():
             for batch in tqdm(
@@ -82,7 +82,7 @@ class GraniteVisionEmbeddingWrapper:
         texts: DataLoader[BatchedInput],
         show_progress_bar: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_embeds = []
 
         with torch.no_grad():
@@ -107,7 +107,7 @@ class GraniteVisionEmbeddingWrapper:
         task_name: str | None = None,
         prompt_type: PromptType | None = None,
         batch_size: int = 32,
-        fusion_mode="sum",
+        fusion_mode: str = "sum",
         **kwargs: Any,
     ):
         raise NotImplementedError(
@@ -148,7 +148,7 @@ class GraniteVisionEmbeddingWrapper:
             return image_embeddings
         raise ValueError
 
-    def similarity(self, a, b):
+    def similarity(self, a: Array, b: Array) -> Array:
         return self.processor.score_multi_vector(a, b)
 
 

--- a/mteb/models/model_implementations/jina_clip.py
+++ b/mteb/models/model_implementations/jina_clip.py
@@ -46,7 +46,7 @@ class JinaCLIPModel(AbsEncoder):
         convert_to_numpy: bool = False,
         convert_to_tensor: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_text_embeddings = []
 
         with torch.no_grad():
@@ -71,7 +71,7 @@ class JinaCLIPModel(AbsEncoder):
         convert_to_tensor: bool = True,
         show_progress_bar: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_image_embeddings = []
 
         with torch.no_grad():

--- a/mteb/models/model_implementations/jina_models.py
+++ b/mteb/models/model_implementations/jina_models.py
@@ -411,8 +411,8 @@ class JinaV4Wrapper(AbsEncoder):
         revision: str | None = None,
         device: str | None = None,
         device_map: str | None = None,
-        torch_dtype=torch.bfloat16,
-        attn_implementation="sdpa",
+        torch_dtype: torch.dtype = torch.bfloat16,
+        attn_implementation: str = "sdpa",
         trust_remote_code: bool = True,
         model_prompts: dict[str, str] | None = None,
         vector_type: Literal[SUPPORTED_VECTOR_TYPES] = "single_vector",
@@ -561,9 +561,9 @@ class JinaV4Wrapper(AbsEncoder):
         task_metadata: TaskMetadata,
         prompt_type: PromptType | None = None,
         batch_size: int = 32,
-        return_numpy=False,
+        return_numpy: bool = False,
         **kwargs: Any,
-    ):
+    ) -> Array:
         prompt_name = self.get_prompt_name(task_metadata, prompt_type)
         if prompt_name:
             logger.info(
@@ -598,7 +598,7 @@ class JinaV4Wrapper(AbsEncoder):
         task_metadata: TaskMetadata,
         prompt_type: PromptType | None = None,
         max_pixels: int = 37788800,
-        return_numpy=False,
+        return_numpy: bool = False,
         **kwargs: Any,
     ) -> Array:
         # Resolve task parameters
@@ -635,7 +635,7 @@ class JinaV4Wrapper(AbsEncoder):
             return converted
         return embeddings
 
-    def similarity(self, a, b):
+    def similarity(self, a: Array, b: Array) -> Array:
         """Compute similarity between embeddings.
 
         Args:
@@ -667,7 +667,7 @@ class JinaV4Wrapper(AbsEncoder):
             raise ValueError("No passages provided")
 
         # Normalize inputs to 2D tensors
-        def normalize_input(x):
+        def normalize_input(x: torch.Tensor | list[torch.Tensor]) -> torch.Tensor:
             if isinstance(x, torch.Tensor):
                 return x.unsqueeze(0) if x.ndim == 1 else x
             # list

--- a/mteb/models/model_implementations/kalm_reranker.py
+++ b/mteb/models/model_implementations/kalm_reranker.py
@@ -126,7 +126,7 @@ class KaLMRerankerWrapper:
             raise ValueError(f"Failed to tokenize the answer {answer!r}.")
         return token_ids[-1]
 
-    def _get_encoder(self):
+    def _get_encoder(self) -> torch.nn.Module:
         if hasattr(self.model, "get_encoder"):
             return self.model.get_encoder()
         if hasattr(self.model, "encoder"):

--- a/mteb/models/model_implementations/listconranker.py
+++ b/mteb/models/model_implementations/listconranker.py
@@ -53,7 +53,7 @@ class ListConRanker(RerankerWrapper):
         hf_subset: str,
         prompt_type: PromptType | None = None,
         **kwargs: Any,
-    ):
+    ) -> list[float]:
         queries = [text for batch in inputs1 for text in batch["query"]]
         passages = [text for batch in inputs2 for text in batch["text"]["text"]]
 

--- a/mteb/models/model_implementations/llm2clip_models.py
+++ b/mteb/models/model_implementations/llm2clip_models.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from torch.utils.data import DataLoader
 
     from mteb.abstasks.task_metadata import TaskMetadata
+    from mteb.models.models_protocols import EncoderProtocol
     from mteb.types import Array, BatchedInput, PromptType
 
 LLM2CLIP_CITATION = """@misc{huang2024llm2clippowerfullanguagemodel,
@@ -32,7 +33,7 @@ MODEL2PROCESSOR = {
 }
 
 
-def llm2clip_loader(model_name, **kwargs: Any):
+def llm2clip_loader(model_name: str, **kwargs: Any) -> EncoderProtocol:
     from llm2vec import LLM2Vec
     from transformers import AutoConfig, AutoModel, AutoTokenizer, CLIPImageProcessor
     from transformers.modeling_outputs import BaseModelOutputWithPooling
@@ -98,7 +99,7 @@ def llm2clip_loader(model_name, **kwargs: Any):
             texts: DataLoader[BatchedInput],
             show_progress_bar: bool = True,
             **kwargs: Any,
-        ):
+        ) -> Array:
             all_text_embeddings = []
 
             with torch.no_grad(), torch.amp.autocast("cuda"):
@@ -123,7 +124,7 @@ def llm2clip_loader(model_name, **kwargs: Any):
             images: DataLoader[BatchedInput],
             show_progress_bar: bool = True,
             **kwargs: Any,
-        ):
+        ) -> Array:
             all_image_embeddings = []
 
             with torch.no_grad(), torch.amp.autocast("cuda"):

--- a/mteb/models/model_implementations/llm2vec_models.py
+++ b/mteb/models/model_implementations/llm2vec_models.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def llm2vec_instruction(instruction):
+def llm2vec_instruction(instruction: str) -> str:
     if len(instruction) > 0 and instruction[-1] != ":":
         instruction = instruction.strip(".") + ":"
     return instruction

--- a/mteb/models/model_implementations/metaclip_models.py
+++ b/mteb/models/model_implementations/metaclip_models.py
@@ -57,7 +57,7 @@ class MetaClip2Model(AbsEncoder):
         texts: DataLoader[BatchedInput],
         show_progress_bar: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_text_embeddings = []
 
         with torch.no_grad():
@@ -86,7 +86,7 @@ class MetaClip2Model(AbsEncoder):
         images: DataLoader[BatchedInput],
         show_progress_bar: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_image_embeddings = []
 
         for batch in tqdm(images, disable=not show_progress_bar, desc="Image Encoding"):

--- a/mteb/models/model_implementations/moca_models.py
+++ b/mteb/models/model_implementations/moca_models.py
@@ -45,7 +45,7 @@ MIN_IMAGE_SIDE = 28
 
 
 def _bidirectional_causal_mask(
-    self,
+    self: torch.nn.Module,
     attention_mask: torch.Tensor | None,
     input_tensor: torch.Tensor,
     cache_position: torch.Tensor | None = None,

--- a/mteb/models/model_implementations/moco_models.py
+++ b/mteb/models/model_implementations/moco_models.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from torch.utils.data import DataLoader
 
     from mteb.abstasks.task_metadata import TaskMetadata
+    from mteb.models.models_protocols import EncoderProtocol
     from mteb.types import Array, BatchedInput, PromptType
 
 MOCOV3_CITATION = """@Article{chen2021mocov3,
@@ -22,7 +23,7 @@ MOCOV3_CITATION = """@Article{chen2021mocov3,
 }"""
 
 
-def mocov3_loader(model_name, **kwargs: Any):
+def mocov3_loader(model_name: str, **kwargs: Any) -> EncoderProtocol:
     import timm
 
     class MOCOv3Model(AbsEncoder):
@@ -58,7 +59,7 @@ def mocov3_loader(model_name, **kwargs: Any):
 
         @staticmethod
         def get_text_embeddings(
-            self,  # noqa: PLW0211
+            self: object,  # noqa: PLW0211
             texts: DataLoader[BatchedInput],
             show_progress_bar: bool = True,
             **kwargs: Any,
@@ -70,7 +71,7 @@ def mocov3_loader(model_name, **kwargs: Any):
             images: DataLoader[BatchedInput],
             show_progress_bar: bool = True,
             **kwargs: Any,
-        ):
+        ) -> Array:
             all_image_embeddings = []
 
             import torchvision.transforms.functional as F

--- a/mteb/models/model_implementations/no_instruct_sentence_models.py
+++ b/mteb/models/model_implementations/no_instruct_sentence_models.py
@@ -11,7 +11,7 @@ from mteb.models.model_meta import ModelMeta, ScoringFunction
 from mteb.types import PromptType
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Generator, Iterable
 
     from torch.utils.data import DataLoader
 
@@ -21,7 +21,9 @@ if TYPE_CHECKING:
 
 # https://docs.python.org/3/library/itertools.html#itertools.batched
 # Added in version 3.12.
-def batched(iterable, n: int, *, strict: bool = False) -> Generator[tuple, None, None]:
+def batched(
+    iterable: Iterable[Any], n: int, *, strict: bool = False
+) -> Generator[tuple, None, None]:
     # batched('ABCDEFG', 3) → ABC DEF G
     if n < 1:
         raise ValueError("n must be at least one")

--- a/mteb/models/model_implementations/nomic_models_vision.py
+++ b/mteb/models/model_implementations/nomic_models_vision.py
@@ -12,6 +12,8 @@ from mteb.models.model_meta import ModelMeta, ScoringFunction
 if TYPE_CHECKING:
     from PIL import Image
     from torch.utils.data import DataLoader
+    from transformers import BatchFeature
+    from transformers.modeling_outputs import BaseModelOutput
 
     from mteb.abstasks.task_metadata import TaskMetadata
     from mteb.types import Array, BatchedInput, PromptType
@@ -65,7 +67,7 @@ class NomicVisionModel(AbsEncoder):
         self,
         texts: list[str],
         images: list[Image.Image],
-    ):
+    ) -> BatchFeature:
         return self.processor(
             text=texts, images=images, return_tensors="pt", padding=True
         )
@@ -75,7 +77,7 @@ class NomicVisionModel(AbsEncoder):
         texts: DataLoader[BatchedInput],
         show_progress_bar: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_text_embeddings = []
 
         with torch.no_grad():
@@ -99,7 +101,9 @@ class NomicVisionModel(AbsEncoder):
         all_text_embeddings = torch.cat(all_text_embeddings, dim=0)
         return all_text_embeddings
 
-    def mean_pooling(self, model_output, attention_mask):  # noqa: PLR6301
+    def mean_pooling(  # noqa: PLR6301
+        self, model_output: BaseModelOutput, attention_mask: torch.Tensor
+    ) -> torch.Tensor:
         token_embeddings = model_output[0]
         input_mask_expanded = (
             attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
@@ -113,7 +117,7 @@ class NomicVisionModel(AbsEncoder):
         images: DataLoader[BatchedInput],
         show_progress_bar: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_image_embeddings = []
 
         with torch.no_grad():

--- a/mteb/models/model_implementations/nomic_multimodal.py
+++ b/mteb/models/model_implementations/nomic_multimodal.py
@@ -100,10 +100,10 @@ class BiQwen2_5Wrapper(AbsEncoder):  # noqa: N801
 
     def get_image_embeddings(
         self,
-        images,
+        images: DataLoader[BatchedInput],
         batch_size: int = 32,
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_embeds = []
 
         with torch.no_grad():
@@ -120,10 +120,10 @@ class BiQwen2_5Wrapper(AbsEncoder):  # noqa: N801
 
     def get_text_embeddings(
         self,
-        texts,
+        texts: DataLoader[BatchedInput],
         batch_size: int = 32,
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_embeds = []
         with torch.no_grad():
             for batch in tqdm(texts, desc="Encoding texts"):
@@ -138,8 +138,8 @@ class BiQwen2_5Wrapper(AbsEncoder):  # noqa: N801
         return padded
 
     def similarity(
-        self, a, b
-    ):  # Using the processing it goes from 0.57382 to 0.57297 on Vidore2ESGReportsHLRetrieval (without flash attention 2)
+        self, a: Array, b: Array
+    ) -> Array:  # Using the processing it goes from 0.57382 to 0.57297 on Vidore2ESGReportsHLRetrieval (without flash attention 2)
         return self.processor.score(a, b, device=self.device)
 
 

--- a/mteb/models/model_implementations/nvidia_nemotron_vl_models.py
+++ b/mteb/models/model_implementations/nvidia_nemotron_vl_models.py
@@ -53,9 +53,9 @@ class NemotronColEmbedVL(AbsEncoder):
         model_name_or_path: str,
         revision: str,
         trust_remote_code: bool,
-        device_map="cuda",
-        torch_dtype=torch.bfloat16,
-        attn_implementation="flash_attention_2",
+        device_map: str = "cuda",
+        torch_dtype: torch.dtype = torch.bfloat16,
+        attn_implementation: str = "flash_attention_2",
         **kwargs: Any,
     ):
         from transformers import AutoModel
@@ -69,15 +69,17 @@ class NemotronColEmbedVL(AbsEncoder):
             attn_implementation=attn_implementation,
         ).eval()
 
-    def get_text_embeddings(self, texts, batch_size: int = 32, **kwargs: Any):
+    def get_text_embeddings(
+        self, texts: DataLoader[BatchedInput], batch_size: int = 32, **kwargs: Any
+    ) -> Array:
         return self.model.forward_queries(texts, batch_size=batch_size)
 
     def get_image_embeddings(
         self,
-        images,
+        images: DataLoader[BatchedInput],
         batch_size: int = 32,
         **kwargs: Any,
-    ):
+    ) -> Array:
         import torchvision.transforms.functional as F
         from PIL import Image
 
@@ -98,7 +100,7 @@ class NemotronColEmbedVL(AbsEncoder):
 
         return self.model.forward_images(all_images, batch_size=batch_size)
 
-    def similarity(self, a, b):
+    def similarity(self, a: Array, b: Array) -> Array:
         return self.model.get_scores(a, b)
 
     def get_fused_embeddings(
@@ -326,9 +328,9 @@ class LlamaNemotronEmbedVL(AbsEncoder):
         revision: str,
         trust_remote_code: bool,
         extra_name: str = "llama-nemotron-embed-vl-1b-v2",
-        device_map="cuda",
-        torch_dtype=torch.bfloat16,
-        attn_implementation="flash_attention_2",
+        device_map: str = "cuda",
+        torch_dtype: torch.dtype = torch.bfloat16,
+        attn_implementation: str = "flash_attention_2",
         use_image_modality: bool = True,
         use_text_modality: bool = True,
         **kwargs: Any,

--- a/mteb/models/model_implementations/omniretriever_models.py
+++ b/mteb/models/model_implementations/omniretriever_models.py
@@ -155,7 +155,9 @@ class OmniRetrieverWrapper(AbsEncoder):
         """Convert torchcodec ``(T, C, H, W)`` uint8 frames to ``(T, H, W, C)``."""
         return frames.permute(0, 2, 3, 1).contiguous().numpy()
 
-    def _build_prompt(self, caption: str | None, has_video: bool, has_audio: bool):
+    def _build_prompt(
+        self, caption: str | None, has_video: bool, has_audio: bool
+    ) -> str:
         """Build the bare user-turn prompt for a modality combination.
 
         Mirrors ``_prepare_submodal_input`` in ``data_qwen.py``: a single media

--- a/mteb/models/model_implementations/omnivinci_models.py
+++ b/mteb/models/model_implementations/omnivinci_models.py
@@ -20,7 +20,8 @@ if TYPE_CHECKING:
     from torch.utils.data import DataLoader
 
     from mteb.abstasks.task_metadata import TaskMetadata
-    from mteb.types import Array, AudioInputItem, BatchedInput, PromptType
+    from mteb.types import Array, BatchedInput, PromptType
+    from mteb.types._encoder_io import AudioInputItem
 
 
 class OmniVinciWrapper(AbsEncoder):

--- a/mteb/models/model_implementations/openai_models.py
+++ b/mteb/models/model_implementations/openai_models.py
@@ -12,6 +12,7 @@ from mteb.models.model_meta import ModelMeta, ScoringFunction
 if TYPE_CHECKING:
     from numpy.typing import NDArray
     from openai import OpenAI
+    from openai.types import CreateEmbeddingResponse
     from torch.utils.data import DataLoader
 
     from mteb.abstasks.task_metadata import TaskMetadata
@@ -154,7 +155,9 @@ class OpenAIModel(AbsEncoder):
             all_embeddings[mask] = no_empty_embeddings
         return all_embeddings
 
-    def _to_numpy(self, embedding_response) -> NDArray[np.floating]:  # noqa: PLR6301
+    def _to_numpy(  # noqa: PLR6301
+        self, embedding_response: CreateEmbeddingResponse
+    ) -> NDArray[np.floating]:
         return np.array([e.embedding for e in embedding_response.data])
 
 

--- a/mteb/models/model_implementations/openclip_models.py
+++ b/mteb/models/model_implementations/openclip_models.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from torch.utils.data import DataLoader
 
     from mteb.abstasks.task_metadata import TaskMetadata
+    from mteb.models.models_protocols import EncoderProtocol
     from mteb.types import Array, BatchedInput, PromptType
 
 OPENCLIP_CITATION = """@inproceedings{cherti2023reproducible,
@@ -23,7 +24,7 @@ OPENCLIP_CITATION = """@inproceedings{cherti2023reproducible,
 }"""
 
 
-def openclip_loader(model_name, **kwargs: Any):
+def openclip_loader(model_name: str, **kwargs: Any) -> EncoderProtocol:
     import open_clip
 
     class OpenCLIPModel(AbsEncoder):
@@ -47,7 +48,7 @@ def openclip_loader(model_name, **kwargs: Any):
             texts: DataLoader[BatchedInput],
             show_progress_bar: bool = True,
             **kwargs: Any,
-        ):
+        ) -> Array:
             all_text_embeddings = []
 
             with torch.no_grad(), torch.cuda.amp.autocast():
@@ -66,7 +67,7 @@ def openclip_loader(model_name, **kwargs: Any):
             images: DataLoader[BatchedInput],
             show_progress_bar: bool = True,
             **kwargs: Any,
-        ):
+        ) -> Array:
             all_image_embeddings = []
 
             with torch.no_grad(), torch.cuda.amp.autocast():

--- a/mteb/models/model_implementations/ops_colqwen3_models.py
+++ b/mteb/models/model_implementations/ops_colqwen3_models.py
@@ -83,7 +83,7 @@ class OpsColQwen3Wrapper(AbsEncoder):
             return image_embeddings
         raise ValueError("No text or image inputs found")
 
-    def encode_input(self, inputs):
+    def encode_input(self, inputs: dict[str, Any]) -> torch.Tensor:
         return self.mdl(**inputs)
 
     def get_image_embeddings(

--- a/mteb/models/model_implementations/ps3_models.py
+++ b/mteb/models/model_implementations/ps3_models.py
@@ -103,7 +103,7 @@ class PS3Model(AbsEncoder):
         texts: DataLoader[BatchedInput],
         show_progress_bar: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_text_embeddings = []
         with torch.no_grad():
             for batch in tqdm(
@@ -119,7 +119,7 @@ class PS3Model(AbsEncoder):
         images: DataLoader[BatchedInput],
         show_progress_bar: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_image_embeddings = []
         with torch.no_grad():
             for batch in tqdm(

--- a/mteb/models/model_implementations/radio_models.py
+++ b/mteb/models/model_implementations/radio_models.py
@@ -80,7 +80,7 @@ class RADIOModel(AbsEncoder):
         images: DataLoader[BatchedInput],
         show_progress_bar: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Array:
         import torch.nn.functional as F
         from torchvision.transforms.functional import pil_to_tensor
 

--- a/mteb/models/model_implementations/repllama_models.py
+++ b/mteb/models/model_implementations/repllama_models.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from torch.utils.data import DataLoader
+    from transformers import BatchEncoding, PreTrainedTokenizerBase
 
     from mteb.abstasks.task_metadata import TaskMetadata
     from mteb.models.models_protocols import EncoderProtocol
@@ -58,7 +59,9 @@ class RepLLaMAModel(AbsEncoder):
         self.tokenizer.model_max_length = 512
         self.model_prompts = self.validate_task_to_prompt_name(model_prompts)
 
-    def create_batch_dict(self, tokenizer, input_texts):
+    def create_batch_dict(
+        self, tokenizer: PreTrainedTokenizerBase, input_texts: list[str]
+    ) -> BatchEncoding:
         max_length = self.model.config.max_length
         batch_dict = tokenizer(
             input_texts,
@@ -80,7 +83,9 @@ class RepLLaMAModel(AbsEncoder):
             return_tensors="pt",
         )
 
-    def combine_query_and_instruction(self, query, instruction):  # noqa: PLR6301
+    def combine_query_and_instruction(  # noqa: PLR6301
+        self, query: str, instruction: str
+    ) -> str:
         end_punct = "?" if query.strip()[-1] not in ["?", ".", "!"] else ""  # noqa: PLR6201
         return f"{query}{end_punct} {instruction}".strip()
 

--- a/mteb/models/model_implementations/rerankers_custom.py
+++ b/mteb/models/model_implementations/rerankers_custom.py
@@ -51,8 +51,8 @@ class BGEReranker(RerankerWrapper):
 
     def __init__(
         self,
-        model_name_or_path="BAAI/bge-reranker-v2-m3",
-        torch_compile=False,
+        model_name_or_path: str = "BAAI/bge-reranker-v2-m3",
+        torch_compile: bool = False,
         **kwargs: Any,
     ):
         super().__init__(model_name_or_path, **kwargs)
@@ -107,8 +107,8 @@ class JinaReranker(RerankerWrapper):
 
     def __init__(
         self,
-        model_name_or_path="jinaai/jina-reranker-v2-base-multilingual",
-        torch_compile=False,
+        model_name_or_path: str = "jinaai/jina-reranker-v2-base-multilingual",
+        torch_compile: bool = False,
         **kwargs: Any,
     ):
         from sentence_transformers import CrossEncoder

--- a/mteb/models/model_implementations/rerankers_monot5_based.py
+++ b/mteb/models/model_implementations/rerankers_monot5_based.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import torch
 
@@ -9,8 +9,13 @@ from mteb.models.model_meta import ModelMeta
 
 from .rerankers_custom import RerankerWrapper
 
+T = TypeVar("T")
+
 if TYPE_CHECKING:
+    from collections.abc import Generator
+
     from torch.utils.data import DataLoader
+    from transformers import PreTrainedTokenizerBase
 
     from mteb.abstasks.task_metadata import TaskMetadata
     from mteb.types import Array, BatchedInput, PromptType
@@ -37,7 +42,7 @@ prediction_tokens = {
 }
 
 
-def chunks(lst, n):
+def chunks(lst: list[T], n: int) -> Generator[list[T], None, None]:
     for i in range(0, len(lst), n):
         yield lst[i : i + n]
 
@@ -48,7 +53,7 @@ class MonoT5Reranker(RerankerWrapper):
 
     def __init__(
         self,
-        model_name_or_path="castorini/monot5-base-msmarco-10k",
+        model_name_or_path: str = "castorini/monot5-base-msmarco-10k",
         **kwargs: Any,
     ):
         super().__init__(model_name_or_path, **kwargs)
@@ -92,8 +97,12 @@ class MonoT5Reranker(RerankerWrapper):
         self.model.eval()
 
     def get_prediction_tokens(  # noqa: PLR6301
-        self, model_name_or_path, tokenizer, token_false=None, token_true=None
-    ):
+        self,
+        model_name_or_path: str,
+        tokenizer: PreTrainedTokenizerBase,
+        token_false: str | None = None,
+        token_true: str | None = None,
+    ) -> tuple[int, int]:
         if not (token_false and token_true):
             if model_name_or_path in prediction_tokens:
                 token_false, token_true = prediction_tokens[model_name_or_path]
@@ -314,7 +323,7 @@ class FLANT5Reranker(MonoT5Reranker):
 Query: {query}
 Passage: {text}"""
 
-    def get_prediction_tokens(self, *args: Any, **kwargs: Any):
+    def get_prediction_tokens(self, *args: Any, **kwargs: Any) -> tuple[int, int]:
         yes_token_id, *_ = self.tokenizer.encode("yes")
         no_token_id, *_ = self.tokenizer.encode("no")
         return no_token_id, yes_token_id

--- a/mteb/models/model_implementations/samilpwc_models.py
+++ b/mteb/models/model_implementations/samilpwc_models.py
@@ -30,7 +30,7 @@ def instruction_template(
     return INSTRUCTION.format(instruction=instruction)
 
 
-def instruct_loader(*args: Any, **kwargs: Any):
+def instruct_loader(*args: Any, **kwargs: Any) -> InstructSentenceTransformerModel:
     model = InstructSentenceTransformerModel(*args, **kwargs)
     encoder = model.model._first_module()
     if encoder.auto_model.config._attn_implementation == "flash_attention_2":

--- a/mteb/models/model_implementations/seed_1_6_embedding_models.py
+++ b/mteb/models/model_implementations/seed_1_6_embedding_models.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def pil_to_base64(image, image_format="jpeg"):
+def pil_to_base64(image: Image.Image, image_format: str = "jpeg") -> str:
     buffer = BytesIO()
     image.save(buffer, format=image_format)
     img_bytes = buffer.getvalue()
@@ -38,7 +38,9 @@ def pil_to_base64(image, image_format="jpeg"):
     return encoded_bytes.decode("utf-8")
 
 
-def multimodal_embedding(image_base64=None, text_content=None):
+def multimodal_embedding(
+    image_base64: str | None = None, text_content: str | None = None
+) -> dict[str, Any] | None:
     auth_token = os.getenv("VOLCES_AUTH_TOKEN")
     model_name = "doubao-embedding-vision-250615"
     api_url = "https://ark.cn-beijing.volces.com/api/v3/embeddings/multimodal"
@@ -91,7 +93,9 @@ def multimodal_embedding(image_base64=None, text_content=None):
     return None
 
 
-def multi_thread_encode(sentences, batch_size=1, max_workers=8):
+def multi_thread_encode(
+    sentences: list[str], batch_size: int = 1, max_workers: int = 8
+) -> torch.Tensor:
     batches = []
     for idx in range(0, len(sentences), batch_size):
         batches.append((idx // batch_size, sentences[idx : idx + batch_size]))
@@ -100,7 +104,9 @@ def multi_thread_encode(sentences, batch_size=1, max_workers=8):
     results = [None] * n_batches  # Pre-allocated result list
     all_embeddings = []  # Final ordered embeddings
 
-    def _process_batch(batch_idx, batch_sentences):
+    def _process_batch(
+        batch_idx: int, batch_sentences: list[str]
+    ) -> tuple[int, torch.Tensor]:
         sentence = batch_sentences[0]
 
         retries = 5
@@ -275,7 +281,7 @@ class Seed16EmbeddingWrapper(AbsEncoder):
         self,
         texts: list[str] | None = None,
         images: list[Image.Image] | DataLoader | None = None,
-        fusion_mode="sum",
+        fusion_mode: str = "sum",
         **kwargs: Any,
     ) -> Array:
         if (

--- a/mteb/models/model_implementations/seed_1_6_embedding_models_1215.py
+++ b/mteb/models/model_implementations/seed_1_6_embedding_models_1215.py
@@ -20,6 +20,8 @@ from mteb.models.model_meta import ModelMeta
 from mteb.types import PromptType
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from PIL import Image
     from torch.utils.data import DataLoader
 
@@ -60,7 +62,9 @@ class Seed16EmbeddingWrapper(AbsEncoder):
         self._embed_dim = embed_dim
         self._available_embed_dims = [2048, 1024]
 
-    def pil_to_base64(self, image, image_format="jpeg"):  # noqa: PLR6301
+    def pil_to_base64(  # noqa: PLR6301
+        self, image: Image.Image | None, image_format: str = "jpeg"
+    ) -> str | None:
         if image is None:
             return None
         buffer = BytesIO()
@@ -69,7 +73,9 @@ class Seed16EmbeddingWrapper(AbsEncoder):
         encoded_bytes = base64.b64encode(img_bytes)
         return encoded_bytes.decode("utf-8")
 
-    def multimodal_embedding(self, instruction, image_base64, text_content):
+    def multimodal_embedding(
+        self, instruction: str, image_base64: str | None, text_content: str | None
+    ) -> dict[str, Any]:
         auth_token = os.getenv("VOLCES_AUTH_TOKEN")
         model_name = "doubao-embedding-vision-251215"
         api_url = "https://ark.cn-beijing.volces.com/api/v3/embeddings/multimodal"
@@ -161,8 +167,13 @@ class Seed16EmbeddingWrapper(AbsEncoder):
             raise ValueError("images and texts cannot be None at the same time")
 
         def process_item(
-            i, prompt_type, task_name, texts, images_base64, multimodal_embedding
-        ):
+            i: int,
+            prompt_type: PromptType | None,
+            task_name: str,
+            texts: list[str] | None,
+            images_base64: list[str | None],
+            multimodal_embedding: Callable[..., dict[str, Any]],
+        ) -> torch.Tensor:
             if (
                 prompt_type == PromptType("query") or prompt_type is None
             ) and task_name in TASK_NAME_TO_INSTRUCTION:

--- a/mteb/models/model_implementations/seed_models.py
+++ b/mteb/models/model_implementations/seed_models.py
@@ -69,7 +69,7 @@ class SeedTextEmbeddingModel(AbsEncoder):
 
     def _encode(
         self, inputs: list[str], task_name: str, prompt_type: PromptType | None = None
-    ):
+    ) -> list[list[float]]:
         if (
             self._embed_dim is not None
             and self._embed_dim not in self._available_embed_dims

--- a/mteb/models/model_implementations/siglip_models.py
+++ b/mteb/models/model_implementations/siglip_models.py
@@ -47,7 +47,7 @@ class SiglipModelWrapper(AbsEncoder):
         texts: DataLoader[BatchedInput],
         show_progress_bar: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_text_embeddings = []
 
         with torch.no_grad():
@@ -76,7 +76,7 @@ class SiglipModelWrapper(AbsEncoder):
         images: DataLoader[BatchedInput],
         show_progress_bar: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_image_embeddings = []
 
         with torch.no_grad():

--- a/mteb/models/model_implementations/slm_models.py
+++ b/mteb/models/model_implementations/slm_models.py
@@ -69,7 +69,7 @@ class SLMBaseWrapper(AbsEncoder):
         self.mdl.eval()
 
     def _load_model_and_processor(
-        self, model_name, revision, use_flash_attn, **kwargs: Any
+        self, model_name: str, revision: str | None, use_flash_attn: bool, **kwargs: Any
     ):
         """Override in subclasses to load specific model/processor."""
         raise NotImplementedError
@@ -105,7 +105,7 @@ class SLMBaseWrapper(AbsEncoder):
             return image_embeddings
         raise ValueError("No text or image features found in inputs")
 
-    def encode_input(self, inputs):
+    def encode_input(self, inputs: dict[str, Any]) -> torch.Tensor:
         """Forward pass through the model."""
         return self.mdl(**inputs)
 
@@ -179,7 +179,7 @@ class SLMColQwen3Wrapper(SLMBaseWrapper):
     """Wrapper for SLM-ColQwen3 models (Qwen3-VL backbone)."""
 
     def _load_model_and_processor(
-        self, model_name, revision, use_flash_attn, **kwargs: Any
+        self, model_name: str, revision: str | None, use_flash_attn: bool, **kwargs: Any
     ):
         from sauerkrautlm_colpali.models.qwen3.colqwen3 import (
             ColQwen3,
@@ -206,7 +206,7 @@ class SLMColLFM2Wrapper(SLMBaseWrapper):
     """Wrapper for SLM-ColLFM2 models (LFM2 backbone)."""
 
     def _load_model_and_processor(
-        self, model_name, revision, use_flash_attn, **kwargs: Any
+        self, model_name: str, revision: str | None, use_flash_attn: bool, **kwargs: Any
     ):
         from sauerkrautlm_colpali.models.lfm2.collfm2 import ColLFM2, ColLFM2Processor
 
@@ -229,7 +229,7 @@ class SLMColMinistral3Wrapper(SLMBaseWrapper):
     """Wrapper for SLM-ColMinistral3 models (Ministral3 backbone)."""
 
     def _load_model_and_processor(
-        self, model_name, revision, use_flash_attn, **kwargs: Any
+        self, model_name: str, revision: str | None, use_flash_attn: bool, **kwargs: Any
     ):
         from sauerkrautlm_colpali.models.ministral3.colministral3 import (
             ColMinistral3,

--- a/mteb/models/model_implementations/tipsv2_models.py
+++ b/mteb/models/model_implementations/tipsv2_models.py
@@ -71,7 +71,7 @@ class TIPSv2Model(AbsEncoder):
         texts: DataLoader[BatchedInput],
         show_progress_bar: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_text_embeddings = []
         with torch.no_grad():
             for batch in tqdm(
@@ -86,7 +86,7 @@ class TIPSv2Model(AbsEncoder):
         images: DataLoader[BatchedInput],
         show_progress_bar: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_image_embeddings = []
         with torch.no_grad():
             for batch in tqdm(

--- a/mteb/models/model_implementations/unite_models.py
+++ b/mteb/models/model_implementations/unite_models.py
@@ -11,7 +11,9 @@ from mteb.models.modality_collators import VideoCollator
 from mteb.models.model_meta import ModelMeta, ScoringFunction
 
 if TYPE_CHECKING:
+    from PIL import Image
     from torch.utils.data import DataLoader
+    from transformers import PretrainedConfig, PreTrainedModel
 
     from mteb.abstasks.task_metadata import TaskMetadata
     from mteb.types import Array, BatchedInput, PromptType
@@ -31,26 +33,28 @@ UNITE_CITATION = """@article{kong2025modality,
 # Qwen2VL refactor; each is marked inline.
 
 
-def _build_unite_model(model_name: str, revision: str | None, **kwargs: Any):
+def _build_unite_model(
+    model_name: str, revision: str | None, **kwargs: Any
+) -> PreTrainedModel:
     from transformers import Qwen2VLForConditionalGeneration
 
     class UniteQwen2VL(Qwen2VLForConditionalGeneration):
-        def __init__(self, config):
+        def __init__(self, config: PretrainedConfig) -> None:
             super().__init__(config)
             self.normalize = True
 
         def forward(  # noqa: PLR0913, PLR0917 - signature mirrors upstream Qwen2VLForConditionalGeneration
             self,
-            input_ids=None,
-            attention_mask=None,
-            position_ids=None,
-            past_key_values=None,
-            inputs_embeds=None,
-            pixel_values=None,
-            pixel_values_videos=None,
-            image_grid_thw=None,
-            video_grid_thw=None,
-            pooling_mask=None,
+            input_ids: torch.Tensor | None = None,
+            attention_mask: torch.Tensor | None = None,
+            position_ids: torch.Tensor | None = None,
+            past_key_values: Any = None,  # noqa: ANN401 -- transformers Cache object
+            inputs_embeds: torch.Tensor | None = None,
+            pixel_values: torch.Tensor | None = None,
+            pixel_values_videos: torch.Tensor | None = None,
+            image_grid_thw: torch.Tensor | None = None,
+            video_grid_thw: torch.Tensor | None = None,
+            pooling_mask: torch.Tensor | None = None,
             **unused: Any,
         ) -> torch.Tensor:
             if inputs_embeds is None:
@@ -174,7 +178,9 @@ class UniteWrapper(AbsEncoder):
             return "\nSummary above image in one word:"
         return "\nSummary above sentence in one word:"
 
-    def _build_prompt(self, text=None, has_image=False, has_video=False) -> str:
+    def _build_prompt(
+        self, text: str | None = None, has_image: bool = False, has_video: bool = False
+    ) -> str:
         content = []
         if has_video:
             content.append({"type": "video", "video": ""})
@@ -193,7 +199,12 @@ class UniteWrapper(AbsEncoder):
             + "<|endoftext|>"
         )
 
-    def _embed_batch(self, texts=None, images=None, videos=None) -> torch.Tensor:
+    def _embed_batch(
+        self,
+        texts: list[str] | None = None,
+        images: list[Image.Image] | None = None,
+        videos: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         n = len(texts or images or videos)
         prompts = [
             self._build_prompt(

--- a/mteb/models/model_implementations/vggish_models.py
+++ b/mteb/models/model_implementations/vggish_models.py
@@ -15,13 +15,14 @@ if TYPE_CHECKING:
     from torch.utils.data import DataLoader
 
     from mteb import TaskMetadata
+    from mteb.models.models_protocols import EncoderProtocol
     from mteb.types import Array, BatchedInput, PromptType
     from mteb.types._encoder_io import AudioInput
 
 logger = logging.getLogger(__name__)
 
 
-def vggish_loader(*args: Any, **kwargs: Any):
+def vggish_loader(*args: Any, **kwargs: Any) -> EncoderProtocol:
     """Factory function to create a VGGish model wrapper."""
     import torchaudio
     from torch_vggish_yamnet import vggish
@@ -44,7 +45,9 @@ def vggish_loader(*args: Any, **kwargs: Any):
             self.embed_dim = 128
             self.min_samples = int(0.96 * self.sampling_rate)  # 15,360 samples
 
-        def _resample_audio(self, audio, source_rate):
+        def _resample_audio(
+            self, audio: torch.Tensor, source_rate: int
+        ) -> torch.Tensor:
             """Resample audio to target sampling rate."""
             if source_rate != self.sampling_rate:
                 resampler = torchaudio.transforms.Resample(
@@ -53,7 +56,7 @@ def vggish_loader(*args: Any, **kwargs: Any):
                 return resampler(audio)
             return audio
 
-        def _normalize_audio(self, audio):
+        def _normalize_audio(self, audio: Array) -> torch.Tensor:
             """Normalize and pad audio to minimum length."""
             if isinstance(audio, np.ndarray):
                 audio = torch.from_numpy(audio)
@@ -78,7 +81,7 @@ def vggish_loader(*args: Any, **kwargs: Any):
 
             return audio
 
-        def _prepare_input_tensor(self, audio_data):
+        def _prepare_input_tensor(self, audio_data: Array) -> torch.Tensor:
             """Convert audio to VGGish input format and handle tensor dimensions."""
             if isinstance(audio_data, np.ndarray):
                 audio_data = torch.from_numpy(audio_data)
@@ -110,9 +113,9 @@ def vggish_loader(*args: Any, **kwargs: Any):
         def get_audio_embeddings(
             self,
             inputs: DataLoader[AudioInput],
-            show_progress_bar=True,
+            show_progress_bar: bool = True,
             **kwargs: Any,
-        ):
+        ) -> Array:
             """Generate embeddings for audio inputs."""
             all_embeddings = []
 

--- a/mteb/models/model_implementations/viclip_models.py
+++ b/mteb/models/model_implementations/viclip_models.py
@@ -84,7 +84,7 @@ class ViCLIPWrapper(AbsEncoder):
         texts: DataLoader[BatchedInput],
         show_progress_bar: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_embeddings = []
 
         for batch in tqdm(texts, disable=not show_progress_bar, desc="Text Encoding"):
@@ -108,7 +108,7 @@ class ViCLIPWrapper(AbsEncoder):
         videos: DataLoader[BatchedInput],
         show_progress_bar: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_embeddings = []
 
         for batch in tqdm(videos, disable=not show_progress_bar, desc="Video Encoding"):

--- a/mteb/models/model_implementations/vista_models.py
+++ b/mteb/models/model_implementations/vista_models.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from torch.utils.data import DataLoader
 
     from mteb.abstasks.task_metadata import TaskMetadata
+    from mteb.models.models_protocols import EncoderProtocol
     from mteb.types import Array, BatchedInput, PromptType
 
 VISTA_CITATION = """@article{zhou2024vista,
@@ -22,7 +23,7 @@ VISTA_CITATION = """@article{zhou2024vista,
 }"""
 
 
-def vista_loader(model_name, **kwargs: Any):
+def vista_loader(model_name: str, **kwargs: Any) -> EncoderProtocol:
     try:  # a temporal fix for the dependency issues of vista models.
         from visual_bge.modeling import Visualized_BGE
     except ImportError:
@@ -61,12 +62,12 @@ def vista_loader(model_name, **kwargs: Any):
         def __init__(
             self,
             model_name_bge: str | None = None,
-            model_weight=None,
+            model_weight: str | None = None,
             normlized: bool = True,
             sentence_pooling_method: str = "cls",
             negatives_cross_device: bool = False,
             temperature: float = 0.02,
-            from_pretrained=None,
+            from_pretrained: str | None = None,
             image_tokens_num: int | None = None,
             **kwargs: Any,
         ):
@@ -147,7 +148,7 @@ def vista_loader(model_name, **kwargs: Any):
             prompt_type: PromptType | None = None,
             input_type: Literal["document", "query"] | None = None,
             **kwargs: Any,
-        ):
+        ) -> Array:
             all_text_embeddings = []
             for batch in tqdm(
                 texts, disable=not show_progress_bar, desc="Text Encoding"
@@ -170,7 +171,7 @@ def vista_loader(model_name, **kwargs: Any):
             prompt_type: PromptType | None = None,
             input_type: Literal["document", "query"] | None = None,
             **kwargs: Any,
-        ):
+        ) -> Array:
             all_image_embeddings = []
             with torch.no_grad():
                 for batch in tqdm(images):

--- a/mteb/models/model_implementations/vlm2vec_models.py
+++ b/mteb/models/model_implementations/vlm2vec_models.py
@@ -94,13 +94,15 @@ class VLM2VecWrapper(AbsEncoder):
             num_crops=4,
         )
 
-    def encode_input(self, inputs):
+    def encode_input(self, inputs: dict[str, Any]) -> torch.Tensor:
         hidden_states = self.mdl(**inputs, return_dict=True, output_hidden_states=True)
         hidden_states = hidden_states.hidden_states[-1]
         pooled_output = self._pooling(hidden_states, inputs["attention_mask"])
         return pooled_output
 
-    def _pooling(self, last_hidden_state, attention_mask):
+    def _pooling(
+        self, last_hidden_state: torch.Tensor, attention_mask: torch.Tensor
+    ) -> torch.Tensor:
         if self.pooling == "last":
             sequence_lengths = attention_mask.sum(dim=1) - 1
             batch_size = last_hidden_state.shape[0]
@@ -120,7 +122,7 @@ class VLM2VecWrapper(AbsEncoder):
         images: DataLoader[BatchedInput],
         show_progress_bar: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Array:
         text = "<|image_1|> Represent the given image."
         all_image_embeddings = []
 
@@ -169,7 +171,7 @@ class VLM2VecWrapper(AbsEncoder):
         texts: DataLoader[BatchedInput],
         show_progress_bar: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_text_embeddings = []
 
         with torch.no_grad():

--- a/mteb/models/model_implementations/voyage_models.py
+++ b/mteb/models/model_implementations/voyage_models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import time
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 import numpy as np
 from tqdm.auto import tqdm
@@ -14,7 +14,11 @@ from mteb.models.sentence_transformer_wrapper import (
 )
 from mteb.types import OutputDType, PromptType
 
+T = TypeVar("T")
+
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from torch.utils.data import DataLoader
 
     from mteb.abstasks.task_metadata import TaskMetadata
@@ -135,13 +139,15 @@ OUTPUT_TYPES = [
 ]
 
 
-def token_limit(max_tpm: int, interval: int = 60):
+def token_limit(
+    max_tpm: int, interval: int = 60
+) -> Callable[[Callable[..., T]], Callable[..., T]]:
     limit_interval_start_ts = time.time()
     used_tokens = 0
 
-    def decorator(func):
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
         @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any):
+        def wrapper(*args: Any, **kwargs: Any) -> T:
             nonlocal limit_interval_start_ts, used_tokens
 
             result = func(*args, **kwargs)
@@ -162,13 +168,15 @@ def token_limit(max_tpm: int, interval: int = 60):
     return decorator
 
 
-def rate_limit(max_rpm: int, interval: int = 60):
+def rate_limit(
+    max_rpm: int, interval: int = 60
+) -> Callable[[Callable[..., T]], Callable[..., T]]:
     request_interval = interval / max_rpm
     previous_call_ts: float | None = None
 
-    def decorator(func):
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
         @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any):
+        def wrapper(*args: Any, **kwargs: Any) -> T:
             current_time = time.time()
             nonlocal previous_call_ts
             if (

--- a/mteb/models/model_implementations/voyage_v.py
+++ b/mteb/models/model_implementations/voyage_v.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from torch.utils.data import DataLoader
 
     from mteb.abstasks.task_metadata import TaskMetadata
+    from mteb.models.models_protocols import EncoderProtocol
     from mteb.types import Array, BatchedInput
 
 logger = logging.getLogger(__name__)
@@ -56,7 +57,7 @@ def _downsample_image(
     return image
 
 
-def voyage_v_loader(model_name, **kwargs: Any):
+def voyage_v_loader(model_name: str, **kwargs: Any) -> EncoderProtocol:
     import voyageai
     from tenacity import retry, stop_after_attempt, wait_exponential
 
@@ -73,7 +74,12 @@ def voyage_v_loader(model_name, **kwargs: Any):
             stop=stop_after_attempt(6),  # Stop after 6 attempts
             wait=wait_exponential(multiplier=1, max=60),  # Exponential backoff
         )
-        def _multimodal_embed(self, inputs, model, input_type):
+        def _multimodal_embed(
+            self,
+            inputs: list[list[str | Image.Image]],
+            model: str,
+            input_type: str | None,
+        ) -> Any:  # noqa: ANN401 -- voyageai response object; voyageai is untyped
             return self.vo.multimodal_embed(inputs, model=model, input_type=input_type)
 
         def get_text_embeddings(
@@ -83,7 +89,7 @@ def voyage_v_loader(model_name, **kwargs: Any):
             prompt_type: PromptType | None = None,
             input_type: Literal["document", "query"] | None = None,
             **kwargs: Any,
-        ):
+        ) -> Array:
             if input_type is None and prompt_type is not None:
                 if prompt_type == PromptType.document:
                     input_type = "document"
@@ -112,7 +118,7 @@ def voyage_v_loader(model_name, **kwargs: Any):
             prompt_type: PromptType | None = None,
             input_type: Literal["document", "query"] | None = None,
             **kwargs: Any,
-        ):
+        ) -> Array:
             if input_type is None and prompt_type is not None:
                 if prompt_type == PromptType.document:
                     input_type = "document"

--- a/mteb/models/model_implementations/webai_models.py
+++ b/mteb/models/model_implementations/webai_models.py
@@ -90,8 +90,12 @@ class ColVec1Wrapper(AbsEncoder):
         return self.model(**encoded_inputs)
 
     def get_image_embeddings(
-        self, images, batch_size=32, show_progress_bar=True, **kwargs: Any
-    ):
+        self,
+        images: DataLoader[BatchedInput],
+        batch_size: int = 32,
+        show_progress_bar: bool = True,
+        **kwargs: Any,
+    ) -> Array:
         import torchvision.transforms.functional as F
         from PIL import Image
 
@@ -116,8 +120,12 @@ class ColVec1Wrapper(AbsEncoder):
         )
 
     def get_text_embeddings(
-        self, texts, batch_size=32, show_progress_bar=True, **kwargs: Any
-    ):
+        self,
+        texts: DataLoader[BatchedInput],
+        batch_size: int = 32,
+        show_progress_bar: bool = True,
+        **kwargs: Any,
+    ) -> Array:
         all_embeds = []
         with torch.no_grad():
             for batch in tqdm(
@@ -131,7 +139,7 @@ class ColVec1Wrapper(AbsEncoder):
             all_embeds, batch_first=True, padding_value=0
         )
 
-    def similarity(self, a, b):
+    def similarity(self, a: Array, b: Array) -> Array:
         a = [torch.as_tensor(x) for x in a]
         b = [torch.as_tensor(x) for x in b]
         return self.processor.score_multi_vector(a, b, device=self.device)
@@ -175,8 +183,12 @@ class ColVec11Wrapper(ColVec1Wrapper):
         )
 
     def get_image_embeddings(
-        self, images, batch_size=32, show_progress_bar=True, **kwargs: Any
-    ):
+        self,
+        images: DataLoader[BatchedInput],
+        batch_size: int = 32,
+        show_progress_bar: bool = True,
+        **kwargs: Any,
+    ) -> Array:
         import torchvision.transforms.functional as F
         from PIL import Image
 
@@ -218,7 +230,7 @@ class ColVec11Wrapper(ColVec1Wrapper):
             return self.get_text_embeddings(inputs, **kwargs)
         raise ValueError("No text or image features found in inputs.")
 
-    def similarity(self, a, b):
+    def similarity(self, a: Array, b: Array) -> Array:
         a = [torch.as_tensor(x) for x in a]
         b = [torch.as_tensor(x) for x in b]
         return self.processor.score_retrieval(

--- a/mteb/models/model_implementations/xclip_models.py
+++ b/mteb/models/model_implementations/xclip_models.py
@@ -43,7 +43,7 @@ class XCLIPModel(AbsEncoder):
         texts: DataLoader[BatchedInput],
         show_progress_bar: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_embeddings = []
 
         for batch in tqdm(texts, disable=not show_progress_bar, desc="Text Encoding"):
@@ -67,7 +67,7 @@ class XCLIPModel(AbsEncoder):
         videos: DataLoader[BatchedInput],
         show_progress_bar: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Array:
         all_embeddings = []
 
         for batch in tqdm(videos, disable=not show_progress_bar, desc="Video Encoding"):

--- a/mteb/models/model_implementations/yamnet_models.py
+++ b/mteb/models/model_implementations/yamnet_models.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from torch.utils.data import DataLoader
 
     from mteb import TaskMetadata
+    from mteb.models.models_protocols import EncoderProtocol
     from mteb.types import Array, BatchedInput, PromptType
     from mteb.types._encoder_io import AudioInput
 
@@ -22,7 +23,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def yamnet_loader(*args: Any, **kwargs: Any):
+def yamnet_loader(*args: Any, **kwargs: Any) -> EncoderProtocol:
     """Factory function to create a YAMNet model wrapper."""
     from torch_vggish_yamnet import yamnet
     from torch_vggish_yamnet.input_proc import WaveformToInput
@@ -44,7 +45,9 @@ def yamnet_loader(*args: Any, **kwargs: Any):
             self.embed_dim = 1024  # YAMNet embedding dimension
             self.min_samples = int(0.96 * self.sampling_rate)  # 15,360 samples
 
-        def _resample_audio(self, audio, source_rate):
+        def _resample_audio(
+            self, audio: torch.Tensor, source_rate: int
+        ) -> torch.Tensor:
             """Resample audio to target sampling rate."""
             import torchaudio
 
@@ -55,7 +58,7 @@ def yamnet_loader(*args: Any, **kwargs: Any):
                 return resampler(audio)
             return audio
 
-        def _normalize_audio(self, audio):
+        def _normalize_audio(self, audio: Array) -> torch.Tensor:
             """Normalize and pad audio to minimum length."""
             if isinstance(audio, np.ndarray):
                 audio = torch.from_numpy(audio)
@@ -80,7 +83,7 @@ def yamnet_loader(*args: Any, **kwargs: Any):
 
             return audio
 
-        def _prepare_input_tensor(self, audio_data):
+        def _prepare_input_tensor(self, audio_data: Array) -> torch.Tensor | None:
             """Convert audio to YAMNet input format and handle tensor dimensions."""
             if isinstance(audio_data, np.ndarray):
                 audio_data = torch.from_numpy(audio_data)
@@ -115,9 +118,9 @@ def yamnet_loader(*args: Any, **kwargs: Any):
         def get_audio_embeddings(
             self,
             inputs: DataLoader[AudioInput],
-            show_progress_bar=True,
+            show_progress_bar: bool = True,
             **kwargs: Any,
-        ):
+        ) -> Array:
             """Generate embeddings for audio inputs."""
             all_embeddings = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -387,7 +387,7 @@ preview = true
     "PLC2701",  # Private name import
     "PLR6301",  # Method could be a function - pytest test methods are instance methods
     # tests are not type-checked (`make mypy` covers `mteb` only), so annotations
-    # here would be unverified;
+    # here would go unverified.
     "ANN001",
     "ANN201",
     "ANN202",
@@ -404,10 +404,6 @@ preview = true
 "mteb/models/model_implementations/*" = [
     "D",
     "DOC",
-    # TODO: annotate and remove -- needs a type inferred per call site
-    "ANN001",
-    "ANN201",
-    "ANN202",
 ]
 "mteb/benchmarks/benchmark.py" = [
     # pydantic would try to validate fields in Benchmark class


### PR DESCRIPTION
Enable ANN001, ANN201, ANN202 for `mteb/models/model_implementations/.` Final part of the ANN rollout for #2416. 
With this, flake8-annotations is fully enabled across `mteb/` . ANN001(missing type annotation for a function argument)
ANN201(missing return type on a public function), ANN202(missing return type on a private function)
341 violations fixed across 59 files.

How types were chosen:

1. Encoder API (get_text_embeddings, get_image_embeddings, get_audio_embeddings, get_video_embeddings, get_fused_embeddings, encode, similarity) — taken from the declarations already in mteb/models/abs_encoder.py, so overrides match the protocol they implement: inputs/texts/images/audio/videos: DataLoader[BatchedInput], similarity(a: Array, b: Array) -> Array, -> Array returns. Array (NDArray | torch.Tensor) is the supertype every backend here actually satisfies.
2. Everything else — read from the body and call sites rather than the parameter name: Tokenized for the bm25/bb25 tokenizers, BatchFeature/BatchEncoding/PreTrainedModel/ProcessorMixin for transformers plumbing, cohere.EmbedResponse (v1 client) vs cohere.EmbedByTypeResponse (ClientV2), openai.types.CreateEmbeddingResponse, tuple[int, int] for monoT5 prediction tokens.
3. Rate-limit/retry decorators (cohere.retry_with_rate_limit, voyage.token_limit/rate_limit, conan.execute_with_retry) are generic in the wrapped function's return type via a TypeVar, so T | None correctly records that the cohere/conan wrappers return None once retries are exhausted.
4. Lazily-defined wrapper classes (blip2_loader, evaclip_loader, vista_loader, …) define their class inside the loader, so EncoderProtocol is the only nameable return type — matching the existing precedent in llm2vec_models.py.
5. Any is used only where a real type doesn't exist: untyped optional deps (botocore client, voyageai response) and the transformers Cache object, each with # noqa: ANN401 and a reason, following the convention already in bedrock_models.py.