### PR TITLE
[MOEB] task: add MetaWorld MT50 I2V/V2I Retrieval

### DIFF
--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/MetaWorldMT50I2VRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/MetaWorldMT50I2VRetrieval.json
@@ -1,0 +1,64 @@
+{
+    "test": {
+        "num_samples": 735,
+        "num_queries": 245,
+        "num_documents": 490,
+        "number_of_characters": 0,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": {
+            "total_duration_seconds": 3948.6,
+            "total_frames": 39486,
+            "min_width": 256,
+            "average_width": 256.0,
+            "max_width": 256,
+            "min_height": 256,
+            "average_height": 256.0,
+            "max_height": 256,
+            "min_duration_seconds": 1.7,
+            "average_duration_seconds": 8.058367346938775,
+            "max_duration_seconds": 50.0,
+            "unique_videos": 490,
+            "average_fps": 10.0,
+            "fps": {
+                "10": 490
+            },
+            "min_resolution": [
+                256,
+                256
+            ],
+            "average_resolution": [
+                256.0,
+                256.0
+            ],
+            "max_resolution": [
+                256,
+                256
+            ],
+            "resolutions": {
+                "256x256": 490
+            }
+        },
+        "queries_text_statistics": null,
+        "queries_image_statistics": {
+            "min_image_width": 256,
+            "average_image_width": 256.0,
+            "max_image_width": 256,
+            "min_image_height": 256,
+            "average_image_height": 256.0,
+            "max_image_height": 256,
+            "unique_images": 245
+        },
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 2450,
+            "min_relevant_docs_per_query": 10,
+            "average_relevant_docs_per_query": 10.0,
+            "max_relevant_docs_per_query": 10,
+            "unique_relevant_docs": 490
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Image/Any2AnyRetrieval/MetaWorldMT50V2IRetrieval.json
+++ b/mteb/descriptive_stats/Image/Any2AnyRetrieval/MetaWorldMT50V2IRetrieval.json
@@ -1,0 +1,64 @@
+{
+    "test": {
+        "num_samples": 735,
+        "num_queries": 245,
+        "num_documents": 490,
+        "number_of_characters": 0,
+        "documents_text_statistics": null,
+        "documents_image_statistics": {
+            "min_image_width": 256,
+            "average_image_width": 256.0,
+            "max_image_width": 256,
+            "min_image_height": 256,
+            "average_image_height": 256.0,
+            "max_image_height": 256,
+            "unique_images": 490
+        },
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": {
+            "total_duration_seconds": 2007.0,
+            "total_frames": 20070,
+            "min_width": 256,
+            "average_width": 256.0,
+            "max_width": 256,
+            "min_height": 256,
+            "average_height": 256.0,
+            "max_height": 256,
+            "min_duration_seconds": 2.6,
+            "average_duration_seconds": 8.191836734693878,
+            "max_duration_seconds": 50.0,
+            "unique_videos": 245,
+            "average_fps": 10.0,
+            "fps": {
+                "10": 245
+            },
+            "min_resolution": [
+                256,
+                256
+            ],
+            "average_resolution": [
+                256.0,
+                256.0
+            ],
+            "max_resolution": [
+                256,
+                256
+            ],
+            "resolutions": {
+                "256x256": 245
+            }
+        },
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 2450,
+            "min_relevant_docs_per_query": 10,
+            "average_relevant_docs_per_query": 10.0,
+            "max_relevant_docs_per_query": 10,
+            "unique_relevant_docs": 490
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/tasks/retrieval/zxx/__init__.py
+++ b/mteb/tasks/retrieval/zxx/__init__.py
@@ -4,6 +4,10 @@ from .evve_retrieval import EVVERetrieval
 from .libero_retrieval import LIBEROI2VRetrieval, LIBEROV2IRetrieval
 from .lp_music_caps import LPMusicCapsMTTA2TRetrieval, LPMusicCapsMTTT2ARetrieval
 from .maniskill_retrieval import ManiSkillI2VRetrieval, ManiSkillV2IRetrieval
+from .metaworld_retrieval import (
+    MetaWorldMT50I2VRetrieval,
+    MetaWorldMT50V2IRetrieval,
+)
 from .moving_fashion_retrieval import (
     MovingFashionI2VRetrieval,
     MovingFashionV2IRetrieval,
@@ -30,6 +34,8 @@ __all__ = [
     "LPMusicCapsMTTT2ARetrieval",
     "ManiSkillI2VRetrieval",
     "ManiSkillV2IRetrieval",
+    "MetaWorldMT50I2VRetrieval",
+    "MetaWorldMT50V2IRetrieval",
     "MovingFashionI2VRetrieval",
     "MovingFashionV2IRetrieval",
     "MusicCapsA2TRetrieval",

--- a/mteb/tasks/retrieval/zxx/metaworld_retrieval.py
+++ b/mteb/tasks/retrieval/zxx/metaworld_retrieval.py
@@ -68,8 +68,7 @@ class MetaWorldMT50V2IRetrieval(AbsTaskRetrieval):
         description=(
             "Video-to-image retrieval over robot manipulation episodes: given "
             "a manipulation video, retrieve goal-state images (final frames "
-            "of held-out episodes) of the same task. "
-            + _METAWORLD_DESCRIPTION_TAIL
+            "of held-out episodes) of the same task. " + _METAWORLD_DESCRIPTION_TAIL
         ),
         reference="https://meta-world.github.io/",
         dataset={

--- a/mteb/tasks/retrieval/zxx/metaworld_retrieval.py
+++ b/mteb/tasks/retrieval/zxx/metaworld_retrieval.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.task_metadata import TaskMetadata
+
+_METAWORLD_BIBTEX = r"""
+@inproceedings{yu2019meta,
+  author = {Yu, Tianhe and Quillen, Deirdre and He, Zhanpeng and Julian, Ryan and Hausman, Karol and Finn, Chelsea and Levine, Sergey},
+  booktitle = {Conference on Robot Learning (CoRL)},
+  title = {{Meta-World}: A Benchmark and Evaluation for Multi-Task and Meta-Reinforcement Learning},
+  year = {2019},
+}
+"""
+
+_METAWORLD_DESCRIPTION_TAIL = (
+    "Built from the Meta-World benchmark for multi-task robot learning "
+    "(MT50 benchmark: 49 tabletop manipulation tasks with simulated Sawyer robot, "
+    "teleoperated demonstrations rendered at 256x256, 10 fps). "
+    "Per task, 5 episodes are held out as queries and 10 episodes form the corpus, "
+    "so the query's own episode never appears in the corpus and exact frame matching "
+    "cannot solve the task. A corpus item is relevant if and only if it comes from an "
+    "episode of the same task as the query (10 relevant items per query); every other "
+    "item is non-relevant."
+)
+
+
+class MetaWorldMT50I2VRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="MetaWorldMT50I2VRetrieval",
+        description=(
+            "Image-to-video retrieval over robot manipulation episodes: given "
+            "a goal-state image (the final frame of a held-out episode), "
+            "retrieve manipulation videos that accomplish the same task. "
+            + _METAWORLD_DESCRIPTION_TAIL
+        ),
+        reference="https://meta-world.github.io/",
+        dataset={
+            "path": "iamfortytwo/MetaWorld-MT50-I2V",
+            "revision": "3feedd96246340c75c5191db7cabbe0d9fb3c27d",
+        },
+        type="Any2AnyRetrieval",
+        category="i2v",
+        modalities=["image", "video"],
+        eval_splits=["test"],
+        eval_langs=["zxx-Zxxx"],
+        main_score="ndcg_at_10",
+        date=("2019-10-01", "2020-05-01"),
+        domains=["Robotics", "Scene"],
+        task_subtypes=["Cross-Modal Retrieval"],
+        license="apache-2.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="rendered",
+        is_beta=True,
+        bibtex_citation=_METAWORLD_BIBTEX,
+        prompt={
+            "query": (
+                "Retrieve robot manipulation videos that accomplish the task "
+                "whose completed goal state is shown in the image."
+            )
+        },
+    )
+
+
+class MetaWorldMT50V2IRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="MetaWorldMT50V2IRetrieval",
+        description=(
+            "Video-to-image retrieval over robot manipulation episodes: given "
+            "a manipulation video, retrieve goal-state images (final frames "
+            "of held-out episodes) of the same task. "
+            + _METAWORLD_DESCRIPTION_TAIL
+        ),
+        reference="https://meta-world.github.io/",
+        dataset={
+            "path": "iamfortytwo/MetaWorld-MT50-V2I",
+            "revision": "ee03d6c2f978924bb31325cc5241fb0a589f0287",
+        },
+        type="Any2AnyRetrieval",
+        category="v2i",
+        modalities=["video", "image"],
+        eval_splits=["test"],
+        eval_langs=["zxx-Zxxx"],
+        main_score="ndcg_at_10",
+        date=("2019-10-01", "2020-05-01"),
+        domains=["Robotics", "Scene"],
+        task_subtypes=["Cross-Modal Retrieval"],
+        license="apache-2.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="rendered",
+        is_beta=True,
+        bibtex_citation=_METAWORLD_BIBTEX,
+        prompt={
+            "query": (
+                "Retrieve goal-state images showing the completed outcome of "
+                "the task performed in the robot manipulation video."
+            )
+        },
+    )

--- a/scripts/data/metaworld_retrieval/create_data.py
+++ b/scripts/data/metaworld_retrieval/create_data.py
@@ -1,0 +1,319 @@
+﻿"""Construction script for MetaWorld-MT50-I2V and MetaWorld-MT50-V2I.
+
+Builds image<->video retrieval tasks from lerobot/metaworld_mt50:
+- 49 robot manipulation tasks.
+- For each task, 15 episodes are deterministically selected:
+  - Lowest 5 indices become queries (49 * 5 = 245 queries).
+  - Next 10 indices become corpus (49 * 10 = 490 corpus videos/images).
+  - 0 leakage: query episodes are NEVER in the corpus pool.
+- Each episode is rendered to an H.264 MP4 (256x256, 10 fps) via PyAV.
+- The final frame of each episode is saved as the goal-state image.
+- Both directions (I2V and V2I) are built and pushed to Hugging Face Hub:
+  - iamfortytwo/MetaWorld-MT50-I2V
+  - iamfortytwo/MetaWorld-MT50-V2I
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import os
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import av
+import pyarrow.parquet as pq
+from datasets import Dataset, DatasetDict, Image, Video
+from huggingface_hub import HfApi, create_repo, get_token, hf_hub_download
+from PIL import Image as PILImage
+from tqdm import tqdm
+
+SOURCE_REPO = "lerobot/metaworld_mt50"
+FPS = 10
+QUERIES_PER_TASK = 5
+CORPUS_PER_TASK = 10
+TOTAL_PER_TASK = QUERIES_PER_TASK + CORPUS_PER_TASK
+TARGET_SIZE = (256, 256)
+CRF = 23
+
+
+def encode_video_av(
+    frames: list[bytes],
+    out_path: Path,
+    fps: int = FPS,
+    target_size: tuple[int, int] = TARGET_SIZE,
+) -> None:
+    container = av.open(str(out_path), mode="w", format="mp4")
+    stream = container.add_stream("libx264", rate=fps)
+    stream.width = target_size[0]
+    stream.height = target_size[1]
+    stream.pix_fmt = "yuv420p"
+    stream.options = {"crf": str(CRF), "preset": "fast"}
+
+    for f_bytes in frames:
+        img = PILImage.open(io.BytesIO(f_bytes)).convert("RGB")
+        if img.size != target_size:
+            img = img.resize(target_size, PILImage.Resampling.BILINEAR)
+        frame = av.VideoFrame.from_image(img)
+        for packet in stream.encode(frame):
+            container.mux(packet)
+
+    for packet in stream.encode():
+        container.mux(packet)
+    container.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Build Meta-World MT50 I2V and V2I retrieval datasets."
+    )
+    parser.add_argument(
+        "--workdir",
+        type=Path,
+        default=Path.home() / ".cache" / "metaworld_retrieval",
+        help="Local directory for temporary storage and media files.",
+    )
+    parser.add_argument(
+        "--hf-user",
+        type=str,
+        default="iamfortytwo",
+        help="Hugging Face user or organization for repository upload.",
+    )
+    parser.add_argument(
+        "--token",
+        type=str,
+        default=None,
+        help="Hugging Face write token.",
+    )
+    parser.add_argument(
+        "--push",
+        action="store_true",
+        default=True,
+        help="Push datasets to Hugging Face Hub (default: True).",
+    )
+    parser.add_argument(
+        "--no-push",
+        action="store_false",
+        dest="push",
+        help="Disable pushing to Hugging Face Hub.",
+    )
+    parser.add_argument(
+        "--num-workers",
+        type=int,
+        default=4,
+        help="Number of worker threads for parallel downloading and encoding.",
+    )
+    args = parser.parse_args()
+
+    workdir: Path = args.workdir
+    video_dir = workdir / "videos"
+    image_dir = workdir / "goal_images"
+    video_dir.mkdir(parents=True, exist_ok=True)
+    image_dir.mkdir(parents=True, exist_ok=True)
+
+    token = args.token or os.environ.get("HF_TOKEN") or get_token()
+
+    print(f"Step 1: Downloading metadata from {SOURCE_REPO}...")
+    episodes_meta_path = hf_hub_download(
+        repo_id=SOURCE_REPO,
+        filename="meta/episodes/chunk-000/file-000.parquet",
+        repo_type="dataset",
+        token=token,
+    )
+    ep_tab = pq.read_table(
+        episodes_meta_path,
+        columns=["episode_index", "tasks", "data/file_index", "length"],
+    )
+    df = ep_tab.to_pandas()
+
+    by_task: dict[str, list[dict]] = defaultdict(list)
+    for _, row in df.iterrows():
+        task_name = row["tasks"][0]
+        by_task[task_name].append(
+            {
+                "episode_index": int(row["episode_index"]),
+                "file_index": int(row["data/file_index"]),
+                "length": int(row["length"]),
+            }
+        )
+
+    print(f"Found {len(by_task)} tasks total.")
+
+    # Select 15 episodes per task: 5 queries, 10 corpus
+    query_pool: dict[str, list[int]] = {}
+    corpus_pool: dict[str, list[int]] = {}
+    selected_episodes: set[int] = set()
+    file_to_episodes: dict[int, list[int]] = defaultdict(list)
+
+    for task, eps in sorted(by_task.items()):
+        eps.sort(key=lambda x: x["episode_index"])
+        chosen = eps[:TOTAL_PER_TASK]
+        q_eps = [e["episode_index"] for e in chosen[:QUERIES_PER_TASK]]
+        c_eps = [e["episode_index"] for e in chosen[QUERIES_PER_TASK:TOTAL_PER_TASK]]
+        query_pool[task] = q_eps
+        corpus_pool[task] = c_eps
+        for e in chosen:
+            selected_episodes.add(e["episode_index"])
+            file_to_episodes[e["file_index"]].append(e["episode_index"])
+
+    total_queries = sum(len(v) for v in query_pool.values())
+    total_corpus = sum(len(v) for v in corpus_pool.values())
+    print(
+        f"Selected {len(selected_episodes)} episodes: "
+        f"{total_queries} queries, {total_corpus} corpus across {len(file_to_episodes)} parquet files."
+    )
+
+    # Render videos and goal images in parallel
+    print(f"Step 2: Rendering MP4 videos and extracting goal images ({args.num_workers} workers)...")
+    needed_files = sorted(file_to_episodes.keys())
+
+    def process_file(f_idx: int) -> None:
+        eps_in_file = file_to_episodes[f_idx]
+        missing_eps = [
+            ep
+            for ep in eps_in_file
+            if not (
+                (video_dir / f"ep{ep:06d}.mp4").exists()
+                and (image_dir / f"ep{ep:06d}.png").exists()
+            )
+        ]
+        if not missing_eps:
+            return
+
+        parquet_path = hf_hub_download(
+            repo_id=SOURCE_REPO,
+            filename=f"data/chunk-000/file-{f_idx:03d}.parquet",
+            repo_type="dataset",
+            token=token,
+        )
+        tab = pq.read_table(
+            parquet_path,
+            columns=["episode_index", "observation.image"],
+        )
+        ep_indices = tab["episode_index"].to_pylist()
+        img_rows = tab["observation.image"].to_pylist()
+
+        frames_by_ep: dict[int, list[bytes]] = defaultdict(list)
+        for ep, img_row in zip(ep_indices, img_rows):
+            if ep in missing_eps:
+                frames_by_ep[ep].append(img_row["bytes"])
+
+        for ep in missing_eps:
+            frames = frames_by_ep[ep]
+            if not frames:
+                continue
+            mp4_path = video_dir / f"ep{ep:06d}.mp4"
+            png_path = image_dir / f"ep{ep:06d}.png"
+
+            encode_video_av(frames, mp4_path, fps=FPS, target_size=TARGET_SIZE)
+            goal_img = PILImage.open(io.BytesIO(frames[-1])).convert("RGB")
+            if goal_img.size != TARGET_SIZE:
+                goal_img = goal_img.resize(TARGET_SIZE, PILImage.Resampling.BILINEAR)
+            goal_img.save(png_path)
+
+    with ThreadPoolExecutor(max_workers=args.num_workers) as executor:
+        list(
+            tqdm(
+                executor.map(process_file, needed_files),
+                total=len(needed_files),
+                desc="Processing parquet files",
+            )
+        )
+
+    # Build HuggingFace datasets
+    print("Step 3: Building Arrow datasets for I2V and V2I...")
+
+    def build_direction(query_modality: str) -> dict[str, Dataset]:
+        doc_modality = "video" if query_modality == "image" else "image"
+        query_rows: list[dict] = []
+        corpus_rows: list[dict] = []
+        qrel_rows: list[dict] = []
+
+        for task in sorted(by_task):
+            for q in query_pool[task]:
+                query_rows.append(
+                    {
+                        "id": f"q-ep{q:06d}",
+                        "image": str(image_dir / f"ep{q:06d}.png"),
+                        "video": str(video_dir / f"ep{q:06d}.mp4"),
+                    }
+                )
+                for c in corpus_pool[task]:
+                    qrel_rows.append(
+                        {
+                            "query-id": f"q-ep{q:06d}",
+                            "corpus-id": f"c-ep{c:06d}",
+                            "score": 1,
+                        }
+                    )
+            for c in corpus_pool[task]:
+                corpus_rows.append(
+                    {
+                        "id": f"c-ep{c:06d}",
+                        "image": str(image_dir / f"ep{c:06d}.png"),
+                        "video": str(video_dir / f"ep{c:06d}.mp4"),
+                    }
+                )
+
+        queries = Dataset.from_list(
+            [{k: r[k] for k in ("id", query_modality)} for r in query_rows]
+        ).cast_column(
+            query_modality, Video() if query_modality == "video" else Image()
+        )
+
+        corpus = Dataset.from_list(
+            [{k: r[k] for k in ("id", doc_modality)} for r in corpus_rows]
+        ).cast_column(
+            doc_modality, Video() if doc_modality == "video" else Image()
+        )
+
+        qrels = Dataset.from_list(qrel_rows)
+        return {"queries": queries, "corpus": corpus, "qrels": qrels}
+
+    api = HfApi(token=token)
+    commit_hashes: dict[str, str] = {}
+
+    for direction, query_modality in (("I2V", "image"), ("V2I", "video")):
+        print(f"\nBuilding MetaWorld-MT50-{direction}...")
+        parts = build_direction(query_modality)
+        repo_id = f"{args.hf_user}/MetaWorld-MT50-{direction}"
+
+        for config_name, ds in parts.items():
+            print(f"  {repo_id} [{config_name}]: {len(ds)} rows")
+
+        # Save locally to disk
+        local_save_dir = workdir / f"MetaWorld-MT50-{direction}"
+        DatasetDict({k: v for k, v in parts.items()}).save_to_disk(str(local_save_dir))
+        print(f"  Saved locally to {local_save_dir}")
+
+        if args.push:
+            print(f"  Pushing {repo_id} to Hugging Face Hub...")
+            try:
+                create_repo(
+                    repo_id=repo_id,
+                    repo_type="dataset",
+                    token=token,
+                    exist_ok=True,
+                )
+                for config_name, ds in parts.items():
+                    print(f"  Uploading config '{config_name}'...")
+                    DatasetDict({"test": ds}).push_to_hub(
+                        repo_id,
+                        config_name=config_name,
+                        token=token,
+                    )
+                info = api.repo_info(repo_id=repo_id, repo_type="dataset")
+                commit_hashes[direction] = info.sha
+                print(f"  Successfully pushed {repo_id} at revision {info.sha}")
+            except Exception as e:
+                print(f"  WARNING: Push failed for {repo_id}: {e}")
+                print("  Data is saved locally and can be pushed once write credentials are provided.")
+
+    print("\nSummary:")
+    for d, sha in commit_hashes.items():
+        print(f"  MetaWorld-MT50-{d}: https://huggingface.co/datasets/{args.hf_user}/MetaWorld-MT50-{d} (commit {sha})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_metaworld_mt50_retrieval.py
+++ b/scripts/run_metaworld_mt50_retrieval.py
@@ -54,9 +54,7 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     args = parse_args()
     model = get_model(args.model, device=args.device)
-    evaluation = MTEB(
-        tasks=[MetaWorldMT50I2VRetrieval(), MetaWorldMT50V2IRetrieval()]
-    )
+    evaluation = MTEB(tasks=[MetaWorldMT50I2VRetrieval(), MetaWorldMT50V2IRetrieval()])
     evaluation.run(
         model,
         output_folder=args.output_folder,

--- a/scripts/run_metaworld_mt50_retrieval.py
+++ b/scripts/run_metaworld_mt50_retrieval.py
@@ -1,0 +1,69 @@
+"""Run the MetaWorld MT50 image-to-video and video-to-image retrieval tasks.
+
+For a quick reproducibility check:
+
+    python scripts/run_metaworld_mt50_retrieval.py
+
+To evaluate a multimodal model instead:
+
+    python scripts/run_metaworld_mt50_retrieval.py \\
+        --model jinaai/jina-embeddings-v5-omni-nano --batch-size 1
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from mteb import MTEB, get_model
+from mteb.tasks.retrieval.zxx.metaworld_retrieval import (
+    MetaWorldMT50I2VRetrieval,
+    MetaWorldMT50V2IRetrieval,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--model",
+        default="mteb/baseline-random-encoder",
+        help="MTEB model name to evaluate.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=4,
+        help="Encoding batch size. Use 1 for large multimodal models.",
+    )
+    parser.add_argument(
+        "--device",
+        help="Device passed to the MTEB model loader, for example 'cuda' or 'cpu'.",
+    )
+    parser.add_argument(
+        "--output-folder",
+        default="results",
+        help="Directory in which MTEB stores result files.",
+    )
+    parser.add_argument(
+        "--overwrite-results",
+        action="store_true",
+        help="Overwrite any existing results for this model and task.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    model = get_model(args.model, device=args.device)
+    evaluation = MTEB(
+        tasks=[MetaWorldMT50I2VRetrieval(), MetaWorldMT50V2IRetrieval()]
+    )
+    evaluation.run(
+        model,
+        output_folder=args.output_folder,
+        overwrite_results=args.overwrite_results,
+        encode_kwargs={"batch_size": args.batch_size},
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## MetaWorld MT50 image↔video retrieval

Adds two MOEB cross-modal retrieval tasks:

- `MetaWorldMT50I2VRetrieval`: goal-state image → robot-manipulation video
- `MetaWorldMT50V2IRetrieval`: robot-manipulation video → goal-state image

The tasks fill an image↔video retrieval gap for robotics. They use 49 MetaWorld MT50 tabletop-manipulation tasks, with held-out episodes as queries and different episodes of the same task as relevant corpus items.

Datasets: [I2V](https://huggingface.co/datasets/iamfortytwo/MetaWorld-MT50-I2V) / [V2I](https://huggingface.co/datasets/iamfortytwo/MetaWorld-MT50-V2I)

Descriptive statistics:

- 245 queries, 490 corpus videos, 2,450 qrels
- 10 relevant corpus items per query
- No query/corpus episode overlap

Reference runs (nDCG@10):

| Model | I2V | V2I |
| --- | ---: | ---: |
| `mteb/baseline-random-encoder` | 0.02397 | 0.01877 |
| `jinaai/jina-embeddings-v5-omni-nano` | 0.23006 | 0.29589 |

The random baseline is near chance; the multimodal reference model is substantially higher without saturating, indicating a discriminative task.

Validation:

- [x] `test_metadata.py` passes for both tasks
- [x] `test_task_quality.py` passes
- [x] Dataset runs with MTEB and both reference encoders
- [x] No paper retrieval result to reproduce: this is a novel goal-image↔demonstration-video construction; MetaWorld’s source paper evaluates RL.

Reproducibility: `python scripts/run_metaworld_mt50_retrieval.py`