### PR TITLE
fix: declare ModelMeta load dtypes with OutputDType instead of torch.dtype

### DIFF
--- a/docs/contributing/adding_a_model.md
+++ b/docs/contributing/adding_a_model.md
@@ -30,6 +30,7 @@ Typically, it only requires that you fill in metadata about the model and add it
 ??? example "Adding a ModelMeta object"
     ```python
     from mteb.models import ModelMeta, SentenceTransformerEncoderWrapper
+    from mteb.types import OutputDType
 
     my_model = ModelMeta(
         name="model_name",
@@ -118,6 +119,21 @@ model = ModelMeta(
     ...
 )
 ```
+
+If your model must be loaded in a specific precision, name the dtype with an [`OutputDType`][mteb.types.OutputDType] member rather than passing a `torch.dtype` object:
+
+```python
+model = ModelMeta(
+    loader=MyWrapper,
+    loader_kwargs=dict(
+        torch_dtype=OutputDType.BF16,  # not torch.bfloat16
+    ),
+    ...
+)
+```
+
+`ModelMeta` entries are evaluated when `mteb` is imported, so a `torch.dtype` here would make reading model metadata require torch. `OutputDType` is a string enum: it resolves via
+`OutputDType.get_dtype()`, and `transformers` accepts it directly wherever it accepts a string dtype.
 
 ### Using a custom Implementation
 

--- a/docs/get_started/advanced_usage/compress_embeddings.md
+++ b/docs/get_started/advanced_usage/compress_embeddings.md
@@ -22,7 +22,7 @@ model_with_compression = CompressionWrapper(model, output_dtype=OutputDType.INT8
 results = mteb.evaluate(model_with_compression, tasks=[task])
 ```
 
-The `output_dtype` parameter determines the value range to which embeddings are compressed. Consult the [`OutputDType`][mteb.types.OutputDType] class for a full overview of valid compression levels.
+The `output_dtype` parameter determines the value range to which embeddings are compressed. Consult the [`OutputDType`][mteb.types.OutputDType] class for the available dtypes; note that it also names dtypes used elsewhere for model loading, and passing one that is not a compression level (such as `FLOAT32`) raises a `ValueError`.
 
 ### Threshold Estimation
 

--- a/mteb/models/model_implementations/audio_flamingo.py
+++ b/mteb/models/model_implementations/audio_flamingo.py
@@ -9,6 +9,7 @@ from tqdm.auto import tqdm
 from mteb.models.abs_encoder import AbsEncoder
 from mteb.models.modality_collators import AudioCollator
 from mteb.models.model_meta import ModelMeta, ScoringFunction
+from mteb.types import OutputDType
 
 if TYPE_CHECKING:
     from torch.utils.data import DataLoader
@@ -26,10 +27,13 @@ class AudioFlamingoWrapper(AbsEncoder):
         revision: str | None = None,
         device: str | None = None,
         max_audio_length_seconds: float = 30.0,
-        torch_dtype: torch.dtype = torch.bfloat16,
+        torch_dtype: OutputDType | torch.dtype = OutputDType.BF16,
         device_map: str | dict | None = None,
         **kwargs: Any,
     ):
+        if isinstance(torch_dtype, OutputDType):
+            torch_dtype = torch_dtype.get_dtype()
+
         from transformers import AudioFlamingo3ForConditionalGeneration, AutoProcessor
 
         self.model_name = model_name

--- a/mteb/models/model_implementations/bmretriever_models.py
+++ b/mteb/models/model_implementations/bmretriever_models.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-import torch
 from sentence_transformers import SentenceTransformer
 from sentence_transformers.models import Pooling, Transformer
 
 from mteb.models import ModelMeta
 from mteb.models.instruct_wrapper import InstructSentenceTransformerModel
-from mteb.types import PromptType
+from mteb.types import OutputDType, PromptType
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -89,7 +88,7 @@ BMRETRIEVER_TRAINING_DATA = {
 BMRetriever_410M = ModelMeta(
     loader=BMRetrieverWrapper,
     loader_kwargs=dict(
-        model_args={"torch_dtype": torch.float32},
+        model_args={"torch_dtype": OutputDType.FLOAT32},
         instruction_template=instruction_template,
         padding_side="left",
         add_eos_token=True,
@@ -120,7 +119,7 @@ BMRetriever_410M = ModelMeta(
 BMRetriever_1B = ModelMeta(
     loader=BMRetrieverWrapper,
     loader_kwargs=dict(
-        model_args={"torch_dtype": torch.float32},
+        model_args={"torch_dtype": OutputDType.FLOAT32},
         instruction_template=instruction_template,
         padding_side="left",
         add_eos_token=True,
@@ -151,7 +150,7 @@ BMRetriever_1B = ModelMeta(
 BMRetriever_2B = ModelMeta(
     loader=BMRetrieverWrapper,
     loader_kwargs=dict(
-        model_args={"torch_dtype": torch.float32},
+        model_args={"torch_dtype": OutputDType.FLOAT32},
         instruction_template=instruction_template,
         padding_side="left",
         add_eos_token=True,
@@ -182,7 +181,7 @@ BMRetriever_2B = ModelMeta(
 BMRetriever_7B = ModelMeta(
     loader=BMRetrieverWrapper,
     loader_kwargs=dict(
-        model_args={"torch_dtype": torch.float32},
+        model_args={"torch_dtype": OutputDType.FLOAT32},
         instruction_template=instruction_template,
         padding_side="left",
         add_eos_token=True,

--- a/mteb/models/model_implementations/codefuse_models.py
+++ b/mteb/models/model_implementations/codefuse_models.py
@@ -1,9 +1,7 @@
-import torch
-
 from mteb.models import ModelMeta
 from mteb.models.instruct_wrapper import InstructSentenceTransformerModel
 from mteb.models.model_meta import ScoringFunction
-from mteb.types import PromptType
+from mteb.types import OutputDType, PromptType
 
 F2LLM_CITATION = """@article{2025F2LLM,
     title={F2LLM Technical Report: Matching SOTA Embedding Performance with 6 Million Open-Source Data},
@@ -958,7 +956,7 @@ F2LLM_v2_80M = ModelMeta(
         add_eos_token=True,
         max_seq_length=8192,
         model_kwargs={
-            "torch_dtype": torch.bfloat16,
+            "torch_dtype": OutputDType.BF16,
         },
     ),
     name="codefuse-ai/F2LLM-v2-80M",
@@ -997,7 +995,7 @@ F2LLM_v2_160M = ModelMeta(
         add_eos_token=True,
         max_seq_length=8192,
         model_kwargs={
-            "torch_dtype": torch.bfloat16,
+            "torch_dtype": OutputDType.BF16,
         },
     ),
     name="codefuse-ai/F2LLM-v2-160M",
@@ -1036,7 +1034,7 @@ F2LLM_v2_330M = ModelMeta(
         add_eos_token=True,
         max_seq_length=8192,
         model_kwargs={
-            "torch_dtype": torch.bfloat16,
+            "torch_dtype": OutputDType.BF16,
         },
     ),
     name="codefuse-ai/F2LLM-v2-330M",
@@ -1075,7 +1073,7 @@ F2LLM_v2_0B6 = ModelMeta(
         add_eos_token=True,
         max_seq_length=8192,
         model_kwargs={
-            "torch_dtype": torch.bfloat16,
+            "torch_dtype": OutputDType.BF16,
         },
     ),
     name="codefuse-ai/F2LLM-v2-0.6B",
@@ -1114,7 +1112,7 @@ F2LLM_v2_1B7 = ModelMeta(
         add_eos_token=True,
         max_seq_length=8192,
         model_kwargs={
-            "torch_dtype": torch.bfloat16,
+            "torch_dtype": OutputDType.BF16,
         },
     ),
     name="codefuse-ai/F2LLM-v2-1.7B",
@@ -1153,7 +1151,7 @@ F2LLM_v2_4B = ModelMeta(
         add_eos_token=True,
         max_seq_length=8192,
         model_kwargs={
-            "torch_dtype": torch.bfloat16,
+            "torch_dtype": OutputDType.BF16,
         },
     ),
     name="codefuse-ai/F2LLM-v2-4B",
@@ -1192,7 +1190,7 @@ F2LLM_v2_8B = ModelMeta(
         add_eos_token=True,
         max_seq_length=8192,
         model_kwargs={
-            "torch_dtype": torch.bfloat16,
+            "torch_dtype": OutputDType.BF16,
         },
     ),
     name="codefuse-ai/F2LLM-v2-8B",
@@ -1231,7 +1229,7 @@ F2LLM_v2_14B = ModelMeta(
         add_eos_token=True,
         max_seq_length=8192,
         model_kwargs={
-            "torch_dtype": torch.bfloat16,
+            "torch_dtype": OutputDType.BF16,
         },
     ),
     name="codefuse-ai/F2LLM-v2-14B",

--- a/mteb/models/model_implementations/colmodernvbert_models.py
+++ b/mteb/models/model_implementations/colmodernvbert_models.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
-import torch
-
 from mteb.models.model_meta import ModelMeta, ScoringFunction
+from mteb.types import OutputDType
 
 from .colpali_models import COLPALI_TRAINING_DATA, ColPaliEngineWrapper
 
@@ -69,7 +68,7 @@ COLMODERNVBERT_CITATION = """
 colmodernvbert = ModelMeta(
     loader=ColModernVBertWrapper,
     loader_kwargs=dict(
-        torch_dtype=torch.float32,
+        torch_dtype=OutputDType.FLOAT32,
     ),
     name="ModernVBERT/colmodernvbert",
     model_type=["late-interaction"],
@@ -100,7 +99,7 @@ colmodernvbert = ModelMeta(
 bimodernvbert = ModelMeta(
     loader=BiModernVBertWrapper,
     loader_kwargs=dict(
-        torch_dtype=torch.float32,
+        torch_dtype=OutputDType.FLOAT32,
     ),
     name="ModernVBERT/bimodernvbert",
     model_type=["dense"],
@@ -131,7 +130,7 @@ bimodernvbert = ModelMeta(
 modernvbert_embed = ModelMeta(
     loader=BiModernVBertWrapper,
     loader_kwargs=dict(
-        torch_dtype=torch.float32,
+        torch_dtype=OutputDType.FLOAT32,
     ),
     name="ModernVBERT/modernvbert-embed",
     model_type=["dense"],

--- a/mteb/models/model_implementations/colpali_models.py
+++ b/mteb/models/model_implementations/colpali_models.py
@@ -8,6 +8,7 @@ from tqdm.auto import tqdm
 
 from mteb.models.abs_encoder import AbsEncoder
 from mteb.models.model_meta import ModelMeta, ScoringFunction
+from mteb.types import OutputDType
 
 if TYPE_CHECKING:
     from PIL import Image
@@ -205,7 +206,7 @@ COLPALI_TRAINING_DATA = {
 colpali_v1_1 = ModelMeta(
     loader=ColPaliWrapper,
     loader_kwargs=dict(
-        torch_dtype=torch.float16,
+        torch_dtype=OutputDType.FLOAT16,
     ),
     name="vidore/colpali-v1.1",
     model_type=["late-interaction"],
@@ -234,7 +235,7 @@ colpali_v1_1 = ModelMeta(
 colpali_v1_2 = ModelMeta(
     loader=ColPaliWrapper,
     loader_kwargs=dict(
-        torch_dtype=torch.float16,
+        torch_dtype=OutputDType.FLOAT16,
     ),
     name="vidore/colpali-v1.2",
     model_type=["late-interaction"],
@@ -263,7 +264,7 @@ colpali_v1_2 = ModelMeta(
 colpali_v1_3 = ModelMeta(
     loader=ColPaliWrapper,
     loader_kwargs=dict(
-        torch_dtype=torch.float16,
+        torch_dtype=OutputDType.FLOAT16,
     ),
     name="vidore/colpali-v1.3",
     model_type=["late-interaction"],

--- a/mteb/models/model_implementations/colqwen_models.py
+++ b/mteb/models/model_implementations/colqwen_models.py
@@ -9,6 +9,7 @@ from tqdm.auto import tqdm
 from mteb.models.abs_encoder import AbsEncoder
 from mteb.models.modality_collators import AudioCollator, VideoCollator
 from mteb.models.model_meta import ModelMeta, ScoringFunction
+from mteb.types import OutputDType
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
@@ -210,9 +211,12 @@ class ColQwen3Wrapper(AbsEncoder):
         *,
         revision: str | None = None,
         device: str | None = None,
-        dtype: torch.dtype | str | None = torch.bfloat16,
+        dtype: OutputDType | torch.dtype | str | None = OutputDType.BF16,
         **kwargs: Any,
     ):
+        if isinstance(dtype, OutputDType):
+            dtype = dtype.get_dtype()
+
         from transformers import AutoModel, AutoProcessor
 
         self.device = device or (
@@ -447,7 +451,7 @@ class ColQwen2_5OmniWrapper(ColPaliEngineWrapper):  # noqa: N801
 colqwen2 = ModelMeta(
     loader=ColQwen2Wrapper,
     loader_kwargs=dict(
-        torch_dtype=torch.float16,
+        torch_dtype=OutputDType.FLOAT16,
     ),
     name="vidore/colqwen2-v1.0",
     model_type=["late-interaction"],
@@ -476,7 +480,7 @@ colqwen2 = ModelMeta(
 colqwen2_5 = ModelMeta(
     loader=ColQwen2_5Wrapper,
     loader_kwargs=dict(
-        torch_dtype=torch.float16,
+        torch_dtype=OutputDType.FLOAT16,
     ),
     name="vidore/colqwen2.5-v0.2",
     model_type=["late-interaction"],
@@ -596,7 +600,7 @@ COLNOMIC_LANGUAGES = [
 colnomic_3b = ModelMeta(
     loader=ColQwen2_5Wrapper,
     loader_kwargs=dict(
-        torch_dtype=torch.float16, attn_implementation="flash_attention_2"
+        torch_dtype=OutputDType.FLOAT16, attn_implementation="flash_attention_2"
     ),
     name="nomic-ai/colnomic-embed-multimodal-3b",
     model_type=["late-interaction"],
@@ -625,7 +629,7 @@ colnomic_3b = ModelMeta(
 colnomic_7b = ModelMeta(
     loader=ColQwen2_5Wrapper,
     loader_kwargs=dict(
-        torch_dtype=torch.float16,
+        torch_dtype=OutputDType.FLOAT16,
     ),
     name="nomic-ai/colnomic-embed-multimodal-7b",
     model_type=["late-interaction"],
@@ -664,7 +668,7 @@ EVOQWEN_TRAINING_DATA = {
 evoqwen25_vl_retriever_3b_v1 = ModelMeta(
     loader=ColQwen2_5Wrapper,
     loader_kwargs=dict(
-        torch_dtype=torch.float16, attn_implementation="flash_attention_2"
+        torch_dtype=OutputDType.FLOAT16, attn_implementation="flash_attention_2"
     ),
     name="ApsaraStackMaaS/EvoQwen2.5-VL-Retriever-3B-v1",
     model_type=["late-interaction"],
@@ -692,7 +696,7 @@ evoqwen25_vl_retriever_3b_v1 = ModelMeta(
 evoqwen25_vl_retriever_7b_v1 = ModelMeta(
     loader=ColQwen2_5Wrapper,
     loader_kwargs=dict(
-        torch_dtype=torch.float16, attn_implementation="flash_attention_2"
+        torch_dtype=OutputDType.FLOAT16, attn_implementation="flash_attention_2"
     ),
     name="ApsaraStackMaaS/EvoQwen2.5-VL-Retriever-7B-v1",
     model_type=["late-interaction"],
@@ -737,7 +741,7 @@ COLQWEN35_V3_TRAINING_DATA = {
 colqwen3_5_v3 = ModelMeta(
     loader=ColQwen3_5Wrapper,
     loader_kwargs=dict(
-        torch_dtype=torch.bfloat16,
+        torch_dtype=OutputDType.BF16,
     ),
     name="athrael-soju/colqwen3.5-4.5B-v3",
     model_type=["late-interaction"],
@@ -797,7 +801,7 @@ COLTURK_CITATION = """
 colturk_vdr_4b = ModelMeta(
     loader=ColQwen3EngineWrapper,
     loader_kwargs=dict(
-        torch_dtype=torch.bfloat16,
+        torch_dtype=OutputDType.BF16,
     ),
     name="Verm1ion/ColTurk-VDR-Qwen3VL-4B-v1.0",
     model_type=["late-interaction"],
@@ -847,7 +851,7 @@ VULTRON_PRIME_8B_TRAINING_DATA = {
 vultron_prime_qwen35_8b = ModelMeta(
     loader=ColQwen3_5Wrapper,
     loader_kwargs=dict(
-        torch_dtype=torch.bfloat16,
+        torch_dtype=OutputDType.BF16,
     ),
     name="vultr/VultronRetrieverPrime-Qwen3.5-8B",
     model_type=["late-interaction"],
@@ -875,7 +879,7 @@ vultron_prime_qwen35_8b = ModelMeta(
 vultron_flash_qwen35_0_8b = ModelMeta(
     loader=ColQwen3_5Wrapper,
     loader_kwargs=dict(
-        torch_dtype=torch.bfloat16,
+        torch_dtype=OutputDType.BF16,
     ),
     name="vultr/VultronRetrieverFlash-Qwen3.5-0.8B",
     model_type=["late-interaction"],
@@ -903,7 +907,7 @@ vultron_flash_qwen35_0_8b = ModelMeta(
 vultron_core_qwen35_4b = ModelMeta(
     loader=ColQwen3_5Wrapper,
     loader_kwargs=dict(
-        torch_dtype=torch.bfloat16,
+        torch_dtype=OutputDType.BF16,
     ),
     name="vultr/VultronRetrieverCore-Qwen3.5-4.5B",
     model_type=["late-interaction"],
@@ -930,7 +934,7 @@ vultron_core_qwen35_4b = ModelMeta(
 
 colqwen_omni = ModelMeta(
     loader=ColQwen2_5OmniWrapper,
-    loader_kwargs=dict(torch_dtype=torch.bfloat16),
+    loader_kwargs=dict(torch_dtype=OutputDType.BF16),
     name="vidore/colqwen-omni-v0.1",
     model_type=["late-interaction"],
     languages=["eng-Latn"],

--- a/mteb/models/model_implementations/colsmol_models.py
+++ b/mteb/models/model_implementations/colsmol_models.py
@@ -1,9 +1,8 @@
 import logging
 from typing import Any
 
-import torch
-
 from mteb.models.model_meta import ModelMeta
+from mteb.types import OutputDType
 
 from .colpali_models import (
     COLPALI_CITATION,
@@ -48,7 +47,7 @@ class ColSmolWrapper(ColPaliEngineWrapper):
 colsmol_256m = ModelMeta(
     loader=ColSmolWrapper,
     loader_kwargs=dict(
-        torch_dtype=torch.float16,
+        torch_dtype=OutputDType.FLOAT16,
     ),
     name="vidore/colSmol-256M",
     model_type=["late-interaction"],
@@ -77,7 +76,7 @@ colsmol_256m = ModelMeta(
 colsmol_500m = ModelMeta(
     loader=ColSmolWrapper,
     loader_kwargs=dict(
-        torch_dtype=torch.float16, attn_implementation="flash_attention_2"
+        torch_dtype=OutputDType.FLOAT16, attn_implementation="flash_attention_2"
     ),
     name="vidore/colSmol-500M",
     model_type=["late-interaction"],

--- a/mteb/models/model_implementations/e5_instruct.py
+++ b/mteb/models/model_implementations/e5_instruct.py
@@ -1,9 +1,8 @@
-import torch
-
 from mteb.models.instruct_wrapper import (
     InstructSentenceTransformerModel,
 )
 from mteb.models.model_meta import ModelMeta, ScoringFunction
+from mteb.types import OutputDType
 
 from .e5_models import (
     E5_PAPER_RELEASE_DATE,
@@ -32,7 +31,7 @@ e5_instruct = ModelMeta(
     loader=InstructSentenceTransformerModel,
     loader_kwargs=dict(
         instruction_template=E5_INSTRUCTION,
-        model_kwargs={"dtype": torch.float16},
+        model_kwargs={"dtype": OutputDType.FLOAT16},
         apply_instruction_to_passages=False,
     ),
     name="intfloat/multilingual-e5-large-instruct",
@@ -75,7 +74,7 @@ me5_instruct_afri_large_instruct = ModelMeta(
     loader=InstructSentenceTransformerModel,
     loader_kwargs=dict(
         instruction_template=E5_INSTRUCTION,
-        model_kwargs={"dtype": torch.float16},
+        model_kwargs={"dtype": OutputDType.FLOAT16},
     ),
     name="McGill-NLP/AfriE5-Large-instruct",
     languages=XLMR_LANGUAGES,
@@ -103,7 +102,7 @@ e5_mistral = ModelMeta(
     loader=InstructSentenceTransformerModel,
     loader_kwargs=dict(
         instruction_template=E5_INSTRUCTION,
-        model_kwargs={"dtype": torch.float16},
+        model_kwargs={"dtype": OutputDType.FLOAT16},
         apply_instruction_to_passages=False,
         # This model pools the last token, so its embedding is the hidden state of
         # the trailing </s>. Its tokenizer_config.json sets add_eos_token, but its
@@ -163,7 +162,7 @@ zeta_alpha_ai__zeta_alpha_e5_mistral = ModelMeta(
     loader=InstructSentenceTransformerModel,
     loader_kwargs=dict(
         instruction_template=E5_INSTRUCTION,
-        model_kwargs={"dtype": torch.bfloat16},
+        model_kwargs={"dtype": OutputDType.BF16},
         apply_instruction_to_passages=False,
     ),
     name="zeta-alpha-ai/Zeta-Alpha-E5-Mistral",

--- a/mteb/models/model_implementations/eagerworks_models.py
+++ b/mteb/models/model_implementations/eagerworks_models.py
@@ -7,7 +7,7 @@ from tqdm.auto import tqdm
 
 from mteb.models.abs_encoder import AbsEncoder
 from mteb.models.model_meta import ModelMeta, ScoringFunction
-from mteb.types import PromptType
+from mteb.types import OutputDType, PromptType
 
 if TYPE_CHECKING:
     from torch.utils.data import DataLoader
@@ -135,7 +135,7 @@ EAGER_EMBED_V1_TRAINING_DATASETS = {"colpali", "bge-ir", "pixmo-docs", "wiki-ss"
 Eager_Embed_V1 = ModelMeta(
     loader=EagerEmbedV1Wrapper,
     loader_kwargs=dict(
-        dtype=torch.float16,
+        dtype=OutputDType.FLOAT16,
         image_size=784,
     ),
     name="eagerworks/eager-embed-v1",

--- a/mteb/models/model_implementations/geevec_models.py
+++ b/mteb/models/model_implementations/geevec_models.py
@@ -11,7 +11,7 @@ import torch
 from mteb.models.abs_encoder import AbsEncoder
 from mteb.models.instruct_wrapper import InstructSentenceTransformerModel
 from mteb.models.model_meta import ModelMeta, ScoringFunction
-from mteb.types import PromptType
+from mteb.types import OutputDType, PromptType
 
 if TYPE_CHECKING:
     import requests
@@ -675,7 +675,7 @@ geevec_embeddings_1_0_lite = ModelMeta(
         apply_instruction_to_passages=False,
         max_seq_length=GEEVEC_MAX_SEQ_LENGTH,
         prompts_dict=PROMPTS_DICT,
-        model_kwargs={"dtype": torch.bfloat16},
+        model_kwargs={"dtype": OutputDType.BF16},
         trust_remote_code=True,
     ),
     name="geevec-ai/geevec-embeddings-1.0-lite",

--- a/mteb/models/model_implementations/geogpt_models.py
+++ b/mteb/models/model_implementations/geogpt_models.py
@@ -1,9 +1,8 @@
 """Models for GeoGPT-Research-Project"""
 
-import torch
-
 from mteb.models.instruct_wrapper import InstructSentenceTransformerModel
 from mteb.models.model_meta import ModelMeta
+from mteb.types import OutputDType
 
 geoembedding = ModelMeta(
     name="GeoGPT-Research-Project/GeoEmbedding",
@@ -15,7 +14,7 @@ geoembedding = ModelMeta(
     loader_kwargs=dict(
         instruction_template="Instruct: {instruction}\nQuery: ",
         apply_instruction_to_passages=False,
-        model_kwargs={"torch_dtype": torch.bfloat16},
+        model_kwargs={"torch_dtype": OutputDType.BF16},
         trust_remote_code=True,
     ),
     release_date="2025-04-22",

--- a/mteb/models/model_implementations/granite_vision_embedding_models.py
+++ b/mteb/models/model_implementations/granite_vision_embedding_models.py
@@ -7,6 +7,7 @@ import torch
 from tqdm.auto import tqdm
 
 from mteb.models.model_meta import ModelMeta
+from mteb.types import OutputDType
 
 if TYPE_CHECKING:
     from PIL import Image
@@ -155,7 +156,7 @@ class GraniteVisionEmbeddingWrapper:
 granite_vision_embedding = ModelMeta(
     loader=GraniteVisionEmbeddingWrapper,
     loader_kwargs=dict(
-        torch_dtype=torch.float16,
+        torch_dtype=OutputDType.FLOAT16,
     ),
     name="ibm-granite/granite-vision-3.3-2b-embedding",
     model_type=["dense"],

--- a/mteb/models/model_implementations/gte_models.py
+++ b/mteb/models/model_implementations/gte_models.py
@@ -1,12 +1,10 @@
-import torch
-
 from mteb.models.instruct_wrapper import InstructSentenceTransformerModel
 from mteb.models.model_meta import (
     ModelMeta,
     ScoringFunction,
 )
 from mteb.models.sentence_transformer_wrapper import SentenceTransformerEncoderWrapper
-from mteb.types import PromptType
+from mteb.types import OutputDType, PromptType
 
 
 def instruction_template(
@@ -33,7 +31,7 @@ gte_qwen2_7b_instruct = ModelMeta(
     loader_kwargs=dict(
         instruction_template=instruction_template,
         apply_instruction_to_passages=False,
-        model_kwargs={"dtype": torch.bfloat16},
+        model_kwargs={"dtype": OutputDType.BF16},
         # The remote modeling_qwen.py calls DynamicCache.get_usable_length(),
         # removed in transformers>=4.56; encoding never needs the KV cache,
         # and use_cache=False skips that code path.
@@ -68,7 +66,7 @@ gte_qwen1_5_7b_instruct = ModelMeta(
     loader_kwargs=dict(
         instruction_template=instruction_template,
         apply_instruction_to_passages=False,
-        model_kwargs={"dtype": torch.float16},
+        model_kwargs={"dtype": OutputDType.FLOAT16},
         add_eos_token=True,
     ),
     name="Alibaba-NLP/gte-Qwen1.5-7B-instruct",
@@ -103,7 +101,7 @@ gte_qwen2_1_5b_instruct = ModelMeta(
     loader_kwargs=dict(
         instruction_template=instruction_template,
         apply_instruction_to_passages=False,
-        model_kwargs={"dtype": torch.float16},
+        model_kwargs={"dtype": OutputDType.FLOAT16},
         add_eos_token=True,
     ),
     name="Alibaba-NLP/gte-Qwen2-1.5B-instruct",

--- a/mteb/models/model_implementations/jasper_models.py
+++ b/mteb/models/model_implementations/jasper_models.py
@@ -16,7 +16,7 @@ from mteb.models.model_implementations.e5_instruct import E5_MISTRAL_TRAINING_DA
 from mteb.models.model_implementations.nvidia_models import nvidia_training_datasets
 from mteb.models.model_implementations.qzhou_models import qzhou_training_data
 from mteb.models.model_meta import ModelMeta, ScoringFunction
-from mteb.types import PromptType
+from mteb.types import OutputDType, PromptType
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -286,7 +286,7 @@ jasper_en_v1 = ModelMeta(
         config_kwargs={"is_text_encoder": True, "vector_dim": 12288},
         model_kwargs={
             "attn_implementation": "sdpa",
-            "torch_dtype": torch.bfloat16,
+            "torch_dtype": OutputDType.BF16,
         },
         trust_remote_code=True,
         max_seq_length=2048,

--- a/mteb/models/model_implementations/jina_models.py
+++ b/mteb/models/model_implementations/jina_models.py
@@ -15,7 +15,7 @@ from mteb.models.sentence_transformer_wrapper import (
     CrossEncoderWrapper,
     SentenceTransformerEncoderWrapper,
 )
-from mteb.types import PromptType
+from mteb.types import OutputDType, PromptType
 
 if TYPE_CHECKING:
     from sentence_transformers import CrossEncoder
@@ -411,13 +411,16 @@ class JinaV4Wrapper(AbsEncoder):
         revision: str | None = None,
         device: str | None = None,
         device_map: str | None = None,
-        torch_dtype: torch.dtype = torch.bfloat16,
+        torch_dtype: OutputDType | torch.dtype = OutputDType.BF16,
         attn_implementation: str = "sdpa",
         trust_remote_code: bool = True,
         model_prompts: dict[str, str] | None = None,
         vector_type: Literal[SUPPORTED_VECTOR_TYPES] = "single_vector",
         **kwargs: Any,
     ) -> None:
+        if isinstance(torch_dtype, OutputDType):
+            torch_dtype = torch_dtype.get_dtype()
+
         device = device_map or device
 
         self.device = device or (

--- a/mteb/models/model_implementations/kalm_reranker.py
+++ b/mteb/models/model_implementations/kalm_reranker.py
@@ -10,6 +10,7 @@ from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
 from transformers.modeling_outputs import BaseModelOutput
 
 from mteb.models.model_meta import ModelMeta
+from mteb.types import OutputDType
 
 if TYPE_CHECKING:
     from torch.utils.data import DataLoader
@@ -474,7 +475,7 @@ KALM_RERANKER_V1_CITATION = """@misc{zhao2026kalmrerankerv1,
 kalm_reranker_v1_nano = ModelMeta(
     loader=KaLMRerankerWrapper,
     loader_kwargs=dict(
-        dtype=torch.bfloat16,
+        dtype=OutputDType.BF16,
     ),
     name="KaLM-Embedding/KaLM-Reranker-V1-Nano",
     revision="1d3dcd79115a77b91b2ece798f536880d2115e48",
@@ -506,7 +507,7 @@ kalm_reranker_v1_nano = ModelMeta(
 kalm_reranker_v1_small = ModelMeta(
     loader=KaLMRerankerWrapper,
     loader_kwargs=dict(
-        dtype=torch.bfloat16,
+        dtype=OutputDType.BF16,
     ),
     name="KaLM-Embedding/KaLM-Reranker-V1-Small",
     revision="e8eaadc957a7ae383a4983a483c2c399f1056cd3",
@@ -537,7 +538,7 @@ kalm_reranker_v1_small = ModelMeta(
 kalm_reranker_v1_large = ModelMeta(
     loader=KaLMRerankerWrapper,
     loader_kwargs=dict(
-        dtype=torch.bfloat16,
+        dtype=OutputDType.BF16,
     ),
     name="KaLM-Embedding/KaLM-Reranker-V1-Large",
     revision="bc5cb8fe5a266b6d0b5ffdb9da4c06c950ae242f",

--- a/mteb/models/model_implementations/lighton_rerank_models.py
+++ b/mteb/models/model_implementations/lighton_rerank_models.py
@@ -21,6 +21,7 @@ from tqdm.auto import tqdm
 
 from mteb.models.model_meta import ModelMeta
 from mteb.models.sentence_transformer_wrapper import CrossEncoderWrapper
+from mteb.types import OutputDType
 
 if TYPE_CHECKING:
     from PIL import Image
@@ -382,7 +383,7 @@ _LIGHTON_COMMON = dict(
 _PW_COMMON = dict(
     loader=CrossEncoderWrapper,
     loader_kwargs=dict(
-        model_kwargs=dict(dtype=torch.bfloat16),
+        model_kwargs=dict(dtype=OutputDType.BF16),
     ),
     framework=["Sentence Transformers", "PyTorch", "Transformers", "safetensors"],
     **_LIGHTON_COMMON,

--- a/mteb/models/model_implementations/linq_models.py
+++ b/mteb/models/model_implementations/linq_models.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import torch
-
 from mteb.models.instruct_wrapper import InstructSentenceTransformerModel
 from mteb.models.model_meta import ModelMeta, ScoringFunction
+from mteb.types import OutputDType
 
 from .e5_instruct import E5_MISTRAL_TRAINING_DATA
 
@@ -30,7 +29,7 @@ Linq_Embed_Mistral = ModelMeta(
     loader=InstructSentenceTransformerModel,
     loader_kwargs=dict(
         instruction_template=instruction_template,
-        model_kwargs={"dtype": torch.bfloat16},
+        model_kwargs={"dtype": OutputDType.BF16},
         apply_instruction_to_passages=False,
     ),
     name="Linq-AI-Research/Linq-Embed-Mistral",

--- a/mteb/models/model_implementations/llm2vec_models.py
+++ b/mteb/models/model_implementations/llm2vec_models.py
@@ -8,6 +8,7 @@ import torch
 from mteb._requires_package import suggest_package
 from mteb.models.abs_encoder import AbsEncoder
 from mteb.models.model_meta import ModelMeta, ScoringFunction
+from mteb.types import OutputDType
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -136,7 +137,7 @@ llm2vec_llama3_8b_supervised = ModelMeta(
         base_model_name_or_path="McGill-NLP/LLM2Vec-Meta-Llama-3-8B-Instruct-mntp",
         peft_model_name_or_path="McGill-NLP/LLM2Vec-Meta-Llama-3-8B-Instruct-mntp-supervised",
         device_map="auto",
-        torch_dtype=torch.bfloat16,
+        torch_dtype=OutputDType.BF16,
     ),
     name="McGill-NLP/LLM2Vec-Meta-Llama-3-8B-Instruct-mntp-supervised",
     model_type=["dense"],
@@ -168,7 +169,7 @@ llm2vec_llama3_8b_unsupervised = ModelMeta(
         base_model_name_or_path="McGill-NLP/LLM2Vec-Meta-Llama-3-8B-Instruct-mntp",
         peft_model_name_or_path="McGill-NLP/LLM2Vec-Meta-Llama-3-8B-Instruct-mntp-unsup-simcse",
         device_map="auto",
-        torch_dtype=torch.bfloat16,
+        torch_dtype=OutputDType.BF16,
     ),
     name="McGill-NLP/LLM2Vec-Meta-Llama-3-8B-Instruct-mntp-unsup-simcse",
     model_type=["dense"],
@@ -199,7 +200,7 @@ llm2vec_mistral7b_supervised = ModelMeta(
         base_model_name_or_path="McGill-NLP/LLM2Vec-Mistral-7B-Instruct-v2-mntp",
         peft_model_name_or_path="McGill-NLP/LLM2Vec-Mistral-7B-Instruct-v2-mntp-supervised",
         device_map="auto",
-        torch_dtype=torch.bfloat16,
+        torch_dtype=OutputDType.BF16,
     ),
     name="McGill-NLP/LLM2Vec-Mistral-7B-Instruct-v2-mntp-supervised",
     model_type=["dense"],
@@ -230,7 +231,7 @@ llm2vec_mistral7b_unsupervised = ModelMeta(
         base_model_name_or_path="McGill-NLP/LLM2Vec-Mistral-7B-Instruct-v2-mntp",
         peft_model_name_or_path="McGill-NLP/LLM2Vec-Mistral-7B-Instruct-v2-mntp-unsup-simcse",
         device_map="auto",
-        torch_dtype=torch.bfloat16,
+        torch_dtype=OutputDType.BF16,
     ),
     name="McGill-NLP/LLM2Vec-Mistral-7B-Instruct-v2-mntp-unsup-simcse",
     model_type=["dense"],
@@ -261,7 +262,7 @@ llm2vec_llama2_7b_supervised = ModelMeta(
         base_model_name_or_path="McGill-NLP/LLM2Vec-Llama-2-7b-chat-hf-mntp",
         peft_model_name_or_path="McGill-NLP/LLM2Vec-Llama-2-7b-chat-hf-mntp-supervised",
         device_map="auto",
-        torch_dtype=torch.bfloat16,
+        torch_dtype=OutputDType.BF16,
     ),
     name="McGill-NLP/LLM2Vec-Llama-2-7b-chat-hf-mntp-supervised",
     model_type=["dense"],
@@ -292,7 +293,7 @@ llm2vec_llama2_7b_unsupervised = ModelMeta(
         base_model_name_or_path="McGill-NLP/LLM2Vec-Llama-2-7b-chat-hf-mntp",
         peft_model_name_or_path="McGill-NLP/LLM2Vec-Llama-2-7b-chat-hf-mntp-unsup-simcse",
         device_map="auto",
-        torch_dtype=torch.bfloat16,
+        torch_dtype=OutputDType.BF16,
     ),
     name="McGill-NLP/LLM2Vec-Llama-2-7b-chat-hf-mntp-unsup-simcse",
     model_type=["dense"],
@@ -323,7 +324,7 @@ llm2vec_sheared_llama_supervised = ModelMeta(
         base_model_name_or_path="McGill-NLP/LLM2Vec-Sheared-LLaMA-mntp",
         peft_model_name_or_path="McGill-NLP/LLM2Vec-Sheared-LLaMA-mntp-supervised",
         device_map="auto",
-        torch_dtype=torch.bfloat16,
+        torch_dtype=OutputDType.BF16,
     ),
     name="McGill-NLP/LLM2Vec-Sheared-LLaMA-mntp-supervised",
     model_type=["dense"],
@@ -354,7 +355,7 @@ llm2vec_sheared_llama_unsupervised = ModelMeta(
         base_model_name_or_path="McGill-NLP/LLM2Vec-Sheared-LLaMA-mntp",
         peft_model_name_or_path="McGill-NLP/LLM2Vec-Sheared-LLaMA-mntp-unsup-simcse",
         device_map="auto",
-        torch_dtype=torch.bfloat16,
+        torch_dtype=OutputDType.BF16,
     ),
     name="McGill-NLP/LLM2Vec-Sheared-LLaMA-mntp-unsup-simcse",
     model_type=["dense"],

--- a/mteb/models/model_implementations/misc_models.py
+++ b/mteb/models/model_implementations/misc_models.py
@@ -1,10 +1,9 @@
-import torch
-
 from mteb.models.model_meta import (
     ModelMeta,
     ScoringFunction,
 )
 from mteb.models.sentence_transformer_wrapper import SentenceTransformerEncoderWrapper
+from mteb.types import OutputDType
 
 from .bge_models import bge_training_data
 from .e5_models import E5_TRAINING_DATA
@@ -1876,7 +1875,7 @@ openbmb__minicpm_embedding = ModelMeta(
     loader_kwargs=dict(
         model_kwargs={
             # "attn_implementation": "flash_attention_2",
-            "torch_dtype": torch.float16,
+            "torch_dtype": OutputDType.FLOAT16,
         },
         trust_remote_code=True,
         # https://huggingface.co/openbmb/MiniCPM-Embedding/blob/c0cb2de33fb366e17c30f9d53142ff11bc18e049/README.md?code=true#L405

--- a/mteb/models/model_implementations/nomic_multimodal.py
+++ b/mteb/models/model_implementations/nomic_multimodal.py
@@ -9,6 +9,7 @@ from tqdm.auto import tqdm
 from mteb.models.abs_encoder import AbsEncoder
 from mteb.models.model_implementations.colpali_models import COLPALI_TRAINING_DATA
 from mteb.models.model_meta import ModelMeta, ScoringFunction
+from mteb.types import OutputDType
 
 if TYPE_CHECKING:
     from torch.utils.data import DataLoader
@@ -146,7 +147,7 @@ class BiQwen2_5Wrapper(AbsEncoder):  # noqa: N801
 nomic_embed_multimodal_3b = ModelMeta(
     loader=BiQwen2_5Wrapper,
     loader_kwargs=dict(
-        torch_dtype=torch.bfloat16,
+        torch_dtype=OutputDType.BF16,
         base_revision="66285546d2b821cf421d4f5eb2576359d3770cd3",
     ),
     name="nomic-ai/nomic-embed-multimodal-3b",
@@ -176,7 +177,7 @@ nomic_embed_multimodal_3b = ModelMeta(
 nomic_embed_multimodal_7b = ModelMeta(
     loader=BiQwen2_5Wrapper,
     loader_kwargs=dict(
-        torch_dtype=torch.bfloat16,
+        torch_dtype=OutputDType.BF16,
         base_revision="cc594898137f460bfe9f0759e9844b3ce807cfb5",
     ),
     name="nomic-ai/nomic-embed-multimodal-7b",

--- a/mteb/models/model_implementations/nvidia_models.py
+++ b/mteb/models/model_implementations/nvidia_models.py
@@ -764,7 +764,7 @@ nemotron_rerank_1b_v2 = ModelMeta(
         trust_remote_code=True,
         query_prefix="question:",
         passage_prefix=" \n \n passage:",
-        model_kwargs={"torch_dtype": torch.float32},
+        model_kwargs={"torch_dtype": OutputDType.FLOAT32},
     ),
     name="nvidia/llama-nemotron-rerank-1b-v2",
     extra_requirements_groups=["nemotron-rerank"],

--- a/mteb/models/model_implementations/nvidia_nemotron_vl_models.py
+++ b/mteb/models/model_implementations/nvidia_nemotron_vl_models.py
@@ -9,7 +9,7 @@ from tqdm.auto import tqdm
 
 from mteb.models.abs_encoder import AbsEncoder
 from mteb.models.model_meta import ModelMeta
-from mteb.types import PromptType
+from mteb.types import OutputDType, PromptType
 
 if TYPE_CHECKING:
     from mteb.abstasks.task_metadata import TaskMetadata
@@ -54,10 +54,13 @@ class NemotronColEmbedVL(AbsEncoder):
         revision: str,
         trust_remote_code: bool,
         device_map: str = "cuda",
-        torch_dtype: torch.dtype = torch.bfloat16,
+        torch_dtype: OutputDType | torch.dtype = OutputDType.BF16,
         attn_implementation: str = "flash_attention_2",
         **kwargs: Any,
     ):
+        if isinstance(torch_dtype, OutputDType):
+            torch_dtype = torch_dtype.get_dtype()
+
         from transformers import AutoModel
 
         self.model = AutoModel.from_pretrained(
@@ -329,12 +332,15 @@ class LlamaNemotronEmbedVL(AbsEncoder):
         trust_remote_code: bool,
         extra_name: str = "llama-nemotron-embed-vl-1b-v2",
         device_map: str = "cuda",
-        torch_dtype: torch.dtype = torch.bfloat16,
+        torch_dtype: OutputDType | torch.dtype = OutputDType.BF16,
         attn_implementation: str = "flash_attention_2",
         use_image_modality: bool = True,
         use_text_modality: bool = True,
         **kwargs: Any,
     ):
+        if isinstance(torch_dtype, OutputDType):
+            torch_dtype = torch_dtype.get_dtype()
+
         self.use_image_modality = use_image_modality
         self.use_text_modality = use_text_modality
         if not self.use_image_modality and not self.use_text_modality:

--- a/mteb/models/model_implementations/ops_colqwen3_models.py
+++ b/mteb/models/model_implementations/ops_colqwen3_models.py
@@ -8,6 +8,7 @@ from transformers import AutoModel, AutoProcessor
 
 from mteb.models.abs_encoder import AbsEncoder
 from mteb.models.model_meta import ModelMeta, ScoringFunction
+from mteb.types import OutputDType
 
 if TYPE_CHECKING:
     from torch.utils.data import DataLoader
@@ -244,7 +245,7 @@ OPS_COLQWEN3_CITATION = """
 ops_colqwen3_4b = ModelMeta(
     loader=OpsColQwen3Wrapper,
     name="OpenSearch-AI/Ops-Colqwen3-4B",
-    loader_kwargs=dict(dtype=torch.float16, trust_remote_code=True),
+    loader_kwargs=dict(dtype=OutputDType.FLOAT16, trust_remote_code=True),
     languages=multilingual_langs,
     revision="4894b7d451ff33981650acc693bb482dbef302d3",
     release_date="2026-01-24",

--- a/mteb/models/model_implementations/promptriever_models.py
+++ b/mteb/models/model_implementations/promptriever_models.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-import torch
-
 from mteb.models.abs_encoder import AbsEncoder
 from mteb.models.model_meta import ModelMeta, ScoringFunction
+from mteb.types import OutputDType
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -77,7 +76,7 @@ promptriever_llama2 = ModelMeta(
         base_model_name_or_path="meta-llama/Llama-2-7b-hf",
         peft_model_name_or_path="samaya-ai/promptriever-llama2-7b-v1",
         device_map="auto",
-        torch_dtype=torch.bfloat16,
+        torch_dtype=OutputDType.BF16,
         model_prompts=model_prompts,
     ),
     name="samaya-ai/promptriever-llama2-7b-v1",
@@ -110,7 +109,7 @@ promptriever_llama3 = ModelMeta(
         base_model_name_or_path="meta-llama/Meta-Llama-3.1-8B",
         peft_model_name_or_path="samaya-ai/promptriever-llama3.1-8b-v1",
         device_map="auto",
-        torch_dtype=torch.bfloat16,
+        torch_dtype=OutputDType.BF16,
         model_prompts=model_prompts,
     ),
     name="samaya-ai/promptriever-llama3.1-8b-v1",
@@ -144,7 +143,7 @@ promptriever_llama3_instruct = ModelMeta(
         base_model_name_or_path="meta-llama/Meta-Llama-3.1-8B-Instruct",
         peft_model_name_or_path="samaya-ai/promptriever-llama3.1-8b-instruct-v1",
         device_map="auto",
-        torch_dtype=torch.bfloat16,
+        torch_dtype=OutputDType.BF16,
         model_prompts=model_prompts,
     ),
     name="samaya-ai/promptriever-llama3.1-8b-instruct-v1",
@@ -178,7 +177,7 @@ promptriever_mistral_v1 = ModelMeta(
         base_model_name_or_path="mistralai/Mistral-7B-v0.1",
         peft_model_name_or_path="samaya-ai/promptriever-mistral-v0.1-7b-v1",
         device_map="auto",
-        torch_dtype=torch.bfloat16,
+        torch_dtype=OutputDType.BF16,
         model_prompts=model_prompts,
     ),
     name="samaya-ai/promptriever-mistral-v0.1-7b-v1",

--- a/mteb/models/model_implementations/qwen3_reranker.py
+++ b/mteb/models/model_implementations/qwen3_reranker.py
@@ -11,6 +11,7 @@ from transformers import (
 )
 
 from mteb.models.model_meta import ModelMeta
+from mteb.types import OutputDType
 
 if TYPE_CHECKING:
     from torch.utils.data import DataLoader
@@ -180,7 +181,7 @@ QWEN3_CITATION = """@article{qwen3embedding,
 qwen3_reranker_0_6b = ModelMeta(
     loader=Qwen3RerankerWrapper,
     loader_kwargs=dict(
-        dtype=torch.bfloat16,
+        dtype=OutputDType.BF16,
     ),
     name="Qwen/Qwen3-Reranker-0.6B",
     revision="6e9e69830b95c52b5fd889b7690dda3329508de3",
@@ -211,7 +212,7 @@ qwen3_reranker_0_6b = ModelMeta(
 qwen3_reranker_4b = ModelMeta(
     loader=Qwen3RerankerWrapper,
     loader_kwargs=dict(
-        dtype=torch.bfloat16,
+        dtype=OutputDType.BF16,
     ),
     name="Qwen/Qwen3-Reranker-4B",
     revision="f16fc5d5d2b9b1d0db8280929242745d79794ef5",
@@ -242,7 +243,7 @@ qwen3_reranker_4b = ModelMeta(
 qwen3_reranker_8b = ModelMeta(
     loader=Qwen3RerankerWrapper,
     loader_kwargs=dict(
-        dtype=torch.bfloat16,
+        dtype=OutputDType.BF16,
     ),
     name="Qwen/Qwen3-Reranker-8B",
     revision="5fa94080caafeaa45a15d11f969d7978e087a3db",

--- a/mteb/models/model_implementations/repllama_models.py
+++ b/mteb/models/model_implementations/repllama_models.py
@@ -13,7 +13,7 @@ from mteb.models.model_meta import (
     ModelMeta,
     ScoringFunction,
 )
-from mteb.types import PromptType
+from mteb.types import OutputDType, PromptType
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -166,7 +166,7 @@ repllama_llama2_original = ModelMeta(
     loader_kwargs=dict(
         base_model_name_or_path="meta-llama/Llama-2-7b-hf",
         device_map="auto",
-        torch_dtype=torch.bfloat16,
+        torch_dtype=OutputDType.BF16,
         model_prompts=model_prompts,
     ),
     name="castorini/repllama-v1-7b-lora-passage",
@@ -201,7 +201,7 @@ repllama_llama2_reproduced = ModelMeta(
     loader_kwargs=dict(
         base_model_name_or_path="meta-llama/Llama-2-7b-hf",
         device_map="auto",
-        torch_dtype=torch.bfloat16,
+        torch_dtype=OutputDType.BF16,
         model_prompts=model_prompts,
     ),
     name="samaya-ai/RepLLaMA-reproduced",

--- a/mteb/models/model_implementations/ru_sentence_models.py
+++ b/mteb/models/model_implementations/ru_sentence_models.py
@@ -1,14 +1,12 @@
 """Sentence models for evaluation on the Russian part of MTEB"""
 
-import torch
-
 from mteb.models.instruct_wrapper import InstructSentenceTransformerModel
 from mteb.models.model_meta import (
     ModelMeta,
     ScoringFunction,
 )
 from mteb.models.sentence_transformer_wrapper import SentenceTransformerEncoderWrapper
-from mteb.types import PromptType
+from mteb.types import OutputDType, PromptType
 
 from .bge_models import bge_m3_training_data
 from .nomic_models import (
@@ -924,7 +922,7 @@ giga_embeddings = ModelMeta(
         apply_instruction_to_passages=True,
         prompts_dict=GIGA_task_prompts,
         model_kwargs={
-            "torch_dtype": torch.bfloat16,
+            "torch_dtype": OutputDType.BF16,
         },
     ),
     name="ai-sage/Giga-Embeddings-instruct",

--- a/mteb/models/model_implementations/visrag_models.py
+++ b/mteb/models/model_implementations/visrag_models.py
@@ -20,6 +20,7 @@ from tqdm.auto import tqdm
 
 from mteb.models.abs_encoder import AbsEncoder
 from mteb.models.model_meta import ModelMeta, ScoringFunction
+from mteb.types import OutputDType
 
 if TYPE_CHECKING:
     from torch.utils.data import DataLoader
@@ -56,9 +57,12 @@ class VisRAGRetWrapper(AbsEncoder):
         model_name: str = "openbmb/VisRAG-Ret",
         revision: str | None = None,
         device: str | None = None,
-        torch_dtype: torch.dtype = torch.bfloat16,
+        torch_dtype: OutputDType | torch.dtype = OutputDType.BF16,
         **kwargs: Any,
     ) -> None:
+        if isinstance(torch_dtype, OutputDType):
+            torch_dtype = torch_dtype.get_dtype()
+
         from transformers import AutoConfig, AutoModel, AutoTokenizer
 
         self.model_name = model_name
@@ -173,7 +177,7 @@ VISRAG_RET_TRAINING_DATASETS = {
 
 visrag_ret = ModelMeta(
     loader=VisRAGRetWrapper,
-    loader_kwargs=dict(torch_dtype=torch.bfloat16),
+    loader_kwargs=dict(torch_dtype=OutputDType.BF16),
     name="openbmb/VisRAG-Ret",
     revision="95ef596df871b606167cb7e4b7215caf1bfdf761",
     release_date="2024-10-14",

--- a/mteb/models/model_implementations/webai_models.py
+++ b/mteb/models/model_implementations/webai_models.py
@@ -31,9 +31,12 @@ class ColVec1Wrapper(AbsEncoder):
         revision: str | None = None,
         device: str | None = None,
         trust_remote_code: bool = True,
-        torch_dtype: torch.dtype | None = torch.bfloat16,
+        torch_dtype: OutputDType | torch.dtype | None = OutputDType.BF16,
         **kwargs: Any,
     ):
+        if isinstance(torch_dtype, OutputDType):
+            torch_dtype = torch_dtype.get_dtype()
+
         self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
 
         self.model = AutoModel.from_pretrained(
@@ -159,10 +162,13 @@ class ColVec11Wrapper(ColVec1Wrapper):
         revision: str | None = None,
         device: str | None = None,
         trust_remote_code: bool = True,
-        torch_dtype: torch.dtype | None = torch.bfloat16,
+        torch_dtype: OutputDType | torch.dtype | None = OutputDType.BF16,
         processor_kwargs: dict[str, Any] | None = None,
         **model_kwargs: Any,
     ):
+        if isinstance(torch_dtype, OutputDType):
+            torch_dtype = torch_dtype.get_dtype()
+
         self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
         processor_kwargs = dict(processor_kwargs or {})
 
@@ -295,7 +301,7 @@ COLVEC1_1_CITATION = """
 
 colvec1_4b = ModelMeta(
     loader=ColVec1Wrapper,
-    loader_kwargs=dict(torch_dtype=torch.bfloat16),
+    loader_kwargs=dict(torch_dtype=OutputDType.BF16),
     name="webAI-Official/webAI-ColVec1-4b",
     revision="dce73882e6b89a01e702891a593f775dc5711929",
     release_date="2026-04-05",
@@ -327,7 +333,7 @@ colvec1_4b = ModelMeta(
 
 colvec1_9b = ModelMeta(
     loader=ColVec1Wrapper,
-    loader_kwargs=dict(torch_dtype=torch.bfloat16),
+    loader_kwargs=dict(torch_dtype=OutputDType.BF16),
     name="webAI-Official/webAI-ColVec1-9b",
     revision="3767539920b9132abb24cef2c88d42d81817e50b",
     release_date="2026-04-05",
@@ -360,7 +366,7 @@ colvec1_9b = ModelMeta(
 colvec1_1_4b = ModelMeta(
     loader=ColVec11Wrapper,
     loader_kwargs={
-        "torch_dtype": torch.bfloat16,
+        "torch_dtype": OutputDType.BF16,
         "attn_implementation": "sdpa",
         "processor_kwargs": {
             "max_num_visual_tokens": 1792,
@@ -407,7 +413,7 @@ colvec1_1_4b = ModelMeta(
 colvec1_1_8b = ModelMeta(
     loader=ColVec11Wrapper,
     loader_kwargs={
-        "torch_dtype": torch.bfloat16,
+        "torch_dtype": OutputDType.BF16,
         "attn_implementation": "sdpa",
         "processor_kwargs": {
             "max_num_visual_tokens": 1792,

--- a/mteb/types/_encoder_io.py
+++ b/mteb/types/_encoder_io.py
@@ -159,12 +159,14 @@ class MultimodalInput(  # type: ignore[misc]
 
 
 class OutputDType(HelpfulStrEnum):
-    """Enum for valid compression levels.
+    """Enum for torch dtypes, referred to by name rather than by `torch.dtype` object.
 
     Used by the CompressionWrapper class and specified by models to indicate the dtypes of output embeddings they
-    support internally.
+    support internally, and by `ModelMeta` entries to declare the dtype a model should be loaded in -- naming the
+    dtype keeps model metadata importable without torch. Call `get_dtype()` to resolve one to a real `torch.dtype`.
     """
 
+    FLOAT32 = "float32"
     FLOAT16 = "float16"
     BF16 = "bfloat16"
     INT8 = "int8"

--- a/tests/test_ensure_no_torch_at_import.py
+++ b/tests/test_ensure_no_torch_at_import.py
@@ -233,32 +233,40 @@ def test_model_meta_dtypes_are_named_not_torch_objects() -> None:
 
 
 def test_model_implementations_declare_no_import_time_torch_dtypes() -> None:
-    """No model file may evaluate a `torch.<dtype>` at import time; use `OutputDType` instead."""
+    """No model file may evaluate a `torch.<dtype>` at import time; use `OutputDType` instead.
+
+    Everything outside a function body runs at import -- module-level `ModelMeta(...)` calls,
+    class bodies, decorators and signature defaults -- so only function bodies are exempt.
+    """
     import ast
 
-    dtypes = {"float16", "float32", "bfloat16", "uint8", "int8", "float64"}
+    from mteb.types import OutputDType
+
+    # every dtype OutputDType can name (including the float8 variants), plus float64
+    dtypes = {member.value for member in OutputDType} | {"float64"}
+
     offenders = []
     for path in sorted(
         (_REPO_ROOT / "mteb/models/model_implementations").rglob("*.py")
     ):
         tree = ast.parse(path.read_text())
-        for node in ast.walk(tree):
-            # only signature defaults execute at import; bodies are evaluated lazily
-            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                continue
-            for default in [*node.args.defaults, *node.args.kw_defaults]:
-                if default is None:
-                    continue
-                for sub in ast.walk(default):
-                    if (
-                        isinstance(sub, ast.Attribute)
-                        and isinstance(sub.value, ast.Name)
-                        and sub.value.id == "torch"
-                        and sub.attr in dtypes
-                    ):
-                        offenders.append(f"{path.name}:{sub.lineno} torch.{sub.attr}")
+        body_lines = {
+            line
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            for line in range(node.body[0].lineno, node.end_lineno + 1)
+        }
+        offenders += [
+            f"{path.name}:{node.lineno} torch.{node.attr}"
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "torch"
+            and node.attr in dtypes
+            and node.lineno not in body_lines
+        ]
 
     assert not offenders, (
-        "these default arguments evaluate a torch dtype at import time; use the matching "
-        f"OutputDType member instead: {offenders}"
+        "these evaluate a torch dtype at import time; use the matching OutputDType member "
+        f"instead: {offenders}"
     )

--- a/tests/test_ensure_no_torch_at_import.py
+++ b/tests/test_ensure_no_torch_at_import.py
@@ -211,3 +211,54 @@ def test_importing_benchmarks_does_not_import_torch() -> None:
     assert _loaded_heavy_deps("mteb.benchmarks.benchmark", ("mteb",)) == [], (
         "importing mteb.benchmarks.benchmark pulled in a heavy dependency"
     )
+
+
+def test_model_meta_dtypes_are_named_not_torch_objects() -> None:
+    """`ModelMeta` declares load dtypes by name, so metadata stays importable without torch.
+
+    `OutputDType` is a `str` enum, so it resolves through both `getattr(torch, ...)` (the path
+    transformers takes for a string dtype) and `OutputDType.get_dtype()`.
+    """
+    import torch
+
+    import mteb
+    from mteb.types import OutputDType
+
+    meta = mteb.get_model_meta("vidore/colpali-v1.1")
+    declared = meta.loader_kwargs["torch_dtype"]
+
+    assert isinstance(declared, OutputDType)
+    assert declared.get_dtype() is torch.float16
+    assert getattr(torch, declared) is torch.float16
+
+
+def test_model_implementations_declare_no_import_time_torch_dtypes() -> None:
+    """No model file may evaluate a `torch.<dtype>` at import time; use `OutputDType` instead."""
+    import ast
+
+    dtypes = {"float16", "float32", "bfloat16", "uint8", "int8", "float64"}
+    offenders = []
+    for path in sorted(
+        (_REPO_ROOT / "mteb/models/model_implementations").rglob("*.py")
+    ):
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            # only signature defaults execute at import; bodies are evaluated lazily
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for default in [*node.args.defaults, *node.args.kw_defaults]:
+                if default is None:
+                    continue
+                for sub in ast.walk(default):
+                    if (
+                        isinstance(sub, ast.Attribute)
+                        and isinstance(sub.value, ast.Name)
+                        and sub.value.id == "torch"
+                        and sub.attr in dtypes
+                    ):
+                        offenders.append(f"{path.name}:{sub.lineno} torch.{sub.attr}")
+
+    assert not offenders, (
+        "these default arguments evaluate a torch dtype at import time; use the matching "
+        f"OutputDType member instead: {offenders}"
+    )


### PR DESCRIPTION
Refs #5063. Follows #5329, #5350, #5426, #5441.

Model metadata currently needs torch imported just to define it like `ModelMeta(loader_kwargs=dict(torch_dtype=torch.float16))` 
which evaluates at module scope, so building `MODEL_REGISTRY` pulls in torch. This PR changed it and names the `dtype` with an `OutputDType` member instead of holding a `torch.dtype` object.

Changes:

1. `OutputDType:` added FLOAT32 (the enum had no member) and update docstring as it covers both output-embedding dtypes and model load dtypes.
2. Changes in 85 import-time sites across 30 model files: `torch.float16 → OutputDType.FLOAT16`.
3. 8 wrapper `__init__` whose default changed now resolve at the boundary like:
```
if isinstance(torch_dtype, OutputDType):
        torch_dtype = torch_dtype.get_dtype()
```

`OutputDType` is a str enum, so `getattr(torch, member)` works and transformers resolves it natively.
4. Docs: documented the convention in `adding_a_model.md` (and added the OutputDType import its existing example was missing); corrected the compression doc, which described the enum as only compression levels.

Follow-up PR: Files under model_implementations/ needing restructuring: 94 → 68. No dtype sites remain.
1. 50 @torch.no_grad() / @torch.inference_mode() decorators
2. 48 device: str = "cuda" if torch.cuda.is_available() else "cpu" defaults
3. 4 module- or class-scope `torch.nn.* / torch.Tensor` references and the 161 module-level `import torch / transformers `statements which must move to make is genuinely torch-free

Testing: 
2 new tests: one checks a ModelMeta dtype resolves through both `get_dtype()` and `getattr(torch, ...);` the other is an AST check that no model file evaluates a `torch.<dtype>` in a signature default, so the convention doesn't rot as new models land. Confirmed red when a torch.bfloat16 default is restored.