### PR TITLE
recognize OpenMDW-1.1 as an open license

### DIFF
--- a/mteb/models/model_meta.py
+++ b/mteb/models/model_meta.py
@@ -160,6 +160,7 @@ OPEN_LICENSES: frozenset[str] = frozenset(
         "cc-by-sa-4.0",
         "odc-by",
         "cdla-sharing-1.0",
+        "openmdw-1.1",
     }
 )
 

--- a/mteb/types/_metadata.py
+++ b/mteb/types/_metadata.py
@@ -49,6 +49,7 @@ Licenses = (
         "multiple",
         "gemma",
         "eupl-1.2",
+        "openmdw-1.1",
     ]
 )
 """The different licenses that a dataset or model can have. This list can be extended as needed."""

--- a/tests/test_models/test_model_meta.py
+++ b/tests/test_models/test_model_meta.py
@@ -178,10 +178,11 @@ def _openness_meta(**overwrites: Any) -> ModelMeta:
     )
 
 
-def test_openness_score_all_dimensions():
+@pytest.mark.parametrize("license_name", ["apache-2.0", "openmdw-1.1"])
+def test_openness_score_all_dimensions(license_name: str):
     meta = _openness_meta(
         open_weights=True,
-        license="apache-2.0",
+        license=license_name,
         public_training_code="https://github.com/example/train",
         public_training_data="https://huggingface.co/datasets/example",
         citation="@article{example}",


### PR DESCRIPTION
Add [openmdw-1.1](https://openmdw.ai/) to the known license identifiers and open-license allowlist so. 

Extend the existing openness test to cover it.

Fixes #5442.