### PR TITLE
fix: handle experiments in embedding cache

### DIFF
--- a/mteb/evaluate.py
+++ b/mteb/evaluate.py
@@ -24,7 +24,7 @@ from mteb.models.sentence_transformer_wrapper import (
 from mteb.results import ModelResult, TaskResult
 from mteb.results.task_result import TaskError
 from mteb.timing import TimingStack
-from mteb.types import PromptType
+from mteb.types import OutputDType, PromptType
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -93,6 +93,32 @@ def _sanitize_model(
     return wrapped_model, meta, model_name, model_revision
 
 
+def _apply_precision_to_meta(meta: ModelMeta, encode_kwargs: EncodeKwargs) -> ModelMeta:
+    """Fold a ``precision`` encode kwarg into the model metadata's ``experiment_kwargs``.
+
+    ``precision`` is forwarded to ``encode`` and changes the dtype of the produced
+    embeddings, so an evaluation that sets it must not share a cache namespace with the
+    default float run (or with a run using a different precision). Deriving
+    ``output_dtypes`` here -- before the cache lookup -- keeps the lookup and the
+    subsequent save consistent, instead of updating the metadata inside ``encode()``
+    after the lookup has already happened.
+    """
+    precision = encode_kwargs.get("precision")
+    if precision is None:
+        return meta
+
+    output_dtype = OutputDType.from_str(precision)
+    experiment_kwargs = dict(meta.experiment_kwargs) if meta.experiment_kwargs else {}
+    if experiment_kwargs.get("output_dtypes") == output_dtype.value:
+        return meta
+
+    experiment_kwargs["output_dtypes"] = output_dtype.value
+    logger.warning(
+        f"The 'precision' argument passed in encode_kwargs is setting output_dtypes to {output_dtype.value}."
+    )
+    return meta.model_copy(update={"experiment_kwargs": experiment_kwargs}, deep=True)
+
+
 def _evaluate_task(  # noqa: PLR0913, PLR0914
     model: MTEBModels,
     task: AbsTask,
@@ -106,6 +132,7 @@ def _evaluate_task(  # noqa: PLR0913, PLR0914
     num_proc: int | None = None,
     timer: TimingStack | None = None,
     existing_results: TaskResult | None = None,
+    model_meta: ModelMeta | None = None,
 ) -> TaskResult | TaskError:
     """The core logic to run a model on a given task. See `evaluate` for more details.
 
@@ -142,6 +169,7 @@ def _evaluate_task(  # noqa: PLR0913, PLR0914
                 cache=cache,
                 num_proc=num_proc,
                 existing_results=existing_results,
+                model_meta=model_meta,
             )
         if isinstance(result, TaskResult):
             existing_co2_val = (
@@ -157,7 +185,8 @@ def _evaluate_task(  # noqa: PLR0913, PLR0914
     task_results: dict[SplitName, dict[HFSubset, ScoresDict]] = {}
     evaluation_time: float = 0.0
 
-    model_meta = model.mteb_model_meta
+    if model_meta is None:
+        model_meta = model.mteb_model_meta
 
     existing_co2 = existing_results.kg_co2_emissions if existing_results else None
     if existing_results is not None:
@@ -507,6 +536,7 @@ def evaluate(  # noqa: PLR0913, PLR0914
         )
 
     model, meta, model_name, model_revision = _sanitize_model(model)
+    meta = _apply_precision_to_meta(meta, encode_kwargs)
     _check_model_modalities(meta, tasks)
     overwrite_strategy = OverwriteStrategy.from_str(overwrite_strategy)
 
@@ -640,6 +670,7 @@ def evaluate(  # noqa: PLR0913, PLR0914
                 cache=cache,
                 num_proc=num_proc,
                 existing_results=existing_results,
+                model_meta=meta,
             )
         except Exception as e:
             logger.error(
@@ -658,6 +689,7 @@ def evaluate(  # noqa: PLR0913, PLR0914
             cache=cache,
             num_proc=num_proc,
             existing_results=existing_results,
+            model_meta=meta,
         )
     logger.info(f"✓ Finished evaluation for {task.metadata.name}")
 

--- a/mteb/models/cache_wrappers/cache_wrapper.py
+++ b/mteb/models/cache_wrappers/cache_wrapper.py
@@ -10,6 +10,10 @@ from datasets import Dataset
 
 from mteb._create_dataloaders import create_dataloader
 from mteb.models.cache_wrappers.cache_backends.numpy_cache import NumpyCache
+from mteb.models.model_meta import _serialize_experiment_kwargs_to_name
+from mteb.types import OutputDType
+
+_EXPERIMENTS_FOLDER_NAME = "experiments"
 
 if TYPE_CHECKING:
     from torch.utils.data import DataLoader
@@ -93,7 +97,7 @@ class CachedEmbeddingWrapper:
         """
         task_name = task_metadata.name
         try:
-            cache = self._get_or_create_cache(task_name, prompt_type)
+            cache = self._get_or_create_cache(task_name, prompt_type, kwargs)
 
             uncached_items: list[dict[str, Any]] = []
             uncached_indices: list[int] = []
@@ -151,21 +155,49 @@ class CachedEmbeddingWrapper:
             logger.error(f"Error in cached encoding: {str(e)}")
             raise
 
+    def _experiment_name(self, encode_kwargs: dict[str, Any]) -> str | None:
+        """Serialize the settings that change the produced embeddings into a directory name.
+
+        This mirrors the experiment namespacing used by the result cache so that, e.g.,
+        an evaluation run with ``encode_kwargs={"precision": "int8"}`` does not reuse (or
+        overwrite) the cached float embeddings of the default run. Both ablation
+        parameters carried on the wrapped model's ``experiment_kwargs`` and a
+        ``precision`` encode kwarg are taken into account.
+        """
+        experiment_kwargs: dict[str, Any] = {}
+        meta = self.mteb_model_meta
+        if meta is not None and meta.experiment_kwargs:
+            experiment_kwargs.update(meta.experiment_kwargs)
+
+        precision = encode_kwargs.get("precision")
+        if precision is not None:
+            experiment_kwargs["output_dtypes"] = OutputDType.from_str(precision).value
+
+        return _serialize_experiment_kwargs_to_name(experiment_kwargs or None)
+
     def _get_or_create_cache(
-        self, task_name: str, prompt_type: PromptType | None
+        self,
+        task_name: str,
+        prompt_type: PromptType | None,
+        encode_kwargs: dict[str, Any] | None = None,
     ) -> CacheBackendProtocol:
-        """Get or create cache for a specific task and prompt type.
+        """Get or create cache for a specific task, prompt type and experiment.
 
         Args:
             task_name: Name of the task
             prompt_type: Prompt role used to encode the inputs
+            encode_kwargs: Keyword arguments forwarded to the wrapped model's ``encode``.
+                Settings that change the embeddings (e.g. ``precision``) namespace the cache.
 
         Returns:
             Cache backend instance for the task
         """
-        cache_key = (task_name, prompt_type)
+        experiment_name = self._experiment_name(encode_kwargs or {})
+        cache_key = (task_name, prompt_type, experiment_name)
         if cache_key not in self.cache_dict:
             cache_path = self.cache_path / task_name
+            if experiment_name is not None:
+                cache_path = cache_path / _EXPERIMENTS_FOLDER_NAME / experiment_name
             if prompt_type is not None:
                 cache_path /= prompt_type.value
             cache = self.cache_backend(cache_path)

--- a/mteb/models/instruct_wrapper.py
+++ b/mteb/models/instruct_wrapper.py
@@ -10,7 +10,7 @@ from tqdm.auto import tqdm
 from typing_extensions import deprecated
 
 from mteb._requires_package import _is_package_available
-from mteb.types import OutputDType, PromptType
+from mteb.types import PromptType
 
 from .abs_encoder import AbsEncoder
 
@@ -271,23 +271,6 @@ class InstructSentenceTransformerModel(AbsEncoder):
             The encoded input in a numpy array or torch tensor of the shape (Number of sentences) x (Embedding dimension).
         """
         instruction: str | None = self.get_task_instruction(task_metadata, prompt_type)
-
-        if "precision" in kwargs and self.mteb_model_meta is not None:
-            existing_experiment_kwargs = self.mteb_model_meta.experiment_kwargs
-            output_dtype = OutputDType.from_str(kwargs["precision"])
-            if existing_experiment_kwargs is not None:
-                existing_experiment_kwargs["output_dtypes"] = output_dtype  # type: ignore[index]
-            else:
-                existing_experiment_kwargs = {"output_dtypes": output_dtype.value}
-            logger.warning(
-                f"The 'precision' argument passed in encode_kwargs setting output_dtypes to {output_dtype.value}."
-            )
-            self.mteb_model_meta = self.mteb_model_meta.model_copy(
-                update={
-                    "experiment_kwargs": existing_experiment_kwargs,
-                },
-                deep=True,
-            )
 
         # to passage prompts won't be applied to passages
         if (

--- a/mteb/models/sentence_transformer_wrapper.py
+++ b/mteb/models/sentence_transformer_wrapper.py
@@ -12,7 +12,7 @@ from typing_extensions import deprecated
 
 from mteb._log_once import LogOnce
 from mteb.models import ModelMeta
-from mteb.types import OutputDType, PromptType
+from mteb.types import PromptType
 
 from .abs_encoder import AbsEncoder, get_prompt_name
 
@@ -363,23 +363,6 @@ class SentenceTransformerEncoderWrapper(AbsEncoder):
         Returns:
             The encoded sentences.
         """
-        if "precision" in kwargs:
-            existing_experiment_kwargs = self.mteb_model_meta.experiment_kwargs
-            output_dtype = OutputDType.from_str(kwargs["precision"])
-            if existing_experiment_kwargs is not None:
-                existing_experiment_kwargs["output_dtypes"] = output_dtype  # type: ignore[index]
-            else:
-                existing_experiment_kwargs = {"output_dtypes": output_dtype.value}
-            logger.warning(
-                f"The 'precision' argument passed in encode_kwargs setting output_dtypes to {output_dtype.value}."
-            )
-            self.mteb_model_meta = self.mteb_model_meta.model_copy(
-                update={
-                    "experiment_kwargs": existing_experiment_kwargs,
-                },
-                deep=True,
-            )
-
         prompt = _resolve_prompt(self.model_prompts, task_metadata, prompt_type)
 
         is_multimodal = _setup_modality_collator(

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -492,14 +492,38 @@ def test_mrl_unsupported_dim():
         )
 
 
-def test_precision_arg():
-    model = SentenceTransformerEncoderWrapper(MockSentenceTransformer())
-    task = MockRetrievalTask()
-    mteb.evaluate(model, task, cache=None, encode_kwargs={"precision": "float16"})
+def test_precision_arg(tmp_path: Path):
+    """A ``precision`` encode kwarg is recorded as ``output_dtypes`` before the cache
+    lookup, so precision-specific runs live in their own experiment namespace and do
+    not reuse (or overwrite) the default cached result.
 
-    assert (
-        model.mteb_model_meta.experiment_kwargs["output_dtypes"] == OutputDType.FLOAT16
+    Regression test for https://github.com/embeddings-benchmark/mteb/issues/5394
+    """
+    model = SentenceTransformerEncoderWrapper(MockSentenceTransformer())
+    task = MockClassificationTask()
+    cache = ResultCache(tmp_path)
+
+    mteb.evaluate(model, task, cache=cache, encode_kwargs={"precision": "int8"})
+
+    default_path = (
+        tmp_path
+        / "results"
+        / model.mteb_model_meta.model_name_as_path()
+        / model.mteb_model_meta.revision
+        / f"{task.metadata.name}.json"
     )
+    experiment_path = (
+        default_path.parent / "experiments" / "output_dtypes_int8" / default_path.name
+    )
+    assert not default_path.exists()
+    assert experiment_path.exists()
+
+    saved_meta = json.loads((experiment_path.parent / "model_meta.json").read_text())
+    assert saved_meta["experiment_kwargs"]["output_dtypes"] == OutputDType.INT8
+
+    # a later default evaluation must not reuse the quantized result
+    mteb.evaluate(model, task, cache=cache)
+    assert default_path.exists()
 
 
 @pytest.mark.parametrize("task", MOCK_MAEB_TASK_GRID)

--- a/tests/test_models/test_cached_embedding_wrapper.py
+++ b/tests/test_models/test_cached_embedding_wrapper.py
@@ -286,6 +286,49 @@ class TestCachedEmbeddingWrapper:
         np.testing.assert_allclose(cached_document_embeddings, document_embeddings)
         assert model.call_count == 2
 
+    def test_cache_isolated_by_experiment(self, cache_dir: Path):
+        """Runs that produce different embeddings (e.g. a ``precision`` encode kwarg)
+        must not share the embedding cache with the default run.
+
+        Regression test for https://github.com/embeddings-benchmark/mteb/issues/5394
+        """
+        model = DummyModel("test_model", revision=None)
+        wrapped_model = CachedEmbeddingWrapper(model, cache_dir)
+        task_metadata = MockRetrievalTask().metadata
+        inputs = DataLoader(
+            Dataset.from_dict({"id": ["1"], "title": [""], "text": ["same input"]})
+        )
+
+        def cached_encode(**kwargs: Any):
+            return wrapped_model.encode(
+                inputs,
+                task_metadata=task_metadata,
+                hf_subset="default",
+                hf_split="test",
+                **kwargs,
+            )
+
+        try:
+            default_embeddings = cached_encode()
+            int8_embeddings = cached_encode(precision="int8")
+            cached_default = cached_encode()
+            cached_int8 = cached_encode(precision="int8")
+        finally:
+            wrapped_model.close()
+
+        # the int8 run re-encoded instead of reusing the default cache entry
+        assert model.call_count == 2
+        np.testing.assert_allclose(cached_default, default_embeddings)
+        np.testing.assert_allclose(cached_int8, int8_embeddings)
+        assert (cache_dir / task_metadata.name / "vectors.npy").exists()
+        assert (
+            cache_dir
+            / task_metadata.name
+            / "experiments"
+            / "output_dtypes_int8"
+            / "vectors.npy"
+        ).exists()
+
 
 @pytest.mark.parametrize(
     ("task", "model"),


### PR DESCRIPTION
Close https://github.com/embeddings-benchmark/mteb/issues/5394

`CachedEmbeddingWrapper` didn't namespace its cache by experiment (e.g. `precision`), so an `int8` run could reuse or overwrite the cached embeddings of the default float run.

`_experiment_name()` now folds `precision` into the cache path before the cache is opened, matching how the result cache namespaces experiments.