### PR TITLE
move Nano retrieval tasks to the v2 dataset format

### DIFF
--- a/mteb/tasks/retrieval/eng/nano_argu_ana_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_argu_ana_retrieval.py
@@ -1,8 +1,3 @@
-from collections import defaultdict
-from typing import Any
-
-from datasets import load_dataset
-
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -13,8 +8,8 @@ class NanoArguAnaRetrieval(AbsTaskRetrieval):
         description="NanoArguAna is a smaller subset of ArguAna, a dataset for argument retrieval in debate contexts.",
         reference="http://argumentation.bplaced.net/arguana/data",
         dataset={
-            "path": "zeta-alpha-ai/NanoArguAna",
-            "revision": "8f4a982d470a32c45817738b9d29042ca55d75ad",
+            "path": "mteb/NanoArguAnaRetrieval",
+            "revision": "63ac9f026e8f6b85dc0622f3d630ed7a1758e9ec",
         },
         type="Retrieval",
         category="t2t",
@@ -40,50 +35,3 @@ class NanoArguAnaRetrieval(AbsTaskRetrieval):
         prompt={"query": "Given a claim, find documents that refute the claim"},
         adapted_from=["ArguAna"],
     )
-
-    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
-        if self.data_loaded:
-            return
-
-        self.corpus = load_dataset(
-            "zeta-alpha-ai/NanoArguAna",
-            "corpus",
-            revision="8f4a982d470a32c45817738b9d29042ca55d75ad",
-        )
-        self.queries = load_dataset(
-            "zeta-alpha-ai/NanoArguAna",
-            "queries",
-            revision="8f4a982d470a32c45817738b9d29042ca55d75ad",
-        )
-        self.relevant_docs = load_dataset(
-            "zeta-alpha-ai/NanoArguAna",
-            "qrels",
-            revision="8f4a982d470a32c45817738b9d29042ca55d75ad",
-        )
-
-        self.corpus = {
-            split: {
-                sample["_id"]: {"_id": sample["_id"], "text": sample["text"]}
-                for sample in self.corpus[split]
-            }
-            for split in self.corpus
-        }
-
-        self.queries = {
-            split: {sample["_id"]: sample["text"] for sample in self.queries[split]}
-            for split in self.queries
-        }
-
-        relevant_docs = {}
-
-        for split in self.relevant_docs:
-            relevant_docs[split] = defaultdict(dict)
-            for query_id, corpus_id in zip(
-                self.relevant_docs[split]["query-id"],
-                self.relevant_docs[split]["corpus-id"],
-                strict=True,
-            ):
-                relevant_docs[split][query_id][corpus_id] = 1
-        self.relevant_docs = relevant_docs
-
-        self.data_loaded = True

--- a/mteb/tasks/retrieval/eng/nano_climate_fever_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_climate_fever_retrieval.py
@@ -1,8 +1,3 @@
-from collections import defaultdict
-from typing import Any
-
-from datasets import load_dataset
-
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -13,8 +8,8 @@ class NanoClimateFeverRetrieval(AbsTaskRetrieval):
         description="NanoClimateFever is a small version of the BEIR dataset adopting the FEVER methodology that consists of 1,535 real-world claims regarding climate-change.",
         reference="https://arxiv.org/abs/2012.00614",
         dataset={
-            "path": "zeta-alpha-ai/NanoClimateFEVER",
-            "revision": "96741bfa30b9f56db8c9eb7d08e775ed6474f206",
+            "path": "mteb/NanoClimateFeverRetrieval",
+            "revision": "ccb5552bc17e87afe0f9479fb4346898213a71db",
         },
         type="Retrieval",
         category="t2t",
@@ -44,50 +39,3 @@ class NanoClimateFeverRetrieval(AbsTaskRetrieval):
         },
         adapted_from=["ClimateFEVER"],
     )
-
-    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
-        if self.data_loaded:
-            return
-
-        self.corpus = load_dataset(
-            "zeta-alpha-ai/NanoClimateFEVER",
-            "corpus",
-            revision="96741bfa30b9f56db8c9eb7d08e775ed6474f206",
-        )
-        self.queries = load_dataset(
-            "zeta-alpha-ai/NanoClimateFEVER",
-            "queries",
-            revision="96741bfa30b9f56db8c9eb7d08e775ed6474f206",
-        )
-        self.relevant_docs = load_dataset(
-            "zeta-alpha-ai/NanoClimateFEVER",
-            "qrels",
-            revision="96741bfa30b9f56db8c9eb7d08e775ed6474f206",
-        )
-
-        self.corpus = {
-            split: {
-                sample["_id"]: {"_id": sample["_id"], "text": sample["text"]}
-                for sample in self.corpus[split]
-            }
-            for split in self.corpus
-        }
-
-        self.queries = {
-            split: {sample["_id"]: sample["text"] for sample in self.queries[split]}
-            for split in self.queries
-        }
-
-        relevant_docs = {}
-
-        for split in self.relevant_docs:
-            relevant_docs[split] = defaultdict(dict)
-            for query_id, corpus_id in zip(
-                self.relevant_docs[split]["query-id"],
-                self.relevant_docs[split]["corpus-id"],
-                strict=True,
-            ):
-                relevant_docs[split][query_id][corpus_id] = 1
-        self.relevant_docs = relevant_docs
-
-        self.data_loaded = True

--- a/mteb/tasks/retrieval/eng/nano_db_pedia_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_db_pedia_retrieval.py
@@ -1,8 +1,3 @@
-from collections import defaultdict
-from typing import Any
-
-from datasets import load_dataset
-
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -13,8 +8,8 @@ class NanoDBPediaRetrieval(AbsTaskRetrieval):
         description="NanoDBPediaRetrieval is a small version of the standard test collection for entity search over the DBpedia knowledge base.",
         reference="https://huggingface.co/datasets/zeta-alpha-ai/NanoDBPedia",
         dataset={
-            "path": "zeta-alpha-ai/NanoDBPedia",
-            "revision": "438f1c25129f05db6238699b5afdc9c6b58d2096",
+            "path": "mteb/NanoDBPediaRetrieval",
+            "revision": "2d088f80d7a640eac0be5c66408d68c3f782baa1",
         },
         type="Retrieval",
         category="t2t",
@@ -42,50 +37,3 @@ class NanoDBPediaRetrieval(AbsTaskRetrieval):
         },
         adapted_from=["DBPedia"],
     )
-
-    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
-        if self.data_loaded:
-            return
-
-        self.corpus = load_dataset(
-            "zeta-alpha-ai/NanoDBPedia",
-            "corpus",
-            revision="438f1c25129f05db6238699b5afdc9c6b58d2096",
-        )
-        self.queries = load_dataset(
-            "zeta-alpha-ai/NanoDBPedia",
-            "queries",
-            revision="438f1c25129f05db6238699b5afdc9c6b58d2096",
-        )
-        self.relevant_docs = load_dataset(
-            "zeta-alpha-ai/NanoDBPedia",
-            "qrels",
-            revision="438f1c25129f05db6238699b5afdc9c6b58d2096",
-        )
-
-        self.corpus = {
-            split: {
-                sample["_id"]: {"_id": sample["_id"], "text": sample["text"]}
-                for sample in self.corpus[split]
-            }
-            for split in self.corpus
-        }
-
-        self.queries = {
-            split: {sample["_id"]: sample["text"] for sample in self.queries[split]}
-            for split in self.queries
-        }
-
-        relevant_docs = {}
-
-        for split in self.relevant_docs:
-            relevant_docs[split] = defaultdict(dict)
-            for query_id, corpus_id in zip(
-                self.relevant_docs[split]["query-id"],
-                self.relevant_docs[split]["corpus-id"],
-                strict=True,
-            ):
-                relevant_docs[split][query_id][corpus_id] = 1
-        self.relevant_docs = relevant_docs
-
-        self.data_loaded = True

--- a/mteb/tasks/retrieval/eng/nano_fever_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_fever_retrieval.py
@@ -1,8 +1,3 @@
-from collections import defaultdict
-from typing import Any
-
-from datasets import load_dataset
-
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -16,8 +11,8 @@ class NanoFEVERRetrieval(AbsTaskRetrieval):
         " derived from.",
         reference="https://fever.ai/",
         dataset={
-            "path": "zeta-alpha-ai/NanoFEVER",
-            "revision": "a8bfdf1bf15181167a7e22e69cf8754bdea9b4c8",
+            "path": "mteb/NanoFEVERRetrieval",
+            "revision": "a6490dfeed0f13c2a052e39c6ddaeb6086afd4a8",
         },
         type="Retrieval",
         category="t2t",
@@ -57,50 +52,3 @@ Stent, Amanda},
         },
         adapted_from=["FEVER"],
     )
-
-    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
-        if self.data_loaded:
-            return
-
-        self.corpus = load_dataset(
-            "zeta-alpha-ai/NanoFEVER",
-            "corpus",
-            revision="a8bfdf1bf15181167a7e22e69cf8754bdea9b4c8",
-        )
-        self.queries = load_dataset(
-            "zeta-alpha-ai/NanoFEVER",
-            "queries",
-            revision="a8bfdf1bf15181167a7e22e69cf8754bdea9b4c8",
-        )
-        self.relevant_docs = load_dataset(
-            "zeta-alpha-ai/NanoFEVER",
-            "qrels",
-            revision="a8bfdf1bf15181167a7e22e69cf8754bdea9b4c8",
-        )
-
-        self.corpus = {
-            split: {
-                sample["_id"]: {"_id": sample["_id"], "text": sample["text"]}
-                for sample in self.corpus[split]
-            }
-            for split in self.corpus
-        }
-
-        self.queries = {
-            split: {sample["_id"]: sample["text"] for sample in self.queries[split]}
-            for split in self.queries
-        }
-
-        relevant_docs = {}
-
-        for split in self.relevant_docs:
-            relevant_docs[split] = defaultdict(dict)
-            for query_id, corpus_id in zip(
-                self.relevant_docs[split]["query-id"],
-                self.relevant_docs[split]["corpus-id"],
-                strict=True,
-            ):
-                relevant_docs[split][query_id][corpus_id] = 1
-        self.relevant_docs = relevant_docs
-
-        self.data_loaded = True

--- a/mteb/tasks/retrieval/eng/nano_fi_qa2018_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_fi_qa2018_retrieval.py
@@ -1,8 +1,3 @@
-from collections import defaultdict
-from typing import Any
-
-from datasets import load_dataset
-
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -13,8 +8,8 @@ class NanoFiQA2018Retrieval(AbsTaskRetrieval):
         description="NanoFiQA2018 is a smaller subset of the Financial Opinion Mining and Question Answering dataset.",
         reference="https://sites.google.com/view/fiqa/",
         dataset={
-            "path": "zeta-alpha-ai/NanoFiQA2018",
-            "revision": "4163ba032953d5044a7a6244261413f609c14342",
+            "path": "mteb/NanoFiQA2018Retrieval",
+            "revision": "ede84da4793cd2d4e61bba0dd08fc58de90f3681",
         },
         type="Retrieval",
         category="t2t",
@@ -43,50 +38,3 @@ class NanoFiQA2018Retrieval(AbsTaskRetrieval):
         },
         adapted_from=["FiQA2018"],
     )
-
-    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
-        if self.data_loaded:
-            return
-
-        self.corpus = load_dataset(
-            "zeta-alpha-ai/NanoFiQA2018",
-            "corpus",
-            revision="4163ba032953d5044a7a6244261413f609c14342",
-        )
-        self.queries = load_dataset(
-            "zeta-alpha-ai/NanoFiQA2018",
-            "queries",
-            revision="4163ba032953d5044a7a6244261413f609c14342",
-        )
-        self.relevant_docs = load_dataset(
-            "zeta-alpha-ai/NanoFiQA2018",
-            "qrels",
-            revision="4163ba032953d5044a7a6244261413f609c14342",
-        )
-
-        self.corpus = {
-            split: {
-                sample["_id"]: {"_id": sample["_id"], "text": sample["text"]}
-                for sample in self.corpus[split]
-            }
-            for split in self.corpus
-        }
-
-        self.queries = {
-            split: {sample["_id"]: sample["text"] for sample in self.queries[split]}
-            for split in self.queries
-        }
-
-        relevant_docs = {}
-
-        for split in self.relevant_docs:
-            relevant_docs[split] = defaultdict(dict)
-            for query_id, corpus_id in zip(
-                self.relevant_docs[split]["query-id"],
-                self.relevant_docs[split]["corpus-id"],
-                strict=True,
-            ):
-                relevant_docs[split][query_id][corpus_id] = 1
-        self.relevant_docs = relevant_docs
-
-        self.data_loaded = True

--- a/mteb/tasks/retrieval/eng/nano_hotpot_qa_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_hotpot_qa_retrieval.py
@@ -1,8 +1,3 @@
-from collections import defaultdict
-from typing import Any
-
-from datasets import load_dataset
-
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -15,8 +10,8 @@ class NanoHotpotQARetrieval(AbsTaskRetrieval):
         " supervision for supporting facts to enable more explainable question answering systems.",
         reference="https://hotpotqa.github.io/",
         dataset={
-            "path": "zeta-alpha-ai/NanoHotpotQA",
-            "revision": "d79c0cdda980aba54842756770928035e1b61a51",
+            "path": "mteb/NanoHotpotQARetrieval",
+            "revision": "a38a2615f29adba8b47a42905031aa9c137d8fae",
         },
         type="Retrieval",
         category="t2t",
@@ -60,50 +55,3 @@ Tsujii, Jun{'}ichi},
         },
         adapted_from=["HotpotQA"],
     )
-
-    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
-        if self.data_loaded:
-            return
-
-        self.corpus = load_dataset(
-            "zeta-alpha-ai/NanoHotpotQA",
-            "corpus",
-            revision="d79c0cdda980aba54842756770928035e1b61a51",
-        )
-        self.queries = load_dataset(
-            "zeta-alpha-ai/NanoHotpotQA",
-            "queries",
-            revision="d79c0cdda980aba54842756770928035e1b61a51",
-        )
-        self.relevant_docs = load_dataset(
-            "zeta-alpha-ai/NanoHotpotQA",
-            "qrels",
-            revision="d79c0cdda980aba54842756770928035e1b61a51",
-        )
-
-        self.corpus = {
-            split: {
-                sample["_id"]: {"_id": sample["_id"], "text": sample["text"]}
-                for sample in self.corpus[split]
-            }
-            for split in self.corpus
-        }
-
-        self.queries = {
-            split: {sample["_id"]: sample["text"] for sample in self.queries[split]}
-            for split in self.queries
-        }
-
-        relevant_docs = {}
-
-        for split in self.relevant_docs:
-            relevant_docs[split] = defaultdict(dict)
-            for query_id, corpus_id in zip(
-                self.relevant_docs[split]["query-id"],
-                self.relevant_docs[split]["corpus-id"],
-                strict=True,
-            ):
-                relevant_docs[split][query_id][corpus_id] = 1
-        self.relevant_docs = relevant_docs
-
-        self.data_loaded = True

--- a/mteb/tasks/retrieval/eng/nano_msmarco_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_msmarco_retrieval.py
@@ -1,8 +1,3 @@
-from collections import defaultdict
-from typing import Any
-
-from datasets import load_dataset
-
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -13,8 +8,8 @@ class NanoMSMARCORetrieval(AbsTaskRetrieval):
         description="NanoMSMARCORetrieval is a smaller subset of MS MARCO, a collection of datasets focused on deep learning in search.",
         reference="https://microsoft.github.io/msmarco/",
         dataset={
-            "path": "zeta-alpha-ai/NanoMSMARCO",
-            "revision": "7b8ff22f2771dc65ac5b439f222eb19a1f56abda",
+            "path": "mteb/NanoMSMARCORetrieval",
+            "revision": "5a5aa0c3df65d6883d85c8f5cdc88e679633595e",
         },
         type="Retrieval",
         category="t2t",
@@ -55,50 +50,3 @@ Li Deng},
         },
         adapted_from=["MSMARCO"],
     )
-
-    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
-        if self.data_loaded:
-            return
-
-        self.corpus = load_dataset(
-            "zeta-alpha-ai/NanoMSMARCO",
-            "corpus",
-            revision="7b8ff22f2771dc65ac5b439f222eb19a1f56abda",
-        )
-        self.queries = load_dataset(
-            "zeta-alpha-ai/NanoMSMARCO",
-            "queries",
-            revision="7b8ff22f2771dc65ac5b439f222eb19a1f56abda",
-        )
-        self.relevant_docs = load_dataset(
-            "zeta-alpha-ai/NanoMSMARCO",
-            "qrels",
-            revision="7b8ff22f2771dc65ac5b439f222eb19a1f56abda",
-        )
-
-        self.corpus = {
-            split: {
-                sample["_id"]: {"_id": sample["_id"], "text": sample["text"]}
-                for sample in self.corpus[split]
-            }
-            for split in self.corpus
-        }
-
-        self.queries = {
-            split: {sample["_id"]: sample["text"] for sample in self.queries[split]}
-            for split in self.queries
-        }
-
-        relevant_docs = {}
-
-        for split in self.relevant_docs:
-            relevant_docs[split] = defaultdict(dict)
-            for query_id, corpus_id in zip(
-                self.relevant_docs[split]["query-id"],
-                self.relevant_docs[split]["corpus-id"],
-                strict=True,
-            ):
-                relevant_docs[split][query_id][corpus_id] = 1
-        self.relevant_docs = relevant_docs
-
-        self.data_loaded = True

--- a/mteb/tasks/retrieval/eng/nano_nf_corpus_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_nf_corpus_retrieval.py
@@ -1,8 +1,3 @@
-from collections import defaultdict
-from typing import Any
-
-from datasets import load_dataset
-
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -13,8 +8,8 @@ class NanoNFCorpusRetrieval(AbsTaskRetrieval):
         description="NanoNFCorpus is a smaller subset of NFCorpus: A Full-Text Learning to Rank Dataset for Medical Information Retrieval.",
         reference="https://www.cl.uni-heidelberg.de/statnlpgroup/nfcorpus/",
         dataset={
-            "path": "zeta-alpha-ai/NanoNFCorpus",
-            "revision": "dd542a7efb9ad2136b9e00768b60fca9038f8156",
+            "path": "mteb/NanoNFCorpusRetrieval",
+            "revision": "2eec9d63140fb9af7c75ad0fdbf6350aaf20e94e",
         },
         type="Retrieval",
         category="t2t",
@@ -46,50 +41,3 @@ class NanoNFCorpusRetrieval(AbsTaskRetrieval):
         },
         adapted_from=["NFCorpus"],
     )
-
-    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
-        if self.data_loaded:
-            return
-
-        self.corpus = load_dataset(
-            "zeta-alpha-ai/NanoNFCorpus",
-            "corpus",
-            revision="dd542a7efb9ad2136b9e00768b60fca9038f8156",
-        )
-        self.queries = load_dataset(
-            "zeta-alpha-ai/NanoNFCorpus",
-            "queries",
-            revision="dd542a7efb9ad2136b9e00768b60fca9038f8156",
-        )
-        self.relevant_docs = load_dataset(
-            "zeta-alpha-ai/NanoNFCorpus",
-            "qrels",
-            revision="dd542a7efb9ad2136b9e00768b60fca9038f8156",
-        )
-
-        self.corpus = {
-            split: {
-                sample["_id"]: {"_id": sample["_id"], "text": sample["text"]}
-                for sample in self.corpus[split]
-            }
-            for split in self.corpus
-        }
-
-        self.queries = {
-            split: {sample["_id"]: sample["text"] for sample in self.queries[split]}
-            for split in self.queries
-        }
-
-        relevant_docs = {}
-
-        for split in self.relevant_docs:
-            relevant_docs[split] = defaultdict(dict)
-            for query_id, corpus_id in zip(
-                self.relevant_docs[split]["query-id"],
-                self.relevant_docs[split]["corpus-id"],
-                strict=True,
-            ):
-                relevant_docs[split][query_id][corpus_id] = 1
-        self.relevant_docs = relevant_docs
-
-        self.data_loaded = True

--- a/mteb/tasks/retrieval/eng/nano_nq_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_nq_retrieval.py
@@ -1,8 +1,3 @@
-from collections import defaultdict
-from typing import Any
-
-from datasets import load_dataset
-
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -13,8 +8,8 @@ class NanoNQRetrieval(AbsTaskRetrieval):
         description="NanoNQ is a smaller subset of a dataset which contains questions from real users, and it requires QA systems to read and comprehend an entire Wikipedia article that may or may not contain the answer to the question.",
         reference="https://ai.google.com/research/NaturalQuestions",
         dataset={
-            "path": "zeta-alpha-ai/NanoNQ",
-            "revision": "77540146379abf95df8326a3c5bb9eb21c7146c3",
+            "path": "mteb/NanoNQRetrieval",
+            "revision": "e3973b405feb9e94d07fd971d690d24d7f45264a",
         },
         type="Retrieval",
         category="t2t",
@@ -46,50 +41,3 @@ Linguistics},
         },
         adapted_from=["NQ"],
     )
-
-    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
-        if self.data_loaded:
-            return
-
-        self.corpus = load_dataset(
-            "zeta-alpha-ai/NanoNQ",
-            "corpus",
-            revision="77540146379abf95df8326a3c5bb9eb21c7146c3",
-        )
-        self.queries = load_dataset(
-            "zeta-alpha-ai/NanoNQ",
-            "queries",
-            revision="77540146379abf95df8326a3c5bb9eb21c7146c3",
-        )
-        self.relevant_docs = load_dataset(
-            "zeta-alpha-ai/NanoNQ",
-            "qrels",
-            revision="77540146379abf95df8326a3c5bb9eb21c7146c3",
-        )
-
-        self.corpus = {
-            split: {
-                sample["_id"]: {"_id": sample["_id"], "text": sample["text"]}
-                for sample in self.corpus[split]
-            }
-            for split in self.corpus
-        }
-
-        self.queries = {
-            split: {sample["_id"]: sample["text"] for sample in self.queries[split]}
-            for split in self.queries
-        }
-
-        relevant_docs = {}
-
-        for split in self.relevant_docs:
-            relevant_docs[split] = defaultdict(dict)
-            for query_id, corpus_id in zip(
-                self.relevant_docs[split]["query-id"],
-                self.relevant_docs[split]["corpus-id"],
-                strict=True,
-            ):
-                relevant_docs[split][query_id][corpus_id] = 1
-        self.relevant_docs = relevant_docs
-
-        self.data_loaded = True

--- a/mteb/tasks/retrieval/eng/nano_quora_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_quora_retrieval.py
@@ -1,8 +1,3 @@
-from collections import defaultdict
-from typing import Any
-
-from datasets import load_dataset
-
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -15,8 +10,8 @@ class NanoQuoraRetrieval(AbsTaskRetrieval):
         " question, find other (duplicate) questions.",
         reference="https://quoradata.quora.com/First-Quora-Dataset-Release-Question-Pairs",
         dataset={
-            "path": "zeta-alpha-ai/NanoQuoraRetrieval",
-            "revision": "2ab2d73e6c862026282808b913a34f4136928545",
+            "path": "mteb/NanoQuoraRetrieval",
+            "revision": "3ee153e5710da83a7f35df0cb1db4a0ad036072a",
         },
         type="Retrieval",
         category="t2t",
@@ -45,50 +40,3 @@ class NanoQuoraRetrieval(AbsTaskRetrieval):
         },
         adapted_from=["QuoraRetrieval"],
     )
-
-    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
-        if self.data_loaded:
-            return
-
-        self.corpus = load_dataset(
-            "zeta-alpha-ai/NanoQuoraRetrieval",
-            "corpus",
-            revision="2ab2d73e6c862026282808b913a34f4136928545",
-        )
-        self.queries = load_dataset(
-            "zeta-alpha-ai/NanoQuoraRetrieval",
-            "queries",
-            revision="2ab2d73e6c862026282808b913a34f4136928545",
-        )
-        self.relevant_docs = load_dataset(
-            "zeta-alpha-ai/NanoQuoraRetrieval",
-            "qrels",
-            revision="2ab2d73e6c862026282808b913a34f4136928545",
-        )
-
-        self.corpus = {
-            split: {
-                sample["_id"]: {"_id": sample["_id"], "text": sample["text"]}
-                for sample in self.corpus[split]
-            }
-            for split in self.corpus
-        }
-
-        self.queries = {
-            split: {sample["_id"]: sample["text"] for sample in self.queries[split]}
-            for split in self.queries
-        }
-
-        relevant_docs = {}
-
-        for split in self.relevant_docs:
-            relevant_docs[split] = defaultdict(dict)
-            for query_id, corpus_id in zip(
-                self.relevant_docs[split]["query-id"],
-                self.relevant_docs[split]["corpus-id"],
-                strict=True,
-            ):
-                relevant_docs[split][query_id][corpus_id] = 1
-        self.relevant_docs = relevant_docs
-
-        self.data_loaded = True

--- a/mteb/tasks/retrieval/eng/nano_sci_fact_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_sci_fact_retrieval.py
@@ -1,8 +1,3 @@
-from collections import defaultdict
-from typing import Any
-
-from datasets import load_dataset
-
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -13,8 +8,8 @@ class NanoSciFactRetrieval(AbsTaskRetrieval):
         description="NanoSciFact is a smaller subset of SciFact, which verifies scientific claims using evidence from the research literature containing scientific paper abstracts.",
         reference="https://github.com/allenai/scifact",
         dataset={
-            "path": "zeta-alpha-ai/NanoSciFact",
-            "revision": "309f1d1ae3ae2e092444a8a0c25bed59b82318bc",
+            "path": "mteb/NanoSciFactRetrieval",
+            "revision": "8c5f7bbe90bb865f46c67710221afa7d9096251b",
         },
         type="Retrieval",
         category="t2t",
@@ -42,50 +37,3 @@ class NanoSciFactRetrieval(AbsTaskRetrieval):
         },
         adapted_from=["SciFact"],
     )
-
-    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
-        if self.data_loaded:
-            return
-
-        self.corpus = load_dataset(
-            "zeta-alpha-ai/NanoSciFact",
-            "corpus",
-            revision="309f1d1ae3ae2e092444a8a0c25bed59b82318bc",
-        )
-        self.queries = load_dataset(
-            "zeta-alpha-ai/NanoSciFact",
-            "queries",
-            revision="309f1d1ae3ae2e092444a8a0c25bed59b82318bc",
-        )
-        self.relevant_docs = load_dataset(
-            "zeta-alpha-ai/NanoSciFact",
-            "qrels",
-            revision="309f1d1ae3ae2e092444a8a0c25bed59b82318bc",
-        )
-
-        self.corpus = {
-            split: {
-                sample["_id"]: {"_id": sample["_id"], "text": sample["text"]}
-                for sample in self.corpus[split]
-            }
-            for split in self.corpus
-        }
-
-        self.queries = {
-            split: {sample["_id"]: sample["text"] for sample in self.queries[split]}
-            for split in self.queries
-        }
-
-        relevant_docs = {}
-
-        for split in self.relevant_docs:
-            relevant_docs[split] = defaultdict(dict)
-            for query_id, corpus_id in zip(
-                self.relevant_docs[split]["query-id"],
-                self.relevant_docs[split]["corpus-id"],
-                strict=True,
-            ):
-                relevant_docs[split][query_id][corpus_id] = 1
-        self.relevant_docs = relevant_docs
-
-        self.data_loaded = True

--- a/mteb/tasks/retrieval/eng/nano_scidocs_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_scidocs_retrieval.py
@@ -1,8 +1,3 @@
-from collections import defaultdict
-from typing import Any
-
-from datasets import load_dataset
-
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -15,8 +10,8 @@ class NanoSCIDOCSRetrieval(AbsTaskRetrieval):
         " prediction, to document classification and recommendation.",
         reference="https://allenai.org/data/scidocs",
         dataset={
-            "path": "zeta-alpha-ai/NanoSCIDOCS",
-            "revision": "484eb90549fc3f0b9c42b3551e80ceb999515537",
+            "path": "mteb/NanoSCIDOCSRetrieval",
+            "revision": "cf39b8741a6f2e984d0b8f4796b2dd5bb65390f9",
         },
         type="Retrieval",
         category="t2t",
@@ -44,50 +39,3 @@ class NanoSCIDOCSRetrieval(AbsTaskRetrieval):
         },
         adapted_from=["SCIDOCS"],
     )
-
-    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
-        if self.data_loaded:
-            return
-
-        self.corpus = load_dataset(
-            "zeta-alpha-ai/NanoSCIDOCS",
-            "corpus",
-            revision="484eb90549fc3f0b9c42b3551e80ceb999515537",
-        )
-        self.queries = load_dataset(
-            "zeta-alpha-ai/NanoSCIDOCS",
-            "queries",
-            revision="484eb90549fc3f0b9c42b3551e80ceb999515537",
-        )
-        self.relevant_docs = load_dataset(
-            "zeta-alpha-ai/NanoSCIDOCS",
-            "qrels",
-            revision="484eb90549fc3f0b9c42b3551e80ceb999515537",
-        )
-
-        self.corpus = {
-            split: {
-                sample["_id"]: {"_id": sample["_id"], "text": sample["text"]}
-                for sample in self.corpus[split]
-            }
-            for split in self.corpus
-        }
-
-        self.queries = {
-            split: {sample["_id"]: sample["text"] for sample in self.queries[split]}
-            for split in self.queries
-        }
-
-        relevant_docs = {}
-
-        for split in self.relevant_docs:
-            relevant_docs[split] = defaultdict(dict)
-            for query_id, corpus_id in zip(
-                self.relevant_docs[split]["query-id"],
-                self.relevant_docs[split]["corpus-id"],
-                strict=True,
-            ):
-                relevant_docs[split][query_id][corpus_id] = 1
-        self.relevant_docs = relevant_docs
-
-        self.data_loaded = True

--- a/mteb/tasks/retrieval/eng/nano_touche2020_retrieval.py
+++ b/mteb/tasks/retrieval/eng/nano_touche2020_retrieval.py
@@ -1,8 +1,3 @@
-from collections import defaultdict
-from typing import Any
-
-from datasets import load_dataset
-
 from mteb.abstasks.retrieval import AbsTaskRetrieval
 from mteb.abstasks.task_metadata import TaskMetadata
 
@@ -13,8 +8,8 @@ class NanoTouche2020Retrieval(AbsTaskRetrieval):
         description="NanoTouche2020 is a smaller subset of Touché Task 1: Argument Retrieval for Controversial Questions.",
         reference="https://webis.de/events/touche-20/shared-task-1.html",
         dataset={
-            "path": "zeta-alpha-ai/NanoTouche2020",
-            "revision": "0d2f26ed8c5ad309f95c7f9499c70a40e140fccd",
+            "path": "mteb/NanoTouche2020Retrieval",
+            "revision": "ff81c0caff8b6febe1495eae9f2ca3eddad074b8",
         },
         type="Retrieval",
         category="t2t",
@@ -53,50 +48,3 @@ Questions}},
         },
         adapted_from=["Touche2020"],
     )
-
-    def load_data(self, num_proc: int | None = None, **kwargs: Any) -> None:
-        if self.data_loaded:
-            return
-
-        self.corpus = load_dataset(
-            "zeta-alpha-ai/NanoTouche2020",
-            "corpus",
-            revision="0d2f26ed8c5ad309f95c7f9499c70a40e140fccd",
-        )
-        self.queries = load_dataset(
-            "zeta-alpha-ai/NanoTouche2020",
-            "queries",
-            revision="0d2f26ed8c5ad309f95c7f9499c70a40e140fccd",
-        )
-        self.relevant_docs = load_dataset(
-            "zeta-alpha-ai/NanoTouche2020",
-            "qrels",
-            revision="0d2f26ed8c5ad309f95c7f9499c70a40e140fccd",
-        )
-
-        self.corpus = {
-            split: {
-                sample["_id"]: {"_id": sample["_id"], "text": sample["text"]}
-                for sample in self.corpus[split]
-            }
-            for split in self.corpus
-        }
-
-        self.queries = {
-            split: {sample["_id"]: sample["text"] for sample in self.queries[split]}
-            for split in self.queries
-        }
-
-        relevant_docs = {}
-
-        for split in self.relevant_docs:
-            relevant_docs[split] = defaultdict(dict)
-            for query_id, corpus_id in zip(
-                self.relevant_docs[split]["query-id"],
-                self.relevant_docs[split]["corpus-id"],
-                strict=True,
-            ):
-                relevant_docs[split][query_id][corpus_id] = 1
-        self.relevant_docs = relevant_docs
-
-        self.data_loaded = True


### PR DESCRIPTION
Part of #3424 — takes the 13 `Nano*Retrieval` tasks.

All 13 carried an identical v1 `load_data()` override reading the `zeta-alpha-ai` copies
into `self.corpus` / `self.queries` / `self.relevant_docs`. The re-uploads under the
`mteb` org are already in the v2 layout (`corpus/`, `queries/`, `qrels/`, `train` split),
so the override goes and the default `AbsTaskRetrieval` loader handles them. -702/+26.

## Verification

For each task I loaded the original through the v1 logic and the migrated task through
mteb's API, then compared corpus ids and text, query ids and text, and qrels.
**13/13 identical.**

Worth flagging: the v1 override hardcoded every relevance score to `1`. I checked the
uploaded qrels for Touche2020, DBPedia and ArguAna — all scores are `1` there too, so
this is score-neutral rather than silently regrading.

(`NanoTouche2020Retrieval` has 49 queries rather than 50. That is true of the original
too, not introduced here.)

Lint clean. `test_validate_metadata`, `test_get_tasks`, `test_filter_tasks` and
`test_benchmarks` pass (1602).

I used `refactor:` rather than `dataset:` since no content changes — happy to switch if
you'd rather this triggered a release.
