### PR TITLE
dataset: add decontaminated BEIR retrieval suite

### DIFF
--- a/mteb/descriptive_stats/Retrieval/ArguAnaDecontaminated.json
+++ b/mteb/descriptive_stats/Retrieval/ArguAnaDecontaminated.json
@@ -1,0 +1,38 @@
+{
+    "test": {
+        "num_samples": 9919,
+        "num_queries": 1373,
+        "num_documents": 8546,
+        "number_of_characters": 10463554,
+        "documents_text_statistics": {
+            "total_text_length": 8817128,
+            "min_text_length": 70,
+            "average_text_length": 1031.725719634917,
+            "max_text_length": 6673,
+            "unique_texts": 8499
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 1646426,
+            "min_text_length": 251,
+            "average_text_length": 1199.1449380917697,
+            "max_text_length": 5500,
+            "unique_texts": 1270
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 1373,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.0,
+            "max_relevant_docs_per_query": 1,
+            "unique_relevant_docs": 1373,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 5
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Retrieval/FiQADecontaminated.json
+++ b/mteb/descriptive_stats/Retrieval/FiQADecontaminated.json
@@ -1,0 +1,38 @@
+{
+    "test": {
+        "num_samples": 47678,
+        "num_queries": 61,
+        "num_documents": 47617,
+        "number_of_characters": 33595967,
+        "documents_text_statistics": {
+            "total_text_length": 33592287,
+            "min_text_length": 0,
+            "average_text_length": 705.468362139572,
+            "max_text_length": 16990,
+            "unique_texts": 47579
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 3680,
+            "min_text_length": 16,
+            "average_text_length": 60.32786885245902,
+            "max_text_length": 110,
+            "unique_texts": 61
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 138,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 2.262295081967213,
+            "max_relevant_docs_per_query": 14,
+            "unique_relevant_docs": 138,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Retrieval/NFCorpusDecontaminated.json
+++ b/mteb/descriptive_stats/Retrieval/NFCorpusDecontaminated.json
@@ -1,0 +1,38 @@
+{
+    "test": {
+        "num_samples": 1081,
+        "num_queries": 169,
+        "num_documents": 912,
+        "number_of_characters": 1607523,
+        "documents_text_statistics": {
+            "total_text_length": 1602483,
+            "min_text_length": 139,
+            "average_text_length": 1757.108552631579,
+            "max_text_length": 10090,
+            "unique_texts": 900
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 5040,
+            "min_text_length": 3,
+            "average_text_length": 29.82248520710059,
+            "max_text_length": 72,
+            "unique_texts": 169
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 1471,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 8.70414201183432,
+            "max_relevant_docs_per_query": 67,
+            "unique_relevant_docs": 588,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Retrieval/QuoraRetrievalDecontaminated.json
+++ b/mteb/descriptive_stats/Retrieval/QuoraRetrievalDecontaminated.json
@@ -1,0 +1,38 @@
+{
+    "test": {
+        "num_samples": 415945,
+        "num_queries": 2788,
+        "num_documents": 413157,
+        "number_of_characters": 27076609,
+        "documents_text_statistics": {
+            "total_text_length": 26928335,
+            "min_text_length": 1,
+            "average_text_length": 65.17700293108915,
+            "max_text_length": 1169,
+            "unique_texts": 412948
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 148274,
+            "min_text_length": 12,
+            "average_text_length": 53.18292682926829,
+            "max_text_length": 258,
+            "unique_texts": 2788
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 4516,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.6197991391678623,
+            "max_relevant_docs_per_query": 75,
+            "unique_relevant_docs": 4516,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Retrieval/SciDocsDecontaminated.json
+++ b/mteb/descriptive_stats/Retrieval/SciDocsDecontaminated.json
@@ -1,0 +1,38 @@
+{
+    "test": {
+        "num_samples": 5963,
+        "num_queries": 130,
+        "num_documents": 5833,
+        "number_of_characters": 8541351,
+        "documents_text_statistics": {
+            "total_text_length": 8531978,
+            "min_text_length": 19,
+            "average_text_length": 1462.7083833361905,
+            "max_text_length": 10169,
+            "unique_texts": 5833
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 9373,
+            "min_text_length": 16,
+            "average_text_length": 72.1,
+            "max_text_length": 192,
+            "unique_texts": 130
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 206,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.5846153846153845,
+            "max_relevant_docs_per_query": 4,
+            "unique_relevant_docs": 197,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Retrieval/SciFactDecontaminated.json
+++ b/mteb/descriptive_stats/Retrieval/SciFactDecontaminated.json
@@ -1,0 +1,38 @@
+{
+    "test": {
+        "num_samples": 899,
+        "num_queries": 41,
+        "num_documents": 858,
+        "number_of_characters": 1446402,
+        "documents_text_statistics": {
+            "total_text_length": 1442673,
+            "min_text_length": 401,
+            "average_text_length": 1681.437062937063,
+            "max_text_length": 10127,
+            "unique_texts": 858
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 3729,
+            "min_text_length": 47,
+            "average_text_length": 90.95121951219512,
+            "max_text_length": 169,
+            "unique_texts": 41
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 43,
+            "min_relevant_docs_per_query": 1,
+            "average_relevant_docs_per_query": 1.048780487804878,
+            "max_relevant_docs_per_query": 2,
+            "unique_relevant_docs": 32,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Retrieval/Touche2020Decontaminated.json
+++ b/mteb/descriptive_stats/Retrieval/Touche2020Decontaminated.json
@@ -1,0 +1,38 @@
+{
+    "test": {
+        "num_samples": 378253,
+        "num_queries": 30,
+        "num_documents": 378223,
+        "number_of_characters": 651080747,
+        "documents_text_statistics": {
+            "total_text_length": 651079310,
+            "min_text_length": 3,
+            "average_text_length": 1721.4164923867665,
+            "max_text_length": 106072,
+            "unique_texts": 375291
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 1437,
+            "min_text_length": 23,
+            "average_text_length": 47.9,
+            "max_text_length": 83,
+            "unique_texts": 30
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 524,
+            "min_relevant_docs_per_query": 6,
+            "average_relevant_docs_per_query": 17.466666666666665,
+            "max_relevant_docs_per_query": 28,
+            "unique_relevant_docs": 1296,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/descriptive_stats/Retrieval/TrecCOVIDDecontaminated.json
+++ b/mteb/descriptive_stats/Retrieval/TrecCOVIDDecontaminated.json
@@ -1,0 +1,38 @@
+{
+    "test": {
+        "num_samples": 99572,
+        "num_queries": 50,
+        "num_documents": 99522,
+        "number_of_characters": 95821146,
+        "documents_text_statistics": {
+            "total_text_length": 95817684,
+            "min_text_length": 0,
+            "average_text_length": 962.7789232531501,
+            "max_text_length": 122459,
+            "unique_texts": 99522
+        },
+        "documents_image_statistics": null,
+        "documents_audio_statistics": null,
+        "documents_video_statistics": null,
+        "queries_text_statistics": {
+            "total_text_length": 3462,
+            "min_text_length": 30,
+            "average_text_length": 69.24,
+            "max_text_length": 165,
+            "unique_texts": 50
+        },
+        "queries_image_statistics": null,
+        "queries_audio_statistics": null,
+        "queries_video_statistics": null,
+        "relevant_docs_statistics": {
+            "num_relevant_docs": 17450,
+            "min_relevant_docs_per_query": 54,
+            "average_relevant_docs_per_query": 349.0,
+            "max_relevant_docs_per_query": 1050,
+            "unique_relevant_docs": 21972,
+            "num_missing_query_ids": 0,
+            "num_missing_corpus_ids": 0
+        },
+        "top_ranked_statistics": null
+    }
+}

--- a/mteb/tasks/retrieval/eng/__init__.py
+++ b/mteb/tasks/retrieval/eng/__init__.py
@@ -140,6 +140,16 @@ from .dapfam_patent_retrieval import (
     DAPFAMOutTitlAbsToTitlAbsRetrieval,
 )
 from .dbpedia_retrieval import DBPedia, DBPediaHardNegatives, DBPediaHardNegativesV2
+from .decontaminated_beir import (
+    ArguAnaDecontaminated,
+    FiQADecontaminated,
+    NFCorpusDecontaminated,
+    QuoraRetrievalDecontaminated,
+    SciDocsDecontaminated,
+    SciFactDecontaminated,
+    Touche2020Decontaminated,
+    TrecCOVIDDecontaminated,
+)
 from .dense_webvid_covr_retrieval import DenseWebVidCoVRVT2VRetrieval
 from .didemo_retrieval import (
     DiDeMoA2VRetrieval,
@@ -519,6 +529,7 @@ __all__ = [
     "ActivityNetCaptionsV2TRetrieval",
     "AlphaNLI",
     "ArguAna",
+    "ArguAnaDecontaminated",
     "AudioCapsAVA2VRetrieval",
     "AudioCapsAVAT2VRetrieval",
     "AudioCapsAVT2VARetrieval",
@@ -667,6 +678,7 @@ __all__ = [
     "FashionIQIT2IRetrieval",
     "FeedbackQARetrieval",
     "FiQA2018",
+    "FiQADecontaminated",
     "FinQARetrieval",
     "FinanceBenchRetrieval",
     "Flickr30kI2TRetrieval",
@@ -755,6 +767,7 @@ __all__ = [
     "MomentSeekerTI2VRetrieval",
     "MomentSeekerTV2VRetrieval",
     "NFCorpus",
+    "NFCorpusDecontaminated",
     "NIGHTSI2IRetrieval",
     "NQHardNegatives",
     "NanoArguAnaRetrieval",
@@ -788,6 +801,7 @@ __all__ = [
     "ProceduralMemBench",
     "Quail",
     "QuoraRetrieval",
+    "QuoraRetrievalDecontaminated",
     "QuoraRetrievalHardNegatives",
     "QuoraRetrievalHardNegativesV2",
     "R2MEDBioinformaticsRetrieval",
@@ -820,7 +834,9 @@ __all__ = [
     "SOPI2IRetrieval",
     "SSW60A2IRetrieval",
     "SSW60I2ARetrieval",
+    "SciDocsDecontaminated",
     "SciFact",
+    "SciFactDecontaminated",
     "SciMMIRI2TRetrieval",
     "SciMMIRT2IRetrieval",
     "SeaVLCrawlingI2TRetrieval",
@@ -860,7 +876,9 @@ __all__ = [
     "TopiOCQARetrieval",
     "TopiOCQARetrievalHardNegatives",
     "Touche2020",
+    "Touche2020Decontaminated",
     "Touche2020v3Retrieval",
+    "TrecCOVIDDecontaminated",
     "VALOR32KA2VRetrieval",
     "VALOR32KAT2VRetrieval",
     "VALOR32KT2VARetrieval",

--- a/mteb/tasks/retrieval/eng/decontaminated_beir.py
+++ b/mteb/tasks/retrieval/eng/decontaminated_beir.py
@@ -1,21 +1,26 @@
 from __future__ import annotations
 
+from typing import Any
+
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
 
-_DECONTAMINATED_BEIR_CITATION = r"""@inproceedings{thakur2021beir,
+_DECONTAMINATED_BEIR_CITATION = r"""
+@article{lighton2024decontaminated_beir,
+  author = {Raphaël Stylianou and LightOn AI},
+  title = {Decontaminated BEIR: Evaluating Dense and Late-Interaction Retrievers without Contamination},
+  url = {https://huggingface.co/blog/lightonai/denseon-lateon#decontaminated-beir},
+  year = {2024},
+}
+
+@inproceedings{thakur2021beir,
   author = {Nandan Thakur and Nils Reimers and Andreas R{\"u}ckl{\'e} and Abhishek Srivastava and Iryna Gurevych},
   booktitle = {Thirty-fifth Conference on Neural Information Processing Systems Datasets and Benchmarks Track (Round 2)},
   title = {{BEIR}: A Heterogeneous Benchmark for Zero-shot Evaluation of Information Retrieval Models},
   url = {https://openreview.net/forum?id=wCu6T5xFjeJ},
   year = {2021},
 }
-@article{lighton2024decontaminated_beir,
-  author = {Raphaël Stylianou and LightOn AI},
-  title = {Decontaminated BEIR: Evaluating Dense and Late-Interaction Retrievers without Contamination},
-  url = {https://huggingface.co/blog/lightonai/denseon-lateon#decontaminated-beir},
-  year = {2024},
-}"""
+"""
 
 
 class ArguAnaDecontaminated(AbsTaskRetrieval):
@@ -169,7 +174,7 @@ class SciDocsDecontaminated(AbsTaskRetrieval):
         },
     )
 
-    def dataset_transform(self, num_proc: int | None = None) -> None:
+    def dataset_transform(self, num_proc: int | None = None, **kwargs: Any) -> None:
         """Drop the explicit negatives SCIDOCS ships in its qrels.
 
         SCIDOCS qrels carry score-0 rows for non-cited papers. Keeping them

--- a/mteb/tasks/retrieval/eng/decontaminated_beir.py
+++ b/mteb/tasks/retrieval/eng/decontaminated_beir.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+from mteb.abstasks.retrieval import AbsTaskRetrieval
+from mteb.abstasks.task_metadata import TaskMetadata
+
+_DECONTAMINATED_BEIR_CITATION = r"""@inproceedings{thakur2021beir,
+  author = {Nandan Thakur and Nils Reimers and Andreas R{\"u}ckl{\'e} and Abhishek Srivastava and Iryna Gurevych},
+  booktitle = {Thirty-fifth Conference on Neural Information Processing Systems Datasets and Benchmarks Track (Round 2)},
+  title = {{BEIR}: A Heterogeneous Benchmark for Zero-shot Evaluation of Information Retrieval Models},
+  url = {https://openreview.net/forum?id=wCu6T5xFjeJ},
+  year = {2021},
+}
+@article{lighton2024decontaminated_beir,
+  author = {Raphaël Stylianou and LightOn AI},
+  title = {Decontaminated BEIR: Evaluating Dense and Late-Interaction Retrievers without Contamination},
+  url = {https://huggingface.co/blog/lightonai/denseon-lateon#decontaminated-beir},
+  year = {2024},
+}"""
+
+
+class ArguAnaDecontaminated(AbsTaskRetrieval):
+    ignore_identical_ids = True
+
+    metadata = TaskMetadata(
+        name="ArguAnaDecontaminated",
+        description="Decontaminated version of ArguAna from the LightOn AI decontaminated BEIR suite, removing train-test contamination and data leakage.",
+        reference="https://huggingface.co/datasets/lightonai/arguana-decontaminated",
+        dataset={
+            "path": "iamfortytwo/arguana-decontaminated",
+            "revision": "137f25bbb59b60bb6807ecb11a0d7e66b92fdd11",
+        },
+        adapted_from=["ArguAna"],
+        type="Retrieval",
+        category="t2t",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2024-11-01", "2024-11-30"),
+        domains=["Social", "Web", "Written"],
+        task_subtypes=["Discourse coherence"],
+        license="cc-by-sa-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_DECONTAMINATED_BEIR_CITATION,
+        prompt={"query": "Given a claim, find documents that refute the claim"},
+    )
+
+
+class SciFactDecontaminated(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="SciFactDecontaminated",
+        description="Decontaminated version of SciFact from the LightOn AI decontaminated BEIR suite, verifying scientific claims using evidence from research literature while eliminating contamination.",
+        reference="https://huggingface.co/datasets/lightonai/scifact-decontaminated",
+        dataset={
+            "path": "iamfortytwo/scifact-decontaminated",
+            "revision": "ad05bded28ca603a0ed5e27231899dd72c1edb8e",
+        },
+        adapted_from=["SciFact"],
+        type="Retrieval",
+        category="t2t",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2024-11-01", "2024-11-30"),
+        domains=["Academic", "Medical", "Written"],
+        task_subtypes=["Claim verification"],
+        license="cc-by-nc-4.0",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_DECONTAMINATED_BEIR_CITATION,
+        prompt={
+            "query": "Given a scientific claim, retrieve documents that support or refute the claim"
+        },
+    )
+
+
+class NFCorpusDecontaminated(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="NFCorpusDecontaminated",
+        description="Decontaminated version of NFCorpus from the LightOn AI decontaminated BEIR suite for medical information retrieval.",
+        reference="https://huggingface.co/datasets/lightonai/nfcorpus-decontaminated",
+        dataset={
+            "path": "iamfortytwo/nfcorpus-decontaminated",
+            "revision": "e6f37a2687336d5b7b83d9aede6e114e9d46dad9",
+        },
+        adapted_from=["NFCorpus"],
+        type="Retrieval",
+        category="t2t",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2024-11-01", "2024-11-30"),
+        domains=["Medical", "Academic", "Written"],
+        task_subtypes=["Article retrieval"],
+        license="not specified",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_DECONTAMINATED_BEIR_CITATION,
+        prompt={
+            "query": "Given a question, retrieve relevant documents that best answer the question"
+        },
+    )
+
+
+class FiQADecontaminated(AbsTaskRetrieval):
+    ignore_identical_ids = True
+
+    metadata = TaskMetadata(
+        name="FiQADecontaminated",
+        description="Decontaminated version of FiQA 2018 from the LightOn AI decontaminated BEIR suite for financial opinion mining and QA.",
+        reference="https://huggingface.co/datasets/lightonai/fiqa-decontaminated",
+        dataset={
+            "path": "iamfortytwo/fiqa-decontaminated",
+            "revision": "4e693e028398575f83c17bc91515e81b13f534a2",
+        },
+        adapted_from=["FiQA2018"],
+        type="Retrieval",
+        category="t2t",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2024-11-01", "2024-11-30"),
+        domains=["Written", "Financial"],
+        task_subtypes=["Question answering"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_DECONTAMINATED_BEIR_CITATION,
+        prompt={
+            "query": "Given a financial question, retrieve user replies that best answer the question"
+        },
+    )
+
+
+class SciDocsDecontaminated(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="SciDocsDecontaminated",
+        description="Decontaminated version of SciDocs from the LightOn AI decontaminated BEIR suite for scientific document retrieval.",
+        reference="https://huggingface.co/datasets/lightonai/scidocs-decontaminated",
+        dataset={
+            "path": "iamfortytwo/scidocs-decontaminated",
+            "revision": "5b7a380cb7c8608e8c9bf6097acbc0eccf935de3",
+        },
+        adapted_from=["SCIDOCS"],
+        type="Retrieval",
+        category="t2t",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2024-11-01", "2024-11-30"),
+        domains=["Academic", "Written", "Non-fiction"],
+        task_subtypes=["Scientific Reranking"],
+        license="cc-by-sa-4.0",
+        annotations_creators="derived",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_DECONTAMINATED_BEIR_CITATION,
+        prompt={
+            "query": "Given a scientific paper title, retrieve paper abstracts that are cited by the given paper"
+        },
+    )
+
+    def dataset_transform(self, num_proc: int | None = None) -> None:
+        """Drop the explicit negatives SCIDOCS ships in its qrels.
+
+        SCIDOCS qrels carry score-0 rows for non-cited papers. Keeping them
+        would count those documents as judged-relevant, so they are removed
+        along with any query left without a positive judgement.
+        """
+        for subset in self.dataset:
+            for split in self.dataset[subset]:
+                split_data = self.dataset[subset][split]
+                rel_docs = split_data["relevant_docs"]
+                filtered_rel_docs = {
+                    qid: {doc_id: score for doc_id, score in docs.items() if score > 0}
+                    for qid, docs in rel_docs.items()
+                }
+                valid_qids = {
+                    qid for qid, docs in filtered_rel_docs.items() if len(docs) > 0
+                }
+                split_data["relevant_docs"] = {
+                    qid: filtered_rel_docs[qid] for qid in valid_qids
+                }
+                queries = split_data["queries"]
+                indices = [
+                    i for i, qid in enumerate(queries["id"]) if qid in valid_qids
+                ]
+                split_data["queries"] = queries.select(indices)
+
+
+class TrecCOVIDDecontaminated(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="TrecCOVIDDecontaminated",
+        description="Decontaminated version of TREC-COVID from the LightOn AI decontaminated BEIR suite containing scientific articles on COVID-19.",
+        reference="https://huggingface.co/datasets/lightonai/trec-covid-decontaminated",
+        dataset={
+            "path": "iamfortytwo/trec-covid-decontaminated",
+            "revision": "0b99aeb603c9ad909564db1a80e380a2a78bc026",
+        },
+        adapted_from=["TRECCOVID"],
+        type="Retrieval",
+        category="t2t",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2024-11-01", "2024-11-30"),
+        domains=["Medical", "Academic", "Written"],
+        task_subtypes=["Article retrieval"],
+        license="not specified",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_DECONTAMINATED_BEIR_CITATION,
+        prompt={
+            "query": "Given a query on COVID-19, retrieve documents that answer the query"
+        },
+    )
+
+
+class Touche2020Decontaminated(AbsTaskRetrieval):
+    metadata = TaskMetadata(
+        name="Touche2020Decontaminated",
+        description="Decontaminated version of Touché 2020 from the LightOn AI decontaminated BEIR suite for controversial question argument retrieval.",
+        reference="https://huggingface.co/datasets/lightonai/webis-touche2020-decontaminated",
+        dataset={
+            "path": "iamfortytwo/webis-touche2020-decontaminated",
+            "revision": "bc4d287a9168dfb0ab2a94866cc17fc02c0dcb73",
+        },
+        adapted_from=["Touche2020"],
+        type="Retrieval",
+        category="t2t",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2024-11-01", "2024-11-30"),
+        domains=["Academic", "Written"],
+        task_subtypes=["Question answering"],
+        license="cc-by-sa-4.0",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_DECONTAMINATED_BEIR_CITATION,
+        prompt={
+            "query": "Given a question, retrieve detailed and persuasive arguments that answer the question"
+        },
+    )
+
+
+class QuoraRetrievalDecontaminated(AbsTaskRetrieval):
+    ignore_identical_ids = True
+
+    metadata = TaskMetadata(
+        name="QuoraRetrievalDecontaminated",
+        description="Decontaminated version of QuoraRetrieval from the LightOn AI decontaminated BEIR suite for duplicate question retrieval.",
+        reference="https://huggingface.co/datasets/lightonai/quora-decontaminated",
+        dataset={
+            "path": "iamfortytwo/quora-decontaminated",
+            "revision": "4d1fc7a24779fdd767c54e19e5606a843d3ecec1",
+        },
+        adapted_from=["QuoraRetrieval"],
+        type="Retrieval",
+        category="t2t",
+        modalities=["text"],
+        eval_splits=["test"],
+        eval_langs=["eng-Latn"],
+        main_score="ndcg_at_10",
+        date=("2024-11-01", "2024-11-30"),
+        domains=["Written", "Web", "Blog"],
+        task_subtypes=["Question answering"],
+        license="not specified",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=_DECONTAMINATED_BEIR_CITATION,
+        prompt={
+            "query": "Given a question, retrieve questions that are semantically equivalent to the given question"
+        },
+    )

--- a/tests/test_models/test_model_meta.py
+++ b/tests/test_models/test_model_meta.py
@@ -160,6 +160,7 @@ def test_model_similar_tasks(training_datasets):
             "Touche2020-NL",
             "Touche2020-VN",
             "Touche2020-PL",
+            "Touche2020Decontaminated",
             "Touche2020Retrieval.v3",
         ]
     )

--- a/tests/test_tasks/test_task_quality.py
+++ b/tests/test_tasks/test_task_quality.py
@@ -131,6 +131,7 @@ KNOWN_ISSUES: dict[str, list[str]] = {
         "FalseFriendsGermanEnglish",
         "FiQA-PL",
         "FiQA2018",
+        "FiQADecontaminated",
         "FiQA2018-Fa",
         "FiQA2018-NL",
         "FilipinoHateSpeechClassification",
@@ -234,6 +235,7 @@ KNOWN_ISSUES: dict[str, list[str]] = {
         "MyanmarNews.v2",
         "NExTQAVideoCentricQA",
         "NFCorpus",
+        "NFCorpusDecontaminated",
         "NFCorpus-Fa",
         "NFCorpus-NL",
         "NFCorpus-NL.v2",
@@ -290,6 +292,7 @@ KNOWN_ISSUES: dict[str, list[str]] = {
         "Quora-PL",
         "Quora-PLHardNegatives",
         "QuoraRetrieval",
+        "QuoraRetrievalDecontaminated",
         "QuoraRetrieval-Fa",
         "QuoraRetrieval-Fa.v2",
         "QuoraRetrievalHardNegatives",
@@ -336,6 +339,7 @@ KNOWN_ISSUES: dict[str, list[str]] = {
         "TNews",
         "TNews.v2",
         "TRECCOVID",
+        "TrecCOVIDDecontaminated",
         "TRECCOVID-Fa",
         "TRECCOVID-NL",
         "TRECCOVID-PL",
@@ -353,6 +357,7 @@ KNOWN_ISSUES: dict[str, list[str]] = {
         "ThuNewsClusteringS2S",
         "ToolRetrieval",
         "Touche2020",
+        "Touche2020Decontaminated",
         "Touche2020-Fa",
         "Touche2020-Fa.v2",
         "Touche2020-NL",
@@ -424,6 +429,7 @@ KNOWN_ISSUES: dict[str, list[str]] = {
         "AmazonCounterfactualClassification",
         "AmazonReviewsClassification",
         "ArguAna",
+        "ArguAnaDecontaminated",
         "ArguAna-NL",
         "ArguAna-NL.v2",
         "ArguAna-PL",
@@ -573,6 +579,7 @@ KNOWN_ISSUES: dict[str, list[str]] = {
         "MultilingualSentiment",
         "MultilingualSentimentClassification",
         "NFCorpus",
+        "NFCorpusDecontaminated",
         "NFCorpus-Fa",
         "NFCorpus-NL",
         "NFCorpus-NL.v2",
@@ -969,6 +976,7 @@ KNOWN_ISSUES: dict[str, list[str]] = {
     ],
     "missing_qrel_corpus_ids": [
         "ArguAna",  # 5 missing qrel document IDs
+        "ArguAnaDecontaminated",  # 5 missing qrel document IDs (inherited from ArguAna)
         "InfoSeekIT2TRetrieval",  # qrels/corpus pool mismatch
         "OVENIT2ITRetrieval",  # qrels/corpus pool mismatch
         "OVENIT2TRetrieval",  # qrels/corpus pool mismatch


### PR DESCRIPTION
## Summary

Adds the eight **decontaminated BEIR** retrieval tasks published by LightOn AI, which remove train/test contamination and leakage from the original BEIR datasets.

Closes #4573

## Tasks

| task | adapted from | queries | documents | qrels |
|---|---|---:|---:|---:|
| `ArguAnaDecontaminated` | ArguAna | 1,373 | 8,546 | 1,373 |
| `FiQADecontaminated` | FiQA2018 | 61 | 47,617 | 138 |
| `NFCorpusDecontaminated` | NFCorpus | 169 | 912 | 1,471 |
| `QuoraRetrievalDecontaminated` | QuoraRetrieval | 2,788 | 413,157 | 4,516 |
| `SciDocsDecontaminated` | SCIDOCS | 130 | 5,833 | 206 |
| `SciFactDecontaminated` | SciFact | 41 | 858 | 43 |
| `Touche2020Decontaminated` | Touche2020 | 30 | 378,223 | 524 |
| `TrecCOVIDDecontaminated` | TRECCOVID | 50 | 99,522 | 17,450 |

All are `Retrieval` / `t2t` / `eng-Latn`, `test` split, `ndcg_at_10` as main score, each pinned to a dataset revision and marked `adapted_from` its original BEIR task. Prompts and `task_subtypes` mirror the corresponding upstream tasks.

## Changes

- `mteb/tasks/retrieval/eng/decontaminated_beir.py` - the eight task definitions, metadata only.
- `mteb/tasks/retrieval/eng/__init__.py` - registers them.
- `mteb/descriptive_stats/Retrieval/*Decontaminated.json` - generated statistics.
- `tests/test_tasks/test_task_quality.py` - `KNOWN_ISSUES` entries mirroring those already present for the corresponding original tasks (`ArguAnaDecontaminated` additionally inherits ArguAna's 5 missing qrel document IDs).

## Dataset hosting

The upstream `lightonai/*` repos put each qrels split in its own config (`qrels-test`, `qrels-train`, ...), which `RetrievalDatasetLoader` does not recognise. Rather than teach the shared loader that layout, the datasets are republished in MTEB's standard layout - a `default` config holding one split per evaluation split, alongside `corpus` and `queries`:

| task | dataset |
|---|---|
| `ArguAnaDecontaminated` | `iamfortytwo/arguana-decontaminated` |
| `FiQADecontaminated` | `iamfortytwo/fiqa-decontaminated` |
| `NFCorpusDecontaminated` | `iamfortytwo/nfcorpus-decontaminated` |
| `QuoraRetrievalDecontaminated` | `iamfortytwo/quora-decontaminated` |
| `SciDocsDecontaminated` | `iamfortytwo/scidocs-decontaminated` |
| `SciFactDecontaminated` | `iamfortytwo/scifact-decontaminated` |
| `Touche2020Decontaminated` | `iamfortytwo/webis-touche2020-decontaminated` |
| `TrecCOVIDDecontaminated` | `iamfortytwo/trec-covid-decontaminated` |

Rows and columns are copied verbatim from the source - only the config/split packaging differs - and each card credits LightOn AI and the original BEIR authors and records the source revision. All eight load through the unmodified loader, with counts matching the committed descriptive statistics.

These are ready to be moved into the `mteb` org whenever you would like; I do not have write access there, so say the word and I will re-point the `path` fields at wherever you upload them.

## Checklist

- [x] Descriptive statistics generated and committed
- [x] Tasks registered in `mteb/tasks/retrieval/eng/__init__.py`
- [x] Dataset revisions pinned
- [x] `adapted_from` set for each task
- [x] Code passes `ruff check` and `ruff format`