### PR TITLE
dataset add ColDeRReranking benchmark

### DIFF
--- a/mteb/descriptive_stats/Reranking/ColDeRReranking.json
+++ b/mteb/descriptive_stats/Reranking/ColDeRReranking.json
@@ -1,0 +1,332 @@
+{
+    "test": {
+        "num_samples": 5250,
+        "num_queries": 1750,
+        "num_documents": 3500,
+        "number_of_characters": 2712992,
+        "documents_text_statistics": {
+            "total_text_length": 2637325,
+            "min_text_length": 38,
+            "average_text_length": 753.5214285714286,
+            "max_text_length": 2683,
+            "unique_texts": 3002
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 75667,
+            "min_text_length": 14,
+            "average_text_length": 43.238285714285716,
+            "max_text_length": 100,
+            "unique_texts": 1108
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 1750,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 1750,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": {
+            "num_top_ranked": 3500,
+            "min_top_ranked_per_query": 2,
+            "average_top_ranked_per_query": 2.0,
+            "max_top_ranked_per_query": 2
+        },
+        "hf_subset_descriptive_stats": {
+            "foil": {
+                "num_samples": 750,
+                "num_queries": 250,
+                "num_documents": 500,
+                "number_of_characters": 347424,
+                "documents_text_statistics": {
+                    "total_text_length": 335930,
+                    "min_text_length": 57,
+                    "average_text_length": 671.86,
+                    "max_text_length": 2207,
+                    "unique_texts": 418
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 11494,
+                    "min_text_length": 18,
+                    "average_text_length": 45.976,
+                    "max_text_length": 100,
+                    "unique_texts": 223
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 250,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 250,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": {
+                    "num_top_ranked": 500,
+                    "min_top_ranked_per_query": 2,
+                    "average_top_ranked_per_query": 2.0,
+                    "max_top_ranked_per_query": 2
+                }
+            },
+            "answer_importance": {
+                "num_samples": 750,
+                "num_queries": 250,
+                "num_documents": 500,
+                "number_of_characters": 353172,
+                "documents_text_statistics": {
+                    "total_text_length": 341674,
+                    "min_text_length": 93,
+                    "average_text_length": 683.348,
+                    "max_text_length": 1966,
+                    "unique_texts": 377
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 11498,
+                    "min_text_length": 18,
+                    "average_text_length": 45.992,
+                    "max_text_length": 100,
+                    "unique_texts": 221
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 250,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 250,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": {
+                    "num_top_ranked": 500,
+                    "min_top_ranked_per_query": 2,
+                    "average_top_ranked_per_query": 2.0,
+                    "max_top_ranked_per_query": 2
+                }
+            },
+            "brevity_bias": {
+                "num_samples": 750,
+                "num_queries": 250,
+                "num_documents": 500,
+                "number_of_characters": 322724,
+                "documents_text_statistics": {
+                    "total_text_length": 311270,
+                    "min_text_length": 38,
+                    "average_text_length": 622.54,
+                    "max_text_length": 2666,
+                    "unique_texts": 500
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 11454,
+                    "min_text_length": 21,
+                    "average_text_length": 45.816,
+                    "max_text_length": 92,
+                    "unique_texts": 250
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 250,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 250,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": {
+                    "num_top_ranked": 500,
+                    "min_top_ranked_per_query": 2,
+                    "average_top_ranked_per_query": 2.0,
+                    "max_top_ranked_per_query": 2
+                }
+            },
+            "literal_bias": {
+                "num_samples": 750,
+                "num_queries": 250,
+                "num_documents": 500,
+                "number_of_characters": 547219,
+                "documents_text_statistics": {
+                    "total_text_length": 539182,
+                    "min_text_length": 531,
+                    "average_text_length": 1078.364,
+                    "max_text_length": 2673,
+                    "unique_texts": 500
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 8037,
+                    "min_text_length": 14,
+                    "average_text_length": 32.148,
+                    "max_text_length": 76,
+                    "unique_texts": 250
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 250,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 250,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": {
+                    "num_top_ranked": 500,
+                    "min_top_ranked_per_query": 2,
+                    "average_top_ranked_per_query": 2.0,
+                    "max_top_ranked_per_query": 2
+                }
+            },
+            "poison": {
+                "num_samples": 750,
+                "num_queries": 250,
+                "num_documents": 500,
+                "number_of_characters": 380995,
+                "documents_text_statistics": {
+                    "total_text_length": 369501,
+                    "min_text_length": 99,
+                    "average_text_length": 739.002,
+                    "max_text_length": 2207,
+                    "unique_texts": 472
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 11494,
+                    "min_text_length": 18,
+                    "average_text_length": 45.976,
+                    "max_text_length": 100,
+                    "unique_texts": 223
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 250,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 250,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": {
+                    "num_top_ranked": 500,
+                    "min_top_ranked_per_query": 2,
+                    "average_top_ranked_per_query": 2.0,
+                    "max_top_ranked_per_query": 2
+                }
+            },
+            "position_bias": {
+                "num_samples": 750,
+                "num_queries": 250,
+                "num_documents": 500,
+                "number_of_characters": 550180,
+                "documents_text_statistics": {
+                    "total_text_length": 538720,
+                    "min_text_length": 572,
+                    "average_text_length": 1077.44,
+                    "max_text_length": 2683,
+                    "unique_texts": 500
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 11460,
+                    "min_text_length": 21,
+                    "average_text_length": 45.84,
+                    "max_text_length": 86,
+                    "unique_texts": 250
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 250,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 250,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": {
+                    "num_top_ranked": 500,
+                    "min_top_ranked_per_query": 2,
+                    "average_top_ranked_per_query": 2.0,
+                    "max_top_ranked_per_query": 2
+                }
+            },
+            "repetition_bias": {
+                "num_samples": 750,
+                "num_queries": 250,
+                "num_documents": 500,
+                "number_of_characters": 211278,
+                "documents_text_statistics": {
+                    "total_text_length": 201048,
+                    "min_text_length": 155,
+                    "average_text_length": 402.096,
+                    "max_text_length": 1016,
+                    "unique_texts": 500
+                },
+                "documents_image_statistics": null,
+                "documents_audio_statistics": null,
+                "documents_video_statistics": null,
+                "queries_text_statistics": {
+                    "total_text_length": 10230,
+                    "min_text_length": 18,
+                    "average_text_length": 40.92,
+                    "max_text_length": 78,
+                    "unique_texts": 250
+                },
+                "queries_image_statistics": null,
+                "queries_audio_statistics": null,
+                "queries_video_statistics": null,
+                "relevant_docs_statistics": {
+                    "num_relevant_docs": 250,
+                    "min_relevant_docs_per_query": 1,
+                    "average_relevant_docs_per_query": 1.0,
+                    "max_relevant_docs_per_query": 1,
+                    "unique_relevant_docs": 250,
+                    "num_missing_query_ids": 0,
+                    "num_missing_corpus_ids": 0
+                },
+                "top_ranked_statistics": {
+                    "num_top_ranked": 500,
+                    "min_top_ranked_per_query": 2,
+                    "average_top_ranked_per_query": 2.0,
+                    "max_top_ranked_per_query": 2
+                }
+            }
+        }
+    }
+}

--- a/mteb/tasks/reranking/eng/__init__.py
+++ b/mteb/tasks/reranking/eng/__init__.py
@@ -1,5 +1,6 @@
 from .ask_ubuntu_dup_questions import AskUbuntuDupQuestions
 from .built_bench_reranking import BuiltBenchReranking
+from .colder_reranking import ColDeRReranking
 from .ecommerce_product_relevance_reranking import ERESSReranking
 from .fs_dnoisy18k_audio_reranking import FSDnoisy18kAudioReranking
 from .hume_core17_instruction_reranking import HUMECore17InstructionReranking
@@ -33,6 +34,7 @@ from .xmod_bench import (
 __all__ = [
     "AskUbuntuDupQuestions",
     "BuiltBenchReranking",
+    "ColDeRReranking",
     "ERESSReranking",
     "FSDnoisy18kAudioReranking",
     "HUMECore17InstructionReranking",

--- a/mteb/tasks/reranking/eng/colder_reranking.py
+++ b/mteb/tasks/reranking/eng/colder_reranking.py
@@ -71,18 +71,18 @@ class ColDeRReranking(AbsTaskRetrieval):
         sample_creation="created",
         bibtex_citation=r"""
 @inproceedings{fayyaz-etal-2025-collapse,
-    title = "Collapse of Dense Retrievers: Short, Early, and Literal Biases Outranking Factual Evidence",
-    author = "Fayyaz, Mohsen  and
-      Modarressi, Ali  and
-      Schuetze, Hinrich  and
-      Peng, Nanyun",
-    booktitle = "Proceedings of the 63rd Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)",
-    month = jul,
-    year = "2025",
-    address = "Vienna, Austria",
-    publisher = "Association for Computational Linguistics",
-    url = "https://aclanthology.org/2025.acl-long.447/",
-    pages = "9136--9152",
+  address = {Vienna, Austria},
+  author = {Fayyaz, Mohsen  and
+Modarressi, Ali  and
+Schuetze, Hinrich  and
+Peng, Nanyun},
+  booktitle = {Proceedings of the 63rd Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)},
+  month = jul,
+  pages = {9136--9152},
+  publisher = {Association for Computational Linguistics},
+  title = {Collapse of Dense Retrievers: Short, Early, and Literal Biases Outranking Factual Evidence},
+  url = {https://aclanthology.org/2025.acl-long.447/},
+  year = {2025},
 }
 """,
         prompt={

--- a/mteb/tasks/reranking/eng/colder_reranking.py
+++ b/mteb/tasks/reranking/eng/colder_reranking.py
@@ -20,13 +20,15 @@ _SUBSETS = [
     "repetition_bias",
 ]
 
-# For each subset, specify which document is positive (contains factual evidence / unbiased control)
+# For each subset, select the candidate that should rank first.
 # foil: doc2 has evidence, doc1 is foil
 # poison: doc2 has true evidence, doc1 is poisoned
 # answer_importance: doc1 has evidence, doc2 has no evidence
-# brevity_bias, literal_bias, position_bias, repetition_bias:
-# doc1 is the biased variant, doc2 is the control
-_POSITIVE_DOC = {
+# In the four individual-bias subsets, both documents contain the answer. MTEB
+# needs a single target to score the pair, so doc2 is the less-biased control;
+# accuracy for those subsets measures resistance to the named bias rather than
+# ordinary relevance.
+_PREFERRED_DOC = {
     "foil": "doc2",
     "poison": "doc2",
     "answer_importance": "doc1",
@@ -45,7 +47,9 @@ class ColDeRReranking(AbsTaskRetrieval):
         description=(
             "ColDeR (Collapse of Dense Retrievers) evaluates retriever vulnerability to "
             "heuristic biases (brevity, position, repetition, literal matching) and failure "
-            "modes where biased non-evidence documents outrank factual evidence."
+            "modes where biased non-evidence documents outrank factual evidence. For "
+            "the individual-bias subsets where both candidates contain evidence, accuracy "
+            "measures preference for the less-biased control document."
         ),
         reference="https://arxiv.org/abs/2503.05037",
         dataset={
@@ -61,7 +65,7 @@ class ColDeRReranking(AbsTaskRetrieval):
         date=("2025-01-01", "2025-05-01"),
         domains=["Encyclopaedic", "Written"],
         task_subtypes=["Reasoning as Retrieval"],
-        license="cc-by-4.0",
+        license="not specified",
         annotations_creators="derived",
         dialect=[],
         sample_creation="created",
@@ -103,7 +107,7 @@ class ColDeRReranking(AbsTaskRetrieval):
             relevant_docs = {}
             top_ranked = {}
 
-            pos_choice = _POSITIVE_DOC[subset]
+            preferred_doc = _PREFERRED_DOC[subset]
 
             for i, row in enumerate(ds):
                 qid = f"{subset}_{i}"
@@ -114,8 +118,8 @@ class ColDeRReranking(AbsTaskRetrieval):
                 corpus.append({"id": doc1_id, "text": row["document_1"], "title": ""})
                 corpus.append({"id": doc2_id, "text": row["document_2"], "title": ""})
 
-                pos_id = doc1_id if pos_choice == "doc1" else doc2_id
-                relevant_docs[qid] = {pos_id: 1}
+                preferred_id = doc1_id if preferred_doc == "doc1" else doc2_id
+                relevant_docs[qid] = {preferred_id: 1}
                 top_ranked[qid] = [doc1_id, doc2_id]
 
             self.dataset[subset] = {

--- a/mteb/tasks/reranking/eng/colder_reranking.py
+++ b/mteb/tasks/reranking/eng/colder_reranking.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from datasets import Dataset, load_dataset
 
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
-
-logger = logging.getLogger(__name__)
 
 _SUBSETS = [
     "foil",

--- a/mteb/tasks/reranking/eng/colder_reranking.py
+++ b/mteb/tasks/reranking/eng/colder_reranking.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from datasets import Dataset, load_dataset
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.task_metadata import TaskMetadata
+
+logger = logging.getLogger(__name__)
+
+_SUBSETS = [
+    "foil",
+    "answer_importance",
+    "brevity_bias",
+    "literal_bias",
+    "poison",
+    "position_bias",
+    "repetition_bias",
+]
+
+# For each subset, specify which document is positive (contains factual evidence / unbiased control)
+# foil: doc2 has evidence, doc1 is foil
+# poison: doc2 has true evidence, doc1 is poisoned
+# answer_importance: doc1 has evidence, doc2 has no evidence
+# brevity_bias, literal_bias, position_bias, repetition_bias:
+# doc1 is the biased variant, doc2 is the control
+_POSITIVE_DOC = {
+    "foil": "doc2",
+    "poison": "doc2",
+    "answer_importance": "doc1",
+    "brevity_bias": "doc2",
+    "literal_bias": "doc2",
+    "position_bias": "doc2",
+    "repetition_bias": "doc2",
+}
+
+
+class ColDeRReranking(AbsTaskRetrieval):
+    """ColDeR: Collapse of Dense Retrievers - Short, Early, and Literal Biases Outranking Factual Evidence."""
+
+    metadata = TaskMetadata(
+        name="ColDeRReranking",
+        description=(
+            "ColDeR (Collapse of Dense Retrievers) evaluates retriever vulnerability to "
+            "heuristic biases (brevity, position, repetition, literal matching) and failure "
+            "modes where biased non-evidence documents outrank factual evidence."
+        ),
+        reference="https://arxiv.org/abs/2503.05037",
+        dataset={
+            "path": "mohsenfayyaz/ColDeR",
+            "revision": "368a695c5593f5ee7fdd741706caad8dcf4696ac",
+        },
+        type="Reranking",
+        category="t2t",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs={s: ["eng-Latn"] for s in _SUBSETS},
+        main_score="accuracy",
+        date=("2025-01-01", "2025-05-01"),
+        domains=["Encyclopaedic", "Written"],
+        task_subtypes=["Reasoning as Retrieval"],
+        license="cc-by-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="created",
+        bibtex_citation=r"""
+@inproceedings{fayyaz-etal-2025-collapse,
+    title = "Collapse of Dense Retrievers: Short, Early, and Literal Biases Outranking Factual Evidence",
+    author = "Fayyaz, Mohsen  and
+      Modarressi, Ali  and
+      Schuetze, Hinrich  and
+      Peng, Nanyun",
+    booktitle = "Proceedings of the 63rd Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)",
+    month = jul,
+    year = "2025",
+    address = "Vienna, Austria",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2025.acl-long.447/",
+    pages = "9136--9152",
+}
+""",
+        prompt={
+            "query": "Given a question, retrieve the document that provides the factual answer."
+        },
+    )
+
+    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
+        if self.data_loaded:
+            return
+
+        self.dataset = {}
+        for subset in self.hf_subsets:
+            ds = load_dataset(
+                self.metadata.dataset["path"],
+                data_files={"test": f"test/{subset}.jsonl"},
+                split="test",
+                revision=self.metadata.dataset.get("revision"),
+            )
+            queries = []
+            corpus = []
+            relevant_docs = {}
+            top_ranked = {}
+
+            pos_choice = _POSITIVE_DOC[subset]
+
+            for i, row in enumerate(ds):
+                qid = f"{subset}_{i}"
+                doc1_id = f"{qid}_doc1"
+                doc2_id = f"{qid}_doc2"
+
+                queries.append({"id": qid, "text": row["query"]})
+                corpus.append({"id": doc1_id, "text": row["document_1"], "title": ""})
+                corpus.append({"id": doc2_id, "text": row["document_2"], "title": ""})
+
+                pos_id = doc1_id if pos_choice == "doc1" else doc2_id
+                relevant_docs[qid] = {pos_id: 1}
+                top_ranked[qid] = [doc1_id, doc2_id]
+
+            self.dataset[subset] = {
+                "test": {
+                    "queries": Dataset.from_list(queries),
+                    "corpus": Dataset.from_list(corpus),
+                    "relevant_docs": relevant_docs,
+                    "top_ranked": top_ranked,
+                }
+            }
+
+        self.data_loaded = True

--- a/tests/test_tasks/test_task_quality.py
+++ b/tests/test_tasks/test_task_quality.py
@@ -459,7 +459,7 @@ KNOWN_ISSUES: dict[str, list[str]] = {
         "CodeSearchNetCCRetrieval",
         "CodeSearchNetRetrieval",
         "CodeTransOceanDL",
-        "ColDeRReranking",
+        "ColDeRReranking",  # controlled document pairs intentionally reuse text
         "Core17InstructionRetrieval",
         "CosQA",
         "CrisisMMDHumanitarianClassification",  # one tweet can pair with several separately annotated images

--- a/tests/test_tasks/test_task_quality.py
+++ b/tests/test_tasks/test_task_quality.py
@@ -459,6 +459,7 @@ KNOWN_ISSUES: dict[str, list[str]] = {
         "CodeSearchNetCCRetrieval",
         "CodeSearchNetRetrieval",
         "CodeTransOceanDL",
+        "ColDeRReranking",
         "Core17InstructionRetrieval",
         "CosQA",
         "CrisisMMDHumanitarianClassification",  # one tweet can pair with several separately annotated images


### PR DESCRIPTION
## Summary
Fixes #2709
This PR integrates **ColDeR** (*Collapse of Dense Retrievers: Short, Early, and Literal Biases Outranking Factual Evidence*, ACL 2025) as an MTEB Reranking task (`ColDeRReranking`).
ColDeR evaluates dense retrievers' vulnerability to heuristic biases (brevity, position, repetition, literal matching) and catastrophic failure modes where biased, non-evidence documents outrank factual evidence.
## Subsets Included (all 7 official configurations)
1. `foil` (Default / Leaderboard benchmark): synthetic foil document combining multiple biases without the answer vs. factual evidence embedded in unrelated context.
2. `poison`: GPT-4o poisoned hallucination vs. genuine evidence.
3. `answer_importance`: evidence with answer vs. leading sentence without answer.
4. `brevity_bias`: single evidence sentence vs. full document context.
5. `literal_bias`: exact literal match vs. variant entity name.
6. `position_bias`: beginning evidence vs. end evidence.
7. `repetition_bias`: repeated head mentions vs. control.

NOTE: For brevity, literal, position, and repetition bias subsets, both candidates contain factual evidence. The target is the less-biased control document, so accuracy measures resistance to the named retrieval bias rather than ordinary relevance.

## Benchmark Verification Results
- **Random Baseline** (`mteb/baseline-random-encoder` on `foil`): **46.00% accuracy** (close to 50% chance on binary document choice).
- **Dense Retriever Baseline** (`sentence-transformers/all-MiniLM-L6-v2` on `foil`): **0.40% accuracy** (replicates the finding in Table 4 of the ACL 2025 paper where retrievers favor the foil distractor 99.6% of the time).
## Checklist
- [x] Implemented `ColDeRReranking(AbsTaskRetrieval)` with `type="Reranking"`, `category="t2t"`, `modalities=["text"]`, `main_score="accuracy"`.
- [x] Exported in `mteb/tasks/reranking/eng/__init__.py`.
- [x] Generated official descriptive statistics via `calculate_descriptive_statistics()` saved to `mteb/descriptive_stats/Reranking/ColDeRReranking.json` (3,500 docs, 1,750 queries across all 7 subsets).
- [x] Code passes `ruff check` (0 errors) and `ruff format`.