### PR TITLE
test: cover MLDR split and positive qrels loading

### DIFF
--- a/tests/test_tasks/test_load_data.py
+++ b/tests/test_tasks/test_load_data.py
@@ -50,3 +50,109 @@ def test_multilingual_retrieval_load_data(task):
     assert mock_load.called
     assert task.dataset is not None
     assert len(task.dataset) == 1
+
+
+@pytest.mark.parametrize(
+    ("language", "query", "positive_passages", "negative_passage"),
+    [
+        (
+            "fr",
+            "Pourquoi l’élève étudie-t-il à l’université de Montréal ?",
+            [
+                ("positive-1", "L’étudiante prépare un mémoire à Montréal."),
+                ("positive-2", "Elle réussit grâce à sa persévérance."),
+            ],
+            ("negative-1", "Un passage sans rapport évoque l’été."),
+        ),
+        (
+            "es",
+            "¿Cómo cambió la situación después de la elección?",
+            [
+                ("positive-1", "La elección cambió la política económica."),
+                ("positive-2", "También mejoró la cooperación pública."),
+            ],
+            ("negative-1", "Un texto sobre música clásica."),
+        ),
+        (
+            "pt",
+            "Qual é a relação entre educação e inovação?",
+            [
+                ("positive-1", "A educação pública estimula a inovação."),
+                ("positive-2", "A pesquisa também fortalece a ciência."),
+            ],
+            ("negative-1", "Um texto sobre culinária açoriana."),
+        ),
+    ],
+    ids=["french", "spanish", "portuguese"],
+)
+def test_mldr_loads_requested_split_and_all_qrels(
+    language, query, positive_passages, negative_passage
+):
+    task = mteb.get_task(
+        "MultiLongDocRetrieval",
+        eval_splits=["test"],
+        hf_subsets=[language],
+    )
+    configs = [f"{language}-{kind}" for kind in ("corpus", "qrels", "queries")]
+    load_calls = []
+
+    def mock_load_dataset(path, config, *, split, **kwargs: object):
+        assert path == task.metadata.dataset["path"]
+        assert kwargs["revision"] == task.metadata.dataset["revision"]
+        load_calls.append((config, split))
+
+        if config.endswith("-corpus"):
+            passages = [*positive_passages, negative_passage]
+            return Dataset.from_dict(
+                {
+                    "id": [passage_id for passage_id, _ in passages],
+                    "text": [text for _, text in passages],
+                }
+            )
+        if config.endswith("-queries"):
+            return Dataset.from_dict({"id": ["query-1"], "text": [query]})
+        return Dataset.from_dict(
+            {
+                "query-id": ["query-1"] * len(positive_passages),
+                "corpus-id": [passage_id for passage_id, _ in positive_passages],
+                "score": [1] * len(positive_passages),
+            }
+        )
+
+    with (
+        patch(
+            "mteb.abstasks.retrieval_dataset_loaders.get_dataset_config_names",
+            return_value=configs,
+        ),
+        patch(
+            "mteb.abstasks.retrieval_dataset_loaders.get_dataset_split_names",
+            return_value=["dev", "test"],
+        ),
+        patch(
+            "mteb.abstasks.retrieval_dataset_loaders.load_dataset",
+            side_effect=mock_load_dataset,
+        ),
+    ):
+        task.load_data()
+
+    assert task.dataset is not None
+    assert set(task.dataset[language]) == {"test"}
+
+    split_data = task.dataset[language]["test"]
+    assert split_data["queries"]["text"] == [query]
+    assert split_data["corpus"]["text"] == [
+        text for _, text in [*positive_passages, negative_passage]
+    ]
+    assert split_data["relevant_docs"] == {
+        "query-1": {"positive-1": 1, "positive-2": 1}
+    }
+    assert set(split_data["corpus"]["id"]) == {
+        "positive-1",
+        "positive-2",
+        "negative-1",
+    }
+    assert load_calls == [
+        (f"{language}-qrels", "test"),
+        (f"{language}-corpus", "test"),
+        (f"{language}-queries", "test"),
+    ]


### PR DESCRIPTION
## Summary
- add deterministic offline MLDR loading coverage for French, Spanish, and Portuguese
- verify a requested `test` split does not load `dev`
- verify all positive qrels survive when a query has multiple positives
- verify hard-negative documents remain retrieval candidates in the corpus

## Context
#3232 was filed against MLDR's pre-v2 custom loader. That loader fetched a complete split mapping and indexed only `positive_passages[0]`. Current main uses the shared `RetrievalDatasetLoader`, which passes the requested split explicitly and groups every qrels row by query.

The reported negative-list behavior is intentional for retrieval: negatives stay in the corpus but are not marked relevant. MLDR now also has a separate reranking task for candidate-list evaluation. This PR therefore locks the current behavior with focused regression tests instead of reintroducing a custom loader or changing published scoring semantics.

## Validation
- `pytest tests/test_tasks/test_load_data.py -q` (10 passed)
- full non-dataset suite (7,058 passed, 300 skipped)
- repository-wide Ruff format/check and typos checks
- mypy (1,717 source files)

## Compatibility and limitations
No production code, dataset revision, public API, or scoring behavior changes. The published MLDR revision currently has one positive qrel per query; the miniature multi-positive fixture protects future compatible data.

Related to #3232.