### PR TITLE
Add MLCD image encoders (ViT-B/32-224, ViT-L/14-336)

### DIFF
--- a/mteb/models/model_implementations/mlcd_models.py
+++ b/mteb/models/model_implementations/mlcd_models.py
@@ -1,0 +1,136 @@
+"""MLCD image encoders (DeepGlint-AI) - image-only CLIPVisionModel-compatible checkpoints.
+
+Feature endpoint: the public HF checkpoints contain only the vision tower (verified by
+weight inspection - no visual_projection, no unicom embedding head), so embeddings are
+the pooled CLS token after post_layernorm (768-d base, 1024-d large).
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import torch
+from tqdm.auto import tqdm
+
+from mteb.models.abs_encoder import AbsEncoder
+from mteb.models.model_meta import ModelMeta, ScoringFunction
+
+if TYPE_CHECKING:
+    from torch.utils.data import DataLoader
+
+    from mteb.abstasks.task_metadata import TaskMetadata
+    from mteb.types import Array, BatchedInput
+
+
+class MLCDVisionModel(AbsEncoder):
+    """Image-only encoder: pooled CLS vision features from a CLIPVisionModel checkpoint."""
+
+    def __init__(
+        self,
+        model_name: str,
+        revision: str,
+        device: str = "cuda" if torch.cuda.is_available() else "cpu",
+        **kwargs: Any,
+    ):
+        from transformers import CLIPImageProcessor, CLIPVisionModel
+
+        self.model_name = model_name
+        self.device = device
+        self.model = CLIPVisionModel.from_pretrained(
+            model_name, revision=revision
+        ).to(self.device)
+        self.processor = CLIPImageProcessor.from_pretrained(model_name, revision=revision)
+        self.model.eval()
+
+    @torch.no_grad()
+    def get_image_embeddings(
+        self,
+        images: DataLoader[BatchedInput],
+        show_progress_bar: bool = True,
+        **kwargs: Any,
+    ):
+        all_image_embeddings = []
+        for batch in tqdm(images, disable=not show_progress_bar, desc="Image Encoding"):
+            if "image" not in batch:
+                raise ValueError(
+                    "MLCD is image-only: batch has no 'image' field; "
+                    f"got keys {list(batch.keys())}"
+                )
+            imgs = batch["image"]
+            if any(im is None for im in imgs):
+                raise ValueError("MLCD is image-only: a required image is missing (None).")
+            inputs = self.processor(images=imgs, return_tensors="pt")
+            inputs = {k: v.to(self.device) for k, v in inputs.items()}
+            outputs = self.model(**inputs)
+            pooled = outputs.pooler_output  # CLS after post_layernorm
+            all_image_embeddings.append(pooled.cpu())
+
+        return torch.cat(all_image_embeddings, dim=0)
+
+    def encode(
+        self,
+        inputs: DataLoader[BatchedInput],
+        *,
+        task_metadata: TaskMetadata,
+        hf_split: str,
+        hf_subset: str,
+        prompt_type=None,
+        **kwargs: Any,
+    ) -> Array:
+        if "image" in inputs.dataset.features:
+            return self.get_image_embeddings(inputs, **kwargs)
+        raise ValueError(
+            "MLCD is image-only: no 'image' feature in input batch; refusing to "
+            "substitute text or other modalities."
+        )
+
+
+MLCD_CITATION = """
+@article{yin2024mlcd,
+  title={Multi-Label Cluster Discrimination for Visual Representation Learning},
+  author={Yin, Xie and Wang, Yumeng and Cao, Jia and Wang, Qi and Wang, Di and others},
+  journal={arXiv preprint arXiv:2407.17331},
+  year={2024}
+}"""
+
+_common = dict(
+    loader=MLCDVisionModel,
+    model_type=["dense"],
+    languages=["eng-Latn"],
+    modalities=["image"],
+    open_weights=True,
+    framework=["PyTorch", "Transformers"],
+    similarity_fn_name=ScoringFunction.COSINE,
+    use_instructions=False,
+    citation=MLCD_CITATION,
+    max_tokens=77,
+)
+
+mlcd_vit_base_patch32_224 = ModelMeta(
+    **_common,
+    name="DeepGlint-AI/mlcd-vit-base-patch32-224",
+    revision="0862ef00ecb5825c1c79ab5944ceea56a5605113",
+    release_date="2024-11-04",
+    n_parameters=87456000,
+    embed_dim=768,
+    memory_usage_mb=335,
+    license="apache-2.0",
+    reference="https://huggingface.co/DeepGlint-AI/mlcd-vit-base-patch32-224",
+    public_training_code="https://github.com/deepglint/unicom",
+    public_training_data="https://huggingface.co/datasets/kakaobrain/coyo-700m",
+    training_datasets={"COYO700M"},
+)
+
+mlcd_vit_large_patch14_336 = ModelMeta(
+    **_common,
+    name="DeepGlint-AI/mlcd-vit-large-patch14-336",
+    revision="bd75627f99f12c1d2e0a40ed8c9d1f129b54405e",
+    release_date="2024-11-13",
+    n_parameters=303507456,
+    embed_dim=1024,
+    memory_usage_mb=1157,
+    license="apache-2.0",
+    reference="https://huggingface.co/DeepGlint-AI/mlcd-vit-large-patch14-336",
+    public_training_code="https://github.com/deepglint/unicom",
+    public_training_data="https://huggingface.co/datasets/laion/laion400m",
+    training_datasets={"LAION400M", "COYO700M"},
+)

--- a/mteb_mock_run_results.md
+++ b/mteb_mock_run_results.md
@@ -1,0 +1,43 @@
+# MTEB Mock-Run Results for `DeepGlint-AI/mlcd-vit-base-patch32-224`
+
+| Task | Modality | Pass | Reason |
+| --- | --- | --- | --- |
+| MockImageClassification | image | ✓ | - |
+| MockImageClustering | image | ✓ | - |
+| MockVisualSTS | image | ✓ | - |
+| MockImageMultilabelClassification | image | ✓ | - |
+| MockMultilingualImageClassification | image | ✓ | - |
+| MockImageClusteringFastTask | image | ✓ | - |
+| MockImageRegressionTask | image | ✓ | - |
+| MockPairImageClassificationTask | image | ✓ | - |
+
+## Summary by Modality
+
+| Pass    | Modality | Failures |
+| ------- | -------- | -------- |
+| skipped | text     |  |
+| ✓ (8/8) | image    |  |
+| skipped | audio    |  |
+| skipped | video    |  |
+
+# MTEB Mock-Run Results for `DeepGlint-AI/mlcd-vit-large-patch14-336`
+
+| Task | Modality | Pass | Reason |
+| --- | --- | --- | --- |
+| MockImageClassification | image | ✓ | - |
+| MockImageClustering | image | ✓ | - |
+| MockVisualSTS | image | ✓ | - |
+| MockImageMultilabelClassification | image | ✓ | - |
+| MockMultilingualImageClassification | image | ✓ | - |
+| MockImageClusteringFastTask | image | ✓ | - |
+| MockImageRegressionTask | image | ✓ | - |
+| MockPairImageClassificationTask | image | ✓ | - |
+
+## Summary by Modality
+
+| Pass    | Modality | Failures |
+| ------- | -------- | -------- |
+| skipped | text     |  |
+| ✓ (8/8) | image    |  |
+| skipped | audio    |  |
+| skipped | video    |  |


### PR DESCRIPTION
# Add MLCD vision encoders (ViT-B/32-224, ViT-L/14-336)

Resolves #2571.

Image-only encoders (Multi-Label Cluster Discrimination, arXiv:2407.17331). The checkpoints are CLIPVisionModel-compatible; embeddings are pooled CLS features after post_layernorm (768/1024-d). Note: the public checkpoints contain only the vision tower (no visual_projection / unicom embedding head), verified by weight inspection.

- [x] ModelMeta filled out (pinned revisions, dims, license, training data)
- [x] Loads via `mteb.get_model` / `mteb.get_model_meta`
- [x] Tested: mock_run 8/8 image tasks both models (report committed)
- [x] Public weights on HF (Apache-2.0)
- [ ] Reproduced results from the original paper — not possible: the authors' probe used a trained embedding head absent from the public release. Independent evaluation instead:

Official MTEB image classification, 5 exp × 16 samples/class, full 10k test, fp32. Size-matched CLIP baselines, identical pipeline:

| Task | MLCD base | CLIP base | MLCD large | CLIP large |
|---|---|---|---|---|
| CIFAR-10 | 94.29 | 90.10 | 98.28 | 95.44 |
| CIFAR-100 | 77.18 | 67.79 | 89.50 | 79.04 |

Paired bootstrap (10k draws, seed 20260907; Bonferroni 98.75% CIs): all four MLCD−CLIP comparisons above zero (CIFAR-10 +4.19/+2.84 pp; CIFAR-100 +9.39/+10.47 pp). Checkpoint comparisons, not an isolation of the training objective.
