### PR TITLE
fix: defer torch-backed re-exports in mteb.models

### DIFF
--- a/mteb/models/__init__.py
+++ b/mteb/models/__init__.py
@@ -1,6 +1,7 @@
-from .cache_wrappers import CacheBackendProtocol, CachedEmbeddingWrapper
-from .compression_wrappers import CompressionWrapper
-from .hybrid_wrappers import HybridSearch
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from .model_meta import ModelMeta
 from .models_protocols import (
     CrossEncoderProtocol,
@@ -8,21 +9,65 @@ from .models_protocols import (
     MTEBModels,
     SearchProtocol,
 )
-from .openai_wrappers import (
-    OpenAIAPIEncodeWrapper,
-    OpenAIAPIRerankWrapper,
-    OpenAIAPITokenEmbedWrapper,
-)
-from .search_encoder_index.search_backend_protocol import (
-    IndexEncoderSearchProtocol,
-)
-from .search_wrappers import SearchCrossEncoderWrapper, SearchEncoderWrapper
-from .sentence_transformer_wrapper import (
-    CrossEncoderWrapper,
-    SentenceTransformerEncoderWrapper,
-    SparseEncoderWrapper,
-    sentence_transformers_loader,
-)
+
+if TYPE_CHECKING:
+    from .cache_wrappers import CacheBackendProtocol, CachedEmbeddingWrapper
+    from .compression_wrappers import CompressionWrapper
+    from .hybrid_wrappers import HybridSearch
+    from .openai_wrappers import (
+        OpenAIAPIEncodeWrapper,
+        OpenAIAPIRerankWrapper,
+        OpenAIAPITokenEmbedWrapper,
+    )
+    from .search_encoder_index.search_backend_protocol import (
+        IndexEncoderSearchProtocol,
+    )
+    from .search_wrappers import SearchCrossEncoderWrapper, SearchEncoderWrapper
+    from .sentence_transformer_wrapper import (
+        CrossEncoderWrapper,
+        SentenceTransformerEncoderWrapper,
+        SparseEncoderWrapper,
+        sentence_transformers_loader,
+    )
+
+# Every wrapper below imports torch. Importing a submodule runs this `__init__` first, so eager
+# re-exports here put torch on the import path of anything touching `mteb.models` including
+# `mteb.abstasks`, and through it results analysis, the leaderboard and the API. Resolving them on
+# first access keeps that path torch-free while `from mteb.models import X` keeps working.
+_LAZY_ATTRIBUTES: dict[str, str] = {
+    "CacheBackendProtocol": ".cache_wrappers",
+    "CachedEmbeddingWrapper": ".cache_wrappers",
+    "CompressionWrapper": ".compression_wrappers",
+    "CrossEncoderWrapper": ".sentence_transformer_wrapper",
+    "HybridSearch": ".hybrid_wrappers",
+    "IndexEncoderSearchProtocol": ".search_encoder_index.search_backend_protocol",
+    "OpenAIAPIEncodeWrapper": ".openai_wrappers",
+    "OpenAIAPIRerankWrapper": ".openai_wrappers",
+    "OpenAIAPITokenEmbedWrapper": ".openai_wrappers",
+    "SearchCrossEncoderWrapper": ".search_wrappers",
+    "SearchEncoderWrapper": ".search_wrappers",
+    "SentenceTransformerEncoderWrapper": ".sentence_transformer_wrapper",
+    "SparseEncoderWrapper": ".sentence_transformer_wrapper",
+    "sentence_transformers_loader": ".sentence_transformer_wrapper",
+}
+
+
+def __getattr__(name: str) -> object:
+    """Import the wrapper modules on first access rather than at package import time."""
+    module_name = _LAZY_ATTRIBUTES.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    from importlib import import_module
+
+    value = getattr(import_module(module_name, __name__), name)
+    globals()[name] = value  # cache it, so later lookups skip __getattr__ entirely
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)
+
 
 __all__ = [
     "CacheBackendProtocol",

--- a/tests/test_ensure_no_torch_at_import.py
+++ b/tests/test_ensure_no_torch_at_import.py
@@ -14,7 +14,7 @@ import textwrap
 
 _REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 
-# `mteb/__init__.py` (and `mteb/models/__init__.py`) still pull torch in, so importing a submodule
+# `mteb/__init__.py` still pulls torch in, so importing a submodule
 # normally drags it along transitively. Stubbing the parent packages in `sys.modules` lets us
 # import the submodule on its own. Once those packages are lazy too this can become `import mteb`.
 _PREAMBLE = """
@@ -165,3 +165,58 @@ def test_set_seed_works_without_torch(monkeypatch) -> None:
     rng, np_rng = seed_module._set_seed(42)
     assert rng.random() == random.Random(42).random()
     assert np_rng is not None
+
+
+def test_importing_models_package_does_not_import_torch() -> None:
+    """`mteb.models` re-exports torch-backed wrappers, but must not load them to be imported."""
+    assert _loaded_heavy_deps("mteb.models", ("mteb",)) == [], (
+        "importing mteb.models pulled in a heavy dependency; add the re-export to "
+        "_LAZY_ATTRIBUTES in mteb/models/__init__.py instead of importing it eagerly"
+    )
+
+
+def test_importing_abstask_does_not_import_torch() -> None:
+    """`AbsTask` carries task metadata, so describing tasks must not require torch."""
+    assert (
+        _loaded_heavy_deps("mteb.abstasks.abstask", ("mteb", "mteb.abstasks")) == []
+    ), "importing mteb.abstasks.abstask pulled in a heavy dependency"
+
+
+def test_lazy_model_reexports_match_direct_imports() -> None:
+    """Every deferred name must resolve to exactly the object the submodule defines."""
+    output = _run(
+        "mteb.models",
+        ("mteb",),
+        """
+        from importlib import import_module
+
+        import mteb.models as models
+
+        mismatched = [
+            name
+            for name, module in models._LAZY_ATTRIBUTES.items()
+            if getattr(models, name) is not getattr(import_module(module, "mteb.models"), name)
+        ]
+        print(mismatched)
+        print(sorted(models.__all__) == sorted(dir(models)))
+        print(all(hasattr(models, name) for name in models.__all__))
+        """,
+    )
+    assert output.splitlines() == ["[]", "True", "True"]
+
+
+def test_unknown_model_attribute_raises_attribute_error() -> None:
+    """The lazy loader must not turn typos into ImportErrors or silent Nones."""
+    output = _run(
+        "mteb.models",
+        ("mteb",),
+        """
+        import mteb.models as models
+
+        try:
+            models.NoSuchWrapper
+        except AttributeError as exc:
+            print(exc)
+        """,
+    )
+    assert output == "module 'mteb.models' has no attribute 'NoSuchWrapper'"


### PR DESCRIPTION
Third PR in the series making mteb importable without torch. Refs #5063. Follows #5329, #5350.

#### The problem: ####
`mteb/abstasks/abstask.py` needs three protocols (EncoderProtocol, CrossEncoderProtocol, SearchProtocol) for `isinstance` checks. They live in `mteb/models/models_protocols.py,` which is already torch-free; but importing them pulled in torch anyway, putting it on the import path of `AbsTask` and everything downstream `(task_result,` `benchmark,` `result_cache).`

My first attempt was to import from the submodule directly rather than the package. But importing `mteb.models.models_protocols` still executes `mteb/models/__init__.py` first. That's why the fix has to live in the `__init__` itself, and required module-level `__getattr__` mechanism: there is no import-site workaround, and the only alternative is dropping the re-exports, which breaks the public API across the 91 files that `import from mteb.models`.

#### The change: ####
ModelMeta and the protocols stay eager and both are torch-free. 6 torch-backed wrapper modules are listed in `_LAZY_ATTRIBUTES` and resolved on first access by `__getattr__,` which caches into globals() so each name pays the lookup once. `__all__` is unchanged.  Result is `mteb.abstasks.abstask's` own dependency closure drops from 3061 to 2313 modules, with torch no longer among them.

`import mteb `is unchanged, and to be clear: no user sees a speedup from this yet. `mteb/__init__.py` is still eager, so importing any mteb submodule today still loads torch and all ~6800 modules. This is a prerequisite step, as were PRs 1 and 2. `task_result` and `benchmark` are still not clean either — they import mteb.abstasks, whose __init__ pulls in every AbsTask subclass, and those import `_evaluators` / `_create_dataloaders` at module scope. That's the next PR.

#### Testing:  ####
Four new tests added all confirmed to fail when one eager wrapper import is restored.