### PR TITLE
dataset: add Flickr audio-image-text retrieval (A2IT / IT2A)

### DIFF
--- a/mteb/abstasks/task_metadata.py
+++ b/mteb/abstasks/task_metadata.py
@@ -295,6 +295,7 @@ TaskCategory = Literal[
     "it2v",
     "v2i",
     "it2c",
+    "a2it",
 ]
 """The category of the task.
 
@@ -345,6 +346,7 @@ TaskCategory = Literal[
 45. it2v: image+text to video
 46. v2i: video to image
 47. it2c: image+text to category
+48. a2it: audio to image+text
 """
 
 _MODALITY_CODES: dict[str, str] = {

--- a/mteb/descriptive_stats/Retrieval/FlickrAudioToImageTextRetrieval.json
+++ b/mteb/descriptive_stats/Retrieval/FlickrAudioToImageTextRetrieval.json
@@ -1,0 +1,50 @@
+{
+    "train": {
+        "num_samples": 48091,
+        "num_queries": 40000,
+        "num_documents": 8091,
+        "number_of_characters": 450069,
+        "documents_text_statistics": {
+            "total_text_length": 450069,
+            "min_text_length": 1,
+            "average_text_length": 55.62588060808306,
+            "max_text_length": 173,
+            "unique_texts": 8075
+        },
+        "documents_image_statistics": {
+            "min_image_width": 164,
+            "average_image_width": 457.87220368310466,
+            "max_image_width": 500,
+            "min_image_height": 127,
+            "average_image_height": 397.25188481028306,
+            "max_image_height": 500,
+            "unique_images": 8090
+        },
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": null,
+        "queries_image_statistics": null,
+        "queries_audio_statistics": {
+            "total_duration_seconds": 165222.1875,
+            "min_duration_seconds": 0.2305,
+            "average_duration_seconds": 4.1305546875,
+            "max_duration_seconds": 323.50675,
+            "unique_audios": 40000,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 40000
+            }
+        },
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 40000,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 8000,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Retrieval/FlickrImageTextToAudioRetrieval.json
+++ b/mteb/descriptive_stats/Retrieval/FlickrImageTextToAudioRetrieval.json
@@ -1,0 +1,50 @@
+{
+    "train": {
+        "num_samples": 48091,
+        "num_queries": 8091,
+        "num_documents": 40000,
+        "number_of_characters": 450069,
+        "documents_text_statistics": null,
+        "documents_image_statistics": null,
+        "documents_audio_statistics": {
+            "total_duration_seconds": 165222.1875,
+            "min_duration_seconds": 0.2305,
+            "average_duration_seconds": 4.1305546875,
+            "max_duration_seconds": 323.50675,
+            "unique_audios": 40000,
+            "average_sampling_rate": 16000.0,
+            "sampling_rates": {
+                "16000": 40000
+            }
+        },
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 450069,
+            "min_text_length": 1,
+            "average_text_length": 55.62588060808306,
+            "max_text_length": 173,
+            "unique_texts": 8075
+        },
+        "queries_image_statistics": {
+            "min_image_width": 164,
+            "average_image_width": 457.87220368310466,
+            "max_image_width": 500,
+            "min_image_height": 127,
+            "average_image_height": 397.25188481028306,
+            "max_image_height": 500,
+            "unique_images": 8090
+        },
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 40000,
+            "min_relevant_docs_per_query": 5,
+            "average_relevant_docs_per_query": 5.0,
+            "max_relevant_docs_per_query": 5,
+            "unique_relevant_docs": 40000,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -184,6 +184,10 @@ from .flickr_audio_image_retrieval import (
     FlickrAudioToImageRetrieval,
     FlickrImageToAudioRetrieval,
 )
+from .flickr_audio_image_text_retrieval import (
+    FlickrAudioToImageTextRetrieval,
+    FlickrImageTextToAudioRetrieval,
+)
 from .forb_i2i_retrieval import FORBI2I
 from .giga_speech import GigaSpeechA2TRetrieval, GigaSpeechT2ARetrieval
 from .gl_dv2_i2i_retrieval import GLDv2I2IRetrieval
@@ -670,6 +674,8 @@ __all__ = [
     "Flickr30kI2TRetrieval",
     "Flickr30kT2IRetrieval",
     "FlickrAudioToImageRetrieval",
+    "FlickrAudioToImageTextRetrieval",
+    "FlickrImageTextToAudioRetrieval",
     "FlickrImageToAudioRetrieval",
     "GLDv2I2IRetrieval",
     "GLDv2I2TRetrieval",

--- a/mteb/tasks/retrieval/eng/flickr_audio_image_text_retrieval.py
+++ b/mteb/tasks/retrieval/eng/flickr_audio_image_text_retrieval.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from typing import Any
+
+import datasets
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.task_metadata import TaskMetadata
+
+CITATION = r"""
+@inproceedings{harwath2015deep,
+  title={Deep multimodal semantic embeddings for speech and images},
+  author={Harwath, David and Glass, James},
+  booktitle={2015 IEEE workshop on automatic speech recognition and understanding (ASRU)},
+  pages={237--244},
+  year={2015},
+  organization={IEEE}
+}
+"""
+
+_DESCRIPTION_A2IT = (
+    "Audio to (Image, Text) retrieval for the Flickr Audio Image dataset. Queries "
+    "are spoken renditions of Flickr8k captions, corpus items pair each image with "
+    "its written text caption, so only models that use both the image and text "
+    "signal exploit the full corpus."
+)
+_DESCRIPTION_IT2A = (
+    "(Image, Text) to Audio retrieval for the Flickr Audio Image dataset, the "
+    "reverse direction of FlickrAudioToImageTextRetrieval. Queries pair each image "
+    "with its written text caption, corpus items are spoken renditions of Flickr8k "
+    "captions."
+)
+
+
+class FlickrAudioToImageTextRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="FlickrAudioToImageTextRetrieval",
+        description=_DESCRIPTION_A2IT,
+        reference="https://arxiv.org/pdf/1511.03690",
+        dataset={
+            "path": "deep9539/flickr-audio-image",
+            "revision": "eccef427e2398ade609d40c1dcc9b5c30dce8641",
+        },
+        type="Retrieval",
+        category="a2it",
+        eval_splits=["train"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2015-06-01", "2016-05-31"),
+        domains=["Web", "AudioScene"],
+        task_subtypes=["Cross-Modal Retrieval"],
+        license="cc-by-sa-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["audio", "image", "text"],
+        sample_creation="found",
+        bibtex_citation=CITATION,
+        prompt={
+            "query": "Find the (image, text caption) pair described by the spoken audio."
+        },
+        is_beta=True,
+    )
+
+    def load_data(self, **kwargs: Any):
+        if self.data_loaded:
+            return
+
+        revision = self.metadata.dataset.get("revision")
+        audio_ds = datasets.load_dataset(
+            self.metadata.dataset["path"], "audio", split="train", revision=revision
+        )
+        images_ds = datasets.load_dataset(
+            self.metadata.dataset["path"], "images", split="train", revision=revision
+        )
+        qrels_ds = datasets.load_dataset(
+            self.metadata.dataset["path"], "qrels", split="train", revision=revision
+        )
+
+        # qrels_ds has 'image_id' and 'audio_id'
+        # For A2IT: query is audio, corpus is (image, text)
+        qrels = {}
+        for row in qrels_ds:
+            q_id = str(row["audio_id"])
+            c_id = str(row["image_id"])
+            if q_id not in qrels:
+                qrels[q_id] = {}
+            qrels[q_id][c_id] = 1
+
+        self.dataset = {
+            "default": {
+                "train": {
+                    "corpus": images_ds,
+                    "queries": audio_ds,
+                    "relevant_docs": qrels,
+                    "top_ranked": None,
+                }
+            }
+        }
+        self.data_loaded = True
+
+
+class FlickrImageTextToAudioRetrieval(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="FlickrImageTextToAudioRetrieval",
+        description=_DESCRIPTION_IT2A,
+        reference="https://arxiv.org/pdf/1511.03690",
+        dataset={
+            "path": "deep9539/flickr-audio-image",
+            "revision": "eccef427e2398ade609d40c1dcc9b5c30dce8641",
+        },
+        type="Retrieval",
+        category="it2a",
+        eval_splits=["train"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2015-06-01", "2016-05-31"),
+        domains=["Web", "AudioScene"],
+        task_subtypes=["Cross-Modal Retrieval"],
+        license="cc-by-sa-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        modalities=["image", "text", "audio"],
+        sample_creation="found",
+        bibtex_citation=CITATION,
+        prompt={
+            "query": "Find the spoken audio caption describing this (image, text) pair."
+        },
+        is_beta=True,
+    )
+
+    def load_data(self, **kwargs: Any):
+        if self.data_loaded:
+            return
+
+        revision = self.metadata.dataset.get("revision")
+        audio_ds = datasets.load_dataset(
+            self.metadata.dataset["path"], "audio", split="train", revision=revision
+        )
+        images_ds = datasets.load_dataset(
+            self.metadata.dataset["path"], "images", split="train", revision=revision
+        )
+        qrels_ds = datasets.load_dataset(
+            self.metadata.dataset["path"], "qrels", split="train", revision=revision
+        )
+
+        # For IT2A: query is (image, text), corpus is audio
+        qrels = {}
+        for row in qrels_ds:
+            q_id = str(row["image_id"])
+            c_id = str(row["audio_id"])
+            if q_id not in qrels:
+                qrels[q_id] = {}
+            qrels[q_id][c_id] = 1
+
+        self.dataset = {
+            "default": {
+                "train": {
+                    "corpus": audio_ds,
+                    "queries": images_ds,
+                    "relevant_docs": qrels,
+                    "top_ranked": None,
+                }
+            }
+        }
+        self.data_loaded = True


### PR DESCRIPTION
Title:
dataset: add Flickr audio-image-text retrieval (A2IT / IT2A)

Body:
Resolves #5433

Fills 2 of the 3 remaining open slots in "audio + image + text" under rack 1 of the MOEB tracker (#4842).

Adds FlickrAudioToImageTextRetrieval (a2it) and FlickrImageTextToAudioRetrieval (it2a), reusing deep9539/flickr-audio-image (cc-by-sa-4.0), the same dataset already used by the merged  FlickrAudioToImageRetrieval / FlickrImageToAudioRetrieval tasks (#4946, #5137). The images config in that dataset already carries both image and text per row, so this recombines existing data rather than sourcing or uploading anything new.

Also adds "a2it" (audio to image+text) as a new TaskCategory value. "it2a" already existed for the reverse direction, "a2it" did not.

- [x] I have outlined why this dataset is filling an existing gap in mteb
- [x] I have tested that the dataset loads and runs with the mteb package
  (verified corpus/queries/qrels end to end: 8,091 image+text corpus items,
  40,000 audio queries for a2it, matching qrels for every query; reverse
  direction verified too).
- [x] I have run mteb/baseline-random-encoder on both tasks: near-zero
  scores as expected (ndcg@10 0.00067 for a2it, 0.00017 for it2a).