### PR TITLE
fix: isolate precision-specific result caches

### DIFF
--- a/mteb/evaluate.py
+++ b/mteb/evaluate.py
@@ -16,6 +16,7 @@ from mteb.abstasks.abstask import AbsTask
 from mteb.abstasks.aggregated_task import AbsTaskAggregate
 from mteb.benchmarks.benchmark import Benchmark
 from mteb.cache import ResultCache
+from mteb.models._evaluation_meta import resolve_evaluation_model_meta
 from mteb.models.model_meta import ModelMeta
 from mteb.models.sentence_transformer_wrapper import (
     CrossEncoderWrapper,
@@ -95,6 +96,7 @@ def _sanitize_model(
 
 def _evaluate_task(  # noqa: PLR0913, PLR0914
     model: MTEBModels,
+    model_meta: ModelMeta,
     task: AbsTask,
     *,
     splits: dict[SplitName, list[HFSubset]],
@@ -133,6 +135,7 @@ def _evaluate_task(  # noqa: PLR0913, PLR0914
         ) as tracker:
             result = _evaluate_task(
                 model,
+                model_meta,
                 task,
                 splits=splits,
                 encode_kwargs=encode_kwargs,
@@ -156,8 +159,6 @@ def _evaluate_task(  # noqa: PLR0913, PLR0914
 
     task_results: dict[SplitName, dict[HFSubset, ScoresDict]] = {}
     evaluation_time: float = 0.0
-
-    model_meta = model.mteb_model_meta
 
     existing_co2 = existing_results.kg_co2_emissions if existing_results else None
     if existing_results is not None:
@@ -507,6 +508,7 @@ def evaluate(  # noqa: PLR0913, PLR0914
         )
 
     model, meta, model_name, model_revision = _sanitize_model(model)
+    meta = resolve_evaluation_model_meta(meta, encode_kwargs)
     _check_model_modalities(meta, tasks)
     overwrite_strategy = OverwriteStrategy.from_str(overwrite_strategy)
 
@@ -631,6 +633,7 @@ def evaluate(  # noqa: PLR0913, PLR0914
         try:
             result = _evaluate_task(
                 model=model,
+                model_meta=meta,
                 splits=missing_eval,
                 task=task,
                 co2_tracker=co2_tracker,
@@ -649,6 +652,7 @@ def evaluate(  # noqa: PLR0913, PLR0914
     else:
         result = _evaluate_task(
             model=model,
+            model_meta=meta,
             splits=missing_eval,
             task=task,
             co2_tracker=co2_tracker,

--- a/mteb/models/_evaluation_meta.py
+++ b/mteb/models/_evaluation_meta.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from mteb.models.model_meta import ModelMeta
+from mteb.types import EncodeKwargs
+
+EvaluationMetaResolver = Callable[[ModelMeta, EncodeKwargs], ModelMeta]
+EvaluationMetaPredicate = Callable[[ModelMeta], bool]
+
+_EVALUATION_META_RESOLVERS: list[
+    tuple[EvaluationMetaPredicate, EvaluationMetaResolver]
+] = []
+
+
+def register_evaluation_meta_resolver(
+    applies: EvaluationMetaPredicate, resolver: EvaluationMetaResolver
+) -> None:
+    """Register a model backend's evaluation metadata resolver."""
+    _EVALUATION_META_RESOLVERS.append((applies, resolver))
+
+
+def resolve_evaluation_model_meta(
+    meta: ModelMeta, encode_kwargs: EncodeKwargs
+) -> ModelMeta:
+    """Resolve cache-relevant metadata before an evaluation starts."""
+    resolved_meta = meta
+    for applies, resolver in _EVALUATION_META_RESOLVERS:
+        if applies(meta):
+            resolved_meta = resolver(resolved_meta, encode_kwargs)
+    return resolved_meta

--- a/mteb/models/instruct_wrapper.py
+++ b/mteb/models/instruct_wrapper.py
@@ -10,7 +10,7 @@ from tqdm.auto import tqdm
 from typing_extensions import deprecated
 
 from mteb._requires_package import _is_package_available
-from mteb.types import OutputDType, PromptType
+from mteb.types import PromptType
 
 from .abs_encoder import AbsEncoder
 
@@ -271,23 +271,6 @@ class InstructSentenceTransformerModel(AbsEncoder):
             The encoded input in a numpy array or torch tensor of the shape (Number of sentences) x (Embedding dimension).
         """
         instruction: str | None = self.get_task_instruction(task_metadata, prompt_type)
-
-        if "precision" in kwargs and self.mteb_model_meta is not None:
-            existing_experiment_kwargs = self.mteb_model_meta.experiment_kwargs
-            output_dtype = OutputDType.from_str(kwargs["precision"])
-            if existing_experiment_kwargs is not None:
-                existing_experiment_kwargs["output_dtypes"] = output_dtype  # type: ignore[index]
-            else:
-                existing_experiment_kwargs = {"output_dtypes": output_dtype.value}
-            logger.warning(
-                f"The 'precision' argument passed in encode_kwargs setting output_dtypes to {output_dtype.value}."
-            )
-            self.mteb_model_meta = self.mteb_model_meta.model_copy(
-                update={
-                    "experiment_kwargs": existing_experiment_kwargs,
-                },
-                deep=True,
-            )
 
         # to passage prompts won't be applied to passages
         if (

--- a/mteb/models/model_implementations/qwen3_models.py
+++ b/mteb/models/model_implementations/qwen3_models.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from mteb.models.instruct_wrapper import InstructSentenceTransformerModel
 from mteb.models.model_meta import ModelMeta
+from mteb.models.sentence_transformer_wrapper import sentence_transformers_model_loader
 from mteb.types import PromptType
 
 if TYPE_CHECKING:
@@ -121,6 +122,7 @@ training_data = {
 }
 
 
+@sentence_transformers_model_loader
 def q3e_instruct_loader(
     model_name_or_path: str, revision: str, **kwargs: Any
 ) -> EncoderProtocol:

--- a/mteb/models/model_implementations/samilpwc_models.py
+++ b/mteb/models/model_implementations/samilpwc_models.py
@@ -3,6 +3,7 @@ from typing import Any
 from mteb.models.instruct_wrapper import InstructSentenceTransformerModel
 from mteb.models.model_implementations.e5_models import ME5_TRAINING_DATA
 from mteb.models.model_meta import ModelMeta
+from mteb.models.sentence_transformer_wrapper import sentence_transformers_model_loader
 from mteb.types import PromptType
 
 SAMILPWC_GENAI_TRAINING_DATA = {
@@ -30,6 +31,7 @@ def instruction_template(
     return INSTRUCTION.format(instruction=instruction)
 
 
+@sentence_transformers_model_loader
 def instruct_loader(*args: Any, **kwargs: Any) -> InstructSentenceTransformerModel:
     model = InstructSentenceTransformerModel(*args, **kwargs)
     encoder = model.model._first_module()

--- a/mteb/models/sentence_transformer_wrapper.py
+++ b/mteb/models/sentence_transformer_wrapper.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import logging
 import warnings
-from typing import TYPE_CHECKING, Any, cast
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 import numpy as np
 import torch
@@ -12,13 +13,12 @@ from typing_extensions import deprecated
 
 from mteb._log_once import LogOnce
 from mteb.models import ModelMeta
-from mteb.types import OutputDType, PromptType
+from mteb.models._evaluation_meta import register_evaluation_meta_resolver
+from mteb.types import PromptType
 
 from .abs_encoder import AbsEncoder, get_prompt_name
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from sentence_transformers import CrossEncoder, SentenceTransformer
     from sentence_transformers.sparse_encoder import SparseEncoder
     from torch.utils.data import DataLoader
@@ -30,6 +30,53 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 SENTENCE_TRANSFORMERS_QUERY_ENCODE_VERSION = "5.0.0"
+ModelLoaderT = TypeVar("ModelLoaderT", bound=Callable[..., Any])
+
+
+def sentence_transformers_model_loader(loader: ModelLoaderT) -> ModelLoaderT:
+    """Mark an opaque loader as returning a Sentence Transformers model."""
+    loader._mteb_sentence_transformers_loader = True  # type: ignore[attr-defined]
+    return loader
+
+
+def _resolve_sentence_transformer_evaluation_meta(
+    meta: ModelMeta, encode_kwargs: EncodeKwargs
+) -> ModelMeta:
+    precision = encode_kwargs.get("precision")
+    if precision is None:
+        return meta
+
+    experiment_kwargs = dict(meta.experiment_kwargs or {})
+    experiment_kwargs["output_dtypes"] = precision
+    logger.warning(
+        f"The 'precision' argument passed in encode_kwargs setting output_dtypes to {precision}."
+    )
+    return meta.model_copy(
+        update={"experiment_kwargs": experiment_kwargs},
+        deep=True,
+    )
+
+
+def _uses_sentence_transformers(meta: ModelMeta) -> bool:
+    loader = getattr(meta.loader, "func", meta.loader)
+    if loader is sentence_transformers_loader or getattr(
+        loader, "_mteb_sentence_transformers_loader", False
+    ):
+        return True
+    if not isinstance(loader, type):
+        return False
+
+    from mteb.models.instruct_wrapper import InstructSentenceTransformerModel
+
+    return issubclass(
+        loader,
+        (SentenceTransformerEncoderWrapper, InstructSentenceTransformerModel),
+    )
+
+
+register_evaluation_meta_resolver(
+    _uses_sentence_transformers, _resolve_sentence_transformer_evaluation_meta
+)
 
 
 @deprecated(
@@ -363,23 +410,6 @@ class SentenceTransformerEncoderWrapper(AbsEncoder):
         Returns:
             The encoded sentences.
         """
-        if "precision" in kwargs:
-            existing_experiment_kwargs = self.mteb_model_meta.experiment_kwargs
-            output_dtype = OutputDType.from_str(kwargs["precision"])
-            if existing_experiment_kwargs is not None:
-                existing_experiment_kwargs["output_dtypes"] = output_dtype  # type: ignore[index]
-            else:
-                existing_experiment_kwargs = {"output_dtypes": output_dtype.value}
-            logger.warning(
-                f"The 'precision' argument passed in encode_kwargs setting output_dtypes to {output_dtype.value}."
-            )
-            self.mteb_model_meta = self.mteb_model_meta.model_copy(
-                update={
-                    "experiment_kwargs": existing_experiment_kwargs,
-                },
-                deep=True,
-            )
-
         prompt = _resolve_prompt(self.model_prompts, task_metadata, prompt_type)
 
         is_multimodal = _setup_modality_collator(

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -5,6 +5,7 @@ from importlib.metadata import version
 from pathlib import Path
 from typing import Any
 
+import numpy as np
 import pytest
 from datasets.exceptions import DatasetNotFoundError
 
@@ -26,9 +27,9 @@ from mteb.mocks.mock_tasks import (
 )
 from mteb.models import ModelMeta
 from mteb.models.models_protocols import EncoderProtocol
+from mteb.models.sentence_transformer_wrapper import sentence_transformers_model_loader
 from mteb.results.task_result import TaskResult
 from mteb.timing import TimingStack
-from mteb.types import OutputDType
 from tests.mock_models import MockSentenceTransformer
 
 mock_classification = (MockSentenceTransformer(), MockClassificationTask(), 1)
@@ -492,13 +493,64 @@ def test_mrl_unsupported_dim():
         )
 
 
-def test_precision_arg():
-    model = SentenceTransformerEncoderWrapper(MockSentenceTransformer())
-    task = MockRetrievalTask()
-    mteb.evaluate(model, task, cache=None, encode_kwargs={"precision": "float16"})
+def test_precision_uses_separate_result_cache(tmp_path: Path):
+    encode_calls = 0
 
-    assert (
-        model.mteb_model_meta.experiment_kwargs["output_dtypes"] == OutputDType.FLOAT16
+    class PrecisionAwareMockModel(MockSentenceTransformer):
+        def encode(self, inputs, precision="float32", **kwargs: Any):
+            nonlocal encode_calls
+            encode_calls += 1
+            if precision == "int8":
+                return np.zeros((len(inputs), 1))
+            return np.array([["another" in text] for text in inputs])
+
+    @sentence_transformers_model_loader
+    def load_precision_aware_model(*args: Any, **kwargs: Any):
+        return SentenceTransformerEncoderWrapper(PrecisionAwareMockModel())
+
+    model = ModelMeta.create_empty(
+        overwrites={
+            "name": "mock/precision-aware-model",
+            "revision": "test",
+            "loader": load_precision_aware_model,
+        }
+    )
+    task = MockClassificationTask()
+    cache = ResultCache(tmp_path)
+
+    def run(precision: str | None = None):
+        encode_kwargs = {"precision": precision} if precision else None
+        return mteb.evaluate(
+            model,
+            task,
+            cache=cache,
+            co2_tracker=False,
+            encode_kwargs=encode_kwargs,
+        )[0]
+
+    int8_result = run("int8")
+    calls_after_int8 = encode_calls
+    default_result = run()
+
+    assert encode_calls > calls_after_int8
+    assert int8_result.get_score() != default_result.get_score()
+
+    calls_after_uncached_runs = encode_calls
+    assert run("int8").get_score() == int8_result.get_score()
+    assert run().get_score() == default_result.get_score()
+
+    assert encode_calls == calls_after_uncached_runs
+
+
+@pytest.mark.parametrize("precision", ["float32", "ubinary"])
+def test_sentence_transformer_supported_precision(precision: str):
+    model = SentenceTransformerEncoderWrapper(MockSentenceTransformer())
+    mteb.evaluate(
+        model,
+        MockClassificationTask(),
+        cache=None,
+        co2_tracker=False,
+        encode_kwargs={"precision": precision},
     )
 
 


### PR DESCRIPTION
## Purpose

- fix: resolve Sentence Transformers precision into evaluation metadata before result-cache lookup and reuse it for all saves
- keep backend-specific option handling outside generic cache code, including for lazy factory loaders
- add regression coverage for default and quantized cache isolation and supported precision values

Fixes #5394

## Tests

- python -m pytest tests/test_evaluate.py -q
- python -m pytest tests/test_import_hygiene.py -q
- Ruff check and format check