### PR TITLE
Add ModelMeta for NGA-KR/ko-embed-v0

### DIFF
--- a/mteb/models/model_implementations/nga_system_models.py
+++ b/mteb/models/model_implementations/nga_system_models.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from mteb.models import ModelMeta, SentenceTransformerEncoderWrapper
+
+ko_embed_v0 = ModelMeta(
+    name="NGA-KR/ko-embed-v0",
+    loader=SentenceTransformerEncoderWrapper,
+    loader_kwargs=dict(model_prompts={"query": "query: ", "document": "", "passage": "passage: "}),
+    revision="f321741f682310b04b8d96afb3a36d177f1ab900",
+    release_date="2026-09-10",
+    languages=["kor-Hang", "eng-Latn"],
+    open_weights=True,
+    n_parameters=148731648,
+    memory_usage_mb=284,
+    embed_dim=768,
+    max_tokens=512,
+    license="apache-2.0",
+    reference="https://huggingface.co/NGA-KR/ko-embed-v0",
+    similarity_fn_name="cosine",
+    framework=["Sentence Transformers", "PyTorch"],
+    use_instructions=True,
+    public_training_code=None,
+    public_training_data=None,
+    training_datasets={'MSMARCO', 'GooAQ', 'NQ', 'HotpotQA'},
+    adapted_from="skt/A.X-Encoder-base",
+)

--- a/mteb/models/model_implementations/nga_system_models.py
+++ b/mteb/models/model_implementations/nga_system_models.py
@@ -1,26 +1,32 @@
 from __future__ import annotations
 
 from mteb.models import ModelMeta, SentenceTransformerEncoderWrapper
+from mteb.models.model_meta import ScoringFunction
 
 ko_embed_v0 = ModelMeta(
-    name="NGA-KR/ko-embed-v0",
     loader=SentenceTransformerEncoderWrapper,
-    loader_kwargs=dict(model_prompts={"query": "query: ", "document": "", "passage": "passage: "}),
+    loader_kwargs=dict(
+        model_prompts={"query": "query: ", "document": "", "passage": "passage: "}
+    ),
+    name="NGA-KR/ko-embed-v0",
     revision="f321741f682310b04b8d96afb3a36d177f1ab900",
     release_date="2026-09-10",
-    languages=["kor-Hang", "eng-Latn"],
-    open_weights=True,
+    languages=["eng-Latn", "kor-Hang"],
     n_parameters=148731648,
+    n_embedding_parameters=38400000,
     memory_usage_mb=284,
-    embed_dim=768,
     max_tokens=512,
+    embed_dim=768,
     license="apache-2.0",
-    reference="https://huggingface.co/NGA-KR/ko-embed-v0",
-    similarity_fn_name="cosine",
-    framework=["Sentence Transformers", "PyTorch"],
+    open_weights=True,
     use_instructions=True,
     public_training_code=None,
     public_training_data=None,
-    training_datasets={'MSMARCO', 'GooAQ', 'NQ', 'HotpotQA'},
+    framework=["Sentence Transformers", "safetensors"],
+    reference="https://huggingface.co/NGA-KR/ko-embed-v0",
+    similarity_fn_name=ScoringFunction.COSINE,
+    training_datasets={"MSMARCO", "GooAQ", "NQ", "HotpotQA"},
     adapted_from="skt/A.X-Encoder-base",
+    modalities=["text"],
+    model_type=["dense"],
 )


### PR DESCRIPTION
Adds model metadata for [NGA-KR/ko-embed-v0](https://huggingface.co/NGA-KR/ko-embed-v0) (revision `f321741f682310b04b8d96afb3a36d177f1ab900`), including `training_datasets` for zero-shot calculation. Results PR: embeddings-benchmark/results.