### PR TITLE
Add model: sshalimov04/ru-reranker-edge-150m

### DIFF
--- a/mteb/models/model_implementations/ru_reranker_edge.py
+++ b/mteb/models/model_implementations/ru_reranker_edge.py
@@ -23,4 +23,6 @@ ru_reranker_edge_150m = ModelMeta(
     use_instructions=False,
     training_datasets={"MIRACLRetrieval", "MIRACLReranking", "MMarcoRetrieval"},
     modalities=["text"],
+    adapted_from="deepvk/RuModernBERT-base",
+    model_type=["cross-encoder"],
 )

--- a/mteb/models/model_implementations/ru_reranker_edge.py
+++ b/mteb/models/model_implementations/ru_reranker_edge.py
@@ -20,6 +20,6 @@ ru_reranker_edge_150m = ModelMeta(
     reference="https://huggingface.co/sshalimov04/ru-reranker-edge-150m",
     similarity_fn_name=None,
     use_instructions=False,
-    training_datasets={"MIRACLRetrieval": ["train"], "MIRACLReranking": ["train"], "MMarcoRetrieval": ["train"]},
+    training_datasets={"MIRACLRetrieval", "MIRACLReranking", "MMarcoRetrieval"},
     modalities=["text"],
 )

--- a/mteb/models/model_implementations/ru_reranker_edge.py
+++ b/mteb/models/model_implementations/ru_reranker_edge.py
@@ -1,0 +1,25 @@
+from mteb.models.model_meta import ModelMeta
+from mteb.models.sentence_transformer_wrapper import CrossEncoderWrapper
+
+ru_reranker_edge_150m = ModelMeta(
+    loader=CrossEncoderWrapper,
+    loader_kwargs=dict(max_length=512),
+    name="sshalimov04/ru-reranker-edge-150m",
+    revision="d3f4bbf84c4f180696a06a1565981ea37c65fc06",
+    release_date="2026-09-06",
+    languages=["rus-Cyrl"],
+    n_parameters=149_000_000,
+    memory_usage_mb=570,
+    max_tokens=8192,
+    embed_dim=None,
+    license="apache-2.0",
+    open_weights=True,
+    public_training_code=None,
+    public_training_data="https://huggingface.co/datasets/sshalimov04/ru-reranker-teacher-scores",
+    framework=["PyTorch", "Sentence Transformers"],
+    reference="https://huggingface.co/sshalimov04/ru-reranker-edge-150m",
+    similarity_fn_name=None,
+    use_instructions=False,
+    training_datasets={"MIRACLRetrieval": ["train"], "MIRACLReranking": ["train"], "MMarcoRetrieval": ["train"]},
+    modalities=["text"],
+)

--- a/mteb/models/model_implementations/ru_reranker_edge.py
+++ b/mteb/models/model_implementations/ru_reranker_edge.py
@@ -9,6 +9,7 @@ ru_reranker_edge_150m = ModelMeta(
     release_date="2026-09-06",
     languages=["rus-Cyrl"],
     n_parameters=149_000_000,
+    n_embedding_parameters=38_682_624,
     memory_usage_mb=570,
     max_tokens=8192,
     embed_dim=None,

--- a/mteb/tasks/retrieval/multilingual/spoken_wikipedia_retrieval.py
+++ b/mteb/tasks/retrieval/multilingual/spoken_wikipedia_retrieval.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from datasets import load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
@@ -99,7 +101,7 @@ class SpokenWikipediaA2TRetrieval(AbsTaskRetrieval):
         **_COMMON,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load(self, to_text=True)
 
 
@@ -113,5 +115,5 @@ class SpokenWikipediaT2ARetrieval(AbsTaskRetrieval):
         **_COMMON,
     )
 
-    def load_data(self, num_proc: int | None = None, **kwargs) -> None:
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
         _load(self, to_text=False)


### PR DESCRIPTION
Adds `ModelMeta` for `sshalimov04/ru-reranker-edge-150m` — a 150M Russian cross-encoder reranker (`deepvk/RuModernBERT-base`, listwise KL distillation from `BAAI/bge-reranker-v2-m3`), loaded through the existing `CrossEncoderWrapper` (`max_length=512`). No new dependencies.

Results PR: embeddings-benchmark/results#703 (RuBQReranking MAP 0.7706 / nDCG@10 0.836; MIRACLReranking-rus nDCG@10 0.685).

### Model checklist

- [x] I have filled out the ModelMeta object to the extent possible
- [x] I have ensured that my model can be loaded using
  - [x] `mteb.get_model(model_name, revision)` and
  - [x] `mteb.get_model_meta(model_name, revision)`
- [x] I have tested the implementation works on a representative set of tasks (RuBQReranking, MIRACLReranking; results in #703)
- [x] The model is public, i.e., is available either as an API or the weights are publicly available to download
- [x] I reproduced results from the original paper (if applicable) on at least one benchmark, and I am including the results in the PR description — no paper; the model card numbers were produced with this implementation (RuBQReranking MAP 0.7706).

`training_datasets` declares MIRACL (train split) and mMARCO (train split); RuBQReranking is zero-shot.
