### PR TITLE
fix: set the VOC2007 classifier on evaluator_model

### DIFF
--- a/mteb/tasks/multilabel_classification/eng/pascal_voc2007.py
+++ b/mteb/tasks/multilabel_classification/eng/pascal_voc2007.py
@@ -52,4 +52,4 @@ class VOC2007Classification(AbsTaskMultilabelClassification):
     # To be removed when we want full results
     n_experiments: int = 5
     input_column_name: str = "image"
-    evaluator = MultiOutputClassifier(estimator=LogisticRegression())
+    evaluator_model = MultiOutputClassifier(estimator=LogisticRegression())

--- a/tests/test_abstasks/test_classification_evaluator_model.py
+++ b/tests/test_abstasks/test_classification_evaluator_model.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+
+import mteb
+from mteb._evaluators.sklearn_evaluator import SklearnEvaluator
+from mteb.abstasks import AbsTaskClassification
+
+
+@pytest.mark.parametrize(
+    "task",
+    [
+        task
+        for task in mteb.get_tasks(
+            exclude_superseded=False, exclude_aggregate=False, exclude_beta=False
+        )
+        if isinstance(task, AbsTaskClassification)
+    ],
+    ids=lambda task: task.metadata.name,
+)
+def test_classifier_is_set_on_evaluator_model(task: AbsTaskClassification) -> None:
+    """A task that wants a non-default classifier must set `evaluator_model`.
+
+    `evaluator` holds the evaluator class, so putting a classifier there leaves
+    `evaluator_model` on its default and the classifier is never used.
+    """
+    assert isinstance(task.evaluator, type) and issubclass(
+        task.evaluator, SklearnEvaluator
+    ), (
+        f"{task.metadata.name} sets `evaluator` to {task.evaluator!r}; "
+        "a classifier belongs on `evaluator_model`"
+    )


### PR DESCRIPTION
VOC2007 configures its classifier with `evaluator = MultiOutputClassifier(estimator=LogisticRegression())`, but `AbsTaskMultilabelClassification._evaluate_subset` reads `self.evaluator_model`. `evaluator` is something else — the evaluator *class* (`type[SklearnEvaluator]`) inherited from `AbsTaskClassification` — so the configured classifier is never used and the task quietly falls back to the base default:

```python
>>> mteb.get_task("VOC2007").evaluator_model
KNeighborsClassifier()
```

That also moves the headline metric onto a different branch: `_calculate_scores` checks `isinstance(current_classifier, MultiOutputClassifier)` and computes `lrap` from `predict_proba` if it matches, otherwise from the hard 0/1 predictions. `lrap` is VOC2007's `main_score`, so it's currently the degenerate path.

The other five multilabel tasks (`fsd50_hf`, `fsd2019_kaggle`, `audio_set` x2, `bird_set`) all set `evaluator_model`, and VOC2007 is the only place in the repo that puts a classifier on `evaluator` — looks like a plain slip, so I just renamed it.

Also added a check over every classification task that `evaluator` is still an `SklearnEvaluator` subclass. It fails on VOC2007 against main and passes for the other 601 tasks, so the same slip can't come back unnoticed.

One thing worth flagging: I couldn't run VOC2007 end to end locally (image task, and the dataset kept rate-limiting me), so I haven't measured the new lrap. Whatever it is, it will differ from the published one.
