### PR TITLE
fix: make abstasks and model wrappers torch-free

### DIFF
--- a/mteb/abstasks/image/image_text_pair_classification.py
+++ b/mteb/abstasks/image/image_text_pair_classification.py
@@ -4,7 +4,6 @@ import logging
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, TypedDict
 
-import torch
 from datasets import concatenate_datasets
 
 from mteb._evaluators import ImageTextPairClassificationEvaluator
@@ -19,6 +18,7 @@ from mteb.types.statistics import ImageTextPairClassificationDescriptiveStatisti
 if TYPE_CHECKING:
     from pathlib import Path
 
+    import torch
     from datasets import Dataset
 
     from mteb.models.models_protocols import MTEBModels
@@ -181,6 +181,8 @@ class AbsTaskImageTextPairClassification(AbsTask):
         num_images_per_sample: int,
         num_texts_per_sample: int,
     ) -> ImageTextPairClassificationMetrics:
+        import torch
+
         image_score = []
         text_score = []
         all_correct_scores = []

--- a/mteb/models/cache_wrappers/cache_wrapper.py
+++ b/mteb/models/cache_wrappers/cache_wrapper.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-import torch
 from datasets import Dataset
 
 from mteb._create_dataloaders import create_dataloader
@@ -91,6 +90,8 @@ class CachedEmbeddingWrapper:
         Returns:
             The encoded input in a numpy array or torch tensor of the shape (Number of sentences) x (Embedding dimension).
         """
+        import torch
+
         task_name = task_metadata.name
         try:
             cache = self._get_or_create_cache(task_name, prompt_type)

--- a/mteb/models/compression_wrappers/compression_wrapper.py
+++ b/mteb/models/compression_wrappers/compression_wrapper.py
@@ -4,11 +4,10 @@ import logging
 import warnings
 from typing import TYPE_CHECKING, Any
 
-import torch
-
 from mteb.types import OutputDType
 
 if TYPE_CHECKING:
+    import torch
     from torch.utils.data import DataLoader
 
     from mteb.abstasks.task_metadata import TaskMetadata
@@ -45,6 +44,8 @@ class CompressionWrapper:
             output_dtype: The output data type to compress to. Has to be supported by the quantize_embeddings method.
             clipping_margin: Optional lower and upper percentiles to crop embeddings before integer quantization.
         """
+        import torch
+
         self.model = model
         self._quantization_level = output_dtype
         self.clipping_margin = None
@@ -114,6 +115,8 @@ class CompressionWrapper:
         Returns:
             The encoded and quantized input in an array of the shape (Number of sentences) x (Embedding dimension).
         """
+        import torch
+
         embeddings = self.model.encode(
             inputs,
             task_metadata=task_metadata,
@@ -145,6 +148,8 @@ class CompressionWrapper:
         Returns:
             The quantized embeddings.
         """
+        import torch
+
         torch_dtype = self._quantization_level.get_dtype()
         if self._quantization_level in [  # noqa: PLR6201
             OutputDType.FLOAT8_E4M3FN,
@@ -205,6 +210,8 @@ class CompressionWrapper:
         Returns:
             The minimum and maximum values per embedding dimension.
         """
+        import torch
+
         if len(embeddings) < self.min_embeds:
             msg = (
                 f"Estimating quantization parameters on less than {self.min_embeds} embeddings (only "

--- a/mteb/models/instruct_wrapper.py
+++ b/mteb/models/instruct_wrapper.py
@@ -5,7 +5,6 @@ import warnings
 from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
-import torch
 from tqdm.auto import tqdm
 from typing_extensions import deprecated
 
@@ -111,6 +110,8 @@ def instruct_wrapper(
             prompt_type: PromptType | None = None,
             **kwargs: Any,
         ) -> Array:
+            import torch
+
             instruction = self.get_instruction(task_metadata, prompt_type)
 
             if self.instruction_template:

--- a/mteb/models/modality_collators.py
+++ b/mteb/models/modality_collators.py
@@ -4,11 +4,11 @@ import logging
 from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
-import torch
 
 from mteb.types._encoder_io import AudioInputItem
 
 if TYPE_CHECKING:
+    import torch
     from torchcodec.decoders import VideoDecoder  # type: ignore[attr-defined]
 
     from mteb.types import BatchedInput
@@ -86,6 +86,7 @@ class AudioCollator:
             target_sampling_rate: The sampling rate to resample the audio to.
             max_samples: The maximum number of samples to keep for each audio. If None, no truncation is applied.
         """
+        import torch
         import torchaudio
 
         audio = audio["audio"]

--- a/mteb/models/openai_wrappers.py
+++ b/mteb/models/openai_wrappers.py
@@ -56,7 +56,6 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import requests
-import torch
 from tqdm.auto import tqdm
 
 from mteb._create_dataloaders import create_dataloader
@@ -67,6 +66,7 @@ from mteb.types import PromptType
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    import torch
     from numpy.typing import NDArray
     from PIL import Image
     from torch.utils.data import DataLoader
@@ -114,6 +114,8 @@ def _audio_to_data_url(audio: AudioInputItem) -> str:
     encoder — the same package already required to decode video — so audio
     and video share one encoding library.
     """
+    import torch
+
     try:
         from torchcodec.encoders import AudioEncoder  # type: ignore[attr-defined]
     except ImportError as e:
@@ -153,6 +155,8 @@ def _video_to_data_url(video: torch.Tensor, *, fps: float | None) -> str:
             was used instead), a default of 2.0 is used since there's no
             source frame rate to fall back to.
     """
+    import torch
+
     fps = fps or 2.0
 
     try:

--- a/mteb/models/search_encoder_index/search_indexes/faiss_search_index.py
+++ b/mteb/models/search_encoder_index/search_indexes/faiss_search_index.py
@@ -5,7 +5,6 @@ import warnings
 from typing import TYPE_CHECKING, cast
 
 import numpy as np
-import torch
 
 from mteb._requires_package import _is_package_available
 from mteb.models.model_meta import ScoringFunction
@@ -64,6 +63,7 @@ class FaissSearchIndex:
     def add_documents(self, embeddings: Array, idxs: list[str]) -> None:
         """Add all document embeddings and their IDs to FAISS index."""
         import faiss
+        import torch
 
         if isinstance(embeddings, torch.Tensor):
             embeddings = embeddings.detach().cpu().numpy()
@@ -91,6 +91,7 @@ class FaissSearchIndex:
     ) -> tuple[list[list[float]], list[list[int]]]:
         """Search using FAISS."""
         import faiss
+        import torch
 
         if self.index is None:
             raise ValueError("No index built. Call add_document() first.")

--- a/mteb/models/search_wrappers.py
+++ b/mteb/models/search_wrappers.py
@@ -4,8 +4,6 @@ import heapq
 import logging
 from typing import TYPE_CHECKING, Any
 
-import torch
-
 from mteb._create_dataloaders import (
     create_dataloader,
 )
@@ -14,6 +12,7 @@ from mteb.types import (
 )
 
 if TYPE_CHECKING:
+    import torch
     from torch.utils.data import DataLoader
 
     from mteb.abstasks.task_metadata import TaskMetadata
@@ -118,6 +117,8 @@ class SearchEncoderWrapper:
         Returns:
             Dictionary with query IDs as keys with dict as values, where each value is a mapping of document IDs to their relevance scores.
         """
+        import torch
+
         if self.task_corpus is None:
             raise ValueError("Corpus must be indexed before searching.")
 
@@ -231,6 +232,8 @@ class SearchEncoderWrapper:
         top_k: int,
         encode_kwargs: EncodeKwargs,
     ) -> dict[str, list[tuple[float, str]]]:
+        import torch
+
         logger.info("Encoding Corpus in batches (this might take a while)...")
         if self.task_corpus is None:
             raise ValueError("Corpus must be indexed before searching.")
@@ -342,6 +345,8 @@ class SearchEncoderWrapper:
         Returns:
             A dictionary mapping query IDs to a list of tuples, each containing a relevance score and a document ID.
         """
+        import torch
+
         if self.task_corpus is None:
             raise ValueError("Corpus must be indexed before searching.")
         result_heaps: dict[str, list[tuple[float, str]]] = {

--- a/mteb/models/sentence_transformer_wrapper.py
+++ b/mteb/models/sentence_transformer_wrapper.py
@@ -5,7 +5,6 @@ import warnings
 from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
-import torch
 from packaging.version import Version
 from tqdm.auto import tqdm
 from typing_extensions import deprecated
@@ -19,6 +18,7 @@ from .abs_encoder import AbsEncoder, get_prompt_name
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    import torch
     from sentence_transformers import CrossEncoder, SentenceTransformer
     from sentence_transformers.sparse_encoder import SparseEncoder
     from torch.utils.data import DataLoader
@@ -172,6 +172,8 @@ def _select_encode_function(
 
 def _postprocess_dense_embeddings(embeddings: Array) -> Array:
     """Move a batch's embeddings to CPU float32 if it's a torch tensor; otherwise pass through unchanged."""
+    import torch
+
     if isinstance(embeddings, torch.Tensor):
         embeddings = embeddings.cpu().detach().float()
     return embeddings
@@ -179,6 +181,8 @@ def _postprocess_dense_embeddings(embeddings: Array) -> Array:
 
 def _concatenate_sparse_batches(batches: list[torch.Tensor]) -> torch.Tensor:
     """Concatenate per-batch sparse tensors along dim 0 (sparse tensors don't support `np.concatenate`)."""
+    import torch
+
     return torch.cat(batches, dim=0)
 
 
@@ -196,6 +200,8 @@ def _is_sparse_compatible_task(task_metadata: TaskMetadata) -> bool:
 
 def _postprocess_sparse_embeddings(embeddings: Array) -> Array:
     """Densify a batch's embeddings if it's a sparse torch tensor, then move to CPU float32."""
+    import torch
+
     if isinstance(embeddings, torch.Tensor) and embeddings.is_sparse:
         embeddings = embeddings.to_dense()
     return _postprocess_dense_embeddings(embeddings)

--- a/mteb/models/vllm_wrapper.py
+++ b/mteb/models/vllm_wrapper.py
@@ -7,7 +7,6 @@ import os
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
-import torch
 from packaging import version
 
 from mteb._requires_package import _is_package_available
@@ -244,6 +243,8 @@ class VllmEncoderWrapper(AbsEncoder, VllmWrapperBase):
         Returns:
             The encoded sentences.
         """
+        import torch
+
         prompt = ""
         if self.use_instructions and self.prompts_dict is not None:
             prompt = self.get_task_instruction(task_metadata, prompt_type)

--- a/tests/test_ensure_no_torch_at_import.py
+++ b/tests/test_ensure_no_torch_at_import.py
@@ -196,3 +196,18 @@ def test_image_dataset_builder_still_returns_a_torch_dataset() -> None:
         dataset, batch_size=2, collate_fn=lambda b: {"image": [i["image"] for i in b]}
     )
     assert [len(batch["image"]) for batch in loader] == [2, 1]
+
+
+def test_importing_abstasks_does_not_import_torch() -> None:
+    """Task classes carry the metadata the leaderboard and API read; describing them needs no torch."""
+    assert _loaded_heavy_deps("mteb.abstasks", ("mteb",)) == [], (
+        "importing mteb.abstasks pulled in a heavy dependency; move the import into the "
+        "method that uses it"
+    )
+
+
+def test_importing_benchmarks_does_not_import_torch() -> None:
+    """Benchmark definitions are metadata over tasks, so they must not need torch either."""
+    assert _loaded_heavy_deps("mteb.benchmarks.benchmark", ("mteb",)) == [], (
+        "importing mteb.benchmarks.benchmark pulled in a heavy dependency"
+    )


### PR DESCRIPTION
Fourth step toward making mteb importable without torch. Refs #5063. Follows #5329, #5350, #5426.

`AbsTask` and `Benchmark`: the classes carrying the metadata the leaderboard and API read no longer need torch to import.

Changes: 
10 files, each with a single eager import torch and no import-time execution:
- nine under `mteb/models/` — cache, compression, instruct, modality collator, openai, faiss index, search, sentence-transformer and vllm wrappers
- `mteb/abstasks/image/image_text_pair_classification.py,` the one file under `abstasks/` with its own import torch
- Each gets import torch in its `TYPE_CHECKING` block for annotations, plus function-local imports in the methods that use it at runtime.

No `__init__.py` is touched, and no mteb imports are moved. Also, `from mteb.models import EncoderProtocol` imports across `abstasks/` needed no change at all as once the wrappers stopped pulling torch, they became harmless.

Result: 

Module  | Before | After
-- | -- | --
mteb.abstasks | 3260 modules, torch | 2534 modules, no torch
mteb.benchmarks.benchmark | 3439 modules, torch | 2714 modules, no torch

import mteb is still unchanged (6801 modules, torch loaded). It reaches torch through `mteb/__init__.py` and the `model_implementations` registry, which is the remaining step.

Testing
Two new tests added on `mteb.abstasks` and `mteb.benchmarks.benchmark;` both confirmed to fail when an eager import is restored. ruff and mypy clean.